### PR TITLE
UDQ: Allow UPDATE after ASSIGN

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -299,7 +299,7 @@ namespace Opm {
             };
         }
 
-        if (this->m_definitions.count(keyword) == 0) {
+        if (this->m_definitions.count(keyword) == 0 && this->m_assignments.count(keyword) == 0) {
             throw OpmInputError {
                 fmt::format("UDQ variable: {} must be defined before you can use UPDATE", keyword),
                 location

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -22,6 +22,7 @@
 #include <opm/io/eclipse/rst/state.hpp>
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/Schedule/MSW/SegmentMatcher.hpp>
@@ -299,7 +300,12 @@ namespace Opm {
             };
         }
 
-        if (this->m_definitions.count(keyword) == 0 && this->m_assignments.count(keyword) == 0) {
+        if (this->m_definitions.count(keyword) == 0) {
+            if (this->m_assignments.count(keyword) > 0) {
+                OpmLog::warning(fmt::format("UDQ variable {} is constant, so UPDATE will have no effect.", keyword));
+                return;
+            }
+
             throw OpmInputError {
                 fmt::format("UDQ variable: {} must be defined before you can use UPDATE", keyword),
                 location


### PR DESCRIPTION
Allow UDQ expressions like the one below (which, as far as I can see, cause no harm):

UDQ
ASSIGN FU_NNN 123456 /
UPDATE FU_NNN NEXT /
/
