### PR TITLE
fixed: do not dereference null pointers

### DIFF
--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -563,7 +563,7 @@ protected:
     void ptr(const PtrType& data)
     {
         using T1 = typename PtrType::element_type;
-        void* data_ptr = reinterpret_cast<void*>(&(*data));
+        void* data_ptr = reinterpret_cast<void*>(data.get());
         (*this)(data_ptr);
         if (!data_ptr)
             return;


### PR DESCRIPTION
regression in 067d6d44460548e10610b5c753bd2db76bb1887f

This broke among other things test_Serialization running with debug iterator, https://ci.opm-project.org/job/opm-common-static-analysis/461/testReport/(root)/debug_iterator/Serialization/