### PR TITLE
Export some ESMRY methods to python

### DIFF
--- a/python/cxx/eclipse_io.cpp
+++ b/python/cxx/eclipse_io.cpp
@@ -135,6 +135,16 @@ public:
             return m_ext_esmry->keywordList(pattern);
     }
 
+    std::string units(const std::string& field) const
+    {
+        if (m_esmry != nullptr) {
+            return m_esmry->get_unit(field);
+        }
+        else {
+            return m_ext_esmry->get_unit(field);
+        }
+    }
+
 private:
     std::unique_ptr<Opm::EclIO::ESmry> m_esmry;
     std::unique_ptr<Opm::EclIO::ExtESmry> m_ext_esmry;
@@ -449,7 +459,8 @@ void python::common::export_IO(py::module& m) {
             &ESmryBind::keywordList)
         .def("keys", (std::vector<std::string> (ESmryBind::*) (const std::string&) const)
             &ESmryBind::keywordList)
-        .def("dates", &ESmryBind::dates);
+        .def("dates", &ESmryBind::dates)
+        .def("units", &ESmryBind::units);
 
    py::class_<Opm::EclIO::EGrid>(m, "EGrid")
         .def(py::init<const std::string &>())

--- a/python/cxx/eclipse_io.cpp
+++ b/python/cxx/eclipse_io.cpp
@@ -99,6 +99,26 @@ public:
         return TimeService::from_time_t( local_time_t );
     }
 
+    std::vector<time_point> dates() const
+    {
+        std::vector<time_point> result;
+        std::vector<time_point> times;
+        if (m_esmry != nullptr) {
+            times = m_esmry->dates();
+        } else {
+            times = m_ext_esmry->dates();
+        }
+        result.reserve(times.size());
+        for (std::size_t i = 0; i < times.size(); ++i) {
+            auto utc_time_t   = std::chrono::system_clock::to_time_t(times[i]);
+            auto utc_ts       = Opm::TimeStampUTC(utc_time_t);
+            auto local_time_t = Opm::asLocalTimeT(utc_ts);
+            result.push_back(TimeService::from_time_t(local_time_t));
+        }
+
+        return result;
+    }
+
     const std::vector<std::string>& keywordList() const
     {
         if (m_esmry != nullptr)
@@ -428,8 +448,8 @@ void python::common::export_IO(py::module& m) {
         .def("keys", (const std::vector<std::string>& (ESmryBind::*) (void) const)
             &ESmryBind::keywordList)
         .def("keys", (std::vector<std::string> (ESmryBind::*) (const std::string&) const)
-            &ESmryBind::keywordList);
-
+            &ESmryBind::keywordList)
+        .def("dates", &ESmryBind::dates);
 
    py::class_<Opm::EclIO::EGrid>(m, "EGrid")
         .def(py::init<const std::string &>())

--- a/python/tests/test_esmry.py
+++ b/python/tests/test_esmry.py
@@ -30,6 +30,10 @@ class TestEclFile(unittest.TestCase):
         self.assertTrue("BPR:10,10,3" in smry1)
         self.assertFalse("XXXX" in smry1)
 
+        dates = smry1.dates()
+        self.assertEqual(len(dates), len(smry1))
+        self.assertEqual(dates[0], smry1.start_date + datetime.timedelta(days=1))
+
         with self.assertRaises(ValueError):
             test = smry1["XXX"]
 

--- a/python/tests/test_esmry.py
+++ b/python/tests/test_esmry.py
@@ -34,6 +34,8 @@ class TestEclFile(unittest.TestCase):
         self.assertEqual(len(dates), len(smry1))
         self.assertEqual(dates[0], smry1.start_date + datetime.timedelta(days=1))
 
+        self.assertEqual(smry1.units('FGOR'), 'STB/MSCF')
+
         with self.assertRaises(ValueError):
             test = smry1["XXX"]
 


### PR DESCRIPTION
Give ability for python scripts to easily
- get list of dates for summary results
- obtain the units for a summary vector.