### PR TITLE
Fix assignment of selected well variables, also if quoted.

### DIFF
--- a/opm/common/utility/shmatch.cpp
+++ b/opm/common/utility/shmatch.cpp
@@ -21,23 +21,11 @@
 
 #include <opm/common/utility/shmatch.hpp>
 
-namespace {
-    std::string unquote(const std::string& pattern) {
-        if (pattern.size() < 3)
-            return pattern;
-
-        const auto last = pattern.size()-1;
-        if ( (pattern[0]=='\'' && pattern[last]=='\'') || (pattern[0]=='"' && pattern[last]=='"') )
-            return pattern.substr(1, last-1);
-
-        return pattern;
-    }
-}
 
 bool Opm::shmatch(const std::string& pattern, const std::string& symbol) {
     // Shell patterns should implicitly be interpreted as anchored at beginning
     // and end.
-    std::string re_pattern = "^" + unquote(pattern) + "$";
+    std::string re_pattern = "^" + pattern + "$";
 
     {
         // Shell wildcard '*' should be regular expression arbitrary character '.'
@@ -54,6 +42,6 @@ bool Opm::shmatch(const std::string& pattern, const std::string& symbol) {
     }
 
     std::regex regexp(re_pattern);
-    return std::regex_search(unquote(symbol), regexp);
+    return std::regex_search(symbol, regexp);
 }
 

--- a/opm/common/utility/shmatch.cpp
+++ b/opm/common/utility/shmatch.cpp
@@ -21,11 +21,23 @@
 
 #include <opm/common/utility/shmatch.hpp>
 
+namespace {
+    std::string unquote(const std::string& pattern) {
+        if (pattern.size() < 3)
+            return pattern;
+
+        const auto last = pattern.size()-1;
+        if ( (pattern[0]=='\'' && pattern[last]=='\'') || (pattern[0]=='"' && pattern[last]=='"') )
+            return pattern.substr(1, last-1);
+
+        return pattern;
+    }
+}
 
 bool Opm::shmatch(const std::string& pattern, const std::string& symbol) {
     // Shell patterns should implicitly be interpreted as anchored at beginning
     // and end.
-    std::string re_pattern = "^" + pattern + "$";
+    std::string re_pattern = "^" + unquote(pattern) + "$";
 
     {
         // Shell wildcard '*' should be regular expression arbitrary character '.'
@@ -42,6 +54,6 @@ bool Opm::shmatch(const std::string& pattern, const std::string& symbol) {
     }
 
     std::regex regexp(re_pattern);
-    return std::regex_search(symbol, regexp);
+    return std::regex_search(unquote(symbol), regexp);
 }
 

--- a/opm/input/eclipse/Schedule/SummaryState.cpp
+++ b/opm/input/eclipse/Schedule/SummaryState.cpp
@@ -396,18 +396,17 @@ namespace Opm
         this->elapsed += delta;
     }
 
-    void SummaryState::update_udq(const UDQSet& udq_set,
-                                  const double  undefined_value)
+    void SummaryState::update_udq(const UDQSet& udq_set)
     {
         const auto var_type = udq_set.var_type();
         if (var_type == UDQVarType::WELL_VAR) {
             for (const auto& udq_value : udq_set) {
-                this->update_well_var(udq_value.wgname(), udq_set.name(), udq_value.value().value_or(undefined_value));
+                this->update_well_var(udq_value.wgname(), udq_set.name(), udq_value.value().value_or(this->udq_undefined));
             }
         }
         else if (var_type == UDQVarType::GROUP_VAR) {
             for (const auto& udq_value : udq_set) {
-                this->update_group_var(udq_value.wgname(), udq_set.name(), udq_value.value().value_or(undefined_value));
+                this->update_group_var(udq_value.wgname(), udq_set.name(), udq_value.value().value_or(this->udq_undefined));
             }
         }
         else if (var_type == UDQVarType::SEGMENT_VAR) {
@@ -415,12 +414,12 @@ namespace Opm
                 this->update_segment_var(udq_value.wgname(),
                                          udq_set.name(),
                                          udq_value.number(),
-                                         udq_value.value().value_or(undefined_value));
+                                         udq_value.value().value_or(this->udq_undefined));
             }
         }
         else {
             const auto& udq_var = udq_set[0].value();
-            this->update(udq_set.name(), udq_var.value_or(undefined_value));
+            this->update(udq_set.name(), udq_var.value_or(this->udq_undefined));
         }
     }
 

--- a/opm/input/eclipse/Schedule/SummaryState.cpp
+++ b/opm/input/eclipse/Schedule/SummaryState.cpp
@@ -401,27 +401,13 @@ namespace Opm
     {
         const auto var_type = udq_set.var_type();
         if (var_type == UDQVarType::WELL_VAR) {
-            const std::vector<std::string> wells = this->wells(); // Intentional copy
-            for (const auto& well : wells) {
-                if (! udq_set.has(well)) {
-                    this->update_well_var(well, udq_set.name(), undefined_value);
-                    continue;
-                }
-
-                const auto& udq_value = udq_set[well].value();
-                this->update_well_var(well, udq_set.name(), udq_value.value_or(undefined_value));
+            for (const auto& udq_value : udq_set) {
+                this->update_well_var(udq_value.wgname(), udq_set.name(), udq_value.value().value_or(undefined_value));
             }
         }
         else if (var_type == UDQVarType::GROUP_VAR) {
-            const std::vector<std::string> groups = this->groups(); // Intentional copy
-            for (const auto& group : groups) {
-                if (! udq_set.has(group)) {
-                    this->update_group_var(group, udq_set.name(), undefined_value);
-                    continue;
-                }
-
-                const auto& udq_value = udq_set[group].value();
-                this->update_group_var(group, udq_set.name(), udq_value.value_or(undefined_value));
+            for (const auto& udq_value : udq_set) {
+                this->update_group_var(udq_value.wgname(), udq_set.name(), udq_value.value().value_or(undefined_value));
             }
         }
         else if (var_type == UDQVarType::SEGMENT_VAR) {

--- a/opm/input/eclipse/Schedule/SummaryState.hpp
+++ b/opm/input/eclipse/Schedule/SummaryState.hpp
@@ -106,7 +106,7 @@ public:
     void update_well_var(const std::string& well, const std::string& var, double value);
     void update_group_var(const std::string& group, const std::string& var, double value);
     void update_elapsed(double delta);
-    void update_udq(const UDQSet& udq_set, double undefined_value);
+    void update_udq(const UDQSet& udq_set);
     void update_conn_var(const std::string& well, const std::string& var, std::size_t global_index, double value);
     void update_segment_var(const std::string& well, const std::string& var, std::size_t segment, double value);
     void update_region_var(const std::string& regSet, const std::string& var, std::size_t region, double value);

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -336,7 +336,8 @@ namespace Opm {
             this->add_unit(quantity, data.front());
         }
         else if (action == UDQAction::ASSIGN) {
-            const auto selector = std::vector<std::string>(data.begin(), data.end() - 1);
+            auto selector = std::vector<std::string>(data.begin(), data.end() - 1);
+            std::transform(selector.cbegin(), selector.cend(), selector.begin(), strip_quotes);
             const auto value = std::stod(data.back());
             this->add_assign(quantity,
                              std::move(create_segment_matcher),

--- a/opm/input/eclipse/Schedule/UDQ/UDQContext.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQContext.cpp
@@ -279,7 +279,7 @@ namespace Opm {
                                    const UDQSet&      udq_result)
     {
         this->udq_state.add_assign(keyword, udq_result);
-        this->summary_state.update_udq(udq_result, this->udq_state.undefined_value());
+        this->summary_state.update_udq(udq_result);
     }
 
     void UDQContext::update_define(const std::size_t  report_step,
@@ -287,7 +287,7 @@ namespace Opm {
                                    const UDQSet&      udq_result)
     {
         this->udq_state.add_define(report_step, keyword, udq_result);
-        this->summary_state.update_udq(udq_result, this->udq_state.undefined_value());
+        this->summary_state.update_udq(udq_result);
     }
 
     void UDQContext::ensure_segment_matcher_exists() const

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -2890,7 +2890,7 @@ BOOST_AUTO_TEST_CASE(UDQ_ASSIGN_SEGMENT)
 
 BOOST_AUTO_TEST_CASE(UDQ_Update_SummaryState)
 {
-    const double udq_undefined = 0.0;
+    const double udq_undefined = 987.6;
     auto st = SummaryState { TimeService::now(), udq_undefined };
 
     // P2 not yet online

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -2890,7 +2890,8 @@ BOOST_AUTO_TEST_CASE(UDQ_ASSIGN_SEGMENT)
 
 BOOST_AUTO_TEST_CASE(UDQ_Update_SummaryState)
 {
-    auto st = SummaryState { TimeService::now(), 0.0 };
+    const double udq_undefined = 0.0;
+    auto st = SummaryState { TimeService::now(), udq_undefined };
 
     // P2 not yet online
     st.update_well_var("P1", "WBHP",  42.0);
@@ -2903,15 +2904,16 @@ BOOST_AUTO_TEST_CASE(UDQ_Update_SummaryState)
     st.update_group_var("AA", "GOPR", 1234.5);
 
     // P2 not yet online
-    st.update_udq(UDQSet::wells("WUBAR", { "P1", "P3" }, 17.29), -123.4);
+    st.update_udq(UDQSet::wells("WUBAR", { "P1", "P3" }, 17.29));
+    std::cout << "JALLA: " << st.get_well_var("P2", "WUBAR") << std::endl;
     BOOST_CHECK_CLOSE(st.get_well_var("P1", "WUBAR"),   17.29, 1.0e-8);
-    BOOST_CHECK_CLOSE(st.get_well_var("P2", "WUBAR"), -123.4 , 1.0e-8);
+    BOOST_CHECK_CLOSE(st.get_well_var("P2", "WUBAR"), udq_undefined, 1.0e-8);
     BOOST_CHECK_CLOSE(st.get_well_var("P3", "WUBAR"),   17.29, 1.0e-8);
 
     // BB not yet online
-    st.update_udq(UDQSet::groups("GUNDA_ST", { "G1", "AA" }, 652.44), -123.4);
+    st.update_udq(UDQSet::groups("GUNDA_ST", { "G1", "AA" }, 652.44));
     BOOST_CHECK_CLOSE(st.get_group_var("AA", "GUNDA_ST"),  652.44, 1.0e-8);
-    BOOST_CHECK_CLOSE(st.get_group_var("BB", "GUNDA_ST"), -123.4 , 1.0e-8);
+    BOOST_CHECK_CLOSE(st.get_group_var("BB", "GUNDA_ST"), udq_undefined, 1.0e-8);
     BOOST_CHECK_CLOSE(st.get_group_var("G1", "GUNDA_ST"),  652.44, 1.0e-8);
 }
 


### PR DESCRIPTION
Properly handle the following: 

```
UDQ
ASSIGN WURST 'A-*' 1.23e4 /
/
```