### PR TITLE
remove unneccesary decorators

### DIFF
--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -197,7 +197,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 {% if numDerivs < 0 %}\
     //! move other function evaluation (this only makes sense for dynamically
@@ -713,7 +713,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/DynamicEvaluation.hpp
+++ b/opm/material/densead/DynamicEvaluation.hpp
@@ -97,7 +97,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
     //! move other function evaluation (this only makes sense for dynamically
     //! allocated Evaluations)
@@ -448,7 +448,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/Evaluation.hpp
+++ b/opm/material/densead/Evaluation.hpp
@@ -101,7 +101,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -442,7 +442,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/Evaluation1.hpp
+++ b/opm/material/densead/Evaluation1.hpp
@@ -92,7 +92,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -425,7 +425,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/Evaluation10.hpp
+++ b/opm/material/densead/Evaluation10.hpp
@@ -92,7 +92,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -506,7 +506,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/Evaluation11.hpp
+++ b/opm/material/densead/Evaluation11.hpp
@@ -92,7 +92,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -515,7 +515,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/Evaluation12.hpp
+++ b/opm/material/densead/Evaluation12.hpp
@@ -92,7 +92,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -524,7 +524,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/Evaluation2.hpp
+++ b/opm/material/densead/Evaluation2.hpp
@@ -92,7 +92,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -434,7 +434,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/Evaluation3.hpp
+++ b/opm/material/densead/Evaluation3.hpp
@@ -92,7 +92,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -443,7 +443,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/Evaluation4.hpp
+++ b/opm/material/densead/Evaluation4.hpp
@@ -92,7 +92,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -452,7 +452,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/Evaluation5.hpp
+++ b/opm/material/densead/Evaluation5.hpp
@@ -92,7 +92,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -461,7 +461,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/Evaluation6.hpp
+++ b/opm/material/densead/Evaluation6.hpp
@@ -92,7 +92,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -470,7 +470,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/Evaluation7.hpp
+++ b/opm/material/densead/Evaluation7.hpp
@@ -92,7 +92,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -479,7 +479,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/Evaluation8.hpp
+++ b/opm/material/densead/Evaluation8.hpp
@@ -92,7 +92,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -488,7 +488,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const

--- a/opm/material/densead/Evaluation9.hpp
+++ b/opm/material/densead/Evaluation9.hpp
@@ -92,7 +92,7 @@ public:
     {}
 
     //! copy other function evaluation
-    OPM_HOST_DEVICE Evaluation(const Evaluation& other) = default;
+    Evaluation(const Evaluation& other) = default;
 
 
     // create an evaluation which represents a constant function
@@ -497,7 +497,7 @@ public:
     }
 
     // copy assignment from evaluation
-    OPM_HOST_DEVICE Evaluation& operator=(const Evaluation& other) = default;
+    Evaluation& operator=(const Evaluation& other) = default;
 
     template <class RhsValueType>
     OPM_HOST_DEVICE bool operator==(const RhsValueType& other) const


### PR DESCRIPTION
These decorates produces warnings further down the line when instantiated in opm-simulators