### PR TITLE
FluidStateEnthalpyModules: initialize members

### DIFF
--- a/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
+++ b/opm/material/fluidstates/FluidStateEnthalpyModules.hpp
@@ -31,7 +31,7 @@
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/Valgrind.hpp>
 
-#include <algorithm>
+#include <array>
 
 namespace Opm {
 /*!
@@ -94,7 +94,7 @@ protected:
     const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 
-    Scalar enthalpy_[numPhases];
+    std::array<Scalar, numPhases> enthalpy_{};
 };
 
 /*!


### PR DESCRIPTION
to avoid downstream warnings

Ref https://ci.opm-project.org/job/opm-simulators/2349/gcc/fileName.1103635476/source.591ea294-4e48-4031-b253-06e230c28d6d/#137