### PR TITLE
COMPDAT: Skip connections to cells that will be deactivated due to MINPV/MINPVV 

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -1524,6 +1524,16 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
         return this->cellActive(globalIndex);
     }
 
+    bool EclipseGrid::cellActiveAfterMINPV( size_t i , size_t j , size_t k, double cell_porv ) const {
+        assertIJK(i,j,k);
+
+        size_t globalIndex = getGlobalIndex(i,j,k);
+        if (!this->cellActive(globalIndex))
+            return false;
+
+        return m_minpvMode == MinpvMode::Inactive || cell_porv >= m_minpvVector[globalIndex];
+    }
+
     const std::vector<double>& EclipseGrid::activeVolume() const {
         if (!this->active_volume.has_value()) {
             std::vector<double> volume(this->m_nactive);

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -172,6 +172,7 @@ namespace Opm {
         std::array<double, 3> getCellDims(size_t globalIndex) const;
         bool cellActive( size_t globalIndex ) const;
         bool cellActive( size_t i , size_t j, size_t k ) const;
+        bool cellActiveAfterMINPV( size_t i , size_t j , size_t k, double cell_porv ) const;
 
         std::array<double, 3> getCellDimensions(size_t i, size_t j, size_t k) const {
             return getCellDims(i, j, k);

--- a/opm/input/eclipse/Schedule/ScheduleGrid.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleGrid.cpp
@@ -77,16 +77,19 @@ Opm::ScheduleGrid::get_cell(std::size_t i, std::size_t j, std::size_t k) const
         cellRef.dimensions = this->grid->getCellDimensions(i, j, k);
 
         if (this->grid->cellActive(i, j, k)) {
-            auto& props = cellRef.props.emplace(CompletedCells::Cell::Props{});
-
-            props.active_index = this->grid->getActiveIndex(i, j, k);
-            props.permx = try_get_value(*this->fp, "PERMX", props.active_index);
-            props.permy = try_get_value(*this->fp, "PERMY", props.active_index);
-            props.permz = try_get_value(*this->fp, "PERMZ", props.active_index);
-            props.poro = try_get_value(*this->fp, "PORO", props.active_index);
-            props.satnum = this->fp->get_int("SATNUM").at(props.active_index);
-            props.pvtnum = this->fp->get_int("PVTNUM").at(props.active_index);
-            props.ntg = try_get_ntg_value(*this->fp, "NTG", props.active_index);
+            const auto active_index = this->grid->getActiveIndex(i, j, k);
+            const double porv = try_get_value(*this->fp, "PORV", active_index);
+            if (this->grid->cellActiveAfterMINPV(i, j, k, porv)) {
+                auto& props = cellRef.props.emplace(CompletedCells::Cell::Props{});
+                props.active_index = active_index;
+                props.permx = try_get_value(*this->fp, "PERMX", props.active_index);
+                props.permy = try_get_value(*this->fp, "PERMY", props.active_index);
+                props.permz = try_get_value(*this->fp, "PERMZ", props.active_index);
+                props.poro = try_get_value(*this->fp, "PORO", props.active_index);
+                props.satnum = this->fp->get_int("SATNUM").at(props.active_index);
+                props.pvtnum = this->fp->get_int("PVTNUM").at(props.active_index);
+                props.ntg = try_get_ntg_value(*this->fp, "NTG", props.active_index);
+            }
         }
     }
 


### PR DESCRIPTION
This ensures that the user is warned about well connections to cells that will be deactivated due to MINPV/MINPVV, and also avoids a hard crash (in ParallelWellInfo) if any such well is re-completed at a later stage in the simulation.