### PR TITLE
bump minimum dune version to 2.9

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -10,4 +10,4 @@ Label: 2024.10-pre
 Maintainer: opm@opm-project.org
 MaintainerName: OPM community
 Url: http://opm-project.org
-Depends: dune-common (>= 2.7)
+Depends: dune-common (>= 2.9)


### PR DESCRIPTION
Time to bump the minimum dune version. Users on ubuntu can find dune 2.9 packages for 22.04 in the ppa.