### PR TITLE
Check number of arguments to avoid segfault.

### DIFF
--- a/test_util/summary.cpp
+++ b/test_util/summary.cpp
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
         switch (c) {
         case 'h':
             printHelp();
-            return 0;
+            return EXIT_SUCCESS;
         case 'r':
             reportStepsOnly=true;
             break;
@@ -99,7 +99,11 @@ int main(int argc, char **argv) {
         }
     }
 
-    int argOffset = optind;
+    const int argOffset = optind;
+    if (argOffset > argc - 1) {
+        printHelp();
+        return EXIT_SUCCESS;
+    }
 
     std::unique_ptr<Opm::EclIO::ESmry> esmry;
     std::unique_ptr<Opm::EclIO::ExtESmry> ext_esmry;


### PR DESCRIPTION
The `summary` tool will segfault if you run it with no parameters (or no parameters after options). Instead print help message.