### PR TITLE
Recognize .GRID/.FGRID File Types

### DIFF
--- a/opm/io/eclipse/EclUtil.cpp
+++ b/opm/io/eclipse/EclUtil.cpp
@@ -1,20 +1,21 @@
 /*
-   Copyright 2019 Equinor ASA.
+  Copyright 2019 Equinor ASA.
 
-   This file is part of the Open Porous Media project (OPM).
+  This file is part of the Open Porous Media project (OPM).
 
-   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-   OPM is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-   */
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #include <opm/io/eclipse/EclUtil.hpp>
 
@@ -22,10 +23,13 @@
 
 #include <algorithm>
 #include <array>
-#include <stdexcept>
 #include <cmath>
-#include <fstream>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 int Opm::EclIO::flipEndianInt(int num)
 {
@@ -79,11 +83,17 @@ bool Opm::EclIO::is_number(const std::string& numstr)
 
 bool Opm::EclIO::isFormatted(const std::string& filename)
 {
-    const auto p = filename.find_last_of(".");
-    if (p == std::string::npos)
-      OPM_THROW(std::invalid_argument,
-                "Purported ECLIPSE Filename'" + filename + "'does not contain extension");
-    return std::strchr("ABCFGH", static_cast<int>(filename[p+1])) != nullptr;
+    const auto pth = std::filesystem::path { filename };
+
+    const auto& ext = pth.extension();
+    if (ext.empty()) {
+        OPM_THROW(std::invalid_argument,
+                  "Purported ECLIPSE Filename '" +
+                  filename + "' does not contain extension");
+    }
+
+    return (ext != ".GRID")
+        && (ext.string().find_first_of("ABCFGH", 1) == std::string::size_type{1});
 }
 
 bool Opm::EclIO::isEOF(std::fstream* fileH)

--- a/opm/io/eclipse/EclUtil.hpp
+++ b/opm/io/eclipse/EclUtil.hpp
@@ -1,31 +1,32 @@
 /*
-   Copyright 2019 Equinor ASA.
+  Copyright 2019 Equinor ASA.
 
-   This file is part of the Open Porous Media project (OPM).
+  This file is part of the Open Porous Media project (OPM).
 
-   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-   OPM is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-   */
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #ifndef OPM_IO_ECLUTIL_HPP
 #define OPM_IO_ECLUTIL_HPP
 
 #include <opm/io/eclipse/EclIOdata.hpp>
 
+#include <cstdint>
+#include <functional>
 #include <string>
 #include <tuple>
 #include <vector>
-#include <functional>
-#include <cstdint>
 
 namespace Opm { namespace EclIO {
 

--- a/test_util/convertECL.cpp
+++ b/test_util/convertECL.cpp
@@ -192,19 +192,18 @@ void open_grdecl_output(const std::string& output_fname, const std::string& inpu
         }
 
         ofileH.open(grdeclfile, std::ios::out);
-
-    } else {
+    }
+    else {
         std::filesystem::path grdeclfile(output_fname);
         std::filesystem::path path = grdeclfile.parent_path();
-            
-        if ((path.empty()) || (std::filesystem::exists(path))) {
 
+        if (path.empty() || std::filesystem::exists(path)) {
             if (std::filesystem::exists(grdeclfile)) {
                 std::cout << "\nError, cant make grdecl file " << grdeclfile.string() << ". File exists \n";
                 exit(1);
             }
-                 
-        } else {
+        }
+        else {
             std::cout << "\n!Error, output directory : '" << path.string() << "' doesn't exist \n";
             exit(1);
         }
@@ -214,8 +213,8 @@ void open_grdecl_output(const std::string& output_fname, const std::string& inpu
 }
 
 
-int main(int argc, char **argv) {
-
+int main(int argc, char **argv)
+{
     int c                          = 0;
     int reportStepNumber           = -1;
     bool specificReportStepNumber  = false;
@@ -223,32 +222,45 @@ int main(int argc, char **argv) {
     bool enforce_ix_output         = false;
     bool to_grdecl                 = false;
 
-    std::map<std::string, std::string> to_formatted = {{".EGRID", ".FEGRID"}, {".INIT", ".FINIT"}, {".SMSPEC", ".FSMSPEC"},
-        {".UNSMRY", ".FUNSMRY"}, {".UNRST", ".FUNRST"}, {".RFT", ".FRFT"}, {".ESMRY", ".FESMRY"}};
+    const std::map<std::string, std::string> to_formatted {
+        {".GRID"  , ".FGRID"  },
+        {".EGRID" , ".FEGRID" },
+        {".INIT"  , ".FINIT"  },
+        {".SMSPEC", ".FSMSPEC"},
+        {".UNSMRY", ".FUNSMRY"},
+        {".UNRST" , ".FUNRST" },
+        {".RFT"   , ".FRFT"   },
+        {".ESMRY" , ".FESMRY" },
+    };
 
-    std::map<std::string, std::string> to_binary = {{".FEGRID", ".EGRID"}, {".FINIT", ".INIT"}, {".FSMSPEC", ".SMSPEC"},
-        {".FUNSMRY", ".UNSMRY"}, {".FUNRST", ".UNRST"}, {".FRFT", ".RFT"}, {".FESMRY", ".ESMRY"}};
+    const std::map<std::string, std::string> to_binary {
+        {".FGRID"  , ".GRID"  },
+        {".FEGRID" , ".EGRID" },
+        {".FINIT"  , ".INIT"  },
+        {".FSMSPEC", ".SMSPEC"},
+        {".FUNSMRY", ".UNSMRY"},
+        {".FUNRST" , ".UNRST" },
+        {".FRFT"   , ".RFT"   },
+        {".FESMRY" , ".ESMRY" },
+    };
 
-
-    std::string output_fname;
-
-
+    std::string output_fname{};
     while ((c = getopt(argc, argv, "hr:ligo:")) != -1) {
         switch (c) {
         case 'h':
             printHelp();
             return 0;
         case 'l':
-            listProperties=true;
+            listProperties = true;
             break;
         case 'g':
-            to_grdecl=true;
+            to_grdecl = true;
             break;
         case 'i':
-            enforce_ix_output=true;
+            enforce_ix_output = true;
             break;
         case 'r':
-            specificReportStepNumber=true;
+            specificReportStepNumber = true;
             reportStepNumber = atoi(optarg);
             break;
         case 'o':
@@ -261,7 +273,7 @@ int main(int argc, char **argv) {
 
     int argOffset = optind;
 
-    if ((!output_fname.empty()) && (!to_grdecl)){
+    if (!output_fname.empty() && !to_grdecl) {
         std::cout << "\n!Error, option -o only valid whit option -g \n\n";
         exit(1);
     }
@@ -282,7 +294,6 @@ int main(int argc, char **argv) {
 
 
     if (to_grdecl) {
-    
         auto array_list = file1.getList();
         file1.loadData();
 
@@ -327,16 +338,13 @@ int main(int argc, char **argv) {
     }
 
     if (listProperties) {
-
-        if (extension==".UNRST") {
-
+        if (extension == ".UNRST") {
             ERst rst1(filename);
             rst1.loadData("INTEHEAD");
 
-            std::vector<int> reportStepList=rst1.listOfReportStepNumbers();
+            std::vector<int> reportStepList = rst1.listOfReportStepNumbers();
 
             for (auto seqn : reportStepList) {
-
                 std::vector<int> inteh = rst1.getRestartData<int>("INTEHEAD", seqn, 0);
 
                 std::cout << "Report step number: "
@@ -346,8 +354,8 @@ int main(int argc, char **argv) {
             }
 
             std::cout << std::endl;
-
-        } else {
+        }
+        else {
             std::cout << "\n!ERROR, option -l only only available for unified restart files (*.UNRST) " << std::endl;
             exit(1);
         }
@@ -356,30 +364,33 @@ int main(int argc, char **argv) {
     }
 
     if (formattedOutput) {
-
         auto search = to_formatted.find(extension);
-
         if (search != to_formatted.end()){
             resFile = rootN + search->second;
-        } else if (extension.substr(1,1)=="X"){
+        }
+        else if (extension.substr(1,1) == "X") {
             resFile = rootN + ".F" + extension.substr(2);
-        } else if (extension.substr(1,1)=="S"){
+        }
+        else if (extension.substr(1,1) == "S") {
             resFile = rootN + ".A" + extension.substr(2);
-        } else {
+        }
+        else {
             std::cout << "\n!ERROR, unknown file type for input file '" << rootN + extension << "'\n" << std::endl;
             exit(1);
         }
-    } else {
-
+    }
+    else {
         auto search = to_binary.find(extension);
-
         if (search != to_binary.end()){
             resFile = rootN + search->second;
-        } else if (extension.substr(1,1)=="F"){
+        }
+        else if (extension.substr(1,1) == "F") {
             resFile = rootN + ".X" + extension.substr(2);
-        } else if (extension.substr(1,1)=="A"){
+        }
+        else if (extension.substr(1,1) == "A") {
             resFile = rootN + ".S" + extension.substr(2);
-        } else {
+        }
+        else {
             std::cout << "\n!ERROR, unknown file type for input file '" << rootN + extension << "'\n" << std::endl;
             exit(1);
         }
@@ -389,14 +400,13 @@ int main(int argc, char **argv) {
 
     EclOutput outFile(resFile, formattedOutput);
 
-    if ((file1.is_ix()) || (enforce_ix_output)) {
+    if (file1.is_ix() || enforce_ix_output) {
         std::cout << "setting IX flag on output file \n";
         outFile.set_ix();
     }
 
     if (specificReportStepNumber) {
-
-        if (extension!=".UNRST") {
+        if (extension != ".UNRST") {
             std::cout << "\n!ERROR, option -r only can only be used with unified restart files (*.UNRST) " << std::endl;
             exit(1);
         }
@@ -411,11 +421,9 @@ int main(int argc, char **argv) {
         rst1.loadReportStepNumber(reportStepNumber);
 
         auto arrayList = rst1.listOfRstArrays(reportStepNumber);
-
         writeArrayList(arrayList, rst1, reportStepNumber, outFile);
-
-    } else {
-
+    }
+    else {
         file1.loadData();
         auto arrayList = file1.getList();
         std::vector<int> elementSizeList = file1.getElementSizeList();


### PR DESCRIPTION
The I/O code and simulator does not support this grid type, but we should nevertheless be able to convert between the formatted and the unformatted version of this file.