### PR TITLE
Make UDQ SORT Function Backend Private

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQFunction.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQFunction.hpp
@@ -77,7 +77,6 @@ public:
     static UDQSet LN(const UDQSet& arg);
     static UDQSet LOG(const UDQSet& arg);
     static UDQSet NINT(const UDQSet& arg);
-    static UDQSet SORT(const UDQSet& arg, bool ascending);
     static UDQSet SORTA(const UDQSet& arg);
     static UDQSet SORTD(const UDQSet& arg);
     static UDQSet UNDEF(const UDQSet& arg);


### PR DESCRIPTION
There's no need to have this function available to the world, since it's only used to implement `SORTA` and `SORTD`.

While here, switch to taking the predicate as an input parameter instead of hard coding `<` or `>` based on a conditional.