### PR TITLE
Prepare PiecewiseLinearTwoPhaseMaterial for GPU support

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -815,6 +815,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/common/utility/CSRGraphFromCoordinates_impl.hpp
       opm/common/utility/Demangle.hpp
       opm/common/utility/FileSystem.hpp
+      opm/common/utility/gpuDecorators.hpp
       opm/common/utility/MemPacker.hpp
       opm/common/utility/numeric/cmp.hpp
       opm/common/utility/numeric/blas_lapack.h

--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -84,7 +84,6 @@ specializationTemplate = \
 #include <array>
 {% endif %}\
 #include <cassert>
-#include <config.h>
 #include <iosfwd>
 #include <stdexcept>
 

--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -84,8 +84,11 @@ specializationTemplate = \
 #include <array>
 {% endif %}\
 #include <cassert>
+#include <config.h>
 #include <iosfwd>
 #include <stdexcept>
+
+#include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {
 namespace DenseAd {
@@ -131,52 +134,52 @@ public:
 
     //! number of derivatives
 {% if numDerivs < 0 %}\
-    int size() const
+    OPM_HOST_DEVICE int size() const
     { return data_.size() - 1; }
 {% elif numDerivs == 0 %}\
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return numDerivs; }
 {% else %}\
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return {{ numDerivs }}; };
 {% endif %}\
 
 protected:
     //! length of internal data vector
 {% if numDerivs < 0 %}\
-    int length_() const
+    OPM_HOST_DEVICE int length_() const
     { return data_.size(); }
 {% else %}\
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 {% endif %}\
 
 
 {% if numDerivs < 0 %}\
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    int dend_() const
+    OPM_HOST_DEVICE int dend_() const
     { return length_(); }
 {% else %}\
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 {% endif %}\
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
 {% if numDerivs < 0 %}\
@@ -191,21 +194,21 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 {% if numDerivs < 0 %}\
     //! move other function evaluation (this only makes sense for dynamically
     //! allocated Evaluations)
-    Evaluation(Evaluation&& other)
+    OPM_HOST_DEVICE Evaluation(Evaluation&& other)
         : data_(std::move(other.data_))
     { }
 
     //! move assignment
-    Evaluation& operator=(Evaluation&& other)
+    OPM_HOST_DEVICE Evaluation& operator=(Evaluation&& other)
     {
         data_ = std::move(other.data_);
         return *this;
@@ -214,7 +217,7 @@ public:
 
 {% if numDerivs < 0 %}\
     // create a "blank" dynamic evaluation
-    explicit Evaluation(int numDerivatives)
+    OPM_HOST_DEVICE explicit Evaluation(int numDerivatives)
         : data_(1 + numDerivatives)
     {}
 
@@ -223,7 +226,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(int numDerivatives, const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(int numDerivatives, const RhsValueType& c)
         : data_(1 + numDerivatives, 0.0)
     {
         //clearDerivatives();
@@ -237,7 +240,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -252,7 +255,7 @@ public:
     // derivatives being zero.
 {% if numDerivs < 0 %}\
     template <class RhsValueType>
-    Evaluation(int nVars, const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(int nVars, const RhsValueType& c, int varPos)
      : data_(1 + nVars, 0.0)
     {
         // The variable position must be in represented by the given variable descriptor
@@ -266,7 +269,7 @@ public:
     }
 {% else %}\
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -281,7 +284,7 @@ public:
 {% endif %}\
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
 {% if numDerivs <= 0 %}\
         for (int i = dstart_(); i < dend_(); ++i)
@@ -302,42 +305,42 @@ public:
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
 {% if numDerivs < 0 %}\
-    static Evaluation createBlank(const Evaluation& x)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation& x)
     { return Evaluation(x.size()); }
 {% else %}\
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 {% endif %}\
 
     // create an Evaluation with value and all the derivatives to be zero
 {% if numDerivs < 0 %}\
-    static Evaluation createConstantZero(const Evaluation& x)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation& x)
     { return Evaluation(x.size(), 0.0); }
 {% else %}\
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 {% endif %}\
 
     // create an Evaluation with value to be one and all the derivatives to be zero
 {% if numDerivs < 0 %}\
-    static Evaluation createConstantOne(const Evaluation& x)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation& x)
     { return Evaluation(x.size(), 1.); }
 {% else %}\
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 {% endif %}\
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
 {% if numDerivs < 0 %}\
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType&, int)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType&, int)
     {
         throw std::logic_error("Dynamically sized evaluations require that the number of "
                                "derivatives is specified when creating an evaluation");
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -345,7 +348,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -353,7 +356,7 @@ public:
     }
 {% else %}\
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -361,7 +364,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != {{numDerivs}})
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -373,7 +376,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -386,7 +389,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         return Evaluation(nVars, value);
     }
@@ -394,7 +397,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType&)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType&)
     {
         throw std::logic_error("Dynamically-sized evaluation objects require to specify the number of derivatives.");
     }
@@ -402,7 +405,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(x.size(), value);
     }
@@ -410,7 +413,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != {{numDerivs}})
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -421,7 +424,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -429,14 +432,14 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 {% endif %}\
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -452,7 +455,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -470,7 +473,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -479,7 +482,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -497,7 +500,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -506,7 +509,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -533,7 +536,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
 {% if numDerivs <= 0 %}\
         for (int i = 0; i < length_(); ++i)
@@ -548,7 +551,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -575,7 +578,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -592,7 +595,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -605,7 +608,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -615,7 +618,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -628,7 +631,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -638,7 +641,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
 {% if numDerivs < 0 %}\
         Evaluation result(*this);
@@ -659,7 +662,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -671,7 +674,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -680,7 +683,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -692,7 +695,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -702,7 +705,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -711,13 +714,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -729,18 +732,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -748,10 +751,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -759,10 +762,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -770,10 +773,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -781,16 +784,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -798,7 +801,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -806,7 +809,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }
@@ -824,27 +827,27 @@ private:
 {% if numDerivs == 0 %}\
 // the generic operators are only required for the unspecialized case
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-bool operator<(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE bool operator<(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 { return b > a; }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-bool operator>(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE bool operator>(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 { return b < a; }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-bool operator<=(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE bool operator<=(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 { return b >= a; }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-bool operator>=(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE bool operator>=(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 { return b <= a; }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-bool operator!=(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE bool operator!=(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 { return a != b.value(); }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> operator+(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> operator+(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 {
     Evaluation<ValueType, numVars, staticSize> result(b);
     result += a;
@@ -852,13 +855,13 @@ Evaluation<ValueType, numVars, staticSize> operator+(const RhsValueType& a, cons
 }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> operator-(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> operator-(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 {
     return -(b - a);
 }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> operator/(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> operator/(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 {
     Evaluation<ValueType, numVars, staticSize> tmp(a);
     tmp /= b;
@@ -866,7 +869,7 @@ Evaluation<ValueType, numVars, staticSize> operator/(const RhsValueType& a, cons
 }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> operator*(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> operator*(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 {
     Evaluation<ValueType, numVars, staticSize> result(b);
     result *= a;
@@ -886,12 +889,12 @@ struct is_evaluation<Evaluation<ValueType,numVars,staticSize>>
 };
 
 template <class ValueType, int numVars, unsigned staticSize>
-void printEvaluation(std::ostream& os,
+OPM_HOST_DEVICE void printEvaluation(std::ostream& os,
                      const Evaluation<ValueType, numVars, staticSize>& eval,
                      bool withDer = false);
 
 template <class ValueType, int numVars, unsigned staticSize>
-std::ostream& operator<<(std::ostream& os, const Evaluation<ValueType, numVars, staticSize>& eval)
+OPM_HOST_DEVICE std::ostream& operator<<(std::ostream& os, const Evaluation<ValueType, numVars, staticSize>& eval)
 {
     if constexpr (is_evaluation<ValueType>::value)
         printEvaluation(os, eval.value(), false);
@@ -911,11 +914,11 @@ using DynamicEvaluation = Evaluation<Scalar, DynamicSize, staticSize>;
 {% if numDerivs < 0 %}\
 
 template <class Scalar, unsigned staticSize>
-DenseAd::Evaluation<Scalar, -1, staticSize> constant(int numDerivatives, const Scalar& value)
+OPM_HOST_DEVICE DenseAd::Evaluation<Scalar, -1, staticSize> constant(int numDerivatives, const Scalar& value)
 { return DenseAd::Evaluation<Scalar, -1, staticSize>::createConstant(numDerivatives, value); }
 
 template <class Scalar, unsigned staticSize>
-DenseAd::Evaluation<Scalar, -1, staticSize> variable(int numDerivatives, const Scalar& value, unsigned idx)
+OPM_HOST_DEVICE DenseAd::Evaluation<Scalar, -1, staticSize> variable(int numDerivatives, const Scalar& value, unsigned idx)
 { return DenseAd::Evaluation<Scalar, -1, staticSize>::createVariable(numDerivatives, value, idx); }
 
 {% endif %}\

--- a/opm/common/utility/gpuDecorators.hpp
+++ b/opm/common/utility/gpuDecorators.hpp
@@ -30,41 +30,35 @@
 // HAVE_CUDA and USE_HIP are found in config.h
 #ifndef OPM_GPUDECORATORS_HPP
   #define OPM_GPUDECORATORS_HPP
+
   #include <config.h>
+
+  // true if using nvcc/hipcc gpu compiler
+  #define OPM_IS_COMPILING_WITH_GPU_COMPILER defined(__NVCC__) || defined(__HIPCC__)
+
+  // true inside device version of functions marked __device__
+  #define OPM_IS_INSIDE_DEVICE_FUNCTION (defined(__CUDA_ARCH__) || (defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__ > 0))
+
+  // Default macros for non-GPU compilation
+  #define OPM_HOST_DEVICE
+  #define OPM_DEVICE
+  #define OPM_HOST
+  #define OPM_IS_USING_GPU 0
 
   #if HAVE_CUDA // if we will compile with GPU support
 
     //handle inclusion of correct gpu runtime headerfiles
-    #if USE_HIP // if we compile for AMD architectures
+    #if USE_HIP // use HIP if we compile for AMD architectures
       #include <hip/hip_runtime.h>
-    #else // if we compile for Nvidia architectures
+    #else // otherwise include cuda
       #include <cuda_runtime.h>
     #endif // END USE_HIP
 
-    // define host and device function attributes
     #define OPM_HOST_DEVICE __device__ __host__
     #define OPM_DEVICE __device__
     #define OPM_HOST __host__
-    // define a variable keeping track of whether or not we are compiling for GPUs or not
     #define OPM_IS_USING_GPU 1
 
-    // add a variable that can keep track of whether or not we are compiling with hipcc/nvcc (gpu compilers)
-    #if defined(__NVCC__) || defined(__HIPCC__)
-      #define OPM_IS_COMIPING_WITH_GPU_COMPILER 1
-    #endif // END IF GPUCC
-
-    // add a variable keeping track of whether or not it is placed inside a function marked __device__
-    #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-      #define OPM_IS_INSIDE_DEVICE_FUNCTION (defined(__CUDA_ARCH__) || (defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__ > 0))
-    #endif
-
-  #else // if we are not using CUDA/HIP, let the macros be empty
-    #define OPM_HOST_DEVICE
-    #define OPM_DEVICE
-    #define OPM_HOST
-    #define OPM_IS_COMIPING_WITH_GPU_COMPILER
-    #define OPM_IS_USING_GPU
-    #define OPM_IS_INSIDE_DEVICE_FUNCTION
   #endif // END ELSE
 
 #endif // END HEADER GUARD

--- a/opm/common/utility/gpuDecorators.hpp
+++ b/opm/common/utility/gpuDecorators.hpp
@@ -31,7 +31,7 @@
 #ifndef OPM_GPUDECORATORS_HPP
   #define OPM_GPUDECORATORS_HPP
 
-  #include <config.h>
+  //TODO Should probably include config.h if config.h becomes installable
 
   // true if using nvcc/hipcc gpu compiler
   #if defined(__NVCC__) || defined(__HIPCC__)

--- a/opm/common/utility/gpuDecorators.hpp
+++ b/opm/common/utility/gpuDecorators.hpp
@@ -39,12 +39,6 @@
   // true inside device version of functions marked __device__
   #define OPM_IS_INSIDE_DEVICE_FUNCTION (defined(__CUDA_ARCH__) || (defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__ > 0))
 
-  // Default macros for non-GPU compilation
-  #define OPM_HOST_DEVICE
-  #define OPM_DEVICE
-  #define OPM_HOST
-  #define OPM_IS_USING_GPU 0
-
   #if HAVE_CUDA // if we will compile with GPU support
 
     //handle inclusion of correct gpu runtime headerfiles
@@ -58,7 +52,11 @@
     #define OPM_DEVICE __device__
     #define OPM_HOST __host__
     #define OPM_IS_USING_GPU 1
-
+  #else
+    #define OPM_HOST_DEVICE
+    #define OPM_DEVICE
+    #define OPM_HOST
+    #define OPM_IS_USING_GPU 0
   #endif // END ELSE
 
 #endif // END HEADER GUARD

--- a/opm/common/utility/gpuDecorators.hpp
+++ b/opm/common/utility/gpuDecorators.hpp
@@ -27,7 +27,9 @@
     from both GPUs and CPUs.
 */
 
-// HAVE_CUDA and USE_HIP are found in config.h
+/// Decorators for GPU functions
+///
+/// @note This file requires that config.h has already been included
 #ifndef OPM_GPUDECORATORS_HPP
   #define OPM_GPUDECORATORS_HPP
 

--- a/opm/common/utility/gpuDecorators.hpp
+++ b/opm/common/utility/gpuDecorators.hpp
@@ -1,0 +1,70 @@
+/*
+  Copyright 2024 SINTEF Digital
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+    The point of this file is defining macros like OPM_HOST_DEVICE to be empty if
+    we do not compile for GPU architectures, otherwise we will
+    set it to "__device__ __host__" to decorate functions that can
+    be called from a hip/cuda kernel.
+
+    The file also provides some definitions that will probably become useful later,
+    such as OPM_IS_INSIDE_DEVICE_FUNCTION for specializing code that can be called
+    from both GPUs and CPUs.
+*/
+
+// HAVE_CUDA and USE_HIP are found in config.h
+#ifndef OPM_GPUDECORATORS_HPP
+  #define OPM_GPUDECORATORS_HPP
+  #include <config.h>
+
+  #if HAVE_CUDA // if we will compile with GPU support
+
+    //handle inclusion of correct gpu runtime headerfiles
+    #if USE_HIP // if we compile for AMD architectures
+      #include <hip/hip_runtime.h>
+    #else // if we compile for Nvidia architectures
+      #include <cuda_runtime.h>
+    #endif // END USE_HIP
+
+    // define host and device function attributes
+    #define OPM_HOST_DEVICE __device__ __host__
+    #define OPM_DEVICE __device__
+    #define OPM_HOST __host__
+    // define a variable keeping track of whether or not we are compiling for GPUs or not
+    #define OPM_IS_USING_GPU 1
+
+    // add a variable that can keep track of whether or not we are compiling with hipcc/nvcc (gpu compilers)
+    #if defined(__NVCC__) || defined(__HIPCC__)
+      #define OPM_IS_COMIPING_WITH_GPU_COMPILER 1
+    #endif // END IF GPUCC
+
+    // add a variable keeping track of whether or not it is placed inside a function marked __device__
+    #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+      #define OPM_IS_INSIDE_DEVICE_FUNCTION (defined(__CUDA_ARCH__) || (defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__ > 0))
+    #endif
+
+  #else // if we are not using CUDA/HIP, let the macros be empty
+    #define OPM_HOST_DEVICE
+    #define OPM_DEVICE
+    #define OPM_HOST
+    #define OPM_IS_COMIPING_WITH_GPU_COMPILER
+    #define OPM_IS_USING_GPU
+    #define OPM_IS_INSIDE_DEVICE_FUNCTION
+  #endif // END ELSE
+
+#endif // END HEADER GUARD

--- a/opm/common/utility/gpuDecorators.hpp
+++ b/opm/common/utility/gpuDecorators.hpp
@@ -34,10 +34,18 @@
   #include <config.h>
 
   // true if using nvcc/hipcc gpu compiler
-  #define OPM_IS_COMPILING_WITH_GPU_COMPILER defined(__NVCC__) || defined(__HIPCC__)
+  #if defined(__NVCC__) || defined(__HIPCC__)
+  #define OPM_IS_COMPILING_WITH_GPU_COMPILER 1
+  #else
+  #define OPM_IS_COMPILING_WITH_GPU_COMPILER 0
+  #endif
 
   // true inside device version of functions marked __device__
-  #define OPM_IS_INSIDE_DEVICE_FUNCTION (defined(__CUDA_ARCH__) || (defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__ > 0))
+  #if defined(__CUDA_ARCH__) || (defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__ > 0)
+  #define OPM_IS_INSIDE_DEVICE_FUNCTION 1
+  #else
+  #define OPM_IS_INSIDE_DEVICE_FUNCTION 0
+  #endif
 
   #if HAVE_CUDA // if we will compile with GPU support
 

--- a/opm/material/common/EnsureFinalized.hpp
+++ b/opm/material/common/EnsureFinalized.hpp
@@ -30,6 +30,8 @@
 #include <cassert>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 // TODO: move this variable to config.h
 #define OPM_CHECK_PARAM_FINALIZED 1
 
@@ -53,14 +55,14 @@ protected:
     /*!
      * \brief The default constructor.
      */
-    EnsureFinalized()
+    OPM_HOST_DEVICE EnsureFinalized()
 #if USE_OPM_CHECK_PARAM_FINALIZED
         : finalized_( false )
 #endif
     {
     }
 
-    void check() const
+    OPM_HOST_DEVICE void check() const
     {
 #if USE_OPM_CHECK_PARAM_FINALIZED
         if (!finalized_)
@@ -72,7 +74,7 @@ public:
     /*!
      * \brief Mark the object as finalized.
      */
-    void finalize()
+    OPM_HOST_DEVICE void finalize()
     {
 #if USE_OPM_CHECK_PARAM_FINALIZED
         finalized_ = true;

--- a/opm/material/common/MathToolbox.hpp
+++ b/opm/material/common/MathToolbox.hpp
@@ -36,6 +36,7 @@
 #include <algorithm>
 #include <type_traits>
 #include <stdexcept>
+#include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {
 /*
@@ -80,7 +81,7 @@ public:
      * For this toolbox, there are no derivatives so this method is the identity
      * function.
      */
-    static Scalar value(Scalar value)
+    OPM_HOST_DEVICE static Scalar value(Scalar value)
     { return value; }
 
     /*!
@@ -89,7 +90,7 @@ public:
      * Since this toolbox's value objects are primitive scalars, this method just passes
      * through the argument it was given.
      */
-    static Scalar scalarValue(Scalar value)
+    OPM_HOST_DEVICE static Scalar scalarValue(Scalar value)
     { return value; }
 
     /*!
@@ -98,7 +99,7 @@ public:
      * This basically boils down to creating an uninitialized object of sufficient size.
      * This is method only non-trivial for dynamically-sized Evaluation objects.
      */
-    static Scalar createBlank(Scalar /*value*/)
+    OPM_HOST_DEVICE static Scalar createBlank(Scalar /*value*/)
     { return Scalar(); }
 
     /*!
@@ -108,7 +109,7 @@ public:
      * function. In general, this returns an evaluation object for which all derivatives
      * are zero.
      */
-    static Scalar createConstant(Scalar value)
+    OPM_HOST_DEVICE static Scalar createConstant(Scalar value)
     { return value; }
 
     /*!
@@ -119,7 +120,7 @@ public:
      * function. In general, this returns an evaluation object for which all derivatives
      * are zero.
      */
-    static Scalar createConstant(unsigned numDerivatives, Scalar value)
+    OPM_HOST_DEVICE static Scalar createConstant(unsigned numDerivatives, Scalar value)
     {
         if (numDerivatives != 0)
             throw std::logic_error("Plain floating point objects cannot represent any derivatives");
@@ -134,7 +135,7 @@ public:
      * function. In general, this returns an evaluation object for which all derivatives
      * are zero.
      */
-    static Scalar createConstant(Scalar /*x*/, Scalar value)
+    OPM_HOST_DEVICE static Scalar createConstant(Scalar /*x*/, Scalar value)
     { return value; }
 
     /*!
@@ -144,7 +145,7 @@ public:
      * regard to x. For scalars (which do not consider derivatives), this method does
      * nothing.
      */
-    static Scalar createVariable(Scalar /*value*/, unsigned /*varIdx*/)
+    OPM_HOST_DEVICE static Scalar createVariable(Scalar /*value*/, unsigned /*varIdx*/)
     { throw std::logic_error("Plain floating point objects cannot represent variables"); }
 
     /*!
@@ -155,7 +156,7 @@ public:
      * regard to x. For scalars (which do not consider derivatives), this method does
      * nothing.
      */
-    static Scalar createVariable(Scalar /*x*/, Scalar /*value*/, unsigned /*varIdx*/)
+    OPM_HOST_DEVICE static Scalar createVariable(Scalar /*x*/, Scalar /*value*/, unsigned /*varIdx*/)
     { throw std::logic_error("Plain floating point objects cannot represent variables"); }
 
     /*!
@@ -170,7 +171,7 @@ public:
      * in scalar computations.
      */
     template <class LhsEval>
-    static LhsEval decay(Scalar value)
+    OPM_HOST_DEVICE static LhsEval decay(Scalar value)
     {
         static_assert(std::is_floating_point<LhsEval>::value,
                       "The left-hand side must be a primitive floating point type!");
@@ -181,7 +182,7 @@ public:
     /*!
      * \brief Returns true if two values are identical up to a specified tolerance
      */
-    static bool isSame(Scalar a, Scalar b, Scalar tolerance)
+    OPM_HOST_DEVICE static bool isSame(Scalar a, Scalar b, Scalar tolerance)
     {
         Scalar valueDiff = a - b;
         Scalar denom = std::max<Scalar>(1.0, std::abs(a + b));
@@ -194,87 +195,87 @@ public:
     ////////////
 
     //! The maximum of two arguments
-    static Scalar max(Scalar arg1, Scalar arg2)
+    OPM_HOST_DEVICE static Scalar max(Scalar arg1, Scalar arg2)
     { return std::max(arg1, arg2); }
 
     //! The minimum of two arguments
-    static Scalar min(Scalar arg1, Scalar arg2)
+    OPM_HOST_DEVICE static Scalar min(Scalar arg1, Scalar arg2)
     { return std::min(arg1, arg2); }
 
     //! The absolute value
-    static Scalar abs(Scalar arg)
+    OPM_HOST_DEVICE static Scalar abs(Scalar arg)
     { return std::abs(arg); }
 
     //! The tangens of a value
-    static Scalar tan(Scalar arg)
+    OPM_HOST_DEVICE static Scalar tan(Scalar arg)
     { return std::tan(arg); }
 
     //! The arcus tangens of a value
-    static Scalar atan(Scalar arg)
+    OPM_HOST_DEVICE static Scalar atan(Scalar arg)
     { return std::atan(arg); }
 
     //! The arcus tangens of a value
-    static Scalar atan2(Scalar arg1, Scalar arg2)
+    OPM_HOST_DEVICE static Scalar atan2(Scalar arg1, Scalar arg2)
     { return std::atan2(arg1, arg2); }
 
     //! The sine of a value
-    static Scalar sin(Scalar arg)
+    OPM_HOST_DEVICE static Scalar sin(Scalar arg)
     { return std::sin(arg); }
 
     //! The arcus sine of a value
-    static Scalar asin(Scalar arg)
+    OPM_HOST_DEVICE static Scalar asin(Scalar arg)
     { return std::asin(arg); }
 
     //! The sine hyperbolicus of a value
-    static Scalar sinh(Scalar arg)
+    OPM_HOST_DEVICE static Scalar sinh(Scalar arg)
     { return std::sinh(arg); }
 
     //! The arcus sine hyperbolicus of a value
-    static Scalar asinh(Scalar arg)
+    OPM_HOST_DEVICE static Scalar asinh(Scalar arg)
     { return std::asinh(arg); }
 
     //! The cosine of a value
-    static Scalar cos(Scalar arg)
+    OPM_HOST_DEVICE static Scalar cos(Scalar arg)
     { return std::cos(arg); }
 
     //! The arcus cosine of a value
-    static Scalar acos(Scalar arg)
+    OPM_HOST_DEVICE static Scalar acos(Scalar arg)
     { return std::acos(arg); }
 
     //! The cosine hyperbolicus of a value
-    static Scalar cosh(Scalar arg)
+    OPM_HOST_DEVICE static Scalar cosh(Scalar arg)
     { return std::cosh(arg); }
 
     //! The arcus cosine hyperbolicus of a value
-    static Scalar acosh(Scalar arg)
+    OPM_HOST_DEVICE static Scalar acosh(Scalar arg)
     { return std::acosh(arg); }
 
     //! The square root of a value
-    static Scalar sqrt(Scalar arg)
+    OPM_HOST_DEVICE static Scalar sqrt(Scalar arg)
     { return std::sqrt(arg); }
 
     //! The natural exponentiation of a value
-    static Scalar exp(Scalar arg)
+    OPM_HOST_DEVICE static Scalar exp(Scalar arg)
     { return std::exp(arg); }
 
     //! The 10 logarithm of a value
-    static Scalar log10(Scalar arg)
+    OPM_HOST_DEVICE static Scalar log10(Scalar arg)
     { return std::log10(arg); }
 
     //! The natural logarithm of a value
-    static Scalar log(Scalar arg)
+    OPM_HOST_DEVICE static Scalar log(Scalar arg)
     { return std::log(arg); }
 
     //! Exponentiation to an arbitrary base
-    static Scalar pow(Scalar base, Scalar exp)
+    OPM_HOST_DEVICE static Scalar pow(Scalar base, Scalar exp)
     { return std::pow(base, exp); }
 
     //! Return true iff the argument's value and all its derivatives are finite values
-    static bool isfinite(Scalar arg)
+    OPM_HOST_DEVICE static bool isfinite(Scalar arg)
     { return std::isfinite(arg); }
 
     //! Return true iff the argument's value or any of its derivatives are NaN values
-    static bool isnan(Scalar arg)
+    OPM_HOST_DEVICE static bool isnan(Scalar arg)
     { return std::isnan(arg); }
 };
 
@@ -294,134 +295,134 @@ struct ReturnEval_
 
 // these are convenience functions for not having to type MathToolbox<Scalar>::foo()
 template <class Evaluation>
-Evaluation blank(const Evaluation& x)
+OPM_HOST_DEVICE Evaluation blank(const Evaluation& x)
 { return MathToolbox<Evaluation>::createBlank(x); }
 
 template <class Evaluation, class Scalar>
-Evaluation constant(const Scalar& value)
+OPM_HOST_DEVICE Evaluation constant(const Scalar& value)
 { return MathToolbox<Evaluation>::createConstant(value); }
 
 template <class Evaluation, class Scalar>
-Evaluation constant(unsigned numDeriv, const Scalar& value)
+OPM_HOST_DEVICE Evaluation constant(unsigned numDeriv, const Scalar& value)
 { return MathToolbox<Evaluation>::createConstant(numDeriv, value); }
 
 template <class Evaluation, class Scalar>
-Evaluation constant(const Evaluation& x, const Scalar& value)
+OPM_HOST_DEVICE Evaluation constant(const Evaluation& x, const Scalar& value)
 { return MathToolbox<Evaluation>::createConstant(x, value); }
 
 template <class Evaluation, class Scalar>
-Evaluation variable(unsigned numDeriv, const Scalar& value, unsigned idx)
+OPM_HOST_DEVICE Evaluation variable(unsigned numDeriv, const Scalar& value, unsigned idx)
 { return MathToolbox<Evaluation>::createVariable(numDeriv, value, idx); }
 
 template <class Evaluation, class Scalar>
-Evaluation variable(const Evaluation& x, const Scalar& value, unsigned idx)
+OPM_HOST_DEVICE Evaluation variable(const Evaluation& x, const Scalar& value, unsigned idx)
 { return MathToolbox<Evaluation>::createVariable(x, value, idx); }
 
 template <class Evaluation, class Scalar>
-Evaluation variable(const Scalar& value, unsigned idx)
+OPM_HOST_DEVICE Evaluation variable(const Scalar& value, unsigned idx)
 { return MathToolbox<Evaluation>::createVariable(value, idx); }
 
 template <class ResultEval, class Evaluation>
-auto decay(const Evaluation& value)
+OPM_HOST_DEVICE auto decay(const Evaluation& value)
     -> decltype(MathToolbox<Evaluation>::template decay<ResultEval>(value))
 { return MathToolbox<Evaluation>::template decay<ResultEval>(value); }
 
 template <class Evaluation>
-auto getValue(const Evaluation& val)
+OPM_HOST_DEVICE auto getValue(const Evaluation& val)
     -> decltype(MathToolbox<Evaluation>::value(val))
 { return MathToolbox<Evaluation>::value(val); }
 
 template <class Evaluation>
-auto scalarValue(const Evaluation& val)
+OPM_HOST_DEVICE auto scalarValue(const Evaluation& val)
     -> decltype(MathToolbox<Evaluation>::scalarValue(val))
 { return MathToolbox<Evaluation>::scalarValue(val); }
 
 template <class Evaluation1, class Evaluation2>
 typename ReturnEval_<Evaluation1, Evaluation2>::type
-max(const Evaluation1& arg1, const Evaluation2& arg2)
+OPM_HOST_DEVICE max(const Evaluation1& arg1, const Evaluation2& arg2)
 { return MathToolbox<typename ReturnEval_<Evaluation1, Evaluation2>::type>::max(arg1, arg2); }
 
 template <class Evaluation1, class Evaluation2>
 typename ReturnEval_<Evaluation1, Evaluation2>::type
-min(const Evaluation1& arg1, const Evaluation2& arg2)
+OPM_HOST_DEVICE min(const Evaluation1& arg1, const Evaluation2& arg2)
 { return MathToolbox<typename ReturnEval_<Evaluation1, Evaluation2>::type>::min(arg1, arg2); }
 
 template <class Evaluation>
-Evaluation abs(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation abs(const Evaluation& value)
 { return MathToolbox<Evaluation>::abs(value); }
 
 template <class Evaluation>
-Evaluation tan(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation tan(const Evaluation& value)
 { return MathToolbox<Evaluation>::tan(value); }
 
 template <class Evaluation>
-Evaluation atan(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation atan(const Evaluation& value)
 { return MathToolbox<Evaluation>::atan(value); }
 
 template <class Evaluation1, class Evaluation2>
 typename ReturnEval_<Evaluation1, Evaluation2>::type
-atan2(const Evaluation1& value1, const Evaluation2& value2)
+OPM_HOST_DEVICE atan2(const Evaluation1& value1, const Evaluation2& value2)
 { return MathToolbox<typename ReturnEval_<Evaluation1, Evaluation2>::type>::atan2(value1, value2); }
 
 template <class Evaluation>
-Evaluation sin(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation sin(const Evaluation& value)
 { return MathToolbox<Evaluation>::sin(value); }
 
 template <class Evaluation>
-Evaluation asin(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation asin(const Evaluation& value)
 { return MathToolbox<Evaluation>::asin(value); }
 
 template <class Evaluation>
-Evaluation sinh(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation sinh(const Evaluation& value)
 { return MathToolbox<Evaluation>::sinh(value); }
 
 template <class Evaluation>
-Evaluation asinh(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation asinh(const Evaluation& value)
 { return MathToolbox<Evaluation>::asinh(value); }
 
 template <class Evaluation>
-Evaluation cos(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation cos(const Evaluation& value)
 { return MathToolbox<Evaluation>::cos(value); }
 
 template <class Evaluation>
-Evaluation acos(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation acos(const Evaluation& value)
 { return MathToolbox<Evaluation>::acos(value); }
 
 template <class Evaluation>
-Evaluation cosh(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation cosh(const Evaluation& value)
 { return MathToolbox<Evaluation>::cosh(value); }
 
 template <class Evaluation>
-Evaluation acosh(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation acosh(const Evaluation& value)
 { return MathToolbox<Evaluation>::acosh(value); }
 
 template <class Evaluation>
-Evaluation sqrt(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation sqrt(const Evaluation& value)
 { return MathToolbox<Evaluation>::sqrt(value); }
 
 template <class Evaluation>
-Evaluation exp(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation exp(const Evaluation& value)
 { return MathToolbox<Evaluation>::exp(value); }
 
 template <class Evaluation>
-Evaluation log(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation log(const Evaluation& value)
 { return MathToolbox<Evaluation>::log(value); }
 
 template <class Evaluation>
-Evaluation log10(const Evaluation& value)
+OPM_HOST_DEVICE Evaluation log10(const Evaluation& value)
 { return MathToolbox<Evaluation>::log10(value); }
 
 template <class Evaluation1, class Evaluation2>
 typename ReturnEval_<Evaluation1, Evaluation2>::type
-pow(const Evaluation1& base, const Evaluation2& exp)
+OPM_HOST_DEVICE pow(const Evaluation1& base, const Evaluation2& exp)
 { return MathToolbox<typename ReturnEval_<Evaluation1, Evaluation2>::type>::pow(base, exp); }
 
 template <class Evaluation>
-bool isfinite(const Evaluation& value)
+OPM_HOST_DEVICE bool isfinite(const Evaluation& value)
 { return MathToolbox<Evaluation>::isfinite(value); }
 
 template <class Evaluation>
-bool isnan(const Evaluation& value)
+OPM_HOST_DEVICE bool isnan(const Evaluation& value)
 { return MathToolbox<Evaluation>::isnan(value); }
 
 } // namespace Opm

--- a/opm/material/densead/DynamicEvaluation.hpp
+++ b/opm/material/densead/DynamicEvaluation.hpp
@@ -41,6 +41,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -60,28 +62,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    int size() const
+    OPM_HOST_DEVICE int size() const
     { return data_.size() - 1; }
 
 protected:
     //! length of internal data vector
-    int length_() const
+    OPM_HOST_DEVICE int length_() const
     { return data_.size(); }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    int dend_() const
+    OPM_HOST_DEVICE int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
         for (int i = dstart_(); i < dend_(); ++i)
@@ -91,27 +93,27 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
     //! move other function evaluation (this only makes sense for dynamically
     //! allocated Evaluations)
-    Evaluation(Evaluation&& other)
+    OPM_HOST_DEVICE Evaluation(Evaluation&& other)
         : data_(std::move(other.data_))
     { }
 
     //! move assignment
-    Evaluation& operator=(Evaluation&& other)
+    OPM_HOST_DEVICE Evaluation& operator=(Evaluation&& other)
     {
         data_ = std::move(other.data_);
         return *this;
     }
 
     // create a "blank" dynamic evaluation
-    explicit Evaluation(int numDerivatives)
+    OPM_HOST_DEVICE explicit Evaluation(int numDerivatives)
         : data_(1 + numDerivatives)
     {}
 
@@ -120,7 +122,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(int numDerivatives, const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(int numDerivatives, const RhsValueType& c)
         : data_(1 + numDerivatives, 0.0)
     {
         //clearDerivatives();
@@ -134,7 +136,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(int nVars, const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(int nVars, const RhsValueType& c, int varPos)
      : data_(1 + nVars, 0.0)
     {
         // The variable position must be in represented by the given variable descriptor
@@ -148,7 +150,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         for (int i = dstart_(); i < dend_(); ++i)
             data_[i] = 0.0;
@@ -162,27 +164,27 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation& x)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation& x)
     { return Evaluation(x.size()); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation& x)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation& x)
     { return Evaluation(x.size(), 0.0); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation& x)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation& x)
     { return Evaluation(x.size(), 1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType&, int)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType&, int)
     {
         throw std::logic_error("Dynamically sized evaluations require that the number of "
                                "derivatives is specified when creating an evaluation");
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -190,7 +192,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation& x, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -201,7 +203,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         return Evaluation(nVars, value);
     }
@@ -209,7 +211,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType&)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType&)
     {
         throw std::logic_error("Dynamically-sized evaluation objects require to specify the number of derivatives.");
     }
@@ -217,13 +219,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation& x, const RhsValueType& value)
     {
         return Evaluation(x.size(), value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -233,7 +235,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -245,7 +247,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -254,7 +256,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -266,7 +268,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -275,7 +277,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -296,7 +298,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         for (int i = 0; i < length_(); ++i)
             data_[i] *= other;
@@ -305,7 +307,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -326,7 +328,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -337,7 +339,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -350,7 +352,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -360,7 +362,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -373,7 +375,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -383,7 +385,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result(*this);
 
@@ -394,7 +396,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -406,7 +408,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -415,7 +417,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -427,7 +429,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -437,7 +439,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -446,13 +448,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -464,18 +466,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -483,10 +485,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -494,10 +496,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -505,10 +507,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -516,16 +518,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -533,7 +535,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -541,7 +543,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }
@@ -556,11 +558,11 @@ using DynamicEvaluation = Evaluation<Scalar, DynamicSize, staticSize>;
 } // namespace DenseAd
 
 template <class Scalar, unsigned staticSize>
-DenseAd::Evaluation<Scalar, -1, staticSize> constant(int numDerivatives, const Scalar& value)
+OPM_HOST_DEVICE DenseAd::Evaluation<Scalar, -1, staticSize> constant(int numDerivatives, const Scalar& value)
 { return DenseAd::Evaluation<Scalar, -1, staticSize>::createConstant(numDerivatives, value); }
 
 template <class Scalar, unsigned staticSize>
-DenseAd::Evaluation<Scalar, -1, staticSize> variable(int numDerivatives, const Scalar& value, unsigned idx)
+OPM_HOST_DEVICE DenseAd::Evaluation<Scalar, -1, staticSize> variable(int numDerivatives, const Scalar& value, unsigned idx)
 { return DenseAd::Evaluation<Scalar, -1, staticSize>::createVariable(numDerivatives, value, idx); }
 
 } // namespace Opm

--- a/opm/material/densead/Evaluation.cpp
+++ b/opm/material/densead/Evaluation.cpp
@@ -29,12 +29,13 @@
 #endif
 
 #include <ostream>
+#include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {
 namespace DenseAd {
 
 template <class ValueT, int numDerivs, unsigned staticSize>
-void printEvaluation(std::ostream& os,
+OPM_HOST_DEVICE void printEvaluation(std::ostream& os,
                      const Evaluation<ValueT,numDerivs,staticSize>& eval,
                      bool withDer)
 {

--- a/opm/material/densead/Evaluation.hpp
+++ b/opm/material/densead/Evaluation.hpp
@@ -41,6 +41,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -64,28 +66,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return numDerivs; }
 
 protected:
     //! length of internal data vector
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
        for (const auto& v: data_)
@@ -95,11 +97,11 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -107,7 +109,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -120,7 +122,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -134,7 +136,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         for (int i = dstart_(); i < dend_(); ++i)
             data_[i] = 0.0;
@@ -148,20 +150,20 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -169,7 +171,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != 0)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -181,7 +183,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -192,7 +194,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != 0)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -203,7 +205,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -211,13 +213,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -227,7 +229,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -239,7 +241,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -248,7 +250,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -260,7 +262,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -269,7 +271,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -290,7 +292,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         for (int i = 0; i < length_(); ++i)
             data_[i] *= other;
@@ -299,7 +301,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -320,7 +322,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -331,7 +333,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -344,7 +346,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -354,7 +356,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -367,7 +369,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -377,7 +379,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result;
 
@@ -388,7 +390,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -400,7 +402,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -409,7 +411,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -421,7 +423,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -431,7 +433,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -440,13 +442,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -458,18 +460,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -477,10 +479,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -488,10 +490,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -499,10 +501,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -510,16 +512,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -527,7 +529,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -535,7 +537,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }
@@ -546,27 +548,27 @@ private:
 
 // the generic operators are only required for the unspecialized case
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-bool operator<(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE bool operator<(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 { return b > a; }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-bool operator>(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE bool operator>(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 { return b < a; }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-bool operator<=(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE bool operator<=(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 { return b >= a; }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-bool operator>=(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE bool operator>=(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 { return b <= a; }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-bool operator!=(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE bool operator!=(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 { return a != b.value(); }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> operator+(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> operator+(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 {
     Evaluation<ValueType, numVars, staticSize> result(b);
     result += a;
@@ -574,13 +576,13 @@ Evaluation<ValueType, numVars, staticSize> operator+(const RhsValueType& a, cons
 }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> operator-(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> operator-(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 {
     return -(b - a);
 }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> operator/(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> operator/(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 {
     Evaluation<ValueType, numVars, staticSize> tmp(a);
     tmp /= b;
@@ -588,7 +590,7 @@ Evaluation<ValueType, numVars, staticSize> operator/(const RhsValueType& a, cons
 }
 
 template <class RhsValueType, class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> operator*(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> operator*(const RhsValueType& a, const Evaluation<ValueType, numVars, staticSize>& b)
 {
     Evaluation<ValueType, numVars, staticSize> result(b);
     result *= a;
@@ -608,12 +610,12 @@ struct is_evaluation<Evaluation<ValueType,numVars,staticSize>>
 };
 
 template <class ValueType, int numVars, unsigned staticSize>
-void printEvaluation(std::ostream& os,
+OPM_HOST_DEVICE void printEvaluation(std::ostream& os,
                      const Evaluation<ValueType, numVars, staticSize>& eval,
                      bool withDer = false);
 
 template <class ValueType, int numVars, unsigned staticSize>
-std::ostream& operator<<(std::ostream& os, const Evaluation<ValueType, numVars, staticSize>& eval)
+OPM_HOST_DEVICE std::ostream& operator<<(std::ostream& os, const Evaluation<ValueType, numVars, staticSize>& eval)
 {
     if constexpr (is_evaluation<ValueType>::value)
         printEvaluation(os, eval.value(), false);

--- a/opm/material/densead/Evaluation1.hpp
+++ b/opm/material/densead/Evaluation1.hpp
@@ -40,6 +40,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -55,28 +57,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return 1; };
 
 protected:
     //! length of internal data vector
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
        for (const auto& v: data_)
@@ -86,11 +88,11 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -98,7 +100,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -111,7 +113,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -125,7 +127,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         data_[1] = 0.0;
     }
@@ -138,20 +140,20 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -159,7 +161,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != 1)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -171,7 +173,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -182,7 +184,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != 1)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -193,7 +195,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -201,13 +203,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -216,7 +218,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -228,7 +230,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -237,7 +239,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -249,7 +251,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -258,7 +260,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -278,7 +280,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         data_[0] *= other;
         data_[1] *= other;
@@ -287,7 +289,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -303,7 +305,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -314,7 +316,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -327,7 +329,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -337,7 +339,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -350,7 +352,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -360,7 +362,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result;
 
@@ -371,7 +373,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -383,7 +385,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -392,7 +394,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -404,7 +406,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -414,7 +416,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -423,13 +425,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -441,18 +443,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -460,10 +462,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -471,10 +473,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -482,10 +484,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -493,16 +495,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -510,7 +512,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -518,7 +520,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }

--- a/opm/material/densead/Evaluation10.hpp
+++ b/opm/material/densead/Evaluation10.hpp
@@ -40,6 +40,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -55,28 +57,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return 10; };
 
 protected:
     //! length of internal data vector
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
        for (const auto& v: data_)
@@ -86,11 +88,11 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -98,7 +100,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -111,7 +113,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -125,7 +127,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         data_[1] = 0.0;
         data_[2] = 0.0;
@@ -147,20 +149,20 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -168,7 +170,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != 10)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -180,7 +182,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -191,7 +193,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != 10)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -202,7 +204,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -210,13 +212,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -234,7 +236,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -255,7 +257,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -264,7 +266,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -285,7 +287,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -294,7 +296,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -323,7 +325,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         data_[0] *= other;
         data_[1] *= other;
@@ -341,7 +343,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -366,7 +368,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -386,7 +388,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -399,7 +401,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -409,7 +411,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -422,7 +424,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -432,7 +434,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result;
 
@@ -452,7 +454,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -464,7 +466,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -473,7 +475,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -485,7 +487,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -495,7 +497,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -504,13 +506,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -522,18 +524,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -541,10 +543,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -552,10 +554,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -563,10 +565,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -574,16 +576,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -591,7 +593,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -599,7 +601,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }

--- a/opm/material/densead/Evaluation11.hpp
+++ b/opm/material/densead/Evaluation11.hpp
@@ -40,6 +40,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -55,28 +57,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return 11; };
 
 protected:
     //! length of internal data vector
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
        for (const auto& v: data_)
@@ -86,11 +88,11 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -98,7 +100,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -111,7 +113,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -125,7 +127,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         data_[1] = 0.0;
         data_[2] = 0.0;
@@ -148,20 +150,20 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -169,7 +171,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != 11)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -181,7 +183,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -192,7 +194,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != 11)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -203,7 +205,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -211,13 +213,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -236,7 +238,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -258,7 +260,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -267,7 +269,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -289,7 +291,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -298,7 +300,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -328,7 +330,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         data_[0] *= other;
         data_[1] *= other;
@@ -347,7 +349,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -373,7 +375,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -394,7 +396,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -407,7 +409,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -417,7 +419,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -430,7 +432,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -440,7 +442,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result;
 
@@ -461,7 +463,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -473,7 +475,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -482,7 +484,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -494,7 +496,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -504,7 +506,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -513,13 +515,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -531,18 +533,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -550,10 +552,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -561,10 +563,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -572,10 +574,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -583,16 +585,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -600,7 +602,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -608,7 +610,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }

--- a/opm/material/densead/Evaluation12.hpp
+++ b/opm/material/densead/Evaluation12.hpp
@@ -40,6 +40,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -55,28 +57,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return 12; };
 
 protected:
     //! length of internal data vector
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
        for (const auto& v: data_)
@@ -86,11 +88,11 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -98,7 +100,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -111,7 +113,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -125,7 +127,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         data_[1] = 0.0;
         data_[2] = 0.0;
@@ -149,20 +151,20 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -170,7 +172,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != 12)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -182,7 +184,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -193,7 +195,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != 12)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -204,7 +206,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -212,13 +214,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -238,7 +240,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -261,7 +263,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -270,7 +272,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -293,7 +295,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -302,7 +304,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -333,7 +335,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         data_[0] *= other;
         data_[1] *= other;
@@ -353,7 +355,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -380,7 +382,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -402,7 +404,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -415,7 +417,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -425,7 +427,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -438,7 +440,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -448,7 +450,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result;
 
@@ -470,7 +472,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -482,7 +484,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -491,7 +493,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -503,7 +505,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -513,7 +515,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -522,13 +524,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -540,18 +542,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -559,10 +561,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -570,10 +572,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -581,10 +583,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -592,16 +594,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -609,7 +611,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -617,7 +619,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }

--- a/opm/material/densead/Evaluation2.hpp
+++ b/opm/material/densead/Evaluation2.hpp
@@ -40,6 +40,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -55,28 +57,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return 2; };
 
 protected:
     //! length of internal data vector
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
        for (const auto& v: data_)
@@ -86,11 +88,11 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -98,7 +100,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -111,7 +113,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -125,7 +127,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         data_[1] = 0.0;
         data_[2] = 0.0;
@@ -139,20 +141,20 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -160,7 +162,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != 2)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -172,7 +174,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -183,7 +185,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != 2)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -194,7 +196,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -202,13 +204,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -218,7 +220,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -231,7 +233,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -240,7 +242,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -253,7 +255,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -262,7 +264,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -283,7 +285,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         data_[0] *= other;
         data_[1] *= other;
@@ -293,7 +295,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -310,7 +312,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -322,7 +324,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -335,7 +337,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -345,7 +347,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -358,7 +360,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -368,7 +370,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result;
 
@@ -380,7 +382,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -392,7 +394,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -401,7 +403,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -413,7 +415,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -423,7 +425,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -432,13 +434,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -450,18 +452,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -469,10 +471,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -480,10 +482,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -491,10 +493,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -502,16 +504,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -519,7 +521,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -527,7 +529,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }

--- a/opm/material/densead/Evaluation3.hpp
+++ b/opm/material/densead/Evaluation3.hpp
@@ -40,6 +40,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -55,28 +57,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return 3; };
 
 protected:
     //! length of internal data vector
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
        for (const auto& v: data_)
@@ -86,11 +88,11 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -98,7 +100,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -111,7 +113,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -125,7 +127,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         data_[1] = 0.0;
         data_[2] = 0.0;
@@ -140,20 +142,20 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -161,7 +163,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != 3)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -173,7 +175,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -184,7 +186,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != 3)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -195,7 +197,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -203,13 +205,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -220,7 +222,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -234,7 +236,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -243,7 +245,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -257,7 +259,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -266,7 +268,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -288,7 +290,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         data_[0] *= other;
         data_[1] *= other;
@@ -299,7 +301,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -317,7 +319,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -330,7 +332,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -343,7 +345,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -353,7 +355,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -366,7 +368,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -376,7 +378,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result;
 
@@ -389,7 +391,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -401,7 +403,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -410,7 +412,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -422,7 +424,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -432,7 +434,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -441,13 +443,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -459,18 +461,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -478,10 +480,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -489,10 +491,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -500,10 +502,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -511,16 +513,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -528,7 +530,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -536,7 +538,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }

--- a/opm/material/densead/Evaluation4.hpp
+++ b/opm/material/densead/Evaluation4.hpp
@@ -40,6 +40,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -55,28 +57,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return 4; };
 
 protected:
     //! length of internal data vector
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
        for (const auto& v: data_)
@@ -86,11 +88,11 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -98,7 +100,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -111,7 +113,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -125,7 +127,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         data_[1] = 0.0;
         data_[2] = 0.0;
@@ -141,20 +143,20 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -162,7 +164,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != 4)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -174,7 +176,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -185,7 +187,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != 4)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -196,7 +198,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -204,13 +206,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -222,7 +224,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -237,7 +239,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -246,7 +248,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -261,7 +263,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -270,7 +272,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -293,7 +295,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         data_[0] *= other;
         data_[1] *= other;
@@ -305,7 +307,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -324,7 +326,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -338,7 +340,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -351,7 +353,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -361,7 +363,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -374,7 +376,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -384,7 +386,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result;
 
@@ -398,7 +400,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -410,7 +412,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -419,7 +421,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -431,7 +433,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -441,7 +443,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -450,13 +452,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -468,18 +470,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -487,10 +489,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -498,10 +500,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -509,10 +511,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -520,16 +522,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -537,7 +539,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -545,7 +547,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }

--- a/opm/material/densead/Evaluation5.hpp
+++ b/opm/material/densead/Evaluation5.hpp
@@ -40,6 +40,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -55,28 +57,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return 5; };
 
 protected:
     //! length of internal data vector
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
        for (const auto& v: data_)
@@ -86,11 +88,11 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -98,7 +100,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -111,7 +113,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -125,7 +127,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         data_[1] = 0.0;
         data_[2] = 0.0;
@@ -142,20 +144,20 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -163,7 +165,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != 5)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -175,7 +177,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -186,7 +188,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != 5)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -197,7 +199,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -205,13 +207,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -224,7 +226,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -240,7 +242,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -249,7 +251,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -265,7 +267,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -274,7 +276,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -298,7 +300,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         data_[0] *= other;
         data_[1] *= other;
@@ -311,7 +313,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -331,7 +333,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -346,7 +348,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -359,7 +361,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -369,7 +371,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -382,7 +384,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -392,7 +394,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result;
 
@@ -407,7 +409,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -419,7 +421,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -428,7 +430,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -440,7 +442,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -450,7 +452,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -459,13 +461,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -477,18 +479,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -496,10 +498,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -507,10 +509,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -518,10 +520,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -529,16 +531,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -546,7 +548,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -554,7 +556,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }

--- a/opm/material/densead/Evaluation6.hpp
+++ b/opm/material/densead/Evaluation6.hpp
@@ -40,6 +40,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -55,28 +57,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return 6; };
 
 protected:
     //! length of internal data vector
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
        for (const auto& v: data_)
@@ -86,11 +88,11 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -98,7 +100,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -111,7 +113,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -125,7 +127,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         data_[1] = 0.0;
         data_[2] = 0.0;
@@ -143,20 +145,20 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -164,7 +166,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != 6)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -176,7 +178,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -187,7 +189,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != 6)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -198,7 +200,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -206,13 +208,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -226,7 +228,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -243,7 +245,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -252,7 +254,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -269,7 +271,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -278,7 +280,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -303,7 +305,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         data_[0] *= other;
         data_[1] *= other;
@@ -317,7 +319,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -338,7 +340,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -354,7 +356,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -367,7 +369,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -377,7 +379,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -390,7 +392,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -400,7 +402,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result;
 
@@ -416,7 +418,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -428,7 +430,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -437,7 +439,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -449,7 +451,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -459,7 +461,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -468,13 +470,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -486,18 +488,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -505,10 +507,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -516,10 +518,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -527,10 +529,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -538,16 +540,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -555,7 +557,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -563,7 +565,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }

--- a/opm/material/densead/Evaluation7.hpp
+++ b/opm/material/densead/Evaluation7.hpp
@@ -40,6 +40,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -55,28 +57,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return 7; };
 
 protected:
     //! length of internal data vector
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
        for (const auto& v: data_)
@@ -86,11 +88,11 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -98,7 +100,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -111,7 +113,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -125,7 +127,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         data_[1] = 0.0;
         data_[2] = 0.0;
@@ -144,20 +146,20 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -165,7 +167,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != 7)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -177,7 +179,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -188,7 +190,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != 7)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -199,7 +201,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -207,13 +209,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -228,7 +230,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -246,7 +248,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -255,7 +257,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -273,7 +275,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -282,7 +284,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -308,7 +310,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         data_[0] *= other;
         data_[1] *= other;
@@ -323,7 +325,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -345,7 +347,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -362,7 +364,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -375,7 +377,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -385,7 +387,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -398,7 +400,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -408,7 +410,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result;
 
@@ -425,7 +427,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -437,7 +439,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -446,7 +448,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -458,7 +460,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -468,7 +470,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -477,13 +479,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -495,18 +497,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -514,10 +516,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -525,10 +527,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -536,10 +538,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -547,16 +549,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -564,7 +566,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -572,7 +574,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }

--- a/opm/material/densead/Evaluation8.hpp
+++ b/opm/material/densead/Evaluation8.hpp
@@ -40,6 +40,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -55,28 +57,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return 8; };
 
 protected:
     //! length of internal data vector
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
        for (const auto& v: data_)
@@ -86,11 +88,11 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -98,7 +100,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -111,7 +113,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -125,7 +127,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         data_[1] = 0.0;
         data_[2] = 0.0;
@@ -145,20 +147,20 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -166,7 +168,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != 8)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -178,7 +180,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -189,7 +191,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != 8)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -200,7 +202,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -208,13 +210,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -230,7 +232,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -249,7 +251,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -258,7 +260,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -277,7 +279,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -286,7 +288,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -313,7 +315,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         data_[0] *= other;
         data_[1] *= other;
@@ -329,7 +331,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -352,7 +354,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -370,7 +372,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -383,7 +385,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -393,7 +395,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -406,7 +408,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -416,7 +418,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result;
 
@@ -434,7 +436,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -446,7 +448,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -455,7 +457,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -467,7 +469,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -477,7 +479,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -486,13 +488,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -504,18 +506,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -523,10 +525,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -534,10 +536,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -545,10 +547,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -556,16 +558,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -573,7 +575,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -581,7 +583,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }

--- a/opm/material/densead/Evaluation9.hpp
+++ b/opm/material/densead/Evaluation9.hpp
@@ -40,6 +40,8 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 namespace DenseAd {
 
@@ -55,28 +57,28 @@ public:
     typedef ValueT ValueType;
 
     //! number of derivatives
-    constexpr int size() const
+    OPM_HOST_DEVICE constexpr int size() const
     { return 9; };
 
 protected:
     //! length of internal data vector
-    constexpr int length_() const
+    OPM_HOST_DEVICE constexpr int length_() const
     { return size() + 1; }
 
 
     //! position index for value
-    constexpr int valuepos_() const
+    OPM_HOST_DEVICE constexpr int valuepos_() const
     { return 0; }
     //! start index for derivatives
-    constexpr int dstart_() const
+    OPM_HOST_DEVICE constexpr int dstart_() const
     { return 1; }
     //! end+1 index for derivatives
-    constexpr int dend_() const
+    OPM_HOST_DEVICE constexpr int dend_() const
     { return length_(); }
 
     //! instruct valgrind to check that the value and all derivatives of the
     //! Evaluation object are well-defined.
-    void checkDefined_() const
+    OPM_HOST_DEVICE void checkDefined_() const
     {
 #ifndef NDEBUG
        for (const auto& v: data_)
@@ -86,11 +88,11 @@ protected:
 
 public:
     //! default constructor
-    Evaluation() : data_()
+    OPM_HOST_DEVICE Evaluation() : data_()
     {}
 
     //! copy other function evaluation
-    Evaluation(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -98,7 +100,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c)
     {
         setValue(c);
         clearDerivatives();
@@ -111,7 +113,7 @@ public:
     // i.e., f(x) = c. this implies an evaluation with the given value and all
     // derivatives being zero.
     template <class RhsValueType>
-    Evaluation(const RhsValueType& c, int varPos)
+    OPM_HOST_DEVICE Evaluation(const RhsValueType& c, int varPos)
     {
         // The variable position must be in represented by the given variable descriptor
         assert(0 <= varPos && varPos < size());
@@ -125,7 +127,7 @@ public:
     }
 
     // set all derivatives to zero
-    void clearDerivatives()
+    OPM_HOST_DEVICE void clearDerivatives()
     {
         data_[1] = 0.0;
         data_[2] = 0.0;
@@ -146,20 +148,20 @@ public:
     // is equivalent to creating an uninitialized object using the default
     // constructor, while for dynamic evaluations, it creates an Evaluation
     // object which exhibits the same number of derivatives as the argument.
-    static Evaluation createBlank(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation&)
     { return Evaluation(); }
 
     // create an Evaluation with value and all the derivatives to be zero
-    static Evaluation createConstantZero(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation&)
     { return Evaluation(0.); }
 
     // create an Evaluation with value to be one and all the derivatives to be zero
-    static Evaluation createConstantOne(const Evaluation&)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation&)
     { return Evaluation(1.); }
 
     // create a function evaluation for a "naked" depending variable (i.e., f(x) = x)
     template <class RhsValueType>
-    static Evaluation createVariable(const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -167,7 +169,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(int nVars, const RhsValueType& value, int varPos)
     {
         if (nVars != 9)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -179,7 +181,7 @@ public:
     }
 
     template <class RhsValueType>
-    static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
+    OPM_HOST_DEVICE static Evaluation createVariable(const Evaluation&, const RhsValueType& value, int varPos)
     {
         // copy function value and set all derivatives to 0, except for the variable
         // which is represented by the value (which is set to 1.0)
@@ -190,7 +192,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(int nVars, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(int nVars, const RhsValueType& value)
     {
         if (nVars != 9)
             throw std::logic_error("This statically-sized evaluation can only represent objects"
@@ -201,7 +203,7 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const RhsValueType& value)
     {
         return Evaluation(value);
     }
@@ -209,13 +211,13 @@ public:
     // "evaluate" a constant function (i.e. a function that does not depend on the set of
     // relevant variables, f(x) = c).
     template <class RhsValueType>
-    static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation&, const RhsValueType& value)
     {
         return Evaluation(value);
     }
 
     // copy all derivatives from other
-    void copyDerivatives(const Evaluation& other)
+    OPM_HOST_DEVICE void copyDerivatives(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -232,7 +234,7 @@ public:
 
 
     // add value and derivatives from other to this values and derivatives
-    Evaluation& operator+=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -252,7 +254,7 @@ public:
 
     // add value from other to this values
     template <class RhsValueType>
-    Evaluation& operator+=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator+=(const RhsValueType& other)
     {
         // value is added, derivatives stay the same
         data_[valuepos_()] += other;
@@ -261,7 +263,7 @@ public:
     }
 
     // subtract other's value and derivatives from this values
-    Evaluation& operator-=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -281,7 +283,7 @@ public:
 
     // subtract other's value from this values
     template <class RhsValueType>
-    Evaluation& operator-=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator-=(const RhsValueType& other)
     {
         // for constants, values are subtracted, derivatives stay the same
         data_[valuepos_()] -= other;
@@ -290,7 +292,7 @@ public:
     }
 
     // multiply values and apply chain rule to derivatives: (u*v)' = (v'u + u'v)
-    Evaluation& operator*=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -318,7 +320,7 @@ public:
 
     // m(c*u)' = c*u'
     template <class RhsValueType>
-    Evaluation& operator*=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator*=(const RhsValueType& other)
     {
         data_[0] *= other;
         data_[1] *= other;
@@ -335,7 +337,7 @@ public:
     }
 
     // m(u*v)' = (vu' - uv')/v^2
-    Evaluation& operator/=(const Evaluation& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const Evaluation& other)
     {
         assert(size() == other.size());
 
@@ -359,7 +361,7 @@ public:
 
     // divide value and derivatives by value of other
     template <class RhsValueType>
-    Evaluation& operator/=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator/=(const RhsValueType& other)
     {
         const ValueType tmp = 1.0/other;
 
@@ -378,7 +380,7 @@ public:
     }
 
     // add two evaluation objects
-    Evaluation operator+(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -391,7 +393,7 @@ public:
 
     // add constant to this object
     template <class RhsValueType>
-    Evaluation operator+(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator+(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -401,7 +403,7 @@ public:
     }
 
     // subtract two evaluation objects
-    Evaluation operator-(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -414,7 +416,7 @@ public:
 
     // subtract constant from evaluation object
     template <class RhsValueType>
-    Evaluation operator-(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator-(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -424,7 +426,7 @@ public:
     }
 
     // negation (unary minus) operator
-    Evaluation operator-() const
+    OPM_HOST_DEVICE Evaluation operator-() const
     {
         Evaluation result;
 
@@ -443,7 +445,7 @@ public:
         return result;
     }
 
-    Evaluation operator*(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -455,7 +457,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator*(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator*(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -464,7 +466,7 @@ public:
         return result;
     }
 
-    Evaluation operator/(const Evaluation& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -476,7 +478,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation operator/(const RhsValueType& other) const
+    OPM_HOST_DEVICE Evaluation operator/(const RhsValueType& other) const
     {
         Evaluation result(*this);
 
@@ -486,7 +488,7 @@ public:
     }
 
     template <class RhsValueType>
-    Evaluation& operator=(const RhsValueType& other)
+    OPM_HOST_DEVICE Evaluation& operator=(const RhsValueType& other)
     {
         setValue( other );
         clearDerivatives();
@@ -495,13 +497,13 @@ public:
     }
 
     // copy assignment from evaluation
-    Evaluation& operator=(const Evaluation& other) = default;
+    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
-    bool operator==(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const
     { return value() == other; }
 
-    bool operator==(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator==(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -513,18 +515,18 @@ public:
         return true;
     }
 
-    bool operator!=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator!=(const Evaluation& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator!=(const RhsValueType& other) const
+    OPM_HOST_DEVICE bool operator!=(const RhsValueType& other) const
     { return !operator==(other); }
 
     template <class RhsValueType>
-    bool operator>(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>(RhsValueType other) const
     { return value() > other; }
 
-    bool operator>(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -532,10 +534,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<(RhsValueType other) const
     { return value() < other; }
 
-    bool operator<(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -543,10 +545,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator>=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator>=(RhsValueType other) const
     { return value() >= other; }
 
-    bool operator>=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator>=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -554,10 +556,10 @@ public:
     }
 
     template <class RhsValueType>
-    bool operator<=(RhsValueType other) const
+    OPM_HOST_DEVICE bool operator<=(RhsValueType other) const
     { return value() <= other; }
 
-    bool operator<=(const Evaluation& other) const
+    OPM_HOST_DEVICE bool operator<=(const Evaluation& other) const
     {
         assert(size() == other.size());
 
@@ -565,16 +567,16 @@ public:
     }
 
     // return value of variable
-    const ValueType& value() const
+    OPM_HOST_DEVICE const ValueType& value() const
     { return data_[valuepos_()]; }
 
     // set value of variable
     template <class RhsValueType>
-    void setValue(const RhsValueType& val)
+    OPM_HOST_DEVICE void setValue(const RhsValueType& val)
     { data_[valuepos_()] = val; }
 
     // return varIdx'th derivative
-    const ValueType& derivative(int varIdx) const
+    OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -582,7 +584,7 @@ public:
     }
 
     // set derivative at position varIdx
-    void setDerivative(int varIdx, const ValueType& derVal)
+    OPM_HOST_DEVICE void setDerivative(int varIdx, const ValueType& derVal)
     {
         assert(0 <= varIdx && varIdx < size());
 
@@ -590,7 +592,7 @@ public:
     }
 
     template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    OPM_HOST_DEVICE void serializeOp(Serializer& serializer)
     {
         serializer(data_);
     }

--- a/opm/material/densead/Math.hpp
+++ b/opm/material/densead/Math.hpp
@@ -36,6 +36,7 @@
 
 #include <opm/material/common/MathToolbox.hpp>
 
+#include <opm/common/utility/gpuDecorators.hpp>
 namespace Opm {
 namespace DenseAd {
 // forward declaration of the Evaluation template class
@@ -44,16 +45,16 @@ class Evaluation;
 
 // provide some algebraic functions
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> abs(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> abs(const Evaluation<ValueType, numVars, staticSize>& x)
 { return (x > 0.0)?x:-x; }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> min(const Evaluation<ValueType, numVars, staticSize>& x1,
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> min(const Evaluation<ValueType, numVars, staticSize>& x1,
                                                const Evaluation<ValueType, numVars, staticSize>& x2)
 { return (x1 < x2)?x1:x2; }
 
 template <class Arg1ValueType, class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> min(const Arg1ValueType& x1,
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> min(const Arg1ValueType& x1,
                                                const Evaluation<ValueType, numVars, staticSize>& x2)
 {
     if (x1 < x2) {
@@ -66,17 +67,17 @@ Evaluation<ValueType, numVars, staticSize> min(const Arg1ValueType& x1,
 }
 
 template <class ValueType, int numVars, unsigned staticSize, class Arg2ValueType>
-Evaluation<ValueType, numVars, staticSize> min(const Evaluation<ValueType, numVars, staticSize>& x1,
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> min(const Evaluation<ValueType, numVars, staticSize>& x1,
                                                const Arg2ValueType& x2)
 { return min(x2, x1); }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> max(const Evaluation<ValueType, numVars, staticSize>& x1,
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> max(const Evaluation<ValueType, numVars, staticSize>& x1,
                                                const Evaluation<ValueType, numVars, staticSize>& x2)
 { return (x1 > x2)?x1:x2; }
 
 template <class Arg1ValueType, class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> max(const Arg1ValueType& x1,
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> max(const Arg1ValueType& x1,
                                                const Evaluation<ValueType, numVars, staticSize>& x2)
 {
     if (x1 > x2) {
@@ -89,12 +90,12 @@ Evaluation<ValueType, numVars, staticSize> max(const Arg1ValueType& x1,
 }
 
 template <class ValueType, int numVars, unsigned staticSize, class Arg2ValueType>
-Evaluation<ValueType, numVars, staticSize> max(const Evaluation<ValueType, numVars, staticSize>& x1,
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> max(const Evaluation<ValueType, numVars, staticSize>& x1,
                                                const Arg2ValueType& x2)
 { return max(x2, x1); }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> tan(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> tan(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -112,7 +113,7 @@ Evaluation<ValueType, numVars, staticSize> tan(const Evaluation<ValueType, numVa
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> atan(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> atan(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -129,7 +130,7 @@ Evaluation<ValueType, numVars, staticSize> atan(const Evaluation<ValueType, numV
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> atan2(const Evaluation<ValueType, numVars, staticSize>& x,
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> atan2(const Evaluation<ValueType, numVars, staticSize>& x,
                                                  const Evaluation<ValueType, numVars, staticSize>& y)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -150,7 +151,7 @@ Evaluation<ValueType, numVars, staticSize> atan2(const Evaluation<ValueType, num
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> atan2(const Evaluation<ValueType, numVars, staticSize>& x,
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> atan2(const Evaluation<ValueType, numVars, staticSize>& x,
                                                  const ValueType& y)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -171,7 +172,7 @@ Evaluation<ValueType, numVars, staticSize> atan2(const Evaluation<ValueType, num
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> atan2(const ValueType& x,
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> atan2(const ValueType& x,
                                                  const Evaluation<ValueType, numVars, staticSize>& y)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -192,7 +193,7 @@ Evaluation<ValueType, numVars, staticSize> atan2(const ValueType& x,
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> sin(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> sin(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -209,7 +210,7 @@ Evaluation<ValueType, numVars, staticSize> sin(const Evaluation<ValueType, numVa
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> asin(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> asin(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -226,7 +227,7 @@ Evaluation<ValueType, numVars, staticSize> asin(const Evaluation<ValueType, numV
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> sinh(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> sinh(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -243,7 +244,7 @@ Evaluation<ValueType, numVars, staticSize> sinh(const Evaluation<ValueType, numV
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> asinh(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> asinh(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -260,7 +261,7 @@ Evaluation<ValueType, numVars, staticSize> asinh(const Evaluation<ValueType, num
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> cos(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> cos(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -277,7 +278,7 @@ Evaluation<ValueType, numVars, staticSize> cos(const Evaluation<ValueType, numVa
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> acos(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> acos(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -294,7 +295,7 @@ Evaluation<ValueType, numVars, staticSize> acos(const Evaluation<ValueType, numV
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> cosh(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> cosh(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -311,7 +312,7 @@ Evaluation<ValueType, numVars, staticSize> cosh(const Evaluation<ValueType, numV
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> acosh(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> acosh(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -328,7 +329,7 @@ Evaluation<ValueType, numVars, staticSize> acosh(const Evaluation<ValueType, num
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> sqrt(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> sqrt(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -347,7 +348,7 @@ Evaluation<ValueType, numVars, staticSize> sqrt(const Evaluation<ValueType, numV
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> exp(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> exp(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
     Evaluation<ValueType, numVars, staticSize> result(x);
@@ -365,7 +366,7 @@ Evaluation<ValueType, numVars, staticSize> exp(const Evaluation<ValueType, numVa
 
 // exponentiation of arbitrary base with a fixed constant
 template <class ValueType, int numVars, unsigned staticSize, class ExpType>
-Evaluation<ValueType, numVars, staticSize> pow(const Evaluation<ValueType, numVars, staticSize>& base,
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> pow(const Evaluation<ValueType, numVars, staticSize>& base,
                                                const ExpType& exp)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -391,7 +392,7 @@ Evaluation<ValueType, numVars, staticSize> pow(const Evaluation<ValueType, numVa
 
 // exponentiation of constant base with an arbitrary exponent
 template <class BaseType, class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> pow(const BaseType& base,
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> pow(const BaseType& base,
                                                const Evaluation<ValueType, numVars, staticSize>& exp)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -419,7 +420,7 @@ Evaluation<ValueType, numVars, staticSize> pow(const BaseType& base,
 // this is the most expensive power function. Computationally it is pretty expensive, so
 // one of the above two variants above should be preferred if possible.
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> pow(const Evaluation<ValueType, numVars, staticSize>& base,
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> pow(const Evaluation<ValueType, numVars, staticSize>& base,
                                                const Evaluation<ValueType, numVars, staticSize>& exp)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
@@ -451,7 +452,7 @@ Evaluation<ValueType, numVars, staticSize> pow(const Evaluation<ValueType, numVa
 }
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> log(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> log(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -469,7 +470,7 @@ Evaluation<ValueType, numVars, staticSize> log(const Evaluation<ValueType, numVa
 
 
 template <class ValueType, int numVars, unsigned staticSize>
-Evaluation<ValueType, numVars, staticSize> log10(const Evaluation<ValueType, numVars, staticSize>& x)
+OPM_HOST_DEVICE Evaluation<ValueType, numVars, staticSize> log10(const Evaluation<ValueType, numVars, staticSize>& x)
 {
     typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -499,53 +500,53 @@ public:
     typedef typename InnerToolbox::Scalar Scalar;
     typedef DenseAd::Evaluation<ValueType, numVars, staticSize> Evaluation;
 
-    static ValueType value(const Evaluation& eval)
+    OPM_HOST_DEVICE static ValueType value(const Evaluation& eval)
     { return eval.value(); }
 
-    static decltype(InnerToolbox::scalarValue(0.0)) scalarValue(const Evaluation& eval)
+    OPM_HOST_DEVICE static decltype(InnerToolbox::scalarValue(0.0)) scalarValue(const Evaluation& eval)
     { return InnerToolbox::scalarValue(eval.value()); }
 
-    static Evaluation createBlank(const Evaluation& x)
+    OPM_HOST_DEVICE static Evaluation createBlank(const Evaluation& x)
     { return Evaluation::createBlank(x); }
 
-    static Evaluation createConstantZero(const Evaluation& x)
+    OPM_HOST_DEVICE static Evaluation createConstantZero(const Evaluation& x)
     { return Evaluation::createConstantZero(x); }
 
-    static Evaluation createConstantOne(const Evaluation& x)
+    OPM_HOST_DEVICE static Evaluation createConstantOne(const Evaluation& x)
     { return Evaluation::createConstantOne(x); }
 
-    static Evaluation createConstant(ValueType value)
+    OPM_HOST_DEVICE static Evaluation createConstant(ValueType value)
     { return Evaluation::createConstant(value); }
 
-    static Evaluation createConstant(unsigned numDeriv, const ValueType value)
+    OPM_HOST_DEVICE static Evaluation createConstant(unsigned numDeriv, const ValueType value)
     { return Evaluation::createConstant(numDeriv, value); }
 
-    static Evaluation createConstant(const Evaluation& x, const ValueType value)
+    OPM_HOST_DEVICE static Evaluation createConstant(const Evaluation& x, const ValueType value)
     { return Evaluation::createConstant(x, value); }
 
-    static Evaluation createVariable(ValueType value, int varIdx)
+    OPM_HOST_DEVICE static Evaluation createVariable(ValueType value, int varIdx)
     { return Evaluation::createVariable(value, varIdx); }
 
     template <class LhsEval>
-    static typename std::enable_if<std::is_same<Evaluation, LhsEval>::value,
+    OPM_HOST_DEVICE static typename std::enable_if<std::is_same<Evaluation, LhsEval>::value,
                                    LhsEval>::type
     decay(const Evaluation& eval)
     { return eval; }
 
     template <class LhsEval>
-    static typename std::enable_if<std::is_same<Evaluation, LhsEval>::value,
+    OPM_HOST_DEVICE static typename std::enable_if<std::is_same<Evaluation, LhsEval>::value,
                                    LhsEval>::type
     decay(const Evaluation&& eval)
     { return eval; }
 
     template <class LhsEval>
-    static typename std::enable_if<std::is_floating_point<LhsEval>::value,
+    OPM_HOST_DEVICE static typename std::enable_if<std::is_floating_point<LhsEval>::value,
                                    LhsEval>::type
     decay(const Evaluation& eval)
     { return eval.value(); }
 
     // comparison
-    static bool isSame(const Evaluation& a, const Evaluation& b, Scalar tolerance)
+    OPM_HOST_DEVICE static bool isSame(const Evaluation& a, const Evaluation& b, Scalar tolerance)
     {
         typedef MathToolbox<ValueType> ValueTypeToolbox;
 
@@ -563,69 +564,69 @@ public:
 
     // arithmetic functions
     template <class Arg1Eval, class Arg2Eval>
-    static Evaluation max(const Arg1Eval& arg1, const Arg2Eval& arg2)
+    OPM_HOST_DEVICE static Evaluation max(const Arg1Eval& arg1, const Arg2Eval& arg2)
     { return DenseAd::max(arg1, arg2); }
 
     template <class Arg1Eval, class Arg2Eval>
-    static Evaluation min(const Arg1Eval& arg1, const Arg2Eval& arg2)
+    OPM_HOST_DEVICE static Evaluation min(const Arg1Eval& arg1, const Arg2Eval& arg2)
     { return DenseAd::min(arg1, arg2); }
 
-    static Evaluation abs(const Evaluation& arg)
+    OPM_HOST_DEVICE static Evaluation abs(const Evaluation& arg)
     { return DenseAd::abs(arg); }
 
-    static Evaluation tan(const Evaluation& arg)
+    OPM_HOST_DEVICE static Evaluation tan(const Evaluation& arg)
     { return DenseAd::tan(arg); }
 
-    static Evaluation atan(const Evaluation& arg)
+    OPM_HOST_DEVICE static Evaluation atan(const Evaluation& arg)
     { return DenseAd::atan(arg); }
 
-    static Evaluation atan2(const Evaluation& arg1, const Evaluation& arg2)
+    OPM_HOST_DEVICE static Evaluation atan2(const Evaluation& arg1, const Evaluation& arg2)
     { return DenseAd::atan2(arg1, arg2); }
 
     template <class Eval2>
-    static Evaluation atan2(const Evaluation& arg1, const Eval2& arg2)
+    OPM_HOST_DEVICE static Evaluation atan2(const Evaluation& arg1, const Eval2& arg2)
     { return DenseAd::atan2(arg1, arg2); }
 
     template <class Eval1>
-    static Evaluation atan2(const Eval1& arg1, const Evaluation& arg2)
+    OPM_HOST_DEVICE static Evaluation atan2(const Eval1& arg1, const Evaluation& arg2)
     { return DenseAd::atan2(arg1, arg2); }
 
-    static Evaluation sin(const Evaluation& arg)
+    OPM_HOST_DEVICE static Evaluation sin(const Evaluation& arg)
     { return DenseAd::sin(arg); }
 
-    static Evaluation asin(const Evaluation& arg)
+    OPM_HOST_DEVICE static Evaluation asin(const Evaluation& arg)
     { return DenseAd::asin(arg); }
 
-    static Evaluation cos(const Evaluation& arg)
+    OPM_HOST_DEVICE static Evaluation cos(const Evaluation& arg)
     { return DenseAd::cos(arg); }
 
-    static Evaluation acos(const Evaluation& arg)
+    OPM_HOST_DEVICE static Evaluation acos(const Evaluation& arg)
     { return DenseAd::acos(arg); }
 
-    static Evaluation sqrt(const Evaluation& arg)
+    OPM_HOST_DEVICE static Evaluation sqrt(const Evaluation& arg)
     { return DenseAd::sqrt(arg); }
 
-    static Evaluation exp(const Evaluation& arg)
+    OPM_HOST_DEVICE static Evaluation exp(const Evaluation& arg)
     { return DenseAd::exp(arg); }
 
-    static Evaluation log(const Evaluation& arg)
+    OPM_HOST_DEVICE static Evaluation log(const Evaluation& arg)
     { return DenseAd::log(arg); }
 
-    static Evaluation log10(const Evaluation& arg)
+    OPM_HOST_DEVICE static Evaluation log10(const Evaluation& arg)
     { return DenseAd::log10(arg); }
 
     template <class RhsValueType>
-    static Evaluation pow(const Evaluation& arg1, const RhsValueType& arg2)
+    OPM_HOST_DEVICE static Evaluation pow(const Evaluation& arg1, const RhsValueType& arg2)
     { return DenseAd::pow(arg1, arg2); }
 
     template <class RhsValueType>
-    static Evaluation pow(const RhsValueType& arg1, const Evaluation& arg2)
+    OPM_HOST_DEVICE static Evaluation pow(const RhsValueType& arg1, const Evaluation& arg2)
     { return DenseAd::pow(arg1, arg2); }
 
-    static Evaluation pow(const Evaluation& arg1, const Evaluation& arg2)
+    OPM_HOST_DEVICE static Evaluation pow(const Evaluation& arg1, const Evaluation& arg2)
     { return DenseAd::pow(arg1, arg2); }
 
-    static bool isfinite(const Evaluation& arg)
+    OPM_HOST_DEVICE static bool isfinite(const Evaluation& arg)
     {
         if (!InnerToolbox::isfinite(arg.value()))
             return false;
@@ -637,7 +638,7 @@ public:
         return true;
     }
 
-    static bool isnan(const Evaluation& arg)
+    OPM_HOST_DEVICE static bool isnan(const Evaluation& arg)
     {
         if (InnerToolbox::isnan(arg.value()))
             return true;

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -34,6 +34,9 @@
 #include <stdexcept>
 #include <type_traits>
 
+
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm {
 /*!
  * \ingroup FluidMatrixInteractions
@@ -94,7 +97,7 @@ public:
      * \brief The capillary pressure-saturation curve.
      */
     template <class Container, class FluidState>
-    static void capillaryPressures(Container& values, const Params& params, const FluidState& fs)
+    OPM_HOST_DEVICE static void capillaryPressures(Container& values, const Params& params, const FluidState& fs)
     {
         OPM_TIMEFUNCTION_LOCAL();
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
@@ -108,14 +111,14 @@ public:
      *        pressure differences.
      */
     template <class Container, class FluidState>
-    static void saturations(Container& /* values */, const Params& /* params */, const FluidState& /* fs */)
+    OPM_HOST_DEVICE static void saturations(Container& /* values */, const Params& /* params */, const FluidState& /* fs */)
     { throw std::logic_error("Not implemented: saturations()"); }
 
     /*!
      * \brief The relative permeabilities
      */
     template <class Container, class FluidState>
-    static void relativePermeabilities(Container& values, const Params& params, const FluidState& fs)
+    OPM_HOST_DEVICE static void relativePermeabilities(Container& values, const Params& params, const FluidState& fs)
     {
         OPM_TIMEFUNCTION_LOCAL();
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
@@ -128,7 +131,7 @@ public:
      * \brief The capillary pressure-saturation curve
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation pcnw(const Params& params, const FluidState& fs)
+    OPM_HOST_DEVICE static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
         OPM_TIMEFUNCTION_LOCAL();
         const auto& Sw =
@@ -141,7 +144,7 @@ public:
      * \brief The saturation-capillary pressure curve
      */
     template <class Evaluation>
-    static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
+    OPM_HOST_DEVICE static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
         OPM_TIMEFUNCTION_LOCAL();
         return eval_(params.SwPcwnSamples(), params.pcwnSamples(), Sw);
@@ -155,11 +158,11 @@ public:
      * \brief The saturation-capillary pressure curve
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sw(const Params& /* params */, const FluidState& /* fs */)
+    OPM_HOST_DEVICE static Evaluation Sw(const Params& /* params */, const FluidState& /* fs */)
     { throw std::logic_error("Not implemented: Sw()"); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSw(const Params& /* params */, const Evaluation& /* pC */)
+    OPM_HOST_DEVICE static Evaluation twoPhaseSatSw(const Params& /* params */, const Evaluation& /* pC */)
     { throw std::logic_error("Not implemented: twoPhaseSatSw()"); }
 
     /*!
@@ -167,11 +170,11 @@ public:
      *        the phase pressures.
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation Sn(const Params& params, const FluidState& fs)
+    OPM_HOST_DEVICE static Evaluation Sn(const Params& params, const FluidState& fs)
     { return 1 - Sw<FluidState, Scalar>(params, fs); }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatSn(const Params& params, const Evaluation& pC)
+    OPM_HOST_DEVICE static Evaluation twoPhaseSatSn(const Params& params, const Evaluation& pC)
     { return 1 - twoPhaseSatSw(params, pC); }
 
     /*!
@@ -179,7 +182,7 @@ public:
      *        porous medium
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krw(const Params& params, const FluidState& fs)
+    OPM_HOST_DEVICE static Evaluation krw(const Params& params, const FluidState& fs)
     {
         OPM_TIMEFUNCTION_LOCAL();
         const auto& Sw =
@@ -189,14 +192,14 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
+    OPM_HOST_DEVICE static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
     {
         OPM_TIMEFUNCTION_LOCAL();
         return eval_(params.SwKrwSamples(), params.krwSamples(), Sw);
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrwInv(const Params& params, const Evaluation& krw)
+    OPM_HOST_DEVICE static Evaluation twoPhaseSatKrwInv(const Params& params, const Evaluation& krw)
     {
         OPM_TIMEFUNCTION_LOCAL();
         return eval_(params.krwSamples(), params.SwKrwSamples(), krw);
@@ -207,7 +210,7 @@ public:
      *        of the porous medium
      */
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
-    static Evaluation krn(const Params& params, const FluidState& fs)
+    OPM_HOST_DEVICE static Evaluation krn(const Params& params, const FluidState& fs)
     {
         OPM_TIMEFUNCTION_LOCAL();
         const auto& Sw =
@@ -217,28 +220,28 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& Sw)
+    OPM_HOST_DEVICE static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& Sw)
     {
         OPM_TIMEFUNCTION_LOCAL();
         return eval_(params.SwKrnSamples(), params.krnSamples(), Sw);
     }
 
     template <class Evaluation>
-    static Evaluation twoPhaseSatKrnInv(const Params& params, const Evaluation& krn)
+    OPM_HOST_DEVICE static Evaluation twoPhaseSatKrnInv(const Params& params, const Evaluation& krn)
     { return eval_(params.krnSamples(), params.SwKrnSamples(), krn); }
 
     template <class Evaluation>
-    static size_t findSegmentIndex(const ValueVector& xValues, const Evaluation& x){
+    OPM_HOST_DEVICE static size_t findSegmentIndex(const ValueVector& xValues, const Evaluation& x){
         return findSegmentIndex_(xValues, scalarValue(x));
     }
 
     template <class Evaluation>
-    static size_t findSegmentIndexDescending(const ValueVector& xValues, const Evaluation& x){
+    OPM_HOST_DEVICE static size_t findSegmentIndexDescending(const ValueVector& xValues, const Evaluation& x){
         return findSegmentIndexDescending_(xValues, scalarValue(x));
     }
 
     template <class Evaluation>
-    static Evaluation eval(const ValueVector& xValues, const ValueVector& yValues, const Evaluation& x, unsigned segIdx){
+    OPM_HOST_DEVICE static Evaluation eval(const ValueVector& xValues, const ValueVector& yValues, const Evaluation& x, unsigned segIdx){
         Scalar x0 = xValues[segIdx];
         Scalar x1 = xValues[segIdx + 1];
 
@@ -252,7 +255,7 @@ public:
 
 private:
     template <class Evaluation>
-    static Evaluation eval_(const ValueVector& xValues,
+    OPM_HOST_DEVICE static Evaluation eval_(const ValueVector& xValues,
                             const ValueVector& yValues,
                             const Evaluation& x)
     {
@@ -263,7 +266,7 @@ private:
     }
 
     template <class Evaluation>
-    static Evaluation evalAscending_(const ValueVector& xValues,
+    OPM_HOST_DEVICE static Evaluation evalAscending_(const ValueVector& xValues,
                                      const ValueVector& yValues,
                                      const Evaluation& x)
     {
@@ -279,7 +282,7 @@ private:
     }
 
     template <class Evaluation>
-    static Evaluation evalDescending_(const ValueVector& xValues,
+    OPM_HOST_DEVICE static Evaluation evalDescending_(const ValueVector& xValues,
                                       const ValueVector& yValues,
                                       const Evaluation& x)
     {
@@ -295,7 +298,7 @@ private:
     }
 
     template <class Evaluation>
-    static Evaluation evalDeriv_(const ValueVector& xValues,
+    OPM_HOST_DEVICE static Evaluation evalDeriv_(const ValueVector& xValues,
                                  const ValueVector& yValues,
                                  const Evaluation& x)
     {
@@ -316,7 +319,7 @@ private:
         return (y1 - y0)/(x1 - x0);
     }
     template<class ScalarT>
-    static size_t findSegmentIndex_(const ValueVector& xValues, const ScalarT& x)
+    OPM_HOST_DEVICE static size_t findSegmentIndex_(const ValueVector& xValues, const ScalarT& x)
     {
         OPM_TIMEFUNCTION_LOCAL();
         assert(xValues.size() > 1); // we need at least two sampling points!
@@ -339,7 +342,7 @@ private:
         return lowIdx;
     }
 
-    static size_t findSegmentIndexDescending_(const ValueVector& xValues, Scalar x)
+    OPM_HOST_DEVICE static size_t findSegmentIndexDescending_(const ValueVector& xValues, Scalar x)
     {
         OPM_TIMEFUNCTION_LOCAL();
         assert(xValues.size() > 1); // we need at least two sampling points!

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -245,7 +245,7 @@ private:
 };
 } // namespace Opm
 
-namespace Opm::cuistl{
+namespace Opm::gpuistl{
 
 /// @brief this function is intented to make a GPU friendly view of the PiecewiseLinearTwoPhaseMaterialParams
 /// @tparam TraitsT the same traits as in PiecewiseLinearTwoPhaseMaterialParams

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -31,12 +31,15 @@
 #include <cassert>
 #include <vector>
 #include <stdexcept>
+#include <type_traits>
 
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/material/common/EnsureFinalized.hpp>
+#include <vector>
 
-namespace Opm
-{
+#include <opm/common/utility/gpuDecorators.hpp>
+
+namespace Opm {
 /*!
  * \ingroup FluidMatrixInteractions
  *
@@ -96,7 +99,7 @@ public:
     /*!
      * \brief Return the wetting-phase saturation values of all sampling points.
      */
-    const ValueVector& SwKrwSamples() const
+    OPM_HOST_DEVICE const ValueVector& SwKrwSamples() const
     {
         EnsureFinalized::check();
         return SwKrwSamples_;
@@ -105,7 +108,7 @@ public:
     /*!
      * \brief Return the wetting-phase saturation values of all sampling points.
      */
-    const ValueVector& SwKrnSamples() const
+    OPM_HOST_DEVICE const ValueVector& SwKrnSamples() const
     {
         EnsureFinalized::check();
         return SwKrnSamples_;
@@ -114,7 +117,7 @@ public:
     /*!
      * \brief Return the wetting-phase saturation values of all sampling points.
      */
-    const ValueVector& SwPcwnSamples() const
+    OPM_HOST_DEVICE const ValueVector& SwPcwnSamples() const
     {
         EnsureFinalized::check();
         return SwPcwnSamples_;
@@ -125,7 +128,7 @@ public:
      *
      * This curve is assumed to depend on the wetting phase saturation
      */
-    const ValueVector& pcwnSamples() const
+    OPM_HOST_DEVICE const ValueVector& pcwnSamples() const
     {
         EnsureFinalized::check();
         return pcwnSamples_;
@@ -155,7 +158,7 @@ public:
      *
      * This curve is assumed to depend on the wetting phase saturation
      */
-    const ValueVector& krwSamples() const
+    OPM_HOST_DEVICE const ValueVector& krwSamples() const
     {
         EnsureFinalized::check();
         return krwSamples_;
@@ -186,7 +189,7 @@ public:
      *
      * This curve is assumed to depend on the wetting phase saturation
      */
-    const ValueVector& krnSamples() const
+    OPM_HOST_DEVICE const ValueVector& krnSamples() const
     {
         EnsureFinalized::check();
         return krnSamples_;
@@ -212,7 +215,7 @@ public:
     }
 
 private:
-    void swapOrderIfPossibleThrowOtherwise_(ValueVector& swValues, ValueVector& values) const
+    OPM_HOST_DEVICE void swapOrderIfPossibleThrowOtherwise_(ValueVector& swValues, ValueVector& values) const
     {
         // TODO: comparing saturation values to the actual values we sample from looks strange
         // TODO: yet changing to swValues.back() breaks tests
@@ -241,5 +244,37 @@ private:
     ValueVector krnSamples_;
 };
 } // namespace Opm
+
+namespace Opm::cuistl{
+
+/// @brief this function is intented to make a GPU friendly view of the PiecewiseLinearTwoPhaseMaterialParams
+/// @tparam TraitsT the same traits as in PiecewiseLinearTwoPhaseMaterialParams
+/// @tparam ContainerType typically const gpuBuffer<scalarType>
+/// @tparam ViewType  typically gpuView<const scalarType>
+/// @param params the parameters object instansiated with gpuBuffers or similar
+/// @return the GPU view of the GPU PiecewiseLinearTwoPhaseMaterialParams object
+template <class TraitsT, class ContainerType, class ViewType>
+PiecewiseLinearTwoPhaseMaterialParams<TraitsT, ViewType> make_view(const PiecewiseLinearTwoPhaseMaterialParams<TraitsT, ContainerType>& params) {
+
+    using containedType = typename ContainerType::value_type;
+    using viewedTypeNoConst = typename std::remove_const_t<typename ViewType::value_type>;
+
+    static_assert(std::is_same_v<containedType, viewedTypeNoConst>);
+
+    ViewType SwPcwnSamples = make_view<viewedTypeNoConst>(params.SwPcwnSamples());
+    ViewType pcwnSamples = make_view<viewedTypeNoConst>(params.pcwnSamples());
+    ViewType SwKrwSamples = make_view<viewedTypeNoConst>(params.SwKrwSamples());
+    ViewType krwSamples = make_view<viewedTypeNoConst>(params.krwSamples());
+    ViewType SwKrnSamples = make_view<viewedTypeNoConst>(params.SwKrnSamples());
+    ViewType krnSamples = make_view<viewedTypeNoConst>(params.krnSamples());
+
+    return PiecewiseLinearTwoPhaseMaterialParams<TraitsT, ViewType> (SwPcwnSamples,
+                                                                        pcwnSamples,
+                                                                        SwKrwSamples,
+                                                                        krwSamples,
+                                                                        SwKrnSamples,
+                                                                        krnSamples);
+}
+}
 
 #endif


### PR DESCRIPTION
Start work on property evaluation on GPUs 

- Make header with macros for function decoration needed by cuda/hip
- decorate functions that must be callable from both the cpu and gpu
- implement make_view functions that will be used in cuda kernels later to serve as the interface to the property data