### PR TITLE
Generalise Restart Representation of UDQs

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQAssign.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQAssign.cpp
@@ -19,6 +19,8 @@
 
 #include <opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp>
 
+#include <opm/io/eclipse/rst/udq.hpp>
+
 #include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQSet.hpp>
 
@@ -36,18 +38,12 @@ namespace Opm {
 void UDQAssign::AssignRecord::eval(UDQSet& values) const
 {
     if (this->input_selector.empty() &&
-        this->rst_selector.empty() &&
         this->numbered_selector.empty())
     {
         values.assign(this->value);
     }
     else if (! this->input_selector.empty()) {
         values.assign(this->input_selector[0], this->value);
-    }
-    else if (! this->rst_selector.empty()) {
-        for (const auto& wgname : this->rst_selector) {
-            values.assign(wgname, this->value);
-        }
     }
     else {
         for (const auto& item : this->numbered_selector) {
@@ -61,11 +57,12 @@ void UDQAssign::AssignRecord::eval(UDQSet& values) const
 bool UDQAssign::AssignRecord::operator==(const AssignRecord& data) const
 {
     return (this->input_selector == data.input_selector)
-        && (this->rst_selector == data.rst_selector)
         && (this->numbered_selector == data.numbered_selector)
         && (this->report_step == data.report_step)
         && (this->value == data.value);
 }
+
+// ---------------------------------------------------------------------------
 
 UDQAssign::UDQAssign(const std::string&              keyword,
                      const std::vector<std::string>& input_selector,
@@ -75,16 +72,6 @@ UDQAssign::UDQAssign(const std::string&              keyword,
     , m_var_type(UDQ::varType(keyword))
 {
     this->add_record(input_selector, value, report_step);
-}
-
-UDQAssign::UDQAssign(const std::string&                     keyword,
-                     const std::unordered_set<std::string>& rst_selector,
-                     const double                           value,
-                     const std::size_t                      report_step)
-    : m_keyword (keyword)
-    , m_var_type(UDQ::varType(keyword))
-{
-    this->add_record(rst_selector, value, report_step);
 }
 
 UDQAssign::UDQAssign(const std::string&                          keyword,
@@ -107,14 +94,21 @@ UDQAssign::UDQAssign(const std::string&                     keyword,
     this->add_record(std::move(selector), value, report_step);
 }
 
+UDQAssign::UDQAssign(const std::string&       keyword,
+                     const RestartIO::RstUDQ& assignRst,
+                     const std::size_t        report_step)
+    : m_keyword  { keyword }
+    , m_var_type { assignRst.category }
+{
+    this->add_record(assignRst, report_step);
+}
+
 UDQAssign UDQAssign::serializationTestObject()
 {
     UDQAssign result;
     result.m_keyword = "test";
     result.m_var_type = UDQVarType::CONNECTION_VAR;
     result.records.emplace_back(std::vector<std::string>{"test1"}, 1.0, 0);
-
-    result.records.emplace_back(std::unordered_set<std::string>{ "I-45" }, 3.1415, 3);
 
     // Class-template argument deduction for the vector element type.
     result.records.emplace_back(std::vector { UDQSet::EnumeratedItems::serializationTestObject() }, 2.71828, 42);
@@ -129,13 +123,6 @@ void UDQAssign::add_record(const std::vector<std::string>& input_selector,
     this->records.emplace_back(input_selector, value, report_step);
 }
 
-void UDQAssign::add_record(const std::unordered_set<std::string>& rst_selector,
-                           const double                           value,
-                           const std::size_t                      report_step)
-{
-    this->records.emplace_back(rst_selector, value, report_step);
-}
-
 void UDQAssign::add_record(const std::vector<UDQSet::EnumeratedItems>& selector,
                            const double                                value,
                            const std::size_t                           report_step)
@@ -148,6 +135,34 @@ void UDQAssign::add_record(std::vector<UDQSet::EnumeratedItems>&& selector,
                            const std::size_t                      report_step)
 {
     this->records.emplace_back(std::move(selector), value, report_step);
+}
+
+void UDQAssign::add_record(const RestartIO::RstUDQ& assignRst,
+                           const std::size_t        report_step)
+{
+    if (assignRst.name != this->m_keyword) {
+        throw std::invalid_argument {
+            fmt::format("ASSIGN UDQ '{}' must not attempt to include "
+                        "information for unrelated UDQ '{}' from restart file.",
+                        this->m_keyword, assignRst.name)
+        };
+    }
+
+    switch (assignRst.category) {
+    case UDQVarType::SCALAR:
+    case UDQVarType::FIELD_VAR:
+        this->add_record(assignRst.entityNames(),
+                         assignRst.scalarValue(), report_step);
+        break;
+
+    case UDQVarType::WELL_VAR:
+    case UDQVarType::GROUP_VAR:
+        this->add_well_or_group_records(assignRst, report_step);
+        break;
+
+    default:
+        break;
+    }
 }
 
 const std::string& UDQAssign::keyword() const
@@ -223,6 +238,32 @@ bool UDQAssign::operator==(const UDQAssign& data) const
     return (this->keyword() == data.keyword())
         && (this->var_type() == data.var_type())
         && (this->records == data.records);
+}
+
+// ---------------------------------------------------------------------------
+// Private member functions below separator
+// ---------------------------------------------------------------------------
+
+void UDQAssign::add_well_or_group_records(const RestartIO::RstUDQ& assignRst,
+                                          const std::size_t        report_step)
+{
+    const auto& wgnames = assignRst.entityNames();
+    const auto& nameIdx = assignRst.nameIndex();
+    const auto n = assignRst.numEntities();
+
+    // Note: We intentionally allocate a single selector string and reuse
+    // that for every add_record() call.  The loop here guarantees that we
+    // handle the case of different values for well or group, albeit at the
+    // cost of the 'records' data member being larger than necessary if all
+    // entities do have the same value.
+    auto selector = std::vector<std::string>(1);
+
+    for (auto i = 0*n; i < n; ++i) {
+        for (const auto& subValuePair : assignRst[i]) {
+            selector.front() = wgnames[nameIdx[i]];
+            this->add_record(selector, subValuePair.second, report_step);
+        }
+    }
 }
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -442,6 +442,15 @@ namespace Opm {
                              });
     }
 
+    void UDQConfig::exportTypeCount(std::array<int, static_cast<std::size_t>(UDQVarType::NumTypes)>& count) const
+    {
+        count.fill(0);
+
+        for (const auto& [type, cnt] : this->type_count) {
+            count[static_cast<std::size_t>(type)] = cnt;
+        }
+    }
+
     std::vector<UDQAssign> UDQConfig::assignments() const
     {
         std::vector<UDQAssign> ret;

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -20,6 +20,7 @@
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 
 #include <opm/io/eclipse/rst/state.hpp>
+#include <opm/io/eclipse/rst/udq.hpp>
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
@@ -142,35 +143,23 @@ namespace {
 namespace Opm {
 
     UDQConfig::UDQConfig(const UDQParams& params)
-        : udq_params(params)
-        , udqft(this->udq_params)
+        : udq_params { params }
+        , udqft      { udq_params }
     {}
 
-    UDQConfig::UDQConfig(const UDQParams& params, const RestartIO::RstState& rst_state)
-        : UDQConfig(params)
+    UDQConfig::UDQConfig(const UDQParams&           params,
+                         const RestartIO::RstState& rst_state)
+        : UDQConfig { params }
     {
-        for (const auto& rst_udq : rst_state.udqs) {
-            if (rst_udq.is_define()) {
-                KeywordLocation location("UDQ", "Restart file", 0);
-                this->add_define(rst_udq.name,
-                                 location,
-                                 { rst_udq.expression() },
-                                 rst_state.header.report_step);
-
-                auto pos = this->m_definitions.find(rst_udq.name);
-                assert (pos != this->m_definitions.end());
-
-                pos->second.update_status(rst_udq.updateStatus(),
-                                          rst_state.header.report_step);
+        for (const auto& udq : rst_state.udqs) {
+            if (udq.isDefine()) {
+                this->add_define(udq, rst_state.header.report_step);
             }
             else {
-                this->add_assign(rst_udq.name,
-                                 rst_udq.assign_selector(),
-                                 rst_udq.assign_value(),
-                                 rst_state.header.report_step);
+                this->add_assign(udq, rst_state.header.report_step);
             }
 
-            this->add_unit(rst_udq.name, rst_udq.unit);
+            this->add_unit(udq.name, udq.unit);
         }
     }
 
@@ -190,87 +179,60 @@ namespace Opm {
         return result;
     }
 
-    const UDQParams& UDQConfig::params() const
+    const std::string& UDQConfig::unit(const std::string& key) const
     {
-        return this->udq_params;
+        const auto pair_ptr = this->units.find(key);
+        if (pair_ptr == this->units.end()) {
+            throw std::invalid_argument("No such UDQ quantity: " + key);
+        }
+
+        return pair_ptr->second;
     }
 
-    void UDQConfig::add_node(const std::string& quantity, const UDQAction action)
+    bool UDQConfig::has_unit(const std::string& keyword) const
     {
-        auto index_iter = this->input_index.find(quantity);
-        if (this->input_index.find(quantity) == this->input_index.end()) {
-            auto var_type = UDQ::varType(quantity);
-            auto insert_index = this->input_index.size();
+        return this->units.find(keyword) != this->units.end();
+    }
 
-            this->type_count[var_type] += 1;
-            this->input_index[quantity] = UDQIndex(insert_index, this->type_count[var_type], action, var_type);
+    bool UDQConfig::has_keyword(const std::string& keyword) const
+    {
+        return (this->m_assignments.find(keyword) != this->m_assignments.end())
+            || (this->m_definitions.find(keyword) != this->m_definitions.end());
+    }
+
+    void UDQConfig::add_record(SegmentMatcherFactory  create_segment_matcher,
+                               const DeckRecord&      record,
+                               const KeywordLocation& location,
+                               const std::size_t      report_step)
+    {
+        using KW = ParserKeywords::UDQ;
+
+        const auto action = UDQ::actionType(record.getItem<KW::ACTION>().get<RawString>(0));
+        const auto& quantity = record.getItem<KW::QUANTITY>().get<std::string>(0);
+        const auto data = RawString::strings(record.getItem<KW::DATA>().getData<RawString>());
+
+        if (action == UDQAction::UPDATE) {
+            this->add_update(quantity, report_step, location, data);
+        }
+        else if (action == UDQAction::UNITS) {
+            this->add_unit(quantity, data.front());
+        }
+        else if (action == UDQAction::ASSIGN) {
+            auto selector = std::vector<std::string>(data.begin(), data.end() - 1);
+            std::transform(selector.cbegin(), selector.cend(), selector.begin(), strip_quotes);
+            const auto value = std::stod(data.back());
+            this->add_assign(quantity,
+                             std::move(create_segment_matcher),
+                             selector, value, report_step);
+        }
+        else if (action == UDQAction::DEFINE) {
+            this->add_define(quantity, location, data, report_step);
         }
         else {
-            index_iter->second.action = action;
+            throw std::runtime_error {
+                "Unknown UDQ Operation " + std::to_string(static_cast<int>(action))
+            };
         }
-    }
-
-    void UDQConfig::add_assign(const std::string&              quantity,
-                               SegmentMatcherFactory           create_segment_matcher,
-                               const std::vector<std::string>& selector,
-                               const double                    value,
-                               const std::size_t               report_step)
-    {
-        this->add_node(quantity, UDQAction::ASSIGN);
-
-        switch (UDQ::varType(quantity)) {
-        case UDQVarType::SEGMENT_VAR:
-            this->add_enumerated_assign(quantity,
-                                        std::move(create_segment_matcher),
-                                        selector, value, report_step);
-            break;
-
-        default:
-            this->add_named_assign(quantity, selector, value, report_step);
-            break;
-        }
-
-        if (this->m_assignments.find(quantity) != this->m_assignments.end()) {
-            this->pending_assignments_.push_back(quantity);
-        }
-    }
-
-    void UDQConfig::add_assign(const std::string&                     quantity,
-                               const std::unordered_set<std::string>& selector,
-                               const double                           value,
-                               const std::size_t                      report_step)
-    {
-        this->add_node(quantity, UDQAction::ASSIGN);
-
-        auto assignment = this->m_assignments.find(quantity);
-        if (assignment == this->m_assignments.end()) {
-            this->m_assignments.emplace(std::piecewise_construct,
-                                        std::forward_as_tuple(quantity),
-                                        std::forward_as_tuple(quantity, selector,
-                                                              value, report_step));
-        }
-        else {
-            assignment->second.add_record(selector, value, report_step);
-        }
-    }
-
-    void UDQConfig::add_define(const std::string&              quantity,
-                               const KeywordLocation&          location,
-                               const std::vector<std::string>& expression,
-                               const std::size_t               report_step)
-    {
-        this->add_node(quantity, UDQAction::DEFINE);
-
-        this->m_definitions.insert_or_assign(quantity,
-                                             UDQDefine {
-                                                 this->udq_params,
-                                                 quantity,
-                                                 report_step,
-                                                 location,
-                                                 expression
-                                             });
-
-        this->define_order.insert(quantity);
     }
 
     void UDQConfig::add_unit(const std::string& keyword, const std::string& quoted_unit)
@@ -318,39 +280,48 @@ namespace Opm {
         def.update_status(update_status, report_step);
     }
 
-    void UDQConfig::add_record(SegmentMatcherFactory  create_segment_matcher,
-                               const DeckRecord&      record,
-                               const KeywordLocation& location,
-                               const std::size_t      report_step)
+    void UDQConfig::add_assign(const std::string&              quantity,
+                               SegmentMatcherFactory           create_segment_matcher,
+                               const std::vector<std::string>& selector,
+                               const double                    value,
+                               const std::size_t               report_step)
     {
-        using KW = ParserKeywords::UDQ;
+        this->add_node(quantity, UDQAction::ASSIGN);
 
-        const auto action = UDQ::actionType(record.getItem<KW::ACTION>().get<RawString>(0));
-        const auto& quantity = record.getItem<KW::QUANTITY>().get<std::string>(0);
-        const auto data = RawString::strings(record.getItem<KW::DATA>().getData<RawString>());
+        switch (UDQ::varType(quantity)) {
+        case UDQVarType::SEGMENT_VAR:
+            this->add_enumerated_assign(quantity,
+                                        std::move(create_segment_matcher),
+                                        selector, value, report_step);
+            break;
 
-        if (action == UDQAction::UPDATE) {
-            this->add_update(quantity, report_step, location, data);
+        default:
+            this->add_assign_impl(quantity, selector, value, report_step);
+            break;
         }
-        else if (action == UDQAction::UNITS) {
-            this->add_unit(quantity, data.front());
+
+        if (this->m_assignments.find(quantity) != this->m_assignments.end()) {
+            this->pending_assignments_.push_back(quantity);
         }
-        else if (action == UDQAction::ASSIGN) {
-            auto selector = std::vector<std::string>(data.begin(), data.end() - 1);
-            std::transform(selector.cbegin(), selector.cend(), selector.begin(), strip_quotes);
-            const auto value = std::stod(data.back());
-            this->add_assign(quantity,
-                             std::move(create_segment_matcher),
-                             selector, value, report_step);
-        }
-        else if (action == UDQAction::DEFINE) {
-            this->add_define(quantity, location, data, report_step);
-        }
-        else {
-            throw std::runtime_error {
-                "Unknown UDQ Operation " + std::to_string(static_cast<int>(action))
-            };
-        }
+    }
+
+    void UDQConfig::add_define(const std::string&              quantity,
+                               const KeywordLocation&          location,
+                               const std::vector<std::string>& expression,
+                               const std::size_t               report_step)
+    {
+        this->add_node(quantity, UDQAction::DEFINE);
+
+        this->m_definitions.insert_or_assign(quantity,
+                                             UDQDefine {
+                                                 this->udq_params,
+                                                 quantity,
+                                                 report_step,
+                                                 location,
+                                                 expression
+                                             });
+
+        this->define_order.insert(quantity);
     }
 
     void UDQConfig::add_table(const std::string& name, UDT udt)
@@ -366,9 +337,43 @@ namespace Opm {
         return update;
     }
 
-    const UDQAssign& UDQConfig::assign(const std::string& key) const
+    void UDQConfig::eval_assign(const std::size_t     report_step,
+                                const Schedule&       sched,
+                                const WellMatcher&    wm,
+                                SegmentMatcherFactory create_segment_matcher,
+                                SummaryState&         st,
+                                UDQState&             udq_state) const
     {
-        return this->m_assignments.at(key);
+        auto factories = UDQContext::MatcherFactories{};
+        factories.segments = std::move(create_segment_matcher);
+
+        auto context = UDQContext {
+            this->function_table(), wm, this->m_tables,
+            std::move(factories), st, udq_state
+        };
+
+        this->eval_assign(report_step, sched, context);
+    }
+
+    void UDQConfig::eval(const std::size_t       report_step,
+                         const Schedule&         sched,
+                         const WellMatcher&      wm,
+                         SegmentMatcherFactory   create_segment_matcher,
+                         RegionSetMatcherFactory create_region_matcher,
+                         SummaryState&           st,
+                         UDQState&               udq_state) const
+    {
+        auto factories = UDQContext::MatcherFactories {};
+        factories.segments = std::move(create_segment_matcher);
+        factories.regions  = std::move(create_region_matcher);
+
+        auto context = UDQContext {
+            this->function_table(), wm, this->m_tables,
+            std::move(factories), st, udq_state
+        };
+
+        this->eval_assign(report_step, sched, context);
+        this->eval_define(report_step, udq_state, context);
     }
 
     const UDQDefine& UDQConfig::define(const std::string& key) const
@@ -376,10 +381,9 @@ namespace Opm {
         return this->m_definitions.at(key);
     }
 
-    UDQAction UDQConfig::action_type(const std::string& udq_key) const
+    const UDQAssign& UDQConfig::assign(const std::string& key) const
     {
-        auto action_iter = this->input_index.find(udq_key);
-        return action_iter->second.action;
+        return this->m_assignments.at(key);
     }
 
     std::vector<UDQDefine> UDQConfig::definitions() const
@@ -430,6 +434,15 @@ namespace Opm {
         return res;
     }
 
+    void UDQConfig::exportTypeCount(std::array<int, static_cast<std::size_t>(UDQVarType::NumTypes)>& count) const
+    {
+        count.fill(0);
+
+        for (const auto& [type, cnt] : this->type_count) {
+            count[static_cast<std::size_t>(type)] = cnt;
+        }
+    }
+
     std::size_t UDQConfig::size() const
     {
         return std::count_if(this->input_index.begin(), this->input_index.end(),
@@ -440,65 +453,6 @@ namespace Opm {
                                  return (action == UDQAction::DEFINE)
                                      || (action == UDQAction::ASSIGN);
                              });
-    }
-
-    void UDQConfig::exportTypeCount(std::array<int, static_cast<std::size_t>(UDQVarType::NumTypes)>& count) const
-    {
-        count.fill(0);
-
-        for (const auto& [type, cnt] : this->type_count) {
-            count[static_cast<std::size_t>(type)] = cnt;
-        }
-    }
-
-    std::vector<UDQAssign> UDQConfig::assignments() const
-    {
-        std::vector<UDQAssign> ret;
-
-        for (const auto& [key, Input] : this->input_index) {
-            if (Input.action == UDQAction::ASSIGN) {
-                ret.push_back(this->m_assignments.at(key));
-            }
-        }
-
-        return ret;
-    }
-
-    std::vector<UDQAssign> UDQConfig::assignments(const UDQVarType var_type) const
-    {
-        std::vector<UDQAssign> filtered_assigns;
-
-        for (const auto& index_pair : this->input_index) {
-            auto assign_iter = this->m_assignments.find(index_pair.first);
-            if ((assign_iter != this->m_assignments.end()) &&
-                (assign_iter->second.var_type() == var_type))
-            {
-                filtered_assigns.push_back(assign_iter->second);
-            }
-        }
-
-        return filtered_assigns;
-    }
-
-    const std::string& UDQConfig::unit(const std::string& key) const
-    {
-        const auto pair_ptr = this->units.find(key);
-        if (pair_ptr == this->units.end()) {
-            throw std::invalid_argument("No such UDQ quantity: " + key);
-        }
-
-        return pair_ptr->second;
-    }
-
-    bool UDQConfig::has_unit(const std::string& keyword) const
-    {
-        return this->units.find(keyword) != this->units.end();
-    }
-
-    bool UDQConfig::has_keyword(const std::string& keyword) const
-    {
-        return (this->m_assignments.find(keyword) != this->m_assignments.end())
-            || (this->m_definitions.find(keyword) != this->m_definitions.end());
     }
 
     UDQInput UDQConfig::operator[](const std::string& keyword) const
@@ -550,6 +504,40 @@ namespace Opm {
         throw std::logic_error("Internal error - should not be here");
     }
 
+    std::vector<UDQAssign> UDQConfig::assignments() const
+    {
+        std::vector<UDQAssign> ret;
+
+        for (const auto& [key, Input] : this->input_index) {
+            if (Input.action == UDQAction::ASSIGN) {
+                ret.push_back(this->m_assignments.at(key));
+            }
+        }
+
+        return ret;
+    }
+
+    std::vector<UDQAssign> UDQConfig::assignments(const UDQVarType var_type) const
+    {
+        std::vector<UDQAssign> filtered_assigns;
+
+        for (const auto& index_pair : this->input_index) {
+            auto assign_iter = this->m_assignments.find(index_pair.first);
+            if ((assign_iter != this->m_assignments.end()) &&
+                (assign_iter->second.var_type() == var_type))
+            {
+                filtered_assigns.push_back(assign_iter->second);
+            }
+        }
+
+        return filtered_assigns;
+    }
+
+    const UDQParams& UDQConfig::params() const
+    {
+        return this->udq_params;
+    }
+
     const UDQFunctionTable& UDQConfig::function_table() const
     {
         return this->udqft;
@@ -572,6 +560,59 @@ namespace Opm {
             && (this->type_count == data.type_count)
             && (this->pending_assignments_ == data.pending_assignments_)
             ;
+    }
+
+    void UDQConfig::required_summary(std::unordered_set<std::string>& summary_keys) const
+    {
+        for (const auto& def_pair : this->m_definitions) {
+            def_pair.second.required_summary(summary_keys);
+        }
+    }
+
+    // ===========================================================================
+    // Private member functions below separator
+    // ===========================================================================
+
+    void UDQConfig::add_node(const std::string& quantity, const UDQAction action)
+    {
+        auto index_iter = this->input_index.find(quantity);
+        if (this->input_index.find(quantity) == this->input_index.end()) {
+            auto var_type = UDQ::varType(quantity);
+            auto insert_index = this->input_index.size();
+
+            this->type_count[var_type] += 1;
+            this->input_index[quantity] = UDQIndex(insert_index, this->type_count[var_type], action, var_type);
+        }
+        else {
+            index_iter->second.action = action;
+        }
+    }
+
+    UDQAction UDQConfig::action_type(const std::string& udq_key) const
+    {
+        auto action_iter = this->input_index.find(udq_key);
+        return action_iter->second.action;
+    }
+
+    void UDQConfig::add_assign(const RestartIO::RstUDQ& udq,
+                               const std::size_t        report_step)
+    {
+        this->add_node(udq.name, UDQAction::ASSIGN);
+
+        this->add_assign_impl(udq.name, udq, report_step);
+    }
+
+    void UDQConfig::add_define(const RestartIO::RstUDQ& udq,
+                               const std::size_t        report_step)
+    {
+        this->add_define(udq.name, KeywordLocation { "UDQ", "Restart file", 0 },
+                         std::vector { std::string { udq.definingExpression() } },
+                         report_step);
+
+        auto pos = this->m_definitions.find(udq.name);
+        assert (pos != this->m_definitions.end());
+
+        pos->second.update_status(udq.currentUpdateStatus(), report_step);
     }
 
     void UDQConfig::eval_assign(const std::size_t report_step,
@@ -655,67 +696,6 @@ namespace Opm {
         }
     }
 
-    void UDQConfig::eval(const std::size_t       report_step,
-                         const Schedule&         sched,
-                         const WellMatcher&      wm,
-                         SegmentMatcherFactory   create_segment_matcher,
-                         RegionSetMatcherFactory create_region_matcher,
-                         SummaryState&           st,
-                         UDQState&               udq_state) const
-    {
-        auto factories = UDQContext::MatcherFactories {};
-        factories.segments = std::move(create_segment_matcher);
-        factories.regions  = std::move(create_region_matcher);
-
-        auto context = UDQContext {
-            this->function_table(), wm, this->m_tables,
-            std::move(factories), st, udq_state
-        };
-
-        this->eval_assign(report_step, sched, context);
-        this->eval_define(report_step, udq_state, context);
-    }
-
-    void UDQConfig::eval_assign(const std::size_t     report_step,
-                                const Schedule&       sched,
-                                const WellMatcher&    wm,
-                                SegmentMatcherFactory create_segment_matcher,
-                                SummaryState&         st,
-                                UDQState&             udq_state) const
-    {
-        auto factories = UDQContext::MatcherFactories{};
-        factories.segments = std::move(create_segment_matcher);
-
-        auto context = UDQContext {
-            this->function_table(), wm, this->m_tables,
-            std::move(factories), st, udq_state
-        };
-
-        this->eval_assign(report_step, sched, context);
-    }
-
-    void UDQConfig::required_summary(std::unordered_set<std::string>& summary_keys) const
-    {
-        for (const auto& def_pair : this->m_definitions) {
-            def_pair.second.required_summary(summary_keys);
-        }
-    }
-
-    void UDQConfig::add_named_assign(const std::string&              quantity,
-                                     const std::vector<std::string>& selector,
-                                     const double                    value,
-                                     const std::size_t               report_step)
-    {
-        auto [asgnPos, inserted] = this->m_assignments
-            .emplace(std::piecewise_construct,
-                     std::forward_as_tuple(quantity),
-                     std::forward_as_tuple(quantity, selector, value, report_step));
-
-        if (! inserted) {
-            asgnPos->second.add_record(selector, value, report_step);
-        }
-    }
-
     void UDQConfig::add_enumerated_assign(const std::string&              quantity,
                                           SegmentMatcherFactory           create_segment_matcher,
                                           const std::vector<std::string>& selector,
@@ -735,14 +715,7 @@ namespace Opm {
         auto items = UDQSet::
             enumerateItems(segmentMatcher->findSegments(setDescriptor));
 
-        auto [asgnPos, inserted] = this->m_assignments
-            .emplace(std::piecewise_construct,
-                     std::forward_as_tuple(quantity),
-                     std::forward_as_tuple(quantity, items, value, report_step));
-
-        if (! inserted) {
-            asgnPos->second.add_record(std::move(items), value, report_step);
-        }
+        this->add_assign_impl(quantity, std::move(items), value, report_step);
     }
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -588,12 +588,6 @@ namespace Opm {
         }
     }
 
-    UDQAction UDQConfig::action_type(const std::string& udq_key) const
-    {
-        auto action_iter = this->input_index.find(udq_key);
-        return action_iter->second.action;
-    }
-
     void UDQConfig::add_assign(const RestartIO::RstUDQ& udq,
                                const std::size_t        report_step)
     {

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
@@ -31,6 +31,7 @@
 #include <opm/input/eclipse/EclipseState/Util/OrderedMap.hpp>
 #include <opm/input/eclipse/EclipseState/Util/IOrderSet.hpp>
 
+#include <array>
 #include <cstddef>
 #include <functional>
 #include <map>
@@ -129,6 +130,8 @@ namespace Opm {
         std::vector<UDQDefine> definitions() const;
         std::vector<UDQDefine> definitions(UDQVarType var_type) const;
         std::vector<UDQInput> input() const;
+
+        void exportTypeCount(std::array<int, static_cast<std::size_t>(UDQVarType::NumTypes)>& count) const;
 
         // The size() method will return the number of active DEFINE and ASSIGN
         // statements; this will correspond to the length of the vector returned

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
@@ -39,6 +39,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace Opm {
@@ -54,61 +55,203 @@ namespace Opm {
 
 } // namespace Opm
 
-namespace Opm { namespace RestartIO {
+namespace Opm::RestartIO {
     struct RstState;
-}} // namespace Opm::RestartIO
+    class  RstUDQ;
+} // namespace Opm::RestartIO
 
 namespace Opm {
 
+    /// Collection of all user-defined quantities in the current simulation run
     class UDQConfig
     {
     public:
+        /// Factory function for constructing region set matchers.
         using RegionSetMatcherFactory = std::function<std::unique_ptr<RegionSetMatcher>()>;
+
+        /// Factory function for constructing segment set matchers.
         using SegmentMatcherFactory = std::function<std::unique_ptr<SegmentMatcher>()>;
 
+        /// Default constructor
         UDQConfig() = default;
+
+        /// Constructor
+        ///
+        /// Main constructor for a base run.
+        ///
+        /// \param[in] params UDQ parameters from UDQPARAM keyword.
         explicit UDQConfig(const UDQParams& params);
+
+        /// Constructor
+        ///
+        /// Main constructor for a restarted simulation run.
+        ///
+        /// \param[in] params UDQ parameters from UDQPARAM keyword.
+        ///
+        /// \param[in] rst_state Object state from restart file information.
         UDQConfig(const UDQParams& params, const RestartIO::RstState& rst_state);
 
+        /// Create a serialisation test object.
         static UDQConfig serializationTestObject();
 
+        /// Retrieve unit string for a particular UDQ
+        ///
+        /// \param[in] key Unqualified UDQ name such as FUNNY, GUITAR,
+        /// WURST, or SUSHI.
+        ///
+        /// \return Input unit string associated to \p key.  Throws an
+        /// exception of type \code std::invalid_argument \endcode if no
+        /// unit string exists for \p key.
         const std::string& unit(const std::string& key) const;
+
+        /// Query whether or not a particular UDQ has an associated unit
+        /// string.
+        ///
+        /// \param[in] keyword Unqualified UDQ name such as FUNNY, GUITAR,
+        /// WURST, or SUSHI.
+        ///
+        /// \return Whether or not there is a unit string associated to \p
+        /// keyword.
         bool has_unit(const std::string& keyword) const;
+
+        /// Query whether or not a particular UDQ exists in the collection.
+        ///
+        /// \param[in] keyword Unqualified UDQ name such as FUNNY, GUITAR,
+        /// WURST, or SUSHI.
+        ///
+        /// \return whether or not \p keyword exists in the collection.
         bool has_keyword(const std::string& keyword) const;
 
+        /// Incorporate a single UDQ record into the known collection
+        ///
+        /// \param[in] create_segment_matcher Factory function for
+        /// constructing segment set matchers.
+        ///
+        /// \param[in] record UDQ keyword record, such as a DEFINE, ASSIGN,
+        /// UPDATE, or UNIT statement.
+        ///
+        /// \param[in] location Input file/line information for the UDQ
+        /// record.  Mostly for diagnostic purposes.
+        ///
+        /// \param[in] report_step Time at which this record is encountered.
         void add_record(SegmentMatcherFactory  create_segment_matcher,
                         const DeckRecord&      record,
                         const KeywordLocation& location,
                         std::size_t            report_step);
 
+        /// Incorporate a unit string for a UDQ
+        ///
+        /// Implements the UNIT statement.
+        ///
+        /// \param[in] keyword Unqualified UDQ name such as FUNNY, GUITAR,
+        /// WURST, or SUSHI.
+        ///
+        /// \param[in] unit Unit string for UDQ \p keyword.
         void add_unit(const std::string& keyword,
                       const std::string& unit);
 
+        /// Incorporate update status change for a UDQ
+        ///
+        /// Implements the UPDATE statement
+        ///
+        /// \param[in] keyword Unqualified UDQ name such as FUNNY, GUITAR,
+        /// WURST, or SUSHI.
+        ///
+        /// \param[in] report_step Time at which this record is encountered.
+        ///
+        /// \param[in] location Input file/line information for the UDQ
+        /// record.  Mostly for diagnostic purposes.
+        ///
+        /// \param[in] data Update status.  Should be a single element
+        /// vector containing one of the status strings ON, OFF, or NEXT.
         void add_update(const std::string&              keyword,
                         std::size_t                     report_step,
                         const KeywordLocation&          location,
                         const std::vector<std::string>& data);
 
+        /// Incorporate a UDQ assignment.
+        ///
+        /// Implements the ASSIGN statement.
+        ///
+        /// \param[in] quantity Unqualified UDQ name such as FUNNY, GUITAR,
+        /// WURST, or SUSHI.
+        ///
+        /// \param[in] create_segment_matcher Factory function for
+        /// constructing segment set matchers.
+        ///
+        /// \param[in] selector UDQ set element selection to which this
+        /// assignment applies.  Might be a well name pattern if \p quantity
+        /// is a well level UDQ.
+        ///
+        /// \param[in] report_step Time at which this assignment statement
+        /// is encountered.
         void add_assign(const std::string&              quantity,
                         SegmentMatcherFactory           create_segment_matcher,
                         const std::vector<std::string>& selector,
                         double                          value,
                         std::size_t                     report_step);
 
-        void add_assign(const std::string&                     quantity,
-                        const std::unordered_set<std::string>& selector,
-                        double                                 value,
-                        std::size_t                            report_step);
-
+        /// Incorporate a UDQ defining expressions.
+        ///
+        /// Implements the DEFINE statement.
+        ///
+        /// \param[in] quantity Unqualified UDQ name such as FUNNY, GUITAR,
+        /// WURST, or SUSHI.
+        ///
+        /// \param[in] location Input file/line information for the UDQ
+        /// record.  Mostly for diagnostic purposes.
+        ///
+        /// \param[in] expression Defining expression for the UDQ.  Function
+        /// add_define() parses this expression into an abstract syntax tree
+        /// which is used in subsequent evaluation contexts.
+        ///
+        /// \param[in] report_step Time at which this assignment statement
+        /// is encountered.
         void add_define(const std::string&              quantity,
                         const KeywordLocation&          location,
                         const std::vector<std::string>& expression,
                         std::size_t                     report_step);
 
+        /// Incorporate a user defined table.
+        ///
+        /// Implements the UDT keyword.
+        ///
+        /// \param[in] name Name of user defined table.
+        ///
+        /// \param[in] udt Tabulated values.
         void add_table(const std::string& name, UDT udt);
 
+        /// Clear all pending assignments
+        ///
+        /// Clears all internal data structures of any assignment records.
+        /// Typically called at the end of a report step in order to signify
+        /// that all assignments have been applied.
+        ///
+        /// \return Whether or not there were any active assignments in the
+        /// internal representation.  Allows client code to take action, if
+        /// needed, based on the knowledge that all assignments have been
+        /// applied and to prepare for the next report step.
         bool clear_pending_assignments();
 
+        /// Apply all pending assignments.
+        ///
+        /// Assigns new UDQ values to both the summary and UDQ state objects.
+        ///
+        /// \param[in] report_step Current report step.
+        ///
+        /// \param[in] sched Full dynamic input schedule.
+        ///
+        /// \param[in] wm Well name pattern matcher.
+        ///
+        /// \param[in] create_segment_matcher Factory function for
+        /// constructing segment set matchers.
+        ///
+        /// \param[in,out] st Summary vectors.  For output and evaulating
+        /// ACTION condition purposes.  Values pertaining to UDQs being
+        /// assigned here will be updated.
+        ///
+        /// \param[in,out] udq_state Dynamic values for all known UDQs.
+        /// Values pertaining to UDQs being assigned here will be updated.
         void eval_assign(std::size_t           report_step,
                          const Schedule&       sched,
                          const WellMatcher&    wm,
@@ -116,6 +259,30 @@ namespace Opm {
                          SummaryState&         st,
                          UDQState&             udq_state) const;
 
+        /// Compute new values for all UDQs
+        ///
+        /// Uses both assignment and defining expressions as applicable.
+        /// Assigns new UDQ values to both the summary and UDQ state
+        /// objects.
+        ///
+        /// \param[in] report_step Current report step.
+        ///
+        /// \param[in] sched Full dynamic input schedule.
+        ///
+        /// \param[in] wm Well name pattern matcher.
+        ///
+        /// \param[in] create_segment_matcher Factory function for
+        /// constructing segment set matchers.
+        ///
+        /// \param[in] create_region_matcher Factory function for
+        /// constructing region set matchers.
+        ///
+        /// \param[in,out] st Summary vectors.  For output and evaulating
+        /// ACTION condition purposes.  Values pertaining to UDQs being
+        /// assigned here will be updated.
+        ///
+        /// \param[in,out] udq_state Dynamic values for all known UDQs.
+        /// Values pertaining to UDQs being assigned here will be updated.
         void eval(std::size_t             report_step,
                   const Schedule&         sched,
                   const WellMatcher&      wm,
@@ -124,32 +291,119 @@ namespace Opm {
                   SummaryState&           st,
                   UDQState&               udq_state) const;
 
+        /// Retrieve defining expression and evaluation object for a single
+        /// UDQ
+        ///
+        /// \param[in] key Unqualified UDQ name such as FUNNY, GUITAR,
+        /// WURST, or SUSHI.
+        ///
+        /// \return Defining expression and evaluation object for \p key.
+        /// Throws an exception of type \code std::out_of_range \endcode if
+        /// no such object exists for the UDQ \p key.
         const UDQDefine& define(const std::string& key) const;
+
+        /// Retrieve any pending assignment object for a single UDQ
+        ///
+        /// \param[in] key Unqualified UDQ name such as FUNNY, GUITAR,
+        /// WURST, or SUSHI.
+        ///
+        /// \return Pending assingment object for \p key.  Throws an
+        /// exception of type \code std::out_of_range \endcode if no such
+        /// object exists for the UDQ \p key.
         const UDQAssign& assign(const std::string& key) const;
 
+        /// Retrieve defining expressions and evaluation objects for all
+        /// known UDQs.
         std::vector<UDQDefine> definitions() const;
+
+        /// Retrieve defining expressions and evaluation objects for all
+        /// known UDQs of a particular category.
+        ///
+        /// \param[in] var_type UDQ category.
+        ///
+        /// \return Defining expressions and evaluation objects for all
+        /// known UDQs of category \p var_type.
         std::vector<UDQDefine> definitions(UDQVarType var_type) const;
+
+        /// Retrieve unprocessed input objects for all UDQs
+        ///
+        /// Needed for restart file output purposes.
         std::vector<UDQInput> input() const;
 
+        /// Export count of all known UDQ categories in the current run.
+        ///
+        /// \param[out] count Count of all active UDQs of all categories in
+        /// the current run.
         void exportTypeCount(std::array<int, static_cast<std::size_t>(UDQVarType::NumTypes)>& count) const;
 
-        // The size() method will return the number of active DEFINE and ASSIGN
-        // statements; this will correspond to the length of the vector returned
-        // from input().
+        /// Total number of active DEFINE and ASSIGN statements.
+        ///
+        /// Corresponds to the length of the vector returned from input().
         std::size_t size() const;
 
+        /// Unprocessed input object for named quantity.
+        ///
+        /// \param[in] keyword Unqualified UDQ name such as FUNNY, GUITAR,
+        /// WURST, or SUSHI.
+        ///
+        /// \return Unprocessed input object for \p keyword.  Throws an
+        /// exception of type \code std::invalid_argument \endcode if no
+        /// such named UDQ exists.
         UDQInput operator[](const std::string& keyword) const;
+
+        /// Unprocessed input object for enumerated quantity.
+        ///
+        /// \param[in] insert_index Linear index in order of appearance for
+        /// an individual UDQ.
+        ///
+        /// \return Unprocessed input object for \p keyword.  Throws an
+        /// exception of type \code std::invalid_argument \endcode if no
+        /// such numbered UDQ exists.
         UDQInput operator[](std::size_t insert_index) const;
 
+        /// Retrieve pending assignment objects for all known UDQs.
         std::vector<UDQAssign> assignments() const;
+
+        /// Retrieve pending assignment objects for all known UDQs of a
+        /// particular category.
+        ///
+        /// \param[in] var_type UDQ category.
+        ///
+        /// \return Pending assignment objects for all known UDQs of
+        /// category \p var_type.
         std::vector<UDQAssign> assignments(UDQVarType var_type) const;
+
+        /// Retrieve run's active UDQ parameters
         const UDQParams& params() const;
+
+        /// Retrieve run's active UDQ function table.
         const UDQFunctionTable& function_table() const;
+
+        /// Retrieve run's active user defined tables.
         const std::unordered_map<std::string, UDT>& tables() const;
 
+        /// Equality predicate.
+        ///
+        /// \param[in] config Object against which \code *this \endcode will
+        /// be tested for equality.
+        ///
+        /// \return Whether or not \code *this \endcode is the same as \p config.
         bool operator==(const UDQConfig& config) const;
+
+        /// Export all summary vectors needed to compute values for the
+        /// current collection of user defined quantities.
+        ///
+        /// \param[in,out] summary_keys Named summary vectors.  Upon
+        /// completion, any additional summary vectors needed to evaluate
+        /// the current set of user defined quantities will be included in
+        /// this set.
         void required_summary(std::unordered_set<std::string>& summary_keys) const;
 
+        /// Convert between byte array and object representation.
+        ///
+        /// \tparam Serializer Byte array conversion protocol.
+        ///
+        /// \param[in,out] serializer Byte array conversion object.
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
@@ -170,48 +424,177 @@ namespace Opm {
         }
 
     private:
+        /// Run's active UDQ parameters.
+        ///
+        /// Initialised from the run's UDQPARAM keyword.
         UDQParams udq_params;
+
+        /// Run's active function table table.
         UDQFunctionTable udqft;
 
-        // The choices of data structures are strongly motivated by the
-        // constraints imposed by the ECLIPSE formatted restart files; for
-        // writing restart files it is essential to keep meticulous control
-        // over the ordering of the keywords.  In this class the ordering is
-        // mainly maintained by the input_index map which keeps track of the
-        // insert order of each keyword, and whether the keyword is
-        // currently DEFINE'ed or ASSIGN'ed.
-        std::unordered_map<std::string, UDQDefine> m_definitions;
-        std::unordered_map<std::string, UDQAssign> m_assignments;
-        std::unordered_map<std::string, UDT> m_tables;
-        std::unordered_map<std::string, std::string> units;
+        // The following data structures are constrained by compatibility
+        // requirements in our simulation restart files.  In particuar we
+        // need to control the keyword ordering.  In this class the ordering
+        // is maintained mainly by the input_index map which tracks the
+        // insertion order of each keyword and whether the keyword (UDQ
+        // name) is currently DEFINE'ed or ASSIGN'ed.
 
+        /// Defining expressions and evaluation objects for all pertinent
+        /// quantities.
+        ///
+        /// Keyed by UDQ name.
+        std::unordered_map<std::string, UDQDefine> m_definitions{};
+
+        /// Run's UDQ assignment statements.
+        ///
+        /// Keyed by UDQ name.
+        std::unordered_map<std::string, UDQAssign> m_assignments{};
+
+        /// Run's user defined input tables.
+        ///
+        /// Keyed by table name (i.e., TU* strings).
+        std::unordered_map<std::string, UDT> m_tables{};
+
+        /// Unit strings for some or all input UDQs.
+        ///
+        /// Defined only for those UDQs which have an associate UNIT
+        /// statement.
+        ///
+        /// Keyed by UDQ name.
+        std::unordered_map<std::string, std::string> units{};
+
+        /// Ordered set of DEFINE statements.
+        ///
+        /// Mostly unused and should probably be removed.
         IOrderSet<std::string> define_order;
-        OrderedMap<UDQIndex> input_index;
-        std::map<UDQVarType, std::size_t> type_count;
 
+        /// Ordered set of UDQ inputs.
+        OrderedMap<UDQIndex> input_index;
+
+        /// Number of UDQs of each category currently active.
+        std::map<UDQVarType, std::size_t> type_count{};
+
+        /// List of pending assignment statements.
+        ///
+        /// Marked mutable because this will be modified in member function
+        ///
+        ///    UDQConfig::eval_assign(step, sched, context) const
         mutable std::vector<std::string> pending_assignments_{};
 
+        /// Incorporate operation for new or existing UDQ
+        ///
+        /// Preserves order of operations in input_index.
+        ///
+        /// \param[in] quantity Unqualified UDQ name such as FUNNY, GUITAR,
+        /// WURST, or SUSHI.
+        ///
+        /// \param[in] action Kind of operation.
         void add_node(const std::string& quantity, UDQAction action);
+
+        /// Retrieve operation currently associated a UDQ
+        ///
+        /// \param[in] udq_key Unqualified UDQ name such as FUNNY, GUITAR,
+        /// WURST, or SUSHI.  Shall be the name of an existing UDQ since
+        /// this function otherwise will dereference \code input_index.end()
+        /// \endcode.
+        ///
+        /// \return Operation currently associated to \p udq_key.
         UDQAction action_type(const std::string& udq_key) const;
 
+        /// Reconstitute an assignment statement from restart file information.
+        ///
+        /// \param[in] udq Restart file representation of an assignment statement.
+        ///
+        /// \param[in] report_step Time at which this assignment is
+        /// encountered.  Typically corresponds to the restart time.
+        void add_assign(const RestartIO::RstUDQ& udq, const std::size_t report_step);
+
+        /// Reconstitute a definition statement from restart file information.
+        ///
+        /// \param[in] udq Restart file representation of a UDQ definition
+        /// statement.
+        ///
+        /// \param[in] report_step Time at which this definition is
+        /// encountered.  Typically corresponds to the restart time.
+        void add_define(const RestartIO::RstUDQ& udq, const std::size_t report_step);
+
+        /// Apply all pending assignments.
+        ///
+        /// Assigns new UDQ values to both the summary and UDQ state objects.
+        ///
+        /// \param[in] report_step Current report step.
+        ///
+        /// \param[in] schedule Full dynamic input schedule.
+        ///
+        /// \param[in,out] context Pattern matchers and state objects.
+        /// Values pertaining to UDQs being assigned here will be updated.
         void eval_assign(std::size_t     report_step,
                          const Schedule& sched,
                          UDQContext&     context) const;
 
-        void eval_define(std::size_t report_step,
+        /// Compute new values for all UDQs
+        ///
+        /// Evaluates all applicable defining expressions.  Assigns new UDQ
+        /// values to both the summary and UDQ state objects.
+        ///
+        /// \param[in] report_step Current report step.
+        ///
+        /// \param[in] schedule Full dynamic input schedule.
+        ///
+        /// \param[in,out] context Pattern matchers and state objects.
+        /// Values pertaining to UDQs being evaluated here will be updated.
+        void eval_define(std::size_t     report_step,
                          const UDQState& udq_state,
-                         UDQContext& context) const;
+                         UDQContext&     context) const;
 
-        void add_named_assign(const std::string&              quantity,
-                              const std::vector<std::string>& selector,
-                              double                          value,
-                              std::size_t                     report_step);
-
+        /// Incorporate an enumerated assignment statement into known UDQ
+        /// collection.
+        ///
+        /// Typically assigns a segment level UDQ for one or more segments
+        /// in a single multi-segmented well.
+        ///
+        /// \param[in] quantity Unqualified UDQ name.  Typically names a
+        /// segment level UDQ such as SUSHI.
+        ///
+        /// \param[in] create_segment_matcher Factory function for
+        /// constructing segment set matchers.
+        ///
+        /// \param[in] selector UDQ set element selection to which this
+        /// assignment applies.  Might be a well name and a segment number.
+        ///
+        /// \param[in] report_step Time at which this assignment statement
+        /// is encountered.
         void add_enumerated_assign(const std::string&              quantity,
                                    SegmentMatcherFactory           create_segment_matcher,
                                    const std::vector<std::string>& selector,
                                    double                          value,
                                    std::size_t                     report_step);
+
+        /// Common implementation of all add*assign() member functions.
+        ///
+        /// \tparam Args Parameter pack type for UDQAssign::add_record()
+        ///
+        /// \param[in] quantity Unqualified UDQ name such as FUNNY, GUITAR,
+        /// WURST, or SUSHI.
+        ///
+        /// \param[in] args Constructor or add_record() arguments for
+        /// UDQAssign object.
+        template <typename... Args>
+        void add_assign_impl(const std::string& quantity,
+                             Args&&...          args)
+        {
+            // Note: Duplicate 'quantity' arguments is intentional here.
+            // The first is the key in 'm_assignments', while the second is
+            // the first argument to the UDQAssign constructor.
+            const auto& [asgnPos, inserted] =
+                this->m_assignments.try_emplace(quantity, quantity, args...);
+
+            if (! inserted) {
+                // We already have an assignment object for 'quantity'.  Add
+                // a new assignment record to that object.
+                asgnPos->second.add_record(std::forward<Args>(args)...);
+            }
+        }
     };
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
@@ -246,7 +246,7 @@ namespace Opm {
         /// \param[in] create_segment_matcher Factory function for
         /// constructing segment set matchers.
         ///
-        /// \param[in,out] st Summary vectors.  For output and evaulating
+        /// \param[in,out] st Summary vectors.  For output and evaluating
         /// ACTION condition purposes.  Values pertaining to UDQs being
         /// assigned here will be updated.
         ///
@@ -277,7 +277,7 @@ namespace Opm {
         /// \param[in] create_region_matcher Factory function for
         /// constructing region set matchers.
         ///
-        /// \param[in,out] st Summary vectors.  For output and evaulating
+        /// \param[in,out] st Summary vectors.  For output and evaluating
         /// ACTION condition purposes.  Values pertaining to UDQs being
         /// assigned here will be updated.
         ///
@@ -307,7 +307,7 @@ namespace Opm {
         /// \param[in] key Unqualified UDQ name such as FUNNY, GUITAR,
         /// WURST, or SUSHI.
         ///
-        /// \return Pending assingment object for \p key.  Throws an
+        /// \return Pending assignment object for \p key.  Throws an
         /// exception of type \code std::out_of_range \endcode if no such
         /// object exists for the UDQ \p key.
         const UDQAssign& assign(const std::string& key) const;
@@ -433,7 +433,7 @@ namespace Opm {
         UDQFunctionTable udqft;
 
         // The following data structures are constrained by compatibility
-        // requirements in our simulation restart files.  In particuar we
+        // requirements in our simulation restart files.  In particular we
         // need to control the keyword ordering.  In this class the ordering
         // is maintained mainly by the input_index map which tracks the
         // insertion order of each keyword and whether the keyword (UDQ
@@ -465,7 +465,7 @@ namespace Opm {
 
         /// Ordered set of DEFINE statements.
         ///
-        /// Mostly unused and should probably be removed.
+        /// TODO: Mostly unused and should probably be removed.
         IOrderSet<std::string> define_order;
 
         /// Ordered set of UDQ inputs.
@@ -490,16 +490,6 @@ namespace Opm {
         ///
         /// \param[in] action Kind of operation.
         void add_node(const std::string& quantity, UDQAction action);
-
-        /// Retrieve operation currently associated a UDQ
-        ///
-        /// \param[in] udq_key Unqualified UDQ name such as FUNNY, GUITAR,
-        /// WURST, or SUSHI.  Shall be the name of an existing UDQ since
-        /// this function otherwise will dereference \code input_index.end()
-        /// \endcode.
-        ///
-        /// \return Operation currently associated to \p udq_key.
-        UDQAction action_type(const std::string& udq_key) const;
 
         /// Reconstitute an assignment statement from restart file information.
         ///

--- a/opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp
@@ -71,6 +71,10 @@ enum class UDQVarType
     WELL_VAR = 8,
     GROUP_VAR = 9,
     TABLE_LOOKUP = 10,
+
+    // -------------------------------------------------------------------------
+    // Implementation helper.  Must be last enumerator.
+    NumTypes,
 };
 
 enum class UDQTokenType

--- a/opm/io/eclipse/rst/state.hpp
+++ b/opm/io/eclipse/rst/state.hpp
@@ -34,6 +34,7 @@
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <ctime>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -108,12 +109,7 @@ private:
                  const std::vector<int>& iseg,
                  const std::vector<double>& rseg);
 
-    void add_udqs(const std::vector<int>& iudq,
-                  const std::vector<std::string>& zudn,
-                  const std::vector<std::string>& zudl,
-                  const std::vector<double>& dudw,
-                  const std::vector<double>& dudg,
-                  const std::vector<double>& dudf);
+    void add_udqs(std::shared_ptr<EclIO::RestartFileView> rstView);
 
     void add_actions(const Parser& parser,
                      const Runspec& runspec,

--- a/opm/io/eclipse/rst/udq.cpp
+++ b/opm/io/eclipse/rst/udq.cpp
@@ -19,6 +19,8 @@
 
 #include <opm/io/eclipse/rst/udq.hpp>
 
+#include <opm/common/utility/Visitor.hpp>
+
 #include <opm/output/eclipse/UDQDims.hpp>
 
 #include <algorithm>
@@ -35,20 +37,12 @@
 
 #include <fmt/format.h>
 
-namespace detail {
-    template <typename... Ts>
-    struct Overloaded : public Ts... { using Ts::operator()...; };
-
-    template <typename... Ts>
-    Overloaded(Ts...) -> Overloaded<Ts...>;
-}
-
 void Opm::RestartIO::RstUDQ::ValueRange::Iterator::setValue()
 {
     this->deref_value_.first = this->i_[this->ix_];
 
     this->deref_value_.second =
-        std::visit(detail::Overloaded {
+        std::visit(VisitorOverloadSet {
             []              (const double  v) { return v; },
             [ix = this->ix_](const double* v) { return v[ix]; }
         }, this->value_);

--- a/opm/io/eclipse/rst/udq.cpp
+++ b/opm/io/eclipse/rst/udq.cpp
@@ -3,7 +3,8 @@
 
   This file is part of the Open Porous Media project (OPM).
 
-  OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
@@ -16,137 +17,279 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <fmt/format.h>
-
 #include <opm/io/eclipse/rst/udq.hpp>
+
 #include <opm/output/eclipse/UDQDims.hpp>
 
-namespace Opm {
-namespace RestartIO {
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <numeric>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
 
-RstUDQ::RstDefine::RstDefine(const std::string& expression_arg, UDQUpdate status_arg) :
-    expression(expression_arg),
-    status(status_arg)
+#include <fmt/format.h>
+
+namespace detail {
+    template <typename... Ts>
+    struct Overloaded : public Ts... { using Ts::operator()...; };
+
+    template <typename... Ts>
+    Overloaded(Ts...) -> Overloaded<Ts...>;
+}
+
+void Opm::RestartIO::RstUDQ::ValueRange::Iterator::setValue()
+{
+    this->deref_value_.first = this->i_[this->ix_];
+
+    this->deref_value_.second =
+        std::visit(detail::Overloaded {
+            []              (const double  v) { return v; },
+            [ix = this->ix_](const double* v) { return v[ix]; }
+        }, this->value_);
+}
+
+// ---------------------------------------------------------------------------
+
+Opm::RestartIO::RstUDQ::RstUDQ(const std::string& name_arg,
+                               const std::string& unit_arg,
+                               const std::string& define_arg,
+                               const UDQUpdate    update_arg)
+    : name       { name_arg }
+    , unit       { unit_arg }
+    , category   { UDQ::varType(name_arg) }
+    , definition_{ std::in_place, define_arg, update_arg }
 {}
 
+Opm::RestartIO::RstUDQ::RstUDQ(const std::string& name_arg,
+                               const std::string& unit_arg)
+    : name     { name_arg }
+    , unit     { unit_arg }
+    , category { UDQ::varType(name_arg) }
+{}
 
-void RstUDQ::RstAssign::update_value(const std::string& name_arg, double new_value) {
-    auto current_value = this->value.value_or(new_value);
-    if (current_value != new_value)
-        throw std::logic_error(fmt::format("Internal error: the UDQ {} changes value {} -> {} during restart load", name_arg, current_value, new_value));
-
-    this->value = new_value;
-}
-
-
-RstUDQ::RstUDQ(const std::string& name_arg, const std::string& unit_arg, const std::string& define_arg, UDQUpdate update_arg)
-    : name(name_arg)
-    , unit(unit_arg)
-    , var_type(UDQ::varType(name_arg))
-    , data(RstDefine{define_arg,update_arg})
+void Opm::RestartIO::RstUDQ::prepareValues()
 {
+    this->entityMap_.clear();
 }
 
-RstUDQ::RstUDQ(const std::string& name_arg, const std::string& unit_arg)
-    : name(name_arg)
-    , unit(unit_arg)
-    , var_type(UDQ::varType(name_arg))
-    , data(RstAssign{})
+void Opm::RestartIO::RstUDQ::
+addValue(const int entity, const int subEntity, const double value)
 {
+    if (this->isScalar()) {
+        throw std::logic_error {
+            fmt::format("UDQ {} cannot be defined as a scalar "
+                        "and then used as UDQ set at restart time",
+                        this->name)
+        };
+    }
+
+    if (std::holds_alternative<std::monostate>(this->sa_)) {
+        this->sa_.emplace<std::vector<double>>();
+    }
+
+    this->entityMap_.addConnection(entity, subEntity);
+    std::get<std::vector<double>>(this->sa_).push_back(value);
+
+    this->maxEntityIdx_ = ! this->maxEntityIdx_.has_value()
+        ? entity
+        : std::max(entity, *this->maxEntityIdx_);
 }
 
-bool RstUDQ::is_define() const {
-    return std::holds_alternative<RstDefine>(this->data);
-}
-
-UDQUpdate RstUDQ::updateStatus() const
+void Opm::RestartIO::RstUDQ::commitValues()
 {
-    return this->is_define()
-        ? std::get<RstDefine>(this->data).status
+    if (! this->isUDQSet()) {
+        // Scalar or monostate.  Nothing to do.
+        return;
+    }
+
+    // If we get here this is a UDQ set.  Form compressed UDQ mapping and
+    // reorder the values to match this compressed mapping.
+
+    this->entityMap_.compress(this->maxEntityIdx_.value() + 1);
+
+    auto newSA = std::vector<double>(this->entityMap_.numEdges(), 0.0);
+    {
+        const auto& currSA = std::get<std::vector<double>>(this->sa_);
+
+        const auto& ix = this->entityMap_.compressedIndexMap();
+
+        for (auto i = 0*currSA.size(); i < currSA.size(); ++i) {
+            newSA[ix[i]] += currSA[i];
+        }
+    }
+
+    std::get<std::vector<double>>(this->sa_).swap(newSA);
+}
+
+void Opm::RestartIO::RstUDQ::assignScalarValue(const double value)
+{
+    if (this->isUDQSet()) {
+        throw std::logic_error {
+            fmt::format("UDQ {} cannot be defined as a UDQ set "
+                        "and then used as a scalar at restart time",
+                        this->name)
+        };
+    }
+
+    this->sa_ = value;
+}
+
+void Opm::RestartIO::RstUDQ::addEntityName(std::string_view wgname)
+{
+    this->wgnames_.emplace_back(wgname);
+}
+
+double Opm::RestartIO::RstUDQ::scalarValue() const
+{
+    if (std::holds_alternative<std::monostate>(this->sa_)) {
+        throw std::logic_error {
+            fmt::format("Cannot request scalar value from UDQ "
+                        "{} when no values have been assigned",
+                        this->name)
+        };
+    }
+
+    if (! this->isScalar()) {
+        throw std::logic_error {
+            fmt::format("Cannot request scalar value "
+                        "from non-scalar UDQ set {}",
+                        this->name)
+        };
+    }
+
+    return std::get<double>(this->sa_);
+}
+
+std::size_t Opm::RestartIO::RstUDQ::numEntities() const
+{
+    return this->maxEntityIdx_.has_value()
+        ? static_cast<std::size_t>(1 + *this->maxEntityIdx_)
+        : this->wgnames_.size();
+}
+
+Opm::RestartIO::RstUDQ::ValueRange
+Opm::RestartIO::RstUDQ::operator[](const std::size_t i) const
+{
+    if (std::holds_alternative<std::monostate>(this->sa_)) {
+        throw std::logic_error {
+            fmt::format("Cannot request values for "
+                        "entity {} from UDQ {} when "
+                        "no values have been assigned",
+                        i, this->name)
+        };
+    }
+
+    if (this->isScalar()) {
+        return this->scalarRange(i);
+    }
+
+    return this->udqSetRange(i);
+}
+
+Opm::UDQUpdate Opm::RestartIO::RstUDQ::currentUpdateStatus() const
+{
+    return this->isDefine()
+        ? this->definition_->status
         : UDQUpdate::OFF;
 }
 
-void RstUDQ::add_value(const std::string& wgname, double value) {
-    if (this->is_define()) {
-        auto& def = std::get<RstDefine>(this->data);
-        def.values.emplace_back(wgname, value);
-    } else {
-        auto& assign = std::get<RstAssign>(this->data);
-        assign.update_value(this->name, value);
-        assign.selector.insert(wgname);
-    }
-}
-
-void RstUDQ::add_value(double value) {
-    if (this->is_define()) {
-        auto& def = std::get<RstDefine>(this->data);
-        def.field_value = value;
-    } else {
-        auto& assign = std::get<RstAssign>(this->data);
-        assign.update_value(this->name, value);
-    }
-}
-
-double RstUDQ::assign_value() const {
-    const auto& assign = std::get<RstAssign>(this->data);
-    return assign.value.value();
-}
-
-const std::unordered_set<std::string>& RstUDQ::assign_selector() const {
-    const auto& assign = std::get<RstAssign>(this->data);
-    return assign.selector;
-}
-
-const std::string& RstUDQ::expression() const {
-    const auto& define = std::get<RstDefine>(this->data);
-    return define.expression;
-}
-
-const std::vector<std::pair<std::string, double>>& RstUDQ::values() const {
-    const auto& define = std::get<RstDefine>(this->data);
-    return define.values;
-}
-
-std::optional<double> RstUDQ::field_value() const {
-    const auto& define = std::get<RstDefine>(this->data);
-    return define.field_value;
-}
-
-RstUDQActive::RstRecord::RstRecord(UDAControl c, std::size_t i, std::size_t u1, std::size_t u2)
-    : control(c)
-    , input_index(i)
-    , use_count(u1)
-    , wg_offset(u2)
-{}
-
-RstUDQActive::RstUDQActive(const std::vector<int>& iuad_arg, const std::vector<int>& iuap, const std::vector<int>& igph)
+const std::vector<int>& Opm::RestartIO::RstUDQ::nameIndex() const
 {
-    auto uda_size = UDQDims::entriesPerIUAD();
-    for (std::size_t iuad_index = 0; iuad_index < iuad_arg.size() / uda_size; iuad_index++) {
-        auto offset = iuad_index * uda_size;
-        this->iuad.emplace_back( UDQ::udaControl(iuad_arg[offset + 0]),
-                                 iuad_arg[offset + 1] - 1,
-                                 iuad_arg[offset + 3],
-                                 iuad_arg[offset + 4] - 1);
-    }
+    this->ensureValidNameIndex();
 
-    std::transform(iuap.begin(), iuap.end(), std::back_inserter(this->wg_index), [](const int& value) { return value - 1;});
+    return *this->wgNameIdx_;
+}
 
-    for (const auto& int_phase : igph) {
-        Phase phase{Phase::OIL};
+std::string_view Opm::RestartIO::RstUDQ::definingExpression() const
+{
+    return this->isDefine()
+        ? std::string_view { this->definition_->expression }
+        : std::string_view {};
+}
 
-        if (int_phase == 1)
-            phase = Phase::OIL;
+Opm::RestartIO::RstUDQ::ValueRange
+Opm::RestartIO::RstUDQ::scalarRange(const std::size_t i) const
+{
+    this->ensureValidNameIndex();
 
-        if (int_phase == 2)
-            phase = Phase::WATER;
-
-        if (int_phase == 3)
-            phase = Phase::GAS;
-
-        this->ig_phase.push_back(phase);
+    return ValueRange {
+        i, i + 1, this->wgNameIdx_->data(),
+        std::get<double>(this->sa_)
     };
 }
 
+Opm::RestartIO::RstUDQ::ValueRange
+Opm::RestartIO::RstUDQ::udqSetRange(const std::size_t i) const
+{
+    const auto& start = this->entityMap_.startPointers();
+    const auto& cols  = this->entityMap_.columnIndices();
+    const auto& sa    = std::get<std::vector<double>>(this->sa_);
+
+    return ValueRange {
+        start[i + 0], start[i + 1], cols.data(), sa.data()
+    };
 }
+
+void Opm::RestartIO::RstUDQ::ensureValidNameIndex() const
+{
+    if (! this->wgNameIdx_.has_value()) {
+        this->wgNameIdx_.emplace(this->wgnames_.size());
+
+        std::iota(this->wgNameIdx_->begin(), this->wgNameIdx_->end(),
+                  std::vector<std::string>::size_type{0});
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+Opm::RestartIO::RstUDQActive::
+RstRecord::RstRecord(const UDAControl  c,
+                     const std::size_t i,
+                     const std::size_t u1,
+                     const std::size_t u2)
+    : control    (c)
+    , input_index(i)
+    , use_count  (u1)
+    , wg_offset  (u2)
+{}
+
+Opm::RestartIO::RstUDQActive::
+RstUDQActive(const std::vector<int>& iuad_arg,
+             const std::vector<int>& iuap,
+             const std::vector<int>& igph)
+    : wg_index { iuap }
+    , ig_phase (igph.size(), Phase::OIL)
+{
+    for (auto offset = 0*iuad_arg.size();
+         offset < iuad_arg.size();
+         offset += UDQDims::entriesPerIUAD())
+    {
+        const auto* uda = &iuad_arg[offset];
+
+        this->iuad.emplace_back(UDQ::udaControl(uda[0]),
+                                uda[1] - 1,
+                                uda[3],
+                                uda[4] - 1);
+    }
+
+    std::transform(this->wg_index.begin(),
+                   this->wg_index.end(),
+                   this->wg_index.begin(),
+                   [](const int wgObjectID) { return wgObjectID - 1; });
+
+    std::transform(igph.begin(), igph.end(), this->ig_phase.begin(),
+                   [](const int phase)
+                   {
+                       if (phase == 1) { return Phase::OIL;   }
+                       if (phase == 2) { return Phase::WATER; }
+                       if (phase == 3) { return Phase::GAS;   }
+
+                       return Phase::OIL;
+                   });
 }

--- a/opm/io/eclipse/rst/udq.hpp
+++ b/opm/io/eclipse/rst/udq.hpp
@@ -263,7 +263,7 @@ public:
 
     /// UDQ's category, i.e., which level this UDQ applies to.
     ///
-    /// Exmples include, the FIELD (FU*), group (GU*), well (WU*), or well
+    /// Examples include, the FIELD (FU*), group (GU*), well (WU*), or well
     /// segments (SU*).
     UDQVarType category{UDQVarType::NONE};
 

--- a/opm/io/eclipse/rst/udq.hpp
+++ b/opm/io/eclipse/rst/udq.hpp
@@ -3,7 +3,8 @@
 
   This file is part of the Open Porous Media project (OPM).
 
-  OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
@@ -19,96 +20,508 @@
 #ifndef RST_UDQ
 #define RST_UDQ
 
+#include <opm/input/eclipse/EclipseState/Phase.hpp>
+
+#include <opm/common/utility/CSRGraphFromCoordinates.hpp>
+
+#include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
+
 #include <cstddef>
+#include <iterator>
 #include <optional>
 #include <string>
-#include <unordered_set>
+#include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
-#include <algorithm>
 
-#include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
-#include <opm/input/eclipse/EclipseState/Phase.hpp>
+namespace Opm::RestartIO {
 
-namespace Opm {
-
-namespace RestartIO {
-
-struct RstHeader;
-
-class RstUDQ {
+/// Container for a single user defined quantity (UDQ) reconstituted from
+/// restart file information.
+///
+/// The producing side is expected to construct an RstUDQ object, and to
+/// signal if the UDQ represents a quantity with a defining expression (four
+/// parameter constructor) or without a defining expression (two parameter
+/// constructor), the latter typically representing an assigned quantity
+/// only.  Moreover, the producing side should call prepareValues() prior to
+/// incorporating numeric values.  Then to assign the numeric values loaded
+/// from a restart file using one of the functions assignScalarValue() or
+/// addValue().  The former is intended for scalar UDQs, e.g., those at
+/// field level, while the latter is intended for UDQ sets such as those
+/// pertaining to wells, groups, or well segments.  Mixing
+/// assignScalarValue() and addValue() for a single UDQ object will make
+/// class RstUDQ throw an exception.  Once all values have been added, the
+/// producing side is expected to call commitValues().
+///
+/// The consuming side, typically client code which forms \c UDQConfig and
+/// \c UDQState objects, is expected to query the object for how to
+/// interpret the values and then to call \code operator[]() \endcode to
+/// retrieve a range of numeric values for the UDQ pertaining to a sing
+/// entity.
+class RstUDQ
+{
 public:
-    struct RstDefine {
-        RstDefine(const std::string& expression_arg, UDQUpdate status_arg);
+    /// Sequence of sub-entity IDs and values pertaining to a single entity.
+    class ValueRange
+    {
+    public:
+        /// Simple forward iterator over a UDQ set's values pertaining to a
+        /// single entity (e.g., a well or a group).
+        class Iterator
+        {
+        public:
+            /// Iterator's category (forward iterator)
+            using iterator_category = std::forward_iterator_tag;
 
-        std::string expression;
-        UDQUpdate status;
-        std::vector<std::pair<std::string, double>> values;
-        std::optional<double> field_value;
+            /// Iterator's value type
+            ///
+            /// Pair's \code .first \endcode element is the zero-based
+            /// sub-entity index, while \code .second \endcode is the
+            /// sub-entity's value.
+            using value_type = std::pair<std::size_t, double>;
+
+            /// Iterator's difference type.
+            using difference_type = int;
+
+            /// Iterator's pointer type (return type from operator->())
+            using pointer = const value_type*;
+
+            /// Iterator's reference type (return type from operator*())
+            using reference = const value_type&;
+
+            /// Pre-increment operator.
+            ///
+            /// \return *this.
+            Iterator& operator++()
+            {
+                ++this->ix_;
+
+                return *this;
+            }
+
+            /// Post-increment operator.
+            ///
+            /// \return Iterator pointing to element prior to increment result.
+            Iterator operator++(int)
+            {
+                auto iter = *this;
+
+                ++(*this);
+
+                return iter;
+            }
+
+            /// Dereference operator
+            ///
+            /// \return Element at current position.
+            reference operator*()
+            {
+                this->setValue();
+                return this->deref_value_;
+            }
+
+            /// Indirection operator
+            ///
+            /// \return Pointer to element at current position.
+            pointer operator->()
+            {
+                this->setValue();
+                return &this->deref_value_;
+            }
+
+            /// Equality predicate
+            ///
+            /// \param[in] that Object to which \c *this will be compared for equality.
+            ///
+            /// \return Whether or not \c *this equals \p that.
+            bool operator==(const Iterator& that) const
+            {
+                return (this->ix_    == that.ix_)
+                    && (this->i_     == that.i_)
+                    && (this->value_ == that.value_);
+            }
+
+            /// Inequality predicate
+            ///
+            /// \param[in] that Object to which \c *this will be compared for inequality.
+            ///
+            /// \return \code ! (*this == that)
+            bool operator!=(const Iterator& that) const
+            {
+                return ! (*this == that);
+            }
+
+            friend class ValueRange;
+
+        private:
+            /// Constructor
+            ///
+            /// Accessible to RegionIndexRange only.
+            ///
+            /// \param[in] index range element value.
+            Iterator(std::size_t ix,
+                     const int*  i,
+                     const std::variant<double, const double*>& value)
+                : ix_{ix}, i_{i}, value_{value}
+            {}
+
+            /// Index range element value
+            std::size_t ix_;
+            const int* i_;
+            std::variant<double, const double*> value_;
+
+            value_type deref_value_{};
+
+            void setValue();
+        };
+
+        /// Start of value range
+        Iterator begin() const
+        { return this->makeIterator(this->begin_); }
+
+        /// End of value range
+        Iterator end() const
+        { return this->makeIterator(this->end_); }
+
+        friend class RstUDQ;
+
+    private:
+        /// Constructor
+        ///
+        /// Scalar version.
+        ///
+        /// \param[in] begin_arg Index of start of range.
+        ///
+        /// \param[in] end_arg Index of element one past the end of the
+        /// range.
+        ///
+        /// \param[in] i Range of sub-entity indices.
+        ///
+        /// \param[in] value Constant value applicable to every element in
+        /// the range.
+        ValueRange(std::size_t  begin_arg,
+                   std::size_t  end_arg,
+                   const int*   i,
+                   const double value)
+            : begin_{begin_arg}, end_{end_arg}, i_{i}, value_{value}
+        {}
+
+        /// Constructor
+        ///
+        /// Array version.
+        ///
+        /// \param[in] begin_arg Index of start of range.
+        ///
+        /// \param[in] end_arg Index of element one past the end of the
+        /// range.
+        ///
+        /// \param[in] i Range of sub-entity indices.
+        ///
+        /// \param[in] value Range of values, one scalar value for each
+        /// sub-entity in the value range.
+        ValueRange(std::size_t   begin_arg,
+                   std::size_t   end_arg,
+                   const int*    i,
+                   const double* value)
+            : begin_{begin_arg}, end_{end_arg}, i_{i}, value_{value}
+        {}
+
+        /// Index of start of the range.
+        std::size_t begin_{};
+
+        /// Index of element one past the end of the range.
+        std::size_t end_{};
+
+        /// Sub-entities.
+        const int* i_{};
+
+        /// Values pertaining to each sub-entity of the range.
+        ///
+        /// Holds a \c double in the scalar version, and a \code const
+        /// double* \end in the array version.
+        std::variant<double, const double*> value_{};
+
+        /// Form an iterator from a sequence index
+        ///
+        /// \param[in] ix Sequence index
+        ///
+        /// \return Range iterator pointing to position \p ix.
+        Iterator makeIterator(const std::size_t ix) const
+        {
+            return { ix, this->i_, this->value_ };
+        }
     };
 
-    struct RstAssign {
-        void update_value(const std::string& name_arg, double new_value);
+    /// UDQ name.
+    ///
+    /// First argument to a DEFINE or an ASSIGN statement.
+    std::string name{};
 
-        std::optional<double> value;
-        std::unordered_set<std::string> selector;
-    };
+    /// UDQ's unit string.
+    std::string unit{};
 
+    /// UDQ's category, i.e., which level this UDQ applies to.
+    ///
+    /// Exmples include, the FIELD (FU*), group (GU*), well (WU*), or well
+    /// segments (SU*).
+    UDQVarType category{UDQVarType::NONE};
 
+    /// Constructor
+    ///
+    /// Quantity given by DEFINE statement.
+    ///
+    /// \param{in] name_arg UDQ name.
+    ///
+    /// \param{in] unit_arg UDQ's unit string.
+    ///
+    /// \param{in] define_arg UDQ's defining expression, previously entered
+    /// in a DEFINE statement.
+    ///
+    /// \param{in] status_arg UDQ's update status, i.e., when to calculate
+    /// new values for the quantity.
     RstUDQ(const std::string& name_arg,
            const std::string& unit_arg,
            const std::string& define_arg,
-           UDQUpdate status_arg);
+           UDQUpdate          status_arg);
 
+    /// Constructor
+    ///
+    /// Quantity given by ASSIGN statement.
+    ///
+    /// \param{in] name_arg UDQ name.
+    ///
+    /// \param{in] unit_arg UDQ's unit string.
     RstUDQ(const std::string& name_arg,
            const std::string& unit_arg);
 
-    void add_value(double value);
-    void add_value(const std::string& wgname, double value);
+    /// Prepare inclusion of entities and values.
+    ///
+    /// Used by producing code, i.e., the layer which reads UDQ information
+    /// directly from file.
+    void prepareValues();
 
-    bool is_define() const;
-    UDQUpdate updateStatus() const;
-    double assign_value() const;
-    const std::unordered_set<std::string>& assign_selector() const;
-    const std::string& expression() const;
-    const std::vector<std::pair<std::string, double>>& values() const;
-    std::optional<double> field_value() const;
+    /// Assign numeric UDQ value for a entity/sub-entity pair.
+    ///
+    /// Conflicts with assignScalarValue().  If assignScalarValue() has been
+    /// called previously, then this function will throw an exception of
+    /// type \code std::logic_error \endcode.
+    ///
+    /// \param[in] entity Numeric entity index.  Assumed to be zero-based
+    /// linear index of an entity, such as a well or a group.
+    ///
+    /// \param[in] subEntity Numeric sub-entity index.  Assumed to be a
+    /// zero-based linear index of a sub-entity such as a well segment.  For
+    /// well or group level UDQs, pass zero for the sub-entity.
+    ///
+    /// \param[in] value Numeric UDQ value for this entity/sub-entity pair.
+    void addValue(const int entity, const int subEntity, const double value);
 
-    std::string name;
-    std::string unit;
-    UDQVarType var_type;
+    /// End value accumulation.
+    ///
+    /// Builds entity to sub-entity mapping, and sorts the corresponding
+    /// numeric UDQ values.  Should normally be the final member function
+    /// call on the producing side.
+    void commitValues();
+
+    /// Assign a scalar value for the UDQ.
+    ///
+    /// Conflicts with addValue().  If addValue() has been called
+    /// previously, then this function will throw an exception of type \code
+    /// std::logic_error \endcode.
+    ///
+    /// \param[in] value Single numeric value pertaining to all entities in
+    /// this UDQ set.
+    void assignScalarValue(const double value);
+
+    /// Add a name for the last (or next) entity used in a call to addValue()
+    ///
+    /// \param[in] wgname Entity, typically well or group, name.
+    void addEntityName(std::string_view wgname);
+
+    /// Retrieve UDQ's scalar value.
+    ///
+    /// Throws a \code std::logic_error \endcode unless isScalar() returns
+    /// \c true.
+    ///
+    /// Used by consuming code, i.e., the layer which forms \c UDQConfig and
+    /// \c UDQState objects from restart file information.
+    double scalarValue() const;
+
+    /// Retrieve number of of entities known to this UDQ.
+    std::size_t numEntities() const;
+
+    /// Get read-only access to sub-entities and values associated to a
+    /// single top-level entity.
+    ///
+    /// \param[in] i Entity index.  Must be in the range [0..numEntities()).
+    ///
+    /// \return Sequence of values pertaining to entity \p i.
+    ValueRange operator[](const std::size_t i) const;
+
+    /// Get sequence of UDQ's entity names.
+    ///
+    /// \return Sequence of entity names entered in earlier addEntityName()
+    /// calls.  Order not guaranteed.
+    const std::vector<std::string>& entityNames() const
+    {
+        return this->wgnames_;
+    }
+
+    /// Index map for entity names.
+    ///
+    /// The entity name of entity 'i' is
+    /// \code
+    ///   entityNames()[ nameIndex()[i] ]
+    /// \endcode
+    /// provided named entities are meaningful for this UDQ--i.e., if it
+    /// pertains to the well, group, connection, or segment levels.
+    const std::vector<int>& nameIndex() const;
+
+    /// UDQ's defining expression
+    ///
+    /// Empty character sequence if this UDQ does not have a defining
+    /// expression--i.e., if it was entered using ASSIGN statements.
+    std::string_view definingExpression() const;
+
+    /// UDQ's current update status.
+    UDQUpdate currentUpdateStatus() const;
+
+    /// Whether or not this UDQ has a defining expression
+    ///
+    /// Needed to properly reconstitute the UDQConfig object from restart
+    /// file information.
+    bool isDefine() const
+    {
+        return this->definition_.has_value();
+    }
+
+    /// Predicate for whether or not this UDQ is a scalar
+    /// quantity--typically a FIELD level value.
+    bool isScalar() const
+    {
+        return std::holds_alternative<double>(this->sa_);
+    }
 
 private:
-    std::variant<std::monostate, RstDefine, RstAssign> data;
+    /// Entity mapping type.
+    ///
+    /// VertexID = int
+    /// TrackCompressedIdx = true (need SA mapping)
+    /// PermitSelfConnections = true (MS well 5 may have segment number 5).
+    using Graph = utility::CSRGraphFromCoordinates<int, true, true>;
+
+    /// Wrapper for a DEFINE expression
+    struct Definition
+    {
+        /// Constructor
+        ///
+        /// Mostly to enable using optional<>::emplace().
+        ///
+        /// \param[in] expression_arg UDQ's defining expression
+        ///
+        /// \param[in] status_arg UDQ's update status.
+        Definition(const std::string& expression_arg,
+                   const UDQUpdate    status_arg)
+            : expression { expression_arg }
+            , status     { status_arg }
+        {}
+
+        /// UDQ's defining expression.
+        std::string expression{};
+
+        /// UDQ's update status.
+        UDQUpdate status{};
+    };
+
+    /// Map entities to range of sub-entities.
+    ///
+    /// Examples include
+    ///
+    ///   -# Well and its segments (SU*)
+    ///   -# Well and its connections (CU*)
+    ///
+    /// For field, group, and well level UDQs, the sub-entities are usually
+    /// trivial (i.e., one sub-entity of numeric index zero), although one
+    /// *might* choose to represent aquifer and block level UDQs as
+    /// sub-entities of the FIELD.
+    Graph entityMap_{};
+
+    /// UDQ values.
+    ///
+    /// Single scalar if all entities in this UDQ share the same constant
+    /// value--typically only for field level UDQs.  Range of scalars (\code
+    /// vector<double> \endcode) if each entity/sub-entity potentially has a
+    /// different value.  Monostate unless any values have been assigned.
+    std::variant<std::monostate, double, std::vector<double>> sa_;
+
+    /// Entity names.
+    ///
+    /// Typically well or group names.
+    std::vector<std::string> wgnames_{};
+
+    /// Largest entity index seen in all addValue() calls so far.
+    ///
+    /// Nullopt before first call to addValue().
+    std::optional<int> maxEntityIdx_{};
+
+    /// Map entity indices to entity names.
+    mutable std::optional<std::vector<int>> wgNameIdx_{};
+
+    /// UDQ's definition.
+    ///
+    /// Nullopt unless this UDQ has a defining expression (four parameter
+    /// constructor used to form the object).
+    std::optional<Definition> definition_{};
+
+    /// Whether or not this UDQ represents a non-scalar UDQ set.
+    bool isUDQSet() const
+    {
+        return std::holds_alternative<std::vector<double>>(this->sa_);
+    }
+
+    /// Construct a value range for a set of sub-entities that share a
+    /// common, constant numeric value (\c sa_ is \c double).
+    ///
+    /// \param[in] i Entity index.
+    ///
+    /// \return Value range for entity \p i.
+    ValueRange scalarRange(const std::size_t i) const;
+
+    /// Construct a value range for a set of entities whose numeric values
+    /// may differ between sub-entities (\c sa_ is \code vector<double>
+    /// \endcode).
+    ///
+    /// \param[in] i Entity index.
+    ///
+    /// \return Value range for entity \p i.
+    ValueRange udqSetRange(const std::size_t i) const;
+
+    void ensureValidNameIndex() const;
 };
 
-
-
-class RstUDQActive {
-
-    struct RstRecord {
+struct RstUDQActive
+{
+    struct RstRecord
+    {
         RstRecord(UDAControl c, std::size_t i, std::size_t u1, std::size_t u2);
 
-
-        UDAControl control;
+        UDAControl  control;
         std::size_t input_index;
         std::size_t use_count;
         std::size_t wg_offset;
     };
 
-
-public:
     RstUDQActive() = default;
-    RstUDQActive(const std::vector<int>& iuad, const std::vector<int>& iuap, const std::vector<int>& igph);
+    RstUDQActive(const std::vector<int>& iuad,
+                 const std::vector<int>& iuap,
+                 const std::vector<int>& igph);
 
-    std::vector<RstRecord> iuad;
-    std::vector<int> wg_index;
-    std::vector<Phase> ig_phase;
+    std::vector<RstRecord> iuad{};
+    std::vector<int> wg_index{};
+    std::vector<Phase> ig_phase{};
 };
-}
-}
 
+} // namespace Opm::RestartIO
 
-
-#endif
+#endif // RST_UDQ

--- a/opm/output/eclipse/InteHEAD.cpp
+++ b/opm/output/eclipse/InteHEAD.cpp
@@ -31,12 +31,14 @@
 
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/common/utility/TimeService.hpp>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <ctime>
@@ -744,20 +746,24 @@ ngroups(const Group& gr)
 }
 
 Opm::RestartIO::InteHEAD&
-Opm::RestartIO::InteHEAD::
-udqParam_1(const UdqParam& udq_par)
+Opm::RestartIO::InteHEAD::udqParam_1(const UdqParam& udq_par)
 {
     this->data_[UDQPAR_1] = - udq_par.udqParam_1;
     this->data_[R_SEED]   = - udq_par.udqParam_1;
 
-    this->data_[NUM_CONN_UDQS]  = udq_par.num_conn_udqs;
-    this->data_[NUM_FIELD_UDQS] = udq_par.num_field_udqs;
-    this->data_[NUM_REG_UDQS]   = udq_par.num_reg_udqs;
-    this->data_[NUM_GROUP_UDQS] = udq_par.num_group_udqs;
-    this->data_[NUM_SEG_UDQS]   = udq_par.num_seg_udqs;
-    this->data_[NUM_WELL_UDQS]  = udq_par.num_well_udqs;
-    this->data_[NUM_AQU_UDQS]   = udq_par.num_aqu_udqs;
-    this->data_[NUM_BLK_UDQS]   = udq_par.num_blk_udqs;
+    for (const auto& [countIx, vtype] : std::array {
+            std::pair { NUM_CONN_UDQS , UDQVarType::CONNECTION_VAR },
+            std::pair { NUM_FIELD_UDQS, UDQVarType::FIELD_VAR      },
+            std::pair { NUM_REG_UDQS  , UDQVarType::REGION_VAR     },
+            std::pair { NUM_GROUP_UDQS, UDQVarType::GROUP_VAR      },
+            std::pair { NUM_SEG_UDQS  , UDQVarType::SEGMENT_VAR    },
+            std::pair { NUM_WELL_UDQS , UDQVarType::WELL_VAR       },
+            std::pair { NUM_AQU_UDQS  , UDQVarType::AQUIFER_VAR    },
+            std::pair { NUM_BLK_UDQS  , UDQVarType::BLOCK_VAR      },
+        })
+    {
+        this->data_[countIx] = udq_par.numUDQs[static_cast<std::size_t>(vtype)];
+    }
 
     this->data_[NUM_IUADS] = udq_par.num_iuads;
     this->data_[NUM_IUAPS] = udq_par.num_iuaps;

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -21,7 +21,10 @@
 #ifndef OPM_INTEHEAD_HEADER_INCLUDED
 #define OPM_INTEHEAD_HEADER_INCLUDED
 
+#include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
+
 #include <array>
+#include <cstddef>
 #include <ctime>
 #include <memory>
 #include <vector>
@@ -33,6 +36,7 @@ class EclipseState;
 class Phases;
 class Schedule;
 class ScheduleState;
+class UDQInput;
 class UnitSystem;
 
 } // namespace Opm
@@ -108,33 +112,10 @@ namespace Opm { namespace RestartIO {
 
         struct UdqParam {
             int udqParam_1{};
-
-            /// Number of field-level UDQ parameters (FU*)
-            int num_field_udqs{};
-
-            /// Number of group-level UDQ parameters (GU*)
-            int num_group_udqs{};
-
-            /// Number of region-level UDQ parameters (RU*)
-            int num_reg_udqs{};
-
-            /// Number of well-level UDQ parameters (WU*)
-            int num_well_udqs{};
-
-            /// Number of segment-level UDQ parameters (SU*)
-            int num_seg_udqs{};
-
-            /// Number of connection-level UDQ parameters (CU*)
-            int num_conn_udqs{};
-
-            /// Number of aquifer-level UDQ parameters (AU*)
-            int num_aqu_udqs{};
-
-            /// Number of block-level UDQ parameters (BU*)
-            int num_blk_udqs{};
-
             int num_iuads{};
             int num_iuaps{};
+
+            std::array<int, static_cast<std::size_t>(UDQVarType::NumTypes)> numUDQs{};
         };
 
         struct ActionParam {


### PR DESCRIPTION
This PR reimplements the `RestartIO::RstUDQ` type with a view towards introducing support for restarting simulation runs containing user defined quantities (UDQs) associated to the segments of multi-segmented wells.  In particular, we replace the current value container with a back-end based on the `CSRGraphFromCoordinates` helper class.  This, in turn, enables supporting UDQ values at the sub-entity level of a top-level entity such as the segments of a multi-segmented well.

We more clearly distinguish the producing side&ndash;i.e., the layer which loads information from a restart file&ndash;from the consuming side&ndash;i.e., the client code which forms `UDQConfig` and `UDQState` objects based on the restart file information, and require the producing side to signal when the restart information has been fully loaded.  To this end, the producing side is expected to

  1. Call member function `prepareValues()` to signal that new values are being loaded
  2. Call member function `addValue()`, typically in a loop, to include new UDQ values from the restart file
  3. Call member function `commitValues()` to signal that all values have been loaded.

As an alternative to step 2, the producing side may call member function `addScalarValue()` if the quantity in question is scalar&ndash;typically a field level UDQ.

The producing side should also include any relevant entity names, usually well or group names, by calling the `addEntityName()` member function.

The consuming side is expected to interact with the information through `operator[]()` which returns a specialised `ValueRange` type that supports forward iteration, for instance in a range-for() loop.

This new interface begets a significant update to the `UDQAssign` class.  In particular, we no longer need the `rst_selector` and instead add new constructor and add_record interfaces which take a `RestartIO::RstUDQ` object and a report step index.  The previous interface based on the `rst_selector` implicitly assumed that all assignment statements applied a constant value to a collection of wells or groups, but this assumption does not generally hold when we load information from a restart file.  The 
new interface removes this assumption.  While here, also make the `AssignRecord` into a private data type since client code does not generally need to know how we represent the assignment information.

Finally, add Doxygen-style documentation to the types

  * `RestartIO::RstUDQ`
  * `UDQAssign`
  * `UDQConfig`

While not much, this may help future maintainers understand the relationships between these types a little better.