### PR TITLE
Count All UDQ Variable Types for Output Purposes

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -442,6 +442,15 @@ namespace Opm {
                              });
     }
 
+    void UDQConfig::exportTypeCount(std::array<int, static_cast<std::size_t>(UDQVarType::NumTypes)>& count) const
+    {
+        count.fill(0);
+
+        for (const auto& [type, cnt] : this->type_count) {
+            count[static_cast<std::size_t>(type)] = cnt;
+        }
+    }
+
     std::vector<UDQAssign> UDQConfig::assignments() const
     {
         std::vector<UDQAssign> ret;

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
@@ -31,6 +31,7 @@
 #include <opm/input/eclipse/EclipseState/Util/OrderedMap.hpp>
 #include <opm/input/eclipse/EclipseState/Util/IOrderSet.hpp>
 
+#include <array>
 #include <cstddef>
 #include <functional>
 #include <map>
@@ -129,6 +130,8 @@ namespace Opm {
         std::vector<UDQDefine> definitions() const;
         std::vector<UDQDefine> definitions(UDQVarType var_type) const;
         std::vector<UDQInput> input() const;
+
+        void exportTypeCount(std::array<int, static_cast<std::size_t>(UDQVarType::NumTypes)>& count) const;
 
         // The size() method will return the number of active DEFINE and ASSIGN
         // statements; this will correspond to the length of the vector returned

--- a/opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp
@@ -71,6 +71,10 @@ enum class UDQVarType
     WELL_VAR = 8,
     GROUP_VAR = 9,
     TABLE_LOOKUP = 10,
+
+    // -------------------------------------------------------------------------
+    // Implementation helper.  Must be last enumerator.
+    NumTypes,
 };
 
 enum class UDQTokenType

--- a/opm/output/eclipse/InteHEAD.cpp
+++ b/opm/output/eclipse/InteHEAD.cpp
@@ -31,12 +31,14 @@
 
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/common/utility/TimeService.hpp>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <ctime>
@@ -744,20 +746,24 @@ ngroups(const Group& gr)
 }
 
 Opm::RestartIO::InteHEAD&
-Opm::RestartIO::InteHEAD::
-udqParam_1(const UdqParam& udq_par)
+Opm::RestartIO::InteHEAD::udqParam_1(const UdqParam& udq_par)
 {
     this->data_[UDQPAR_1] = - udq_par.udqParam_1;
     this->data_[R_SEED]   = - udq_par.udqParam_1;
 
-    this->data_[NUM_CONN_UDQS]  = udq_par.num_conn_udqs;
-    this->data_[NUM_FIELD_UDQS] = udq_par.num_field_udqs;
-    this->data_[NUM_REG_UDQS]   = udq_par.num_reg_udqs;
-    this->data_[NUM_GROUP_UDQS] = udq_par.num_group_udqs;
-    this->data_[NUM_SEG_UDQS]   = udq_par.num_seg_udqs;
-    this->data_[NUM_WELL_UDQS]  = udq_par.num_well_udqs;
-    this->data_[NUM_AQU_UDQS]   = udq_par.num_aqu_udqs;
-    this->data_[NUM_BLK_UDQS]   = udq_par.num_blk_udqs;
+    for (const auto& [countIx, vtype] : std::array {
+            std::pair { NUM_CONN_UDQS , UDQVarType::CONNECTION_VAR },
+            std::pair { NUM_FIELD_UDQS, UDQVarType::FIELD_VAR      },
+            std::pair { NUM_REG_UDQS  , UDQVarType::REGION_VAR     },
+            std::pair { NUM_GROUP_UDQS, UDQVarType::GROUP_VAR      },
+            std::pair { NUM_SEG_UDQS  , UDQVarType::SEGMENT_VAR    },
+            std::pair { NUM_WELL_UDQS , UDQVarType::WELL_VAR       },
+            std::pair { NUM_AQU_UDQS  , UDQVarType::AQUIFER_VAR    },
+            std::pair { NUM_BLK_UDQS  , UDQVarType::BLOCK_VAR      },
+        })
+    {
+        this->data_[countIx] = udq_par.numUDQs[static_cast<std::size_t>(vtype)];
+    }
 
     this->data_[NUM_IUADS] = udq_par.num_iuads;
     this->data_[NUM_IUAPS] = udq_par.num_iuaps;

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -21,7 +21,10 @@
 #ifndef OPM_INTEHEAD_HEADER_INCLUDED
 #define OPM_INTEHEAD_HEADER_INCLUDED
 
+#include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
+
 #include <array>
+#include <cstddef>
 #include <ctime>
 #include <memory>
 #include <vector>
@@ -33,6 +36,7 @@ class EclipseState;
 class Phases;
 class Schedule;
 class ScheduleState;
+class UDQInput;
 class UnitSystem;
 
 } // namespace Opm
@@ -108,33 +112,10 @@ namespace Opm { namespace RestartIO {
 
         struct UdqParam {
             int udqParam_1{};
-
-            /// Number of field-level UDQ parameters (FU*)
-            int num_field_udqs{};
-
-            /// Number of group-level UDQ parameters (GU*)
-            int num_group_udqs{};
-
-            /// Number of region-level UDQ parameters (RU*)
-            int num_reg_udqs{};
-
-            /// Number of well-level UDQ parameters (WU*)
-            int num_well_udqs{};
-
-            /// Number of segment-level UDQ parameters (SU*)
-            int num_seg_udqs{};
-
-            /// Number of connection-level UDQ parameters (CU*)
-            int num_conn_udqs{};
-
-            /// Number of aquifer-level UDQ parameters (AU*)
-            int num_aqu_udqs{};
-
-            /// Number of block-level UDQ parameters (BU*)
-            int num_blk_udqs{};
-
             int num_iuads{};
             int num_iuaps{};
+
+            std::array<int, static_cast<std::size_t>(UDQVarType::NumTypes)> numUDQs{};
         };
 
         struct ActionParam {


### PR DESCRIPTION
This commit ensures that all known UDQ variable types (e.g, field, group, well, segment) are accounted for in the `INTEHEAD` restart vector.  We switch to having an appropriately sized std::array as a member in `InteHEAD::UdqParam` represent the counts instead of having individual members for each variable type.  This is more extensible as well if we add more categories in the future.  We generate the category counts to class `UDQConfig`, since this class already knows the category counts internally (from `UDQConfig::add_node()`).  To this end, add a new member function `UDQConfig::exportTypeCount()`.

While here, make slight whitespace adjustments to the IUAP and IUAD counting routines to simplify future maintenance.

This PR represents enabling work to support outputting values of segment level UDQs (i.e., those named `SU*`) to the restart file.