### PR TITLE
Tabulated1DFunction: mark constructor explicit

### DIFF
--- a/opm/material/common/Tabulated1DFunction.hpp
+++ b/opm/material/common/Tabulated1DFunction.hpp
@@ -93,8 +93,8 @@ public:
      *               have a size() method)
      */
     template <class PointContainer>
-    Tabulated1DFunction(const PointContainer& points,
-                        bool sortInputs = true)
+    explicit Tabulated1DFunction(const PointContainer& points,
+                                 bool sortInputs = true)
     { this->setContainerOfTuples(points, sortInputs); }
 
     /*!


### PR DESCRIPTION
Separated out since it needs downstream changes and it can be argued that this ctor not being explicit has merit.