### PR TITLE
fixed: quote string parameter to avoid missing parameter if empty

### DIFF
--- a/cmake/Modules/UseFortranWrappers.cmake
+++ b/cmake/Modules/UseFortranWrappers.cmake
@@ -73,7 +73,7 @@ function (define_fc_func verb file)
 	  )
 
 	# massage it to look like the one AC_FC_WRAPPERS provide
-	string (REPLACE "FortranCInterface_GLOBAL" "FC_FUNC" _str ${_str})
+	string (REPLACE "FortranCInterface_GLOBAL" "FC_FUNC" _str "${_str}")
 
 	endif (USE_UNDERSCORING)
 


### PR DESCRIPTION
In particular this causes issues if building on jenkins for fortran enabled code (ie opm-upscaling) in debug mode.