### PR TITLE
Prepare for Restarting Models With Segment Level UDQs

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WellTestState.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestState.cpp
@@ -16,14 +16,22 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <algorithm>
-#include <cassert>
-#include <ctime>
-#include <stdexcept>
+
+#include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
+
+#include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
-#include <opm/common/OpmLog/OpmLog.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <ctime>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 namespace Opm {
 

--- a/opm/input/eclipse/Schedule/Well/WellTestState.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestState.hpp
@@ -20,12 +20,15 @@
 #define WELLTEST_STATE_H
 
 #include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>
+
 #include <opm/io/eclipse/rst/state.hpp>
 
 #include <cstddef>
+#include <ctime>
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace {

--- a/test_util/EclRegressionTest.cpp
+++ b/test_util/EclRegressionTest.cpp
@@ -41,6 +41,7 @@
 #include <iostream>
 #include <set>
 #include <typeinfo>
+#include <unordered_set>
 #include <vector>
 
 // helper macro to handle error throws or not

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -919,10 +919,16 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
             for (const auto& input_assign : input_config.assignments()) {
                 const auto& rst_assign = rst_config.assign(input_assign.keyword());
 
-                auto input_eval = input_assign.eval(wells);
-                auto rst_eval = rst_assign.eval(wells);
+                const auto input_eval = input_assign.eval(wells);
+                const auto rst_eval = rst_assign.eval(wells);
 
-                BOOST_CHECK(input_eval == rst_eval);
+                BOOST_CHECK_MESSAGE(input_eval == rst_eval,
+                                    "UDQ assignments for '"
+                                    << rst_assign.keyword() <<
+                                    "' of type "
+                                    << Opm::UDQ::typeName(rst_assign.var_type())
+                                    << " must provide the same "
+                                    "values in both input and restart cases.");
             }
 
             const auto uda_records =

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -1,4 +1,3 @@
-
 /*
   Copyright 2014 Statoil IT
   This file is part of the Open Porous Media project (OPM).
@@ -61,7 +60,10 @@
 
 #include "tests/WorkArea.hpp"
 
-void verifyWellState(const std::string& rst_filename, const Opm::Schedule& schedule) {
+namespace {
+
+void verifyWellState(const std::string& rst_filename, const Opm::Schedule& schedule)
+{
 
   /*
       reference variables ref_wellList, ref_wellHead and ref_wellConn are 
@@ -208,9 +210,10 @@ void verifyWellState(const std::string& rst_filename, const Opm::Schedule& sched
     }
 }
 
+} // Anonymous namespace
 
-BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
-
+BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo)
+{
     WorkArea work;
     std::string eclipse_data_filename    = "testblackoilstate3.DATA";
     work.copyIn(eclipse_data_filename);


### PR DESCRIPTION
In particular

  - Explicitly include some headers that will not be available through transitive inclusion
  - Remove some unneeded objects/helper functions
  - Move helper functions into anonymous namespaces where appropriate
  - Re-sort `#include` statements