### PR TITLE
Change type of possibleFutureConnections to std::unordered_map<std::string, std::set<int>>

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -679,11 +679,10 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
                 // Retrieve or create the set of future connections for the well
                 auto& currentSet = this->possibleFutureConnections[wellName];
                 for (int k = K1; k <= K2; k++){
+                    // Adds this cell to the "active cells" of the schedule grid by calling grid.get_cell(I, J, k) 
                     auto cell = grid.get_cell(I, J, k);
-                    (void) cell;
-                    //Only interested in activating the cells.
-                    std::array<int,3> ijk{I,J,k};
-                    currentSet.insert(ijk);
+                    // Insert the global id of the cell into the possible future connections of the well
+                    currentSet.insert(cell.global_index);
                 }
             }
             return;
@@ -1065,7 +1064,7 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
         return this->getWell(well_name, this->snapshots.size() - 1);
     }
 
-    const std::unordered_map<std::string, std::set<std::array<int,3>>>& Schedule::getPossibleFutureConnections() const {
+    const std::unordered_map<std::string, std::set<int>>& Schedule::getPossibleFutureConnections() const {
         return this->possibleFutureConnections;
     }
 

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -204,7 +204,7 @@ namespace Opm
         std::vector<Well> getWells(std::size_t timeStep) const;
         std::vector<Well> getWellsatEnd() const;
 
-        const std::unordered_map<std::string, std::set<std::array<int,3>>>& getPossibleFutureConnections() const;
+        const std::unordered_map<std::string, std::set<int>>& getPossibleFutureConnections() const;
 
         void shut_well(const std::string& well_name, std::size_t report_step);
         void shut_well(const std::string& well_name);
@@ -476,7 +476,7 @@ namespace Opm
         // This unordered_map contains possible future connections of wells that might get added through an ACTIONX.
         // For parallel runs, this unordered_map is retrieved by the grid partitioner to ensure these connections
         // end up on the same partition.
-        std::unordered_map<std::string, std::set<std::array<int,3>>> possibleFutureConnections;
+        std::unordered_map<std::string, std::set<int>> possibleFutureConnections;
 
         // The current_report_step is set to the current report step when a PYACTION call is executed.
         // This is needed since the Schedule object does not know the current report step of the simulator and


### PR DESCRIPTION
Now it contains the global ids of the perforated cells for each well instead of the coordinates ijk.

This PR is not relevant for the reference manual.