### PR TITLE
Update ACTNUM in EclipseGrid to account for MINPV/MINPVV

### DIFF
--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -156,6 +156,12 @@ namespace Opm {
             this->m_inputGrid.setMINPVV(field_props.get_global_double("MINPVV"));
             field_props.deleteMINPVV();
         }
+        // Update ACTNUM taking MINPV/MINPVV into account
+        if (this->m_inputGrid.getMinpvMode() != MinpvMode::Inactive) {
+            this->m_inputGrid.resetACTNUM(this->field_props.actnum(& (this->getInputGrid().getMinpvVector())));
+            this->field_props.reset_actnum(this->getInputGrid().getACTNUM());
+        }
+
         this->initLgrs(deck);
         this->aquifer_config.load_connections(deck, this->getInputGrid());
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -1851,11 +1851,11 @@ FieldProps::canonical_fipreg_name(const std::string& fipreg) const
 //           ACTNUM 0 1 10 1 10 1 3 /
 //       /
 //
-//    3. Cells with PORV == 0 will get ACTNUM = 0.
+//    3. Cells with PORV == 0 or PORV < MINPVV will get ACTNUM = 0.
 //
 // Note that steps 2 and 3 generally forms an ACTNUM property which differs
 // from the ACTNUM property stored internally in the FieldProps instance.
-std::vector<int> FieldProps::actnum()
+std::vector<int> FieldProps::actnum(const std::vector<double>* minpvv)
 {
     auto actnum = this->m_actnum;
 
@@ -1883,7 +1883,8 @@ std::vector<int> FieldProps::actnum()
     for (std::size_t active_index = 0; active_index < this->active_size; active_index++) {
         auto global_index = global_map[active_index];
         actnum[global_index] = deck_actnum.data[active_index];
-        if (porv_data[active_index] == 0)
+        const double pv = porv_data[active_index];
+        if (pv == 0 || (minpvv && pv < (*minpvv)[global_index]))
             actnum[global_index] = 0;
     }
     return actnum;

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -533,7 +533,7 @@ public:
 
     const std::string& default_region() const;
 
-    std::vector<int> actnum();
+    std::vector<int> actnum(const std::vector<double>* minpvv = nullptr);
     const std::vector<int>& actnumRaw() const;
 
     template <typename T>

--- a/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -140,8 +140,8 @@ std::vector<std::string> FieldPropsManager::fip_regions() const
     return this->fp->fip_regions();
 }
 
-std::vector<int> FieldPropsManager::actnum() const {
-    return this->fp->actnum();
+std::vector<int> FieldPropsManager::actnum(const std::vector<double>* minpvv) const {
+    return this->fp->actnum(minpvv);
 }
 
 std::vector<double> FieldPropsManager::porv(bool global) const {

--- a/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -53,7 +53,7 @@ public:
     virtual void reset_actnum(const std::vector<int>& actnum);
     void deleteMINPVV();
     const std::string& default_region() const;
-    virtual std::vector<int> actnum() const;
+    virtual std::vector<int> actnum(const std::vector<double>* minpvv = nullptr) const;
     virtual std::vector<double> porv(bool global = false) const;
 
 


### PR DESCRIPTION
This ensures that the user is warned about well connections to cells that will be deactivated due to MINPV/MINPVV, and also avoids a hard crash (in ParallelWellInfo) if any such well is re-completed at a later stage in the simulation. 