### PR TITLE
Some cleanup in PVT classes

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -65,6 +65,7 @@ list (APPEND MAIN_SOURCE_FILES
       opm/material/fluidsystems/blackoilpvt/DryGasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.cpp
+      opm/material/fluidsystems/blackoilpvt/GasPvtThermal.cpp
       opm/material/fluidsystems/blackoilpvt/LiveOilPvt.cpp
       opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.cpp
       opm/material/fluidsystems/blackoilpvt/SolventPvt.cpp
@@ -337,7 +338,6 @@ if(ENABLE_ECL_INPUT)
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
     opm/material/fluidsystems/blackoilpvt/H2GasPvt.cpp
-    opm/material/fluidsystems/blackoilpvt/GasPvtThermal.cpp
     opm/material/fluidsystems/blackoilpvt/OilPvtThermal.cpp
     opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.cpp
     opm/material/thermal/EclThermalLawManager.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -60,6 +60,7 @@ list (APPEND MAIN_SOURCE_FILES
       opm/material/fluidsystems/blackoilpvt/Co2GasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.cpp
       opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.cpp
+      opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DeadOilPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryGasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.cpp
@@ -336,7 +337,6 @@ if(ENABLE_ECL_INPUT)
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
     opm/material/fluidsystems/blackoilpvt/H2GasPvt.cpp
-    opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.cpp
     opm/material/fluidsystems/blackoilpvt/GasPvtThermal.cpp
     opm/material/fluidsystems/blackoilpvt/OilPvtThermal.cpp
     opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -55,6 +55,7 @@ list (APPEND MAIN_SOURCE_FILES
       opm/material/densead/Evaluation.cpp
       opm/material/fluidmatrixinteractions/EclEpsScalingPoints.cpp
       opm/material/fluidsystems/BlackOilFluidSystem.cpp
+      opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.cpp
       opm/material/fluidsystems/blackoilpvt/DeadOilPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryGasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.cpp
@@ -330,7 +331,6 @@ if(ENABLE_ECL_INPUT)
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
-    opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.cpp
     opm/material/fluidsystems/blackoilpvt/Co2GasPvt.cpp
     opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.cpp
     opm/material/fluidsystems/blackoilpvt/H2GasPvt.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -57,6 +57,7 @@ list (APPEND MAIN_SOURCE_FILES
       opm/material/fluidsystems/BlackOilFluidSystem.cpp
       opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.cpp
       opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.cpp
+      opm/material/fluidsystems/blackoilpvt/Co2GasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DeadOilPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryGasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.cpp
@@ -332,7 +333,6 @@ if(ENABLE_ECL_INPUT)
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
-    opm/material/fluidsystems/blackoilpvt/Co2GasPvt.cpp
     opm/material/fluidsystems/blackoilpvt/H2GasPvt.cpp
     opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.cpp
     opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -66,6 +66,7 @@ list (APPEND MAIN_SOURCE_FILES
       opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.cpp
       opm/material/fluidsystems/blackoilpvt/GasPvtThermal.cpp
+      opm/material/fluidsystems/blackoilpvt/H2GasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/LiveOilPvt.cpp
       opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.cpp
       opm/material/fluidsystems/blackoilpvt/SolventPvt.cpp
@@ -337,7 +338,6 @@ if(ENABLE_ECL_INPUT)
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
-    opm/material/fluidsystems/blackoilpvt/H2GasPvt.cpp
     opm/material/fluidsystems/blackoilpvt/OilPvtThermal.cpp
     opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.cpp
     opm/material/thermal/EclThermalLawManager.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -59,6 +59,7 @@ list (APPEND MAIN_SOURCE_FILES
       opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.cpp
       opm/material/fluidsystems/blackoilpvt/Co2GasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.cpp
+      opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DeadOilPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryGasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.cpp
@@ -335,7 +336,6 @@ if(ENABLE_ECL_INPUT)
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
     opm/material/fluidsystems/blackoilpvt/H2GasPvt.cpp
-    opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.cpp
     opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.cpp
     opm/material/fluidsystems/blackoilpvt/GasPvtThermal.cpp
     opm/material/fluidsystems/blackoilpvt/OilPvtThermal.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -58,8 +58,11 @@ list (APPEND MAIN_SOURCE_FILES
       opm/material/fluidsystems/blackoilpvt/DeadOilPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryGasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.cpp
+      opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.cpp
       opm/material/fluidsystems/blackoilpvt/LiveOilPvt.cpp
+      opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.cpp
       opm/material/fluidsystems/blackoilpvt/SolventPvt.cpp
+      opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.cpp
       opm/material/fluidsystems/blackoilpvt/WetGasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/WetHumidGasPvt.cpp
 )
@@ -334,11 +337,8 @@ if(ENABLE_ECL_INPUT)
     opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.cpp
     opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.cpp
     opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.cpp
-    opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.cpp
     opm/material/fluidsystems/blackoilpvt/GasPvtThermal.cpp
-    opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.cpp
     opm/material/fluidsystems/blackoilpvt/OilPvtThermal.cpp
-    opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.cpp
     opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.cpp
     opm/material/thermal/EclThermalLawManager.cpp
   )

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -56,6 +56,7 @@ list (APPEND MAIN_SOURCE_FILES
       opm/material/fluidmatrixinteractions/EclEpsScalingPoints.cpp
       opm/material/fluidsystems/BlackOilFluidSystem.cpp
       opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.cpp
+      opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.cpp
       opm/material/fluidsystems/blackoilpvt/DeadOilPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryGasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.cpp
@@ -332,7 +333,6 @@ if(ENABLE_ECL_INPUT)
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
     opm/material/fluidsystems/blackoilpvt/Co2GasPvt.cpp
-    opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.cpp
     opm/material/fluidsystems/blackoilpvt/H2GasPvt.cpp
     opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.cpp
     opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -69,6 +69,7 @@ list (APPEND MAIN_SOURCE_FILES
       opm/material/fluidsystems/blackoilpvt/H2GasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/LiveOilPvt.cpp
       opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.cpp
+      opm/material/fluidsystems/blackoilpvt/OilPvtThermal.cpp
       opm/material/fluidsystems/blackoilpvt/SolventPvt.cpp
       opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.cpp
       opm/material/fluidsystems/blackoilpvt/WetGasPvt.cpp
@@ -338,7 +339,6 @@ if(ENABLE_ECL_INPUT)
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
-    opm/material/fluidsystems/blackoilpvt/OilPvtThermal.cpp
     opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.cpp
     opm/material/thermal/EclThermalLawManager.cpp
   )

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -58,6 +58,7 @@ list (APPEND MAIN_SOURCE_FILES
       opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.cpp
       opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.cpp
       opm/material/fluidsystems/blackoilpvt/Co2GasPvt.cpp
+      opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.cpp
       opm/material/fluidsystems/blackoilpvt/DeadOilPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryGasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.cpp
@@ -334,7 +335,6 @@ if(ENABLE_ECL_INPUT)
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
     opm/material/fluidsystems/blackoilpvt/H2GasPvt.cpp
-    opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.cpp
     opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.cpp
     opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.cpp
     opm/material/fluidsystems/blackoilpvt/GasPvtThermal.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -72,6 +72,7 @@ list (APPEND MAIN_SOURCE_FILES
       opm/material/fluidsystems/blackoilpvt/OilPvtThermal.cpp
       opm/material/fluidsystems/blackoilpvt/SolventPvt.cpp
       opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.cpp
+      opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.cpp
       opm/material/fluidsystems/blackoilpvt/WetGasPvt.cpp
       opm/material/fluidsystems/blackoilpvt/WetHumidGasPvt.cpp
 )
@@ -339,7 +340,6 @@ if(ENABLE_ECL_INPUT)
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
-    opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.cpp
     opm/material/thermal/EclThermalLawManager.cpp
   )
 

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.cpp
@@ -33,12 +33,13 @@
 
 namespace Opm {
 
+#if HAVE_ECL_INPUT
 template<class Scalar>
 void ConstantCompressibilityBrinePvt<Scalar>::
 initFromState(const EclipseState& eclState, const Schedule&)
 {
     const auto& tableManager = eclState.getTableManager();
-    size_t numRegions = tableManager.getTabdims().getNumPVTTables();
+    std::size_t numRegions = tableManager.getTabdims().getNumPVTTables();
     const auto& densityTable = tableManager.getDensityTable();
 
     formationVolumeTables_.resize(numRegions);
@@ -77,7 +78,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
     }
 
 
-    size_t numPvtwRegions = numRegions;
+    std::size_t numPvtwRegions = numRegions;
     setNumRegions(numPvtwRegions);
 
     for (unsigned regionIdx = 0; regionIdx < numPvtwRegions; ++regionIdx) {
@@ -86,6 +87,18 @@ initFromState(const EclipseState& eclState, const Schedule&)
     }
 
     initEnd();
+}
+#endif
+
+template<class Scalar>
+void ConstantCompressibilityBrinePvt<Scalar>::
+setNumRegions(std::size_t numRegions)
+{
+    waterReferenceDensity_.resize(numRegions);
+
+    for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
+        setReferenceDensities(regionIdx, 650.0, 1.0, 1000.0);
+    }
 }
 
 template class ConstantCompressibilityBrinePvt<double>;

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp
@@ -29,6 +29,7 @@
 
 #include <opm/material/common/Tabulated1DFunction.hpp>
 
+#include <cstddef>
 #include <vector>
 
 namespace Opm {
@@ -59,14 +60,7 @@ public:
     void initFromState(const EclipseState& eclState, const Schedule&);
 #endif
 
-    void setNumRegions(size_t numRegions)
-    {
-        waterReferenceDensity_.resize(numRegions);
-
-        for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
-            setReferenceDensities(regionIdx, 650.0, 1.0, 1000.0);
-        }
-    }
+    void setNumRegions(std::size_t numRegions);
 
     void setVapPars(const Scalar, const Scalar)
     {
@@ -87,7 +81,6 @@ public:
     void initEnd()
     { }
 
-
     /*!
      * \brief Return the number of PVT regions which are considered by this PVT-object.
      */
@@ -107,9 +100,11 @@ public:
         throw std::runtime_error("Requested the enthalpy of water but the thermal option is not enabled");
     }
 
-    Scalar hVap(unsigned) const{
+    Scalar hVap(unsigned) const
+    {
         throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
     }
+
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
@@ -130,7 +125,7 @@ public:
 
         const Evaluation& bw = inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rsw, saltconcentration);
 
-        return MuwRef*BwRef*bw/(1 + Y*(1 + Y/2));
+        return MuwRef * BwRef * bw / (1 + Y * (1 + Y/2));
     }
 
 
@@ -152,7 +147,7 @@ public:
 
         const Evaluation& bw = saturatedInverseFormationVolumeFactor(regionIdx, temperature, pressure, saltconcentration);
 
-        return MuwRef*BwRef*bw/(1 + Y*(1 + Y/2));
+        return MuwRef * BwRef * bw / (1 + Y * (1 + Y/2));
     }
 
     /*!
@@ -165,7 +160,8 @@ public:
                                                     const Evaluation& saltconcentration) const
     {
         Evaluation Rsw = 0.0;
-        return inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rsw, saltconcentration);
+        return inverseFormationVolumeFactor(regionIdx, temperature, pressure,
+                                            Rsw, saltconcentration);
     }
     /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
@@ -183,7 +179,7 @@ public:
         const Evaluation C = compressibilityTables_[regionIdx].eval(saltconcentration, /*extrapolate=*/true);
         const Evaluation X = C * (pressure - pRef);
 
-        return (1.0 + X*(1.0 + X/2.0))/BwRef;
+        return (1.0 + X * (1.0 + X / 2.0)) / BwRef;
 
     }
 
@@ -215,10 +211,11 @@ public:
                                     const Evaluation& /*pressure*/,
                                     unsigned /*compIdx*/) const
     {
-        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+        throw std::runtime_error("Not implemented: The PVT model does not provide "
+                                 "a diffusionCoefficient()");
     }
 
-    const Scalar waterReferenceDensity(unsigned regionIdx) const
+    Scalar waterReferenceDensity(unsigned regionIdx) const
     { return waterReferenceDensity_[regionIdx]; }
 
     const std::vector<Scalar>& referencePressure() const
@@ -237,12 +234,12 @@ public:
     { return viscosibilityTables_; }
 
 private:
-    std::vector<Scalar> waterReferenceDensity_;
-    std::vector<Scalar> referencePressure_;
-    std::vector<TabulatedFunction> formationVolumeTables_;
-    std::vector<TabulatedFunction> compressibilityTables_;
-    std::vector<TabulatedFunction> viscosityTables_;
-    std::vector<TabulatedFunction> viscosibilityTables_;
+    std::vector<Scalar> waterReferenceDensity_{};
+    std::vector<Scalar> referencePressure_{};
+    std::vector<TabulatedFunction> formationVolumeTables_{};
+    std::vector<TabulatedFunction> compressibilityTables_{};
+    std::vector<TabulatedFunction> viscosityTables_{};
+    std::vector<TabulatedFunction> viscosibilityTables_{};
 };
 
 } // namespace Opm

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.cpp
@@ -32,6 +32,7 @@
 
 namespace Opm {
 
+#if HAVE_ECL_INPUT
 template<class Scalar>
 void ConstantCompressibilityOilPvt<Scalar>::
 initFromState(const EclipseState& eclState, const Schedule&)
@@ -45,7 +46,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
                               pvcdoTable.size(), densityTable.size()));
     }
 
-    size_t numRegions = pvcdoTable.size();
+    std::size_t numRegions = pvcdoTable.size();
     setNumRegions(numRegions);
 
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
@@ -63,6 +64,24 @@ initFromState(const EclipseState& eclState, const Schedule&)
     }
 
     initEnd();
+}
+#endif
+
+template<class Scalar>
+void ConstantCompressibilityOilPvt<Scalar>::
+setNumRegions(std::size_t numRegions)
+{
+    oilReferenceDensity_.resize(numRegions);
+    oilReferencePressure_.resize(numRegions);
+    oilReferenceFormationVolumeFactor_.resize(numRegions);
+    oilCompressibility_.resize(numRegions);
+    oilViscosity_.resize(numRegions);
+    oilViscosibility_.resize(numRegions);
+
+    for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
+        setReferenceFormationVolumeFactor(regionIdx, 1.0);
+        setReferencePressure(regionIdx, 1.03125);
+    }
 }
 
 template class ConstantCompressibilityOilPvt<double>;

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -27,6 +27,7 @@
 #ifndef OPM_CONSTANT_COMPRESSIBILITY_OIL_PVT_HPP
 #define OPM_CONSTANT_COMPRESSIBILITY_OIL_PVT_HPP
 
+#include <cstddef>
 #include <stdexcept>
 #include <vector>
 
@@ -56,20 +57,7 @@ public:
     void initFromState(const EclipseState& eclState, const Schedule&);
 #endif
 
-    void setNumRegions(size_t numRegions)
-    {
-        oilReferenceDensity_.resize(numRegions);
-        oilReferencePressure_.resize(numRegions);
-        oilReferenceFormationVolumeFactor_.resize(numRegions);
-        oilCompressibility_.resize(numRegions);
-        oilViscosity_.resize(numRegions);
-        oilViscosibility_.resize(numRegions);
-
-        for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
-            setReferenceFormationVolumeFactor(regionIdx, 1.0);
-            setReferencePressure(regionIdx, 1.03125);
-        }
-    }
+    void setNumRegions(std::size_t numRegions);
 
     void setVapPars(const Scalar, const Scalar)
     {
@@ -138,10 +126,13 @@ public:
                         const Evaluation&,
                         const Evaluation&) const
     {
-        throw std::runtime_error("Requested the enthalpy of oil but the thermal option is not enabled");
+        throw std::runtime_error("Requested the enthalpy of oil but the thermal "
+                                 "option is not enabled");
     }
-    Scalar hVap(unsigned) const{
-        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+    Scalar hVap(unsigned) const
+    {
+        throw std::runtime_error("Requested the hvap of oil but the thermal "
+                                 "option is not enabled");
     }
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of gas saturated oil given a pressure
@@ -169,7 +160,7 @@ public:
         const Evaluation& Y =
             (oilCompressibility_[regionIdx] - oilViscosibility_[regionIdx])
             * (pressure - pRef);
-        return BoMuoRef*bo/(1.0 + Y*(1.0 + Y/2.0));
+        return BoMuoRef * bo / (1.0 + Y * (1.0 + Y / 2.0));
     }
 
     /*!
@@ -225,7 +216,8 @@ public:
      * \brief Returns the saturation pressure of the oil phase [Pa]
      *        depending on its mass fraction of the gas component
      *
-     * \param Rs The surface volume of gas component dissolved in what will yield one cubic meter of oil at the surface [-]
+     * \param Rs The surface volume of gas component dissolved in what
+     *           will yield one cubic meter of oil at the surface [-]
      */
     template <class Evaluation>
     Evaluation saturationPressure(unsigned /*regionIdx*/,
@@ -238,7 +230,8 @@ public:
                                     const Evaluation& /*pressure*/,
                                     unsigned /*compIdx*/) const
     {
-        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+        throw std::runtime_error("Not implemented: The PVT model does not "
+                                 "provide a diffusionCoefficient()");
     }
 
     Scalar oilReferenceDensity(unsigned regionIdx) const
@@ -257,12 +250,12 @@ public:
     { return oilViscosibility_; }
 
 private:
-    std::vector<Scalar> oilReferenceDensity_;
-    std::vector<Scalar> oilReferencePressure_;
-    std::vector<Scalar> oilReferenceFormationVolumeFactor_;
-    std::vector<Scalar> oilCompressibility_;
-    std::vector<Scalar> oilViscosity_;
-    std::vector<Scalar> oilViscosibility_;
+    std::vector<Scalar> oilReferenceDensity_{};
+    std::vector<Scalar> oilReferencePressure_{};
+    std::vector<Scalar> oilReferenceFormationVolumeFactor_{};
+    std::vector<Scalar> oilCompressibility_{};
+    std::vector<Scalar> oilViscosity_{};
+    std::vector<Scalar> oilViscosibility_{};
 };
 
 } // namespace Opm

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.cpp
@@ -32,6 +32,7 @@
 
 namespace Opm {
 
+#if HAVE_ECL_INPUT
 template<class Scalar>
 void ConstantCompressibilityWaterPvt<Scalar>::
 initFromState(const EclipseState& eclState, const Schedule&)
@@ -45,7 +46,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
                               pvtwTable.size(), densityTable.size()));
     }
 
-    size_t numRegions = pvtwTable.size();
+    std::size_t numRegions = pvtwTable.size();
     setNumRegions(numRegions);
 
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
@@ -59,6 +60,25 @@ initFromState(const EclipseState& eclState, const Schedule&)
     }
 
     initEnd();
+}
+#endif
+
+template<class Scalar>
+void ConstantCompressibilityWaterPvt<Scalar>::
+setNumRegions(std::size_t numRegions)
+{
+    waterReferenceDensity_.resize(numRegions);
+    waterReferencePressure_.resize(numRegions);
+    waterReferenceFormationVolumeFactor_.resize(numRegions);
+    waterCompressibility_.resize(numRegions);
+    waterViscosity_.resize(numRegions);
+    waterViscosibility_.resize(numRegions);
+
+    for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
+        setReferenceDensities(regionIdx, 650.0, 1.0, 1000.0);
+        setReferenceFormationVolumeFactor(regionIdx, 1.0);
+        setReferencePressure(regionIdx, 1e5);
+    }
 }
 
 template class ConstantCompressibilityWaterPvt<double>;

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -54,21 +54,7 @@ public:
     void initFromState(const EclipseState& eclState, const Schedule&);
 #endif
 
-    void setNumRegions(size_t numRegions)
-    {
-        waterReferenceDensity_.resize(numRegions);
-        waterReferencePressure_.resize(numRegions);
-        waterReferenceFormationVolumeFactor_.resize(numRegions);
-        waterCompressibility_.resize(numRegions);
-        waterViscosity_.resize(numRegions);
-        waterViscosibility_.resize(numRegions);
-
-        for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
-            setReferenceDensities(regionIdx, 650.0, 1.0, 1000.0);
-            setReferenceFormationVolumeFactor(regionIdx, 1.0);
-            setReferencePressure(regionIdx, 1e5);
-        }
-    }
+    void setNumRegions(std::size_t numRegions);
 
     void setVapPars(const Scalar, const Scalar)
     {
@@ -138,10 +124,14 @@ public:
                         const Evaluation&,
                         const Evaluation&) const
     {
-        throw std::runtime_error("Requested the enthalpy of water but the thermal option is not enabled");
+        throw std::runtime_error("Requested the enthalpy of water but the thermal "
+                                 "option is not enabled");
     }
-    Scalar hVap(unsigned) const{
-        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+
+    Scalar hVap(unsigned) const
+    {
+        throw std::runtime_error("Requested the hvap of oil but the thermal "
+                                 "option is not enabled");
     }
 
     /*!
@@ -160,8 +150,9 @@ public:
         const Evaluation& Y =
             (waterCompressibility_[regionIdx] - waterViscosibility_[regionIdx])
             * (pressure - pRef);
-        return BwMuwRef*bw/(1 + Y*(1 + Y/2));
+        return BwMuwRef * bw / (1 + Y * (1 + Y / 2));
     }
+
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
@@ -179,7 +170,7 @@ public:
         const Evaluation& Y =
             (waterCompressibility_[regionIdx] - waterViscosibility_[regionIdx])
             * (pressure - pRef);
-        return BwMuwRef*bw/(1 + Y*(1 + Y/2));
+        return BwMuwRef * bw / (1 + Y * (1 + Y / 2));
     }
 
     /*!
@@ -192,7 +183,8 @@ public:
                                                      const Evaluation& saltconcentration) const
     {
       Evaluation Rsw = 0.0;
-      return inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rsw, saltconcentration);
+      return inverseFormationVolumeFactor(regionIdx, temperature, pressure,
+                                          Rsw, saltconcentration);
     }
 
     /*!
@@ -211,7 +203,7 @@ public:
         Scalar BwRef = waterReferenceFormationVolumeFactor_[regionIdx];
 
         // TODO (?): consider the salt concentration of the brine
-        return (1.0 + X*(1.0 + X/2.0))/BwRef;
+        return (1.0 + X * (1.0 + X / 2.0)) / BwRef;
     }
 
     template <class Evaluation>
@@ -219,7 +211,8 @@ public:
                        const Evaluation& /*temperature*/,
                        const Evaluation& pressure,
                        const Evaluation& /*Rsw*/,
-                       const Evaluation& /*saltconcentration*/) const{
+                       const Evaluation& /*saltconcentration*/) const
+    {
         inverseBAndMu(bw, muW, regionIdx,pressure);
     }
 
@@ -233,21 +226,22 @@ public:
         Scalar BwRef = waterReferenceFormationVolumeFactor_[regionIdx];
 
         // TODO (?): consider the salt concentration of the brine
-        bw = (1.0 + X*(1.0 + X/2.0))/BwRef;
+        bw = (1.0 + X * (1.0 + X / 2.0)) / BwRef;
 
         Scalar BwMuwRef = waterViscosity_[regionIdx]*BwRef;
 
         const Evaluation& Y =
             (waterCompressibility_[regionIdx] - waterViscosibility_[regionIdx])
             * (pressure - pRef);
-        muW =  BwMuwRef*bw/(1 + Y*(1 + Y/2));
+        muW =  BwMuwRef * bw / (1 + Y * (1 + Y / 2));
     }
 
     /*!
      * \brief Returns the saturation pressure of the water phase [Pa]
      *        depending on its mass fraction of the gas component
      *
-     * \param Rs The surface volume of gas component dissolved in what will yield one cubic meter of oil at the surface [-]
+     * \param Rs The surface volume of gas component dissolved in what
+     *           will yield one cubic meter of oil at the surface [-]
      */
     template <class Evaluation>
     Evaluation saturationPressure(unsigned /*regionIdx*/,
@@ -261,7 +255,8 @@ public:
                                     const Evaluation& /*pressure*/,
                                     unsigned /*compIdx*/) const
     {
-        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+        throw std::runtime_error("Not implemented: The PVT model does not provide "
+                                 "a diffusionCoefficient()");
     }
 
     /*!
@@ -293,12 +288,12 @@ public:
     { return waterViscosibility_; }
 
 private:
-    std::vector<Scalar> waterReferenceDensity_;
-    std::vector<Scalar> waterReferencePressure_;
-    std::vector<Scalar> waterReferenceFormationVolumeFactor_;
-    std::vector<Scalar> waterCompressibility_;
-    std::vector<Scalar> waterViscosity_;
-    std::vector<Scalar> waterViscosibility_;
+    std::vector<Scalar> waterReferenceDensity_{};
+    std::vector<Scalar> waterReferencePressure_{};
+    std::vector<Scalar> waterReferenceFormationVolumeFactor_{};
+    std::vector<Scalar> waterCompressibility_{};
+    std::vector<Scalar> waterViscosity_{};
+    std::vector<Scalar> waterViscosibility_{};
 };
 
 } // namespace Opm

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.cpp
@@ -50,7 +50,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
                               pvdoTables.size(), densityTable.size()));
     }
 
-    size_t numRegions = pvdoTables.size();
+    std::size_t numRegions = pvdoTables.size();
     setNumRegions(numRegions);
 
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
@@ -80,7 +80,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
 #endif
 
 template<class Scalar>
-void DeadOilPvt<Scalar>::setNumRegions(size_t numRegions)
+void DeadOilPvt<Scalar>::setNumRegions(std::size_t numRegions)
 {
     oilReferenceDensity_.resize(numRegions);
     inverseOilB_.resize(numRegions);
@@ -92,7 +92,7 @@ template<class Scalar>
 void DeadOilPvt<Scalar>::initEnd()
 {
     // calculate the final 2D functions which are used for interpolation.
-    size_t numRegions = oilMu_.size();
+    std::size_t numRegions = oilMu_.size();
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
         // calculate the table which stores the inverse of the product of the oil
         // formation volume factor and the oil viscosity

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -29,6 +29,9 @@
 
 #include <opm/material/common/Tabulated1DFunction.hpp>
 
+#include <cstddef>
+#include <vector>
+
 namespace Opm {
 
 #if HAVE_ECL_INPUT
@@ -53,7 +56,7 @@ public:
     void initFromState(const EclipseState& eclState, const Schedule&);
 #endif // HAVE_ECL_INPUT
 
-    void setNumRegions(size_t numRegions);
+    void setNumRegions(std::size_t numRegions);
 
     void setVapPars(const Scalar, const Scalar)
     {
@@ -80,7 +83,8 @@ public:
      * This method sets \f$1/B_o(p_o)\f$. Note that the mass fraction of the gas
      * component in the oil phase is missing when assuming dead oil.
      */
-    void setInverseOilFormationVolumeFactor(unsigned regionIdx, const TabulatedOneDFunction& invBo)
+    void setInverseOilFormationVolumeFactor(unsigned regionIdx,
+                                            const TabulatedOneDFunction& invBo)
     { inverseOilB_[regionIdx] = invBo; }
 
     /*!
@@ -111,11 +115,14 @@ public:
                         const Evaluation&,
                         const Evaluation&) const
     {
-        throw std::runtime_error("Requested the enthalpy of oil but the thermal option is not enabled");
+        throw std::runtime_error("Requested the enthalpy of oil but the thermal "
+                                 "option is not enabled");
     }
 
-    Scalar hVap(unsigned) const{
-        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+    Scalar hVap(unsigned) const
+    {
+        throw std::runtime_error("Requested the hvap of oil but the thermal "
+                                 "option is not enabled");
     }
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
@@ -138,7 +145,7 @@ public:
         const Evaluation& invBo = inverseOilB_[regionIdx].eval(pressure, /*extrapolate=*/true);
         const Evaluation& invMuoBo = inverseOilBMu_[regionIdx].eval(pressure, /*extrapolate=*/true);
 
-        return invBo/invMuoBo;
+        return invBo / invMuoBo;
     }
 
     /*!
@@ -211,7 +218,8 @@ public:
                                     const Evaluation& /*pressure*/,
                                     unsigned /*compIdx*/) const
     {
-        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+        throw std::runtime_error("Not implemented: The PVT model does not provide "
+                                 "a diffusionCoefficient()");
     }
 
     Scalar oilReferenceDensity(unsigned regionIdx) const
@@ -227,10 +235,10 @@ public:
     { return inverseOilBMu_; }
 
 private:
-    std::vector<Scalar> oilReferenceDensity_;
-    std::vector<TabulatedOneDFunction> inverseOilB_;
-    std::vector<TabulatedOneDFunction> oilMu_;
-    std::vector<TabulatedOneDFunction> inverseOilBMu_;
+    std::vector<Scalar> oilReferenceDensity_{};
+    std::vector<TabulatedOneDFunction> inverseOilB_{};
+    std::vector<TabulatedOneDFunction> oilMu_{};
+    std::vector<TabulatedOneDFunction> inverseOilBMu_{};
 };
 
 } // namespace Opm

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.cpp
@@ -50,7 +50,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
                               pvdgTables.size(), densityTable.size()));
     }
 
-    size_t numRegions = pvdgTables.size();
+    std::size_t numRegions = pvdgTables.size();
     setNumRegions(numRegions);
 
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
@@ -80,7 +80,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
             invB[i] = 1.0 / Bg[i];
         }
 
-        size_t numSamples = invB.size();
+        std::size_t numSamples = invB.size();
         inverseGasB_[regionIdx].setXYArrays(numSamples, pvdgTable.getPressureColumn(), invB);
         gasMu_[regionIdx].setXYArrays(numSamples, pvdgTable.getPressureColumn(), pvdgTable.getViscosityColumn());
     }
@@ -90,7 +90,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
 #endif
 
 template<class Scalar>
-void DryGasPvt<Scalar>::setNumRegions(size_t numRegions)
+void DryGasPvt<Scalar>::setNumRegions(std::size_t numRegions)
 {
     gasReferenceDensity_.resize(numRegions);
     inverseGasB_.resize(numRegions);
@@ -117,7 +117,7 @@ template<class Scalar>
 void DryGasPvt<Scalar>::initEnd()
 {
     // calculate the final 2D functions which are used for interpolation.
-    size_t numRegions = gasMu_.size();
+    std::size_t numRegions = gasMu_.size();
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
         // calculate the table which stores the inverse of the product of the gas
         // formation volume factor and the gas viscosity

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -31,6 +31,7 @@
 
 #include <opm/material/common/Tabulated1DFunction.hpp>
 
+#include <cstddef>
 #include <vector>
 
 namespace Opm {
@@ -61,7 +62,7 @@ public:
     void initFromState(const EclipseState& eclState, const Schedule&);
 #endif
 
-    void setNumRegions(size_t numRegions);
+    void setNumRegions(std::size_t numRegions);
 
     void setVapPars(const Scalar, const Scalar)
     {
@@ -119,15 +120,19 @@ public:
      */
     template <class Evaluation>
     Evaluation internalEnergy(unsigned,
-                        const Evaluation&,
-                        const Evaluation&,
-                        const Evaluation&,
-                        const Evaluation&) const
+                              const Evaluation&,
+                              const Evaluation&,
+                              const Evaluation&,
+                              const Evaluation&) const
     {
-        throw std::runtime_error("Requested the enthalpy of gas but the thermal option is not enabled");
+        throw std::runtime_error("Requested the enthalpy of gas but the thermal "
+                                 "option is not enabled");
     }
-    Scalar hVap(unsigned) const{
-        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+
+    Scalar hVap(unsigned) const
+    {
+        throw std::runtime_error("Requested the hvap of oil but the thermal "
+                                 "option is not enabled");
     }
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
@@ -151,7 +156,7 @@ public:
         const Evaluation& invBg = inverseGasB_[regionIdx].eval(pressure, /*extrapolate=*/true);
         const Evaluation& invMugBg = inverseGasBMu_[regionIdx].eval(pressure, /*extrapolate=*/true);
 
-        return invBg/invMugBg;
+        return invBg / invMugBg;
     }
 
     /*!
@@ -178,7 +183,8 @@ public:
      * \brief Returns the saturation pressure of the gas phase [Pa]
      *        depending on its mass fraction of the oil component
      *
-     * \param Rv The surface volume of oil component dissolved in what will yield one cubic meter of gas at the surface [-]
+     * \param Rv The surface volume of oil component dissolved in what
+     *           will yield one cubic meter of gas at the surface [-]
      */
     template <class Evaluation>
     Evaluation saturationPressure(unsigned /*regionIdx*/,
@@ -205,7 +211,6 @@ public:
                                               const Evaluation& /*saltConcentration*/) const
     { return 0.0; }
 
-
     /*!
      * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of the oil phase.
      */
@@ -231,7 +236,8 @@ public:
                                     const Evaluation& /*pressure*/,
                                     unsigned /*compIdx*/) const
     {
-        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+        throw std::runtime_error("Not implemented: The PVT model does not provide "
+                                 "a diffusionCoefficient()");
     }
 
     Scalar gasReferenceDensity(unsigned regionIdx) const
@@ -247,10 +253,10 @@ public:
     { return inverseGasBMu_; }
 
 private:
-    std::vector<Scalar> gasReferenceDensity_;
-    std::vector<TabulatedOneDFunction> inverseGasB_;
-    std::vector<TabulatedOneDFunction> gasMu_;
-    std::vector<TabulatedOneDFunction> inverseGasBMu_;
+    std::vector<Scalar> gasReferenceDensity_{};
+    std::vector<TabulatedOneDFunction> inverseGasB_{};
+    std::vector<TabulatedOneDFunction> gasMu_{};
+    std::vector<TabulatedOneDFunction> inverseGasBMu_{};
 };
 
 } // namespace Opm

--- a/opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.cpp
@@ -49,7 +49,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
                               pvtgwTables.size(), densityTable.size()));
     }
 
-    size_t numRegions = pvtgwTables.size();
+    std::size_t numRegions = pvtgwTables.size();
     setNumRegions(numRegions);
 
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
@@ -78,8 +78,8 @@ initFromState(const EclipseState& eclState, const Schedule&)
                 Scalar pg = saturatedTable.get("PG" , outerIdx);
                 waterVaporizationFac.appendXPos(pg);
 
-                size_t numRows = underSaturatedTable.numRows();
-                for (size_t innerIdx = 0; innerIdx < numRows; ++innerIdx) {
+                std::size_t numRows = underSaturatedTable.numRows();
+                for (std::size_t innerIdx = 0; innerIdx < numRows; ++innerIdx) {
                     Scalar saltConcentration = underSaturatedTable.get("C_SALT" , innerIdx);
                     Scalar rvwSat = underSaturatedTable.get("RVW" , innerIdx);
 
@@ -126,8 +126,8 @@ initFromState(const EclipseState& eclState, const Schedule&)
             assert(gasMu.numX() == outerIdx + 1);
 
             const auto& underSaturatedTable = pvtgwTable.getUnderSaturatedTable(outerIdx);
-            size_t numRows = underSaturatedTable.numRows();
-            for (size_t innerIdx = 0; innerIdx < numRows; ++innerIdx) {
+            std::size_t numRows = underSaturatedTable.numRows();
+            for (std::size_t innerIdx = 0; innerIdx < numRows; ++innerIdx) {
                 Scalar Rw = underSaturatedTable.get("RW" , innerIdx);
                 Scalar Bg = underSaturatedTable.get("BG" , innerIdx);
                 Scalar mug = underSaturatedTable.get("MUG" , innerIdx);
@@ -157,7 +157,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
             // find the master table which will be used as a template to extend the
             // current line. We define master table as the first table which has values
             // for undersaturated gas...
-            size_t masterTableIdx = xIdx + 1;
+            std::size_t masterTableIdx = xIdx + 1;
             for (; masterTableIdx < saturatedTable.numRows(); ++masterTableIdx)
             {
                 if (pvtgwTable.getUnderSaturatedTable(masterTableIdx).numRows() > 1)
@@ -198,7 +198,7 @@ extendPvtgwTable_(unsigned regionIdx,
     auto& invGasB = inverseGasB_[regionIdx];
     auto& gasMu = gasMu_[regionIdx];
 
-    for (size_t newRowIdx = 1; newRowIdx < masterTable.numRows(); ++newRowIdx) {
+    for (std::size_t newRowIdx = 1; newRowIdx < masterTable.numRows(); ++newRowIdx) {
         const auto& RWColumn = masterTable.getColumn("RW");
         const auto& BGColumn = masterTable.getColumn("BG");
         const auto& viscosityColumn = masterTable.getColumn("MUG");
@@ -239,7 +239,7 @@ extendPvtgwTable_(unsigned regionIdx,
 #endif
 
 template<class Scalar>
-void DryHumidGasPvt<Scalar>::setNumRegions(size_t numRegions)
+void DryHumidGasPvt<Scalar>::setNumRegions(std::size_t numRegions)
 {
     waterReferenceDensity_.resize(numRegions);
     gasReferenceDensity_.resize(numRegions);
@@ -276,20 +276,20 @@ setSaturatedGasViscosity(unsigned regionIdx,
     Scalar poMin = samplePoints.front().first;
     Scalar poMax = samplePoints.back().first;
 
-    constexpr const size_t nRw = 20;
-    size_t nP = samplePoints.size()*2;
+    constexpr const std::size_t nRw = 20;
+    std::size_t nP = samplePoints.size()*2;
 
     TabulatedOneDFunction mugTable;
     mugTable.setContainerOfTuples(samplePoints);
 
     // calculate a table of estimated densities depending on pressure and gas mass
     // fraction
-    for (size_t RwIdx = 0; RwIdx < nRw; ++RwIdx) {
+    for (std::size_t RwIdx = 0; RwIdx < nRw; ++RwIdx) {
         Scalar Rw = RwMin + (RwMax - RwMin)*RwIdx/nRw;
 
         gasMu_[regionIdx].appendXPos(Rw);
 
-        for (size_t pIdx = 0; pIdx < nP; ++pIdx) {
+        for (std::size_t pIdx = 0; pIdx < nP; ++pIdx) {
             Scalar pg = poMin + (poMax - poMin)*pIdx/nP;
             Scalar mug = mugTable.eval(pg, /*extrapolate=*/true);
 
@@ -302,7 +302,7 @@ template<class Scalar>
 void DryHumidGasPvt<Scalar>::initEnd()
 {
     // calculate the final 2D functions which are used for interpolation.
-    size_t numRegions = gasMu_.size();
+    std::size_t numRegions = gasMu_.size();
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
         // calculate the table which stores the inverse of the product of the gas
         // formation volume factor and the gas viscosity
@@ -317,13 +317,13 @@ void DryHumidGasPvt<Scalar>::initEnd()
         std::vector<Scalar> satPressuresArray;
         std::vector<Scalar> invSatGasBArray;
         std::vector<Scalar> invSatGasBMuArray;
-        for (size_t pIdx = 0; pIdx < gasMu.numX(); ++pIdx) {
+        for (std::size_t pIdx = 0; pIdx < gasMu.numX(); ++pIdx) {
             invGasBMu.appendXPos(gasMu.xAt(pIdx));
 
             assert(gasMu.numY(pIdx) == invGasB.numY(pIdx));
 
-            size_t numRw = gasMu.numY(pIdx);
-            for (size_t RwIdx = 0; RwIdx < numRw; ++RwIdx)
+            std::size_t numRw = gasMu.numY(pIdx);
+            for (std::size_t RwIdx = 0; RwIdx < numRw; ++RwIdx)
                 invGasBMu.appendSamplePoint(pIdx,
                                             gasMu.yAt(pIdx, RwIdx),
                                             invGasB.valueAt(pIdx, RwIdx)
@@ -352,12 +352,12 @@ updateSaturationPressure_(unsigned regionIdx)
 
     // create the taublated function representing saturation pressure depending of
     // Rw
-    size_t n = waterVaporizationFac.numSamples();
+    std::size_t n = waterVaporizationFac.numSamples();
     const Scalar delta = (waterVaporizationFac.xMax() -
                           waterVaporizationFac.xMin()) / Scalar(n + 1);
 
     SamplingPoints pSatSamplePoints;
-    for (size_t i = 0; i <= n; ++ i) {
+    for (std::size_t i = 0; i <= n; ++ i) {
         const Scalar pSat = waterVaporizationFac.xMin() + i*delta;
         const Scalar Rw = saturatedWaterVaporizationFactor(regionIdx,
                                                            Scalar(1e30),

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.cpp
@@ -104,6 +104,7 @@ hVap(unsigned regionIdx) const
     OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.hVap(regionIdx));
 }
 
+#if HAVE_ECL_INPUT
 template <class Scalar, bool enableThermal>
 void GasPvtMultiplexer<Scalar,enableThermal>::
 initFromState(const EclipseState& eclState, const Schedule& schedule)
@@ -130,6 +131,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
 
     OPM_GAS_PVT_MULTIPLEXER_CALL(pvtImpl.initFromState(eclState, schedule), break);
 }
+#endif
 
 template <class Scalar, bool enableThermal>
 void GasPvtMultiplexer<Scalar,enableThermal>::

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.cpp
@@ -51,7 +51,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
                               pvtoTables.size(), densityTable.size()));
     }
 
-    size_t numRegions = pvtoTables.size();
+    std::size_t numRegions = pvtoTables.size();
     setNumRegions(numRegions);
 
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
@@ -95,7 +95,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
             assert(oilMu.numX() == outerIdx + 1);
 
             const auto& underSaturatedTable = pvtoTable.getUnderSaturatedTable(outerIdx);
-            size_t numRows = underSaturatedTable.numRows();
+            std::size_t numRows = underSaturatedTable.numRows();
             for (unsigned innerIdx = 0; innerIdx < numRows; ++innerIdx) {
                 Scalar po = underSaturatedTable.get("P", innerIdx);
                 Scalar Bo = underSaturatedTable.get("BO", innerIdx);
@@ -131,7 +131,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
             // find the master table which will be used as a template to extend the
             // current line. We define master table as the first table which has values
             // for undersaturated oil...
-            size_t masterTableIdx = xIdx + 1;
+            std::size_t masterTableIdx = xIdx + 1;
             for (; masterTableIdx < saturatedTable.numRows(); ++masterTableIdx)
             {
                 if (pvtoTable.getUnderSaturatedTable(masterTableIdx).numRows() > 1)
@@ -216,7 +216,7 @@ extendPvtoTable_(unsigned regionIdx,
 #endif
 
 template<class Scalar>
-void LiveOilPvt<Scalar>::setNumRegions(size_t numRegions)
+void LiveOilPvt<Scalar>::setNumRegions(std::size_t numRegions)
 {
     oilReferenceDensity_.resize(numRegions);
     gasReferenceDensity_.resize(numRegions);
@@ -252,7 +252,7 @@ setSaturatedOilFormationVolumeFactor(unsigned regionIdx,
     updateSaturationPressure_(regionIdx);
 
     // calculate a table of estimated densities of undersatured gas
-    for (size_t pIdx = 0; pIdx < samplePoints.size(); ++pIdx) {
+    for (std::size_t pIdx = 0; pIdx < samplePoints.size(); ++pIdx) {
         Scalar p1 = std::get<0>(samplePoints[pIdx]);
         Scalar p2 = p1 * 2.0;
 
@@ -280,7 +280,7 @@ setSaturatedOilViscosity(unsigned regionIdx,
 
     // calculate a table of estimated viscosities depending on pressure and gas mass
     // fraction for untersaturated oil to make the other code happy
-    for (size_t pIdx = 0; pIdx < samplePoints.size(); ++pIdx) {
+    for (std::size_t pIdx = 0; pIdx < samplePoints.size(); ++pIdx) {
         Scalar p1 = std::get<0>(samplePoints[pIdx]);
         Scalar p2 = p1 * 2.0;
 
@@ -300,7 +300,7 @@ template<class Scalar>
 void LiveOilPvt<Scalar>::initEnd()
 {
     // calculate the final 2D functions which are used for interpolation.
-    size_t numRegions = oilMuTable_.size();
+    std::size_t numRegions = oilMuTable_.size();
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
         // calculate the table which stores the inverse of the product of the oil
         // formation volume factor and the oil viscosity
@@ -321,7 +321,7 @@ void LiveOilPvt<Scalar>::initEnd()
 
             assert(oilMu.numY(rsIdx) == invOilB.numY(rsIdx));
 
-            size_t numPressures = oilMu.numY(rsIdx);
+            std::size_t numPressures = oilMu.numY(rsIdx);
             for (unsigned pIdx = 0; pIdx < numPressures; ++pIdx)
                 invOilBMu.appendSamplePoint(rsIdx,
                                             oilMu.yAt(rsIdx, pIdx),
@@ -350,12 +350,12 @@ void LiveOilPvt<Scalar>::updateSaturationPressure_(unsigned regionIdx)
 
     // create the function representing saturation pressure depending of the mass
     // fraction in gas
-    size_t n = gasDissolutionFac.numSamples();
+    std::size_t n = gasDissolutionFac.numSamples();
     const Scalar delta = (gasDissolutionFac.xMax() -
                           gasDissolutionFac.xMin()) / Scalar(n + 1);
 
     SamplingPoints pSatSamplePoints;
-    for (size_t i = 0; i <= n; ++ i) {
+    for (std::size_t i = 0; i <= n; ++ i) {
         const Scalar pSat = gasDissolutionFac.xMin() + i*delta;
         const Scalar Rs = saturatedGasDissolutionFactor(regionIdx,
                                                         Scalar(1e30),

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -90,7 +90,8 @@ public:
      *
      * \param samplePoints A container of (x,y) values.
      */
-    void setSaturatedOilGasDissolutionFactor(unsigned regionIdx, const SamplingPoints& samplePoints)
+    void setSaturatedOilGasDissolutionFactor(unsigned regionIdx,
+                                             const SamplingPoints& samplePoints)
     { saturatedGasDissolutionFactorTable_[regionIdx].setContainerOfTuples(samplePoints); }
 
     /*!
@@ -117,7 +118,8 @@ public:
      * factor. Also note, that the order of the arguments needs to be \f$(R_s, p_o)\f$
      * and not the other way around.
      */
-    void setInverseOilFormationVolumeFactor(unsigned regionIdx, const TabulatedTwoDFunction& invBo)
+    void setInverseOilFormationVolumeFactor(unsigned regionIdx,
+                                            const TabulatedTwoDFunction& invBo)
     { inverseOilBTable_[regionIdx] = invBo; }
 
     /*!
@@ -158,11 +160,14 @@ public:
                         const Evaluation&,
                         const Evaluation&) const
     {
-        throw std::runtime_error("Requested the enthalpy of oil but the thermal option is not enabled");
+        throw std::runtime_error("Requested the enthalpy of oil but the thermal "
+                                 "option is not enabled");
     }
 
-    Scalar hVap(unsigned) const{
-        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+    Scalar hVap(unsigned) const
+    {
+        throw std::runtime_error("Requested the hvap of oil but the thermal "
+                                 "option is not enabled");
     }
 
     /*!
@@ -178,7 +183,7 @@ public:
         const Evaluation& invBo = inverseOilBTable_[regionIdx].eval(Rs, pressure, /*extrapolate=*/true);
         const Evaluation& invMuoBo = inverseOilBMuTable_[regionIdx].eval(Rs, pressure, /*extrapolate=*/true);
 
-        return invBo/invMuoBo;
+        return invBo / invMuoBo;
     }
 
     /*!
@@ -193,7 +198,7 @@ public:
         const Evaluation& invBo = inverseSaturatedOilBTable_[regionIdx].eval(pressure, /*extrapolate=*/true);
         const Evaluation& invMuoBo = inverseSaturatedOilBMuTable_[regionIdx].eval(pressure, /*extrapolate=*/true);
 
-        return invBo/invMuoBo;
+        return invBo / invMuoBo;
     }
 
     /*!
@@ -253,7 +258,7 @@ public:
         if (vapPar2_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
             constexpr const Scalar eps = 0.001;
             const Evaluation& So = max(oilSaturation, eps);
-            tmp *= max(1e-3, pow(So/maxOilSaturation, vapPar2_));
+            tmp *= max(1e-3, pow(So / maxOilSaturation, vapPar2_));
         }
 
         return tmp;
@@ -270,10 +275,10 @@ public:
                                   const Evaluation&,
                                   const Evaluation& Rs) const
     {
-        typedef MathToolbox<Evaluation> Toolbox;
+        using Toolbox = MathToolbox<Evaluation>;
 
         const auto& RsTable = saturatedGasDissolutionFactorTable_[regionIdx];
-        constexpr const Scalar eps = std::numeric_limits<typename Toolbox::Scalar>::epsilon()*1e6;
+        constexpr const Scalar eps = std::numeric_limits<typename Toolbox::Scalar>::epsilon() * 1e6;
 
         // use the saturation pressure function to get a pretty good initial value
         Evaluation pSat = saturationPressure_[regionIdx].eval(Rs, /*extrapolate=*/true);
@@ -292,22 +297,24 @@ public:
                 return pSat;
             }
 
-            const Evaluation& delta = f/fPrime;
+            const Evaluation& delta = f / fPrime;
 
             pSat -= delta;
 
             if (pSat < 0.0) {
                 // if the pressure is lower than 0 Pascals, we set it back to 0. if this
                 // happens twice, we give up and just return 0 Pa...
-                if (onProbation)
+                if (onProbation) {
                     return 0.0;
+                }
 
                 onProbation = true;
                 pSat = 0.0;
             }
 
-            if (std::abs(scalarValue(delta)) < std::abs(scalarValue(pSat))*eps)
+            if (std::abs(scalarValue(delta)) < std::abs(scalarValue(pSat))*eps) {
                 return pSat;
+            }
         }
 
         const std::string msg =
@@ -323,7 +330,8 @@ public:
                                     const Evaluation& /*pressure*/,
                                     unsigned /*compIdx*/) const
     {
-        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+        throw std::runtime_error("Not implemented: The PVT model does not provide "
+                                 "a diffusionCoefficient()");
     }
 
     Scalar gasReferenceDensity(unsigned regionIdx) const
@@ -362,16 +370,16 @@ public:
 private:
     void updateSaturationPressure_(unsigned regionIdx);
 
-    std::vector<Scalar> gasReferenceDensity_;
-    std::vector<Scalar> oilReferenceDensity_;
-    std::vector<TabulatedTwoDFunction> inverseOilBTable_;
-    std::vector<TabulatedTwoDFunction> oilMuTable_;
-    std::vector<TabulatedTwoDFunction> inverseOilBMuTable_;
-    std::vector<TabulatedOneDFunction> saturatedOilMuTable_;
-    std::vector<TabulatedOneDFunction> inverseSaturatedOilBTable_;
-    std::vector<TabulatedOneDFunction> inverseSaturatedOilBMuTable_;
-    std::vector<TabulatedOneDFunction> saturatedGasDissolutionFactorTable_;
-    std::vector<TabulatedOneDFunction> saturationPressure_;
+    std::vector<Scalar> gasReferenceDensity_{};
+    std::vector<Scalar> oilReferenceDensity_{};
+    std::vector<TabulatedTwoDFunction> inverseOilBTable_{};
+    std::vector<TabulatedTwoDFunction> oilMuTable_{};
+    std::vector<TabulatedTwoDFunction> inverseOilBMuTable_{};
+    std::vector<TabulatedOneDFunction> saturatedOilMuTable_{};
+    std::vector<TabulatedOneDFunction> inverseSaturatedOilBTable_{};
+    std::vector<TabulatedOneDFunction> inverseSaturatedOilBMuTable_{};
+    std::vector<TabulatedOneDFunction> saturatedGasDissolutionFactorTable_{};
+    std::vector<TabulatedOneDFunction> saturationPressure_{};
 
     Scalar vapPar2_ = 0.0;
 };

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.cpp
@@ -63,6 +63,7 @@ OilPvtMultiplexer<Scalar,enableThermal>::
     }
 }
 
+#if HAVE_ECL_INPUT
 template <class Scalar, bool enableThermal>
 void OilPvtMultiplexer<Scalar,enableThermal>::
 initFromState(const EclipseState& eclState, const Schedule& schedule)
@@ -87,6 +88,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
 
     OPM_OIL_PVT_MULTIPLEXER_CALL(pvtImpl.initFromState(eclState, schedule), break);
 }
+#endif
 
 template <class Scalar, bool enableThermal>
 void OilPvtMultiplexer<Scalar,enableThermal>::

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.cpp
@@ -36,6 +36,7 @@
 
 namespace Opm {
 
+#if HAVE_ECL_INPUT
 template<class Scalar>
 void OilPvtThermal<Scalar>::
 initFromState(const EclipseState& eclState, const Schedule& schedule)
@@ -156,7 +157,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
             std::vector<double> uSamples(temperatureColumn.size());
 
             Scalar u = temperatureColumn[0]*cvOilColumn[0];
-            for (size_t i = 0;; ++i) {
+            for (std::size_t i = 0;; ++i) {
                 uSamples[i] = u;
 
                 if (i >= temperatureColumn.size() - 1)
@@ -174,6 +175,81 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
             internalEnergyCurves_[regionIdx].setXYContainers(temperatureColumn.vectorCopy(), uSamples);
         }
     }
+}
+#endif
+
+template<class Scalar>
+void OilPvtThermal<Scalar>::
+setNumRegions(std::size_t numRegions)
+{
+    oilvisctCurves_.resize(numRegions);
+    viscrefPress_.resize(numRegions);
+    viscrefRs_.resize(numRegions);
+    viscRef_.resize(numRegions);
+    internalEnergyCurves_.resize(numRegions);
+    oildentRefTemp_.resize(numRegions);
+    oildentCT1_.resize(numRegions);
+    oildentCT2_.resize(numRegions);
+    oilJTRefPres_.resize(numRegions);
+    oilJTC_.resize(numRegions);
+    rhoRefG_.resize(numRegions);
+    hVap_.resize(numRegions, 0.0);
+}
+
+template<class Scalar>
+bool OilPvtThermal<Scalar>::
+operator==(const OilPvtThermal<Scalar>& data) const
+{
+    if (isothermalPvt_ && !data.isothermalPvt_) {
+        return false;
+    }
+    if (!isothermalPvt_ && data.isothermalPvt_) {
+        return false;
+    }
+
+    return  this->oilvisctCurves() == data.oilvisctCurves() &&
+            this->viscrefPress() == data.viscrefPress() &&
+            this->viscrefRs() == data.viscrefRs() &&
+            this->viscRef() == data.viscRef() &&
+            this->oildentRefTemp() == data.oildentRefTemp() &&
+            this->oildentCT1() == data.oildentCT1() &&
+            this->oildentCT2() == data.oildentCT2() &&
+            this->oilJTRefPres() == data.oilJTRefPres() &&
+            this->oilJTC() == data.oilJTC() &&
+            this->internalEnergyCurves() == data.internalEnergyCurves() &&
+            this->enableThermalDensity() == data.enableThermalDensity() &&
+            this->enableJouleThomson() == data.enableJouleThomson() &&
+            this->enableThermalViscosity() == data.enableThermalViscosity() &&
+            this->enableInternalEnergy() == data.enableInternalEnergy();
+}
+
+template<class Scalar>
+OilPvtThermal<Scalar>&
+OilPvtThermal<Scalar>::
+operator=(const OilPvtThermal<Scalar>& data)
+{
+    if (data.isothermalPvt_) {
+        isothermalPvt_ = new IsothermalPvt(*data.isothermalPvt_);
+    }
+    else {
+        isothermalPvt_ = nullptr;
+    }
+    oilvisctCurves_ = data.oilvisctCurves_;
+    viscrefPress_ = data.viscrefPress_;
+    viscrefRs_ = data.viscrefRs_;
+    viscRef_ = data.viscRef_;
+    oildentRefTemp_ = data.oildentRefTemp_;
+    oildentCT1_ = data.oildentCT1_;
+    oildentCT2_ = data.oildentCT2_;
+    oilJTRefPres_ =  data.oilJTRefPres_;
+    oilJTC_ =  data.oilJTC_;
+    internalEnergyCurves_ = data.internalEnergyCurves_;
+    enableThermalDensity_ = data.enableThermalDensity_;
+    enableJouleThomson_ = data.enableJouleThomson_;
+    enableThermalViscosity_ = data.enableThermalViscosity_;
+    enableInternalEnergy_ = data.enableInternalEnergy_;
+
+    return *this;
 }
 
 template class OilPvtThermal<double>;

--- a/opm/material/fluidsystems/blackoilpvt/SolventPvt.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/SolventPvt.cpp
@@ -50,7 +50,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
                               pvdsTables.size(), sdensityTables.size()));
     }
 
-    size_t numRegions = pvdsTables.size();
+    std::size_t numRegions = pvdsTables.size();
     setNumRegions(numRegions);
 
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
@@ -68,7 +68,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
             invB[i] = 1.0 / Bg[i];
         }
 
-        size_t numSamples = invB.size();
+        std::size_t numSamples = invB.size();
         inverseSolventB_[regionIdx].setXYArrays(numSamples, pvdsTable.getPressureColumn(), invB);
         solventMu_[regionIdx].setXYArrays(numSamples, pvdsTable.getPressureColumn(), pvdsTable.getViscosityColumn());
     }
@@ -78,7 +78,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
 #endif
 
 template<class Scalar>
-void SolventPvt<Scalar>::setNumRegions(size_t numRegions)
+void SolventPvt<Scalar>::setNumRegions(std::size_t numRegions)
 {
     solventReferenceDensity_.resize(numRegions);
     inverseSolventB_.resize(numRegions);
@@ -105,7 +105,7 @@ template<class Scalar>
 void SolventPvt<Scalar>::initEnd()
 {
     // calculate the final 2D functions which are used for interpolation.
-    size_t numRegions = solventMu_.size();
+    std::size_t numRegions = solventMu_.size();
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
         // calculate the table which stores the inverse of the product of the solvent
         // formation volume factor and its viscosity

--- a/opm/material/fluidsystems/blackoilpvt/SolventPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/SolventPvt.hpp
@@ -29,6 +29,7 @@
 
 #include <opm/material/common/Tabulated1DFunction.hpp>
 
+#include <cstddef>
 #include <vector>
 
 namespace Opm {
@@ -59,7 +60,7 @@ public:
     void initFromState(const EclipseState& eclState, const Schedule&);
 #endif
 
-    void setNumRegions(size_t numRegions);
+    void setNumRegions(std::size_t numRegions);
 
     void setVapPars(const Scalar, const Scalar)
     {
@@ -109,7 +110,7 @@ public:
         const Evaluation& invBg = inverseSolventB_[regionIdx].eval(pressure, /*extrapolate=*/true);
         const Evaluation& invMugBg = inverseSolventBMu_[regionIdx].eval(pressure, /*extrapolate=*/true);
 
-        return invBg/invMugBg;
+        return invBg / invMugBg;
     }
 
     template <class Evaluation>
@@ -117,7 +118,8 @@ public:
                                     const Evaluation& /*pressure*/,
                                     unsigned /*compIdx*/) const
     {
-        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+        throw std::runtime_error("Not implemented: The PVT model does not provide "
+                                 "a diffusionCoefficient()");
     }
 
     /*!
@@ -148,10 +150,10 @@ public:
     { return inverseSolventBMu_; }
 
 private:
-    std::vector<Scalar> solventReferenceDensity_;
-    std::vector<TabulatedOneDFunction> inverseSolventB_;
-    std::vector<TabulatedOneDFunction> solventMu_;
-    std::vector<TabulatedOneDFunction> inverseSolventBMu_;
+    std::vector<Scalar> solventReferenceDensity_{};
+    std::vector<TabulatedOneDFunction> inverseSolventB_{};
+    std::vector<TabulatedOneDFunction> solventMu_{};
+    std::vector<TabulatedOneDFunction> inverseSolventBMu_{};
 };
 
 } // namespace Opm

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.cpp
@@ -59,6 +59,7 @@ WaterPvtMultiplexer<Scalar,enableThermal,enableBrine>::
     }
 }
 
+#if HAVE_ECL_INPUT
 template<class Scalar, bool enableThermal, bool enableBrine>
 void WaterPvtMultiplexer<Scalar,enableThermal,enableBrine>::
 initFromState(const EclipseState& eclState, const Schedule& schedule)
@@ -81,6 +82,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
 
     OPM_WATER_PVT_MULTIPLEXER_CALL(pvtImpl.initFromState(eclState, schedule), break);
 }
+#endif
 
 template<class Scalar, bool enableThermal, bool enableBrine>
 void WaterPvtMultiplexer<Scalar,enableThermal,enableBrine>::

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.cpp
@@ -36,6 +36,7 @@
 
 namespace Opm {
 
+#if HAVE_ECL_INPUT
 template<class Scalar, bool enableBrine>
 void WaterPvtThermal<Scalar,enableBrine>::
 initFromState(const EclipseState& eclState, const Schedule& schedule)
@@ -158,7 +159,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
             std::vector<double> uSamples(temperatureColumn.size());
 
             Scalar u = temperatureColumn[0]*cvWaterColumn[0];
-            for (size_t i = 0;; ++i) {
+            for (std::size_t i = 0;; ++i) {
                 uSamples[i] = u;
 
                 if (i >= temperatureColumn.size() - 1)
@@ -176,6 +177,89 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
             internalEnergyCurves_[regionIdx].setXYContainers(temperatureColumn.vectorCopy(), uSamples);
         }
     }
+}
+#endif
+
+template<class Scalar, bool enableBrine>
+void WaterPvtThermal<Scalar,enableBrine>::
+setNumRegions(std::size_t numRegions)
+{
+    pvtwRefPress_.resize(numRegions);
+    pvtwRefB_.resize(numRegions);
+    pvtwCompressibility_.resize(numRegions);
+    pvtwViscosity_.resize(numRegions);
+    pvtwViscosibility_.resize(numRegions);
+    viscrefPress_.resize(numRegions);
+    watvisctCurves_.resize(numRegions);
+    watdentRefTemp_.resize(numRegions);
+    watdentCT1_.resize(numRegions);
+    watdentCT2_.resize(numRegions);
+    watJTRefPres_.resize(numRegions);
+    watJTC_.resize(numRegions);
+    internalEnergyCurves_.resize(numRegions);
+    hVap_.resize(numRegions,0.0);
+}
+
+template<class Scalar, bool enableBrine>
+bool WaterPvtThermal<Scalar,enableBrine>::
+operator==(const WaterPvtThermal<Scalar, enableBrine>& data) const
+{
+    if (isothermalPvt_ && !data.isothermalPvt_) {
+        return false;
+    }
+    if (!isothermalPvt_ && data.isothermalPvt_) {
+        return false;
+    }
+
+    return this->viscrefPress() == data.viscrefPress() &&
+           this->watdentRefTemp() == data.watdentRefTemp() &&
+           this->watdentCT1() == data.watdentCT1() &&
+           this->watdentCT2() == data.watdentCT2() &&
+           this->watJTRefPres() == data.watJTRefPres() &&
+           this->watJTC() == data.watJTC() &&
+           this->pvtwRefPress() == data.pvtwRefPress() &&
+           this->pvtwRefB() == data.pvtwRefB() &&
+           this->pvtwCompressibility() == data.pvtwCompressibility() &&
+           this->pvtwViscosity() == data.pvtwViscosity() &&
+           this->pvtwViscosibility() == data.pvtwViscosibility() &&
+           this->watvisctCurves() == data.watvisctCurves() &&
+           this->internalEnergyCurves() == data.internalEnergyCurves() &&
+           this->enableThermalDensity() == data.enableThermalDensity() &&
+           this->enableJouleThomson() == data.enableJouleThomson() &&
+           this->enableThermalViscosity() == data.enableThermalViscosity() &&
+           this->enableInternalEnergy() == data.enableInternalEnergy();
+}
+
+template<class Scalar, bool enableBrine>
+WaterPvtThermal<Scalar, enableBrine>&
+WaterPvtThermal<Scalar,enableBrine>::
+operator=(const WaterPvtThermal<Scalar, enableBrine>& data)
+{
+    if (data.isothermalPvt_) {
+        isothermalPvt_ = new IsothermalPvt(*data.isothermalPvt_);
+    }
+    else {
+        isothermalPvt_ = nullptr;
+    }
+    viscrefPress_ = data.viscrefPress_;
+    watdentRefTemp_ = data.watdentRefTemp_;
+    watdentCT1_ = data.watdentCT1_;
+    watdentCT2_ = data.watdentCT2_;
+    watJTRefPres_ =  data.watJTRefPres_;
+    watJTC_ =  data.watJTC_;
+    pvtwRefPress_ = data.pvtwRefPress_;
+    pvtwRefB_ = data.pvtwRefB_;
+    pvtwCompressibility_ = data.pvtwCompressibility_;
+    pvtwViscosity_ = data.pvtwViscosity_;
+    pvtwViscosibility_ = data.pvtwViscosibility_;
+    watvisctCurves_ = data.watvisctCurves_;
+    internalEnergyCurves_ = data.internalEnergyCurves_;
+    enableThermalDensity_ = data.enableThermalDensity_;
+    enableJouleThomson_ = data.enableJouleThomson_;
+    enableThermalViscosity_ = data.enableThermalViscosity_;
+    enableInternalEnergy_ = data.enableInternalEnergy_;
+
+    return *this;
 }
 
 template class WaterPvtThermal<double,false>;

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -34,6 +34,8 @@
 #include <opm/material/common/UniformXTabulated2DFunction.hpp>
 #include <opm/material/common/Tabulated1DFunction.hpp>
 
+#include <cstddef>
+
 namespace Opm {
 
 #if HAVE_ECL_INPUT
@@ -72,7 +74,7 @@ private:
 public:
 #endif // HAVE_ECL_INPUT
 
-    void setNumRegions(size_t numRegions);
+    void setNumRegions(std::size_t numRegions);
 
     void setVapPars(const Scalar par1, const Scalar)
     {
@@ -92,7 +94,8 @@ public:
      *
      * \param samplePoints A container of (x,y) values.
      */
-    void setSaturatedGasOilVaporizationFactor(unsigned regionIdx, const SamplingPoints& samplePoints)
+    void setSaturatedGasOilVaporizationFactor(unsigned regionIdx,
+                                              const SamplingPoints& samplePoints)
     { saturatedOilVaporizationFactorTable_[regionIdx].setContainerOfTuples(samplePoints); }
 
     /*!
@@ -119,7 +122,8 @@ public:
      * factor. Also note, that the order of the arguments needs to be \f$(R_s, p_o)\f$
      * and not the other way around.
      */
-    void setInverseGasFormationVolumeFactor(unsigned regionIdx, const TabulatedTwoDFunction& invBg)
+    void setInverseGasFormationVolumeFactor(unsigned regionIdx,
+                                            const TabulatedTwoDFunction& invBg)
     { inverseGasB_[regionIdx] = invBg; }
 
     /*!
@@ -156,16 +160,21 @@ public:
      */
     template <class Evaluation>
     Evaluation internalEnergy(unsigned,
-                        const Evaluation&,
-                        const Evaluation&,
-                        const Evaluation&,
-                        const Evaluation&) const
+                              const Evaluation&,
+                              const Evaluation&,
+                              const Evaluation&,
+                              const Evaluation&) const
     {
-        throw std::runtime_error("Requested the enthalpy of gas but the thermal option is not enabled");
+        throw std::runtime_error("Requested the enthalpy of gas but the thermal "
+                                 "option is not enabled");
     }
-    Scalar hVap(unsigned) const{
-        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+
+    Scalar hVap(unsigned) const
+    {
+        throw std::runtime_error("Requested the hvap of oil but the thermal "
+                                 "option is not enabled");
     }
+
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
@@ -179,7 +188,7 @@ public:
         const Evaluation& invBg = inverseGasB_[regionIdx].eval(pressure, Rv, /*extrapolate=*/true);
         const Evaluation& invMugBg = inverseGasBMu_[regionIdx].eval(pressure, Rv, /*extrapolate=*/true);
 
-        return invBg/invMugBg;
+        return invBg / invMugBg;
     }
 
     /*!
@@ -193,7 +202,7 @@ public:
         const Evaluation& invBg = inverseSaturatedGasB_[regionIdx].eval(pressure, /*extrapolate=*/true);
         const Evaluation& invMugBg = inverseSaturatedGasBMu_[regionIdx].eval(pressure, /*extrapolate=*/true);
 
-        return invBg/invMugBg;
+        return invBg / invMugBg;
     }
 
     /*!
@@ -221,8 +230,8 @@ public:
      */
     template <class Evaluation>
     Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
-                                              const Evaluation& /*temperature*/,
-                                              const Evaluation& /*pressure*/) const
+                                                const Evaluation& /*temperature*/,
+                                                const Evaluation& /*pressure*/) const
     { return 0.0; /* this is non-humid gas! */ }
 
     /*!
@@ -230,9 +239,9 @@ public:
     */
     template <class Evaluation = Scalar>
     Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
-                                              const Evaluation& /*temperature*/,
-                                              const Evaluation& /*pressure*/,
-                                              const Evaluation& /*saltConcentration*/) const
+                                                const Evaluation& /*temperature*/,
+                                                const Evaluation& /*pressure*/,
+                                                const Evaluation& /*saltConcentration*/) const
     { return 0.0; }
 
     /*!
@@ -269,7 +278,7 @@ public:
         if (vapPar1_ > 0.0 && maxOilSaturation > 0.01 && oilSaturation < maxOilSaturation) {
             constexpr const Scalar eps = 0.001;
             const Evaluation& So = max(oilSaturation, eps);
-            tmp *= max(1e-3, pow(So/maxOilSaturation, vapPar1_));
+            tmp *= max(1e-3, pow(So / maxOilSaturation, vapPar1_));
         }
 
         return tmp;
@@ -290,10 +299,10 @@ public:
                                   const Evaluation&,
                                   const Evaluation& Rv) const
     {
-        typedef MathToolbox<Evaluation> Toolbox;
+        using Toolbox = MathToolbox<Evaluation>;
 
         const auto& RvTable = saturatedOilVaporizationFactorTable_[regionIdx];
-        constexpr const Scalar eps = std::numeric_limits<typename Toolbox::Scalar>::epsilon()*1e6;
+        constexpr const Scalar eps = std::numeric_limits<typename Toolbox::Scalar>::epsilon() * 1e6;
 
         // use the tabulated saturation pressure function to get a pretty good initial value
         Evaluation pSat = saturationPressure_[regionIdx].eval(Rv, /*extrapolate=*/true);
@@ -312,22 +321,24 @@ public:
                 return pSat;
             }
 
-            const Evaluation& delta = f/fPrime;
+            const Evaluation& delta = f / fPrime;
 
             pSat -= delta;
 
             if (pSat < 0.0) {
                 // if the pressure is lower than 0 Pascals, we set it back to 0. if this
                 // happens twice, we give up and just return 0 Pa...
-                if (onProbation)
+                if (onProbation) {
                     return 0.0;
+                }
 
                 onProbation = true;
                 pSat = 0.0;
             }
 
-            if (std::abs(scalarValue(delta)) < std::abs(scalarValue(pSat))*eps)
+            if (std::abs(scalarValue(delta)) < std::abs(scalarValue(pSat))*eps) {
                 return pSat;
+            }
         }
 
         const std::string msg =
@@ -343,7 +354,8 @@ public:
                                     const Evaluation& /*pressure*/,
                                     unsigned /*compIdx*/) const
     {
-        throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
+        throw std::runtime_error("Not implemented: The PVT model does not provide "
+                                 "a diffusionCoefficient()");
     }
 
     Scalar gasReferenceDensity(unsigned regionIdx) const
@@ -352,50 +364,42 @@ public:
     Scalar oilReferenceDensity(unsigned regionIdx) const
     { return oilReferenceDensity_[regionIdx]; }
 
-    const std::vector<TabulatedTwoDFunction>& inverseGasB() const {
-        return inverseGasB_;
-    }
+    const std::vector<TabulatedTwoDFunction>& inverseGasB() const
+    { return inverseGasB_; }
 
-    const std::vector<TabulatedOneDFunction>& inverseSaturatedGasB() const {
-        return inverseSaturatedGasB_;
-    }
+    const std::vector<TabulatedOneDFunction>& inverseSaturatedGasB() const
+    { return inverseSaturatedGasB_; }
 
-    const std::vector<TabulatedTwoDFunction>& gasMu() const {
-        return gasMu_;
-    }
+    const std::vector<TabulatedTwoDFunction>& gasMu() const
+    { return gasMu_; }
 
-    const std::vector<TabulatedTwoDFunction>& inverseGasBMu() const {
-        return inverseGasBMu_;
-    }
+    const std::vector<TabulatedTwoDFunction>& inverseGasBMu() const
+    { return inverseGasBMu_; }
 
-    const std::vector<TabulatedOneDFunction>& inverseSaturatedGasBMu() const {
-        return inverseSaturatedGasBMu_;
-    }
+    const std::vector<TabulatedOneDFunction>& inverseSaturatedGasBMu() const
+    { return inverseSaturatedGasBMu_; }
 
-    const std::vector<TabulatedOneDFunction>& saturatedOilVaporizationFactorTable() const {
-        return saturatedOilVaporizationFactorTable_;
-    }
+    const std::vector<TabulatedOneDFunction>& saturatedOilVaporizationFactorTable() const
+    { return saturatedOilVaporizationFactorTable_; }
 
-    const std::vector<TabulatedOneDFunction>& saturationPressure() const {
-        return saturationPressure_;
-    }
+    const std::vector<TabulatedOneDFunction>& saturationPressure() const
+    { return saturationPressure_; }
 
-    Scalar vapPar1() const {
-        return vapPar1_;
-    }
+    Scalar vapPar1() const
+    { return vapPar1_; }
 
 private:
     void updateSaturationPressure_(unsigned regionIdx);
 
-    std::vector<Scalar> gasReferenceDensity_;
-    std::vector<Scalar> oilReferenceDensity_;
-    std::vector<TabulatedTwoDFunction> inverseGasB_;
-    std::vector<TabulatedOneDFunction> inverseSaturatedGasB_;
-    std::vector<TabulatedTwoDFunction> gasMu_;
-    std::vector<TabulatedTwoDFunction> inverseGasBMu_;
-    std::vector<TabulatedOneDFunction> inverseSaturatedGasBMu_;
-    std::vector<TabulatedOneDFunction> saturatedOilVaporizationFactorTable_;
-    std::vector<TabulatedOneDFunction> saturationPressure_;
+    std::vector<Scalar> gasReferenceDensity_{};
+    std::vector<Scalar> oilReferenceDensity_{};
+    std::vector<TabulatedTwoDFunction> inverseGasB_{};
+    std::vector<TabulatedOneDFunction> inverseSaturatedGasB_{};
+    std::vector<TabulatedTwoDFunction> gasMu_{};
+    std::vector<TabulatedTwoDFunction> inverseGasBMu_{};
+    std::vector<TabulatedOneDFunction> inverseSaturatedGasBMu_{};
+    std::vector<TabulatedOneDFunction> saturatedOilVaporizationFactorTable_{};
+    std::vector<TabulatedOneDFunction> saturationPressure_{};
 
     Scalar vapPar1_ = 0.0;
 };

--- a/opm/material/fluidsystems/blackoilpvt/WetHumidGasPvt.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetHumidGasPvt.cpp
@@ -56,7 +56,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
                               pvtgTables.size(), densityTable.size()));
     }
 
-    size_t numRegions = pvtgwTables.size();
+    std::size_t numRegions = pvtgwTables.size();
     setNumRegions(numRegions);
 
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
@@ -86,8 +86,8 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
                 Scalar pg = saturatedTable.get("PG" , outerIdx);
                 waterVaporizationFac.appendXPos(pg);
 
-                size_t numRows = underSaturatedTable.numRows();
-                for (size_t innerIdx = 0; innerIdx < numRows; ++innerIdx) {
+                std::size_t numRows = underSaturatedTable.numRows();
+                for (std::size_t innerIdx = 0; innerIdx < numRows; ++innerIdx) {
                     Scalar saltConcentration = underSaturatedTable.get("C_SALT" , innerIdx);
                     Scalar rvwSat = underSaturatedTable.get("RVW" , innerIdx);
 
@@ -137,8 +137,8 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
             assert(gasMuRvSat.numX() == outerIdx + 1);
 
             const auto& underSaturatedTable = pvtgwTable.getUnderSaturatedTable(outerIdx);
-            size_t numRows = underSaturatedTable.numRows();
-            for (size_t innerIdx = 0; innerIdx < numRows; ++ innerIdx) {
+            std::size_t numRows = underSaturatedTable.numRows();
+            for (std::size_t innerIdx = 0; innerIdx < numRows; ++ innerIdx) {
                 Scalar Rw = underSaturatedTable.get("RW" , innerIdx);
                 Scalar Bg = underSaturatedTable.get("BG" , innerIdx);
                 Scalar mug = underSaturatedTable.get("MUG" , innerIdx);
@@ -168,7 +168,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
             // find the master table which will be used as a template to extend the
             // current line. We define master table as the first table which has values
             // for undersaturated gas...
-            size_t masterTableIdx = xIdx + 1;
+            std::size_t masterTableIdx = xIdx + 1;
             for (; masterTableIdx < saturatedTable.numRows(); ++masterTableIdx)
             {
                 if (pvtgwTable.getUnderSaturatedTable(masterTableIdx).numRows() > 1)
@@ -229,8 +229,8 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
             assert(gasMuRvwSat.numX() == outerIdx + 1);
 
             const auto& underSaturatedTable = pvtgTable.getUnderSaturatedTable(outerIdx);
-            size_t numRows = underSaturatedTable.numRows();
-            for (size_t innerIdx = 0; innerIdx < numRows; ++innerIdx) {
+            std::size_t numRows = underSaturatedTable.numRows();
+            for (std::size_t innerIdx = 0; innerIdx < numRows; ++innerIdx) {
                 Scalar Rv = underSaturatedTable.get("RV" , innerIdx);
                 Scalar Bg = underSaturatedTable.get("BG" , innerIdx);
                 Scalar mug = underSaturatedTable.get("MUG" , innerIdx);
@@ -260,7 +260,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
             // find the master table which will be used as a template to extend the
             // current line. We define master table as the first table which has values
             // for undersaturated gas...
-            size_t masterTableIdx = xIdx + 1;
+            std::size_t masterTableIdx = xIdx + 1;
             for (; masterTableIdx < saturatedTable.numRows(); ++masterTableIdx)
             {
                 if (pvtgTable.getUnderSaturatedTable(masterTableIdx).numRows() > 1)
@@ -304,7 +304,7 @@ extendPvtgwTable_(unsigned regionIdx,
     auto& invGasBRvSat = inverseGasBRvSat_[regionIdx];
     auto& gasMuRvSat = gasMuRvSat_[regionIdx];
 
-    for (size_t newRowIdx = 1; newRowIdx < masterTable.numRows(); ++newRowIdx) {
+    for (std::size_t newRowIdx = 1; newRowIdx < masterTable.numRows(); ++newRowIdx) {
         const auto& RVColumn = masterTable.getColumn("RW");
         const auto& BGColumn = masterTable.getColumn("BG");
         const auto& viscosityColumn = masterTable.getColumn("MUG");
@@ -357,7 +357,7 @@ extendPvtgTable_(unsigned regionIdx,
     auto& invGasBRvwSat= inverseGasBRvwSat_[regionIdx];
     auto& gasMuRvwSat = gasMuRvwSat_[regionIdx];
 
-    for (size_t newRowIdx = 1; newRowIdx < masterTable.numRows(); ++newRowIdx) {
+    for (std::size_t newRowIdx = 1; newRowIdx < masterTable.numRows(); ++newRowIdx) {
         const auto& RVColumn = masterTable.getColumn("RV");
         const auto& BGColumn = masterTable.getColumn("BG");
         const auto& viscosityColumn = masterTable.getColumn("MUG");
@@ -398,7 +398,7 @@ extendPvtgTable_(unsigned regionIdx,
 #endif
 
 template<class Scalar>
-void WetHumidGasPvt<Scalar>::setNumRegions(size_t numRegions)
+void WetHumidGasPvt<Scalar>::setNumRegions(std::size_t numRegions)
 {
     waterReferenceDensity_.resize(numRegions);
     oilReferenceDensity_.resize(numRegions);
@@ -435,7 +435,7 @@ void WetHumidGasPvt<Scalar>::initEnd()
 
     //PVTGW
     // calculate the final 2D functions which are used for interpolation.
-    size_t numRegions = gasMuRvSat_.size();
+    std::size_t numRegions = gasMuRvSat_.size();
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
         // calculate the table which stores the inverse of the product of the gas
         // formation volume factor and the gas viscosity
@@ -450,13 +450,13 @@ void WetHumidGasPvt<Scalar>::initEnd()
         std::vector<Scalar> satPressuresArray;
         std::vector<Scalar> invSatGasBArray;
         std::vector<Scalar> invSatGasBMuArray;
-        for (size_t pIdx = 0; pIdx < gasMuRvSat.numX(); ++pIdx) {
+        for (std::size_t pIdx = 0; pIdx < gasMuRvSat.numX(); ++pIdx) {
             invGasBMuRvSat.appendXPos(gasMuRvSat.xAt(pIdx));
 
             assert(gasMuRvSat.numY(pIdx) == invGasBRvSat.numY(pIdx));
 
-            size_t numRw = gasMuRvSat.numY(pIdx);
-            for (size_t RwIdx = 0; RwIdx < numRw; ++RwIdx)
+            std::size_t numRw = gasMuRvSat.numY(pIdx);
+            for (std::size_t RwIdx = 0; RwIdx < numRw; ++RwIdx)
                 invGasBMuRvSat.appendSamplePoint(pIdx,
                                             gasMuRvSat.yAt(pIdx, RwIdx),
                                             invGasBRvSat.valueAt(pIdx, RwIdx)
@@ -476,7 +476,7 @@ void WetHumidGasPvt<Scalar>::initEnd()
 
     //PVTG
     // calculate the final 2D functions which are used for interpolation.
-    //size_t numRegions = gasMuRvwSat_.size();
+    //std::size_t numRegions = gasMuRvwSat_.size();
     for (unsigned regionIdx = 0; regionIdx < numRegions; ++ regionIdx) {
         // calculate the table which stores the inverse of the product of the gas
         // formation volume factor and the gas viscosity
@@ -491,13 +491,13 @@ void WetHumidGasPvt<Scalar>::initEnd()
         std::vector<Scalar> satPressuresArray;
         std::vector<Scalar> invSatGasBArray;
         std::vector<Scalar> invSatGasBMuArray;
-        for (size_t pIdx = 0; pIdx < gasMuRvwSat.numX(); ++pIdx) {
+        for (std::size_t pIdx = 0; pIdx < gasMuRvwSat.numX(); ++pIdx) {
             invGasBMuRvwSat.appendXPos(gasMuRvwSat.xAt(pIdx));
 
             assert(gasMuRvwSat.numY(pIdx) == invGasBRvwSat.numY(pIdx));
 
-            size_t numRw = gasMuRvwSat.numY(pIdx);
-            for (size_t RwIdx = 0; RwIdx < numRw; ++RwIdx)
+            std::size_t numRw = gasMuRvwSat.numY(pIdx);
+            for (std::size_t RwIdx = 0; RwIdx < numRw; ++RwIdx)
                 invGasBMuRvwSat.appendSamplePoint(pIdx,
                                             gasMuRvwSat.yAt(pIdx, RwIdx),
                                             invGasBRvwSat.valueAt(pIdx, RwIdx)
@@ -526,12 +526,12 @@ updateSaturationPressure_(unsigned regionIdx)
 
     // create the taublated function representing saturation pressure depending of
     // Rv
-    size_t n = oilVaporizationFac.numSamples();
+    std::size_t n = oilVaporizationFac.numSamples();
     Scalar delta = (oilVaporizationFac.xMax() - oilVaporizationFac.xMin())/Scalar(n + 1);
 
     SamplingPoints pSatSamplePoints;
     Scalar Rv = 0;
-    for (size_t i = 0; i <= n; ++ i) {
+    for (std::size_t i = 0; i <= n; ++ i) {
         Scalar pSat = oilVaporizationFac.xMin() + Scalar(i)*delta;
         Rv = saturatedOilVaporizationFactor(regionIdx, /*temperature=*/Scalar(1e30), pSat);
 


### PR DESCRIPTION
- move more code to translation units
- use std::size_t
- cosmetics

also fixes build the multiplexers that i introduced yesterday - we now need the translation units even if ECL_INPUT is not enabled.