### PR TITLE
avoid OPM_THROW in gpu code

### DIFF
--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -231,7 +231,11 @@ private:
                 }
             }
             else{
+#if OPM_IS_INSIDE_DEVICE_FUNCTION
+                assert(false && "Saturation values in interpolation table provided in wrong order, but table is immutable");
+#else
                 OPM_THROW(std::logic_error, "Saturation values in interpolation table provided in wrong order, but table is immutable");
+#endif
             }
         }
     }


### PR DESCRIPTION
OPM_THROW is not supported in gpu code, replaced with an assert in the device code