### PR TITLE
Add Restart File Support for Segment Level UDQs

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp
@@ -407,6 +407,17 @@ private:
     /// ensures this behaviour.
     void add_well_or_group_records(const RestartIO::RstUDQ& assignRst,
                                    const std::size_t        report_step);
+
+    /// Reconstitute segment level assignment from restart file information
+    ///
+    /// \param[in] assignRst Aggregate UDQ assignment information restored
+    /// from restart file information.
+    ///
+    /// \param[in] report_step Time at which this assignment happens.
+    /// Assignments should be performed exactly once and the time value
+    /// ensures this behaviour.
+    void add_segment_records(const RestartIO::RstUDQ& assignRst,
+                             const std::size_t        report_step);
 };
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/UDQ/UDQState.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQState.hpp
@@ -22,20 +22,25 @@
 
 #include <opm/input/eclipse/Schedule/UDQ/UDQSet.hpp>
 
+#include <opm/output/eclipse/WindowedArray.hpp>
+
 #include <cstddef>
 #include <string>
 #include <unordered_map>
 #include <utility>
 
-namespace Opm { namespace RestartIO {
+namespace Opm::RestartIO {
     struct RstState;
-}} // namespace Opm::RestartIO
+    class RstUDQ;
+} // namespace Opm::RestartIO
 
 namespace Opm {
 
 class UDQState
 {
 public:
+    using ExportRange = RestartIO::Helpers::WindowedArray<double>::WriteWindow;
+
     UDQState() = default;
     explicit UDQState(double undefined);
 
@@ -50,6 +55,10 @@ public:
     double get_group_var(const std::string& well, const std::string& var) const;
     double get_well_var(const std::string& well, const std::string& var) const;
     double get_segment_var(const std::string& well, const std::string& var, const std::size_t segment) const;
+
+    void exportSegmentUDQ(const std::string& var,
+                          const std::string& well,
+                          ExportRange&       output) const;
 
     void add_define(std::size_t report_step, const std::string& udq_key, const UDQSet& result);
     void add_assign(const std::string& udq_key, const UDQSet& result);

--- a/opm/io/eclipse/rst/header.hpp
+++ b/opm/io/eclipse/rst/header.hpp
@@ -3,35 +3,45 @@
 
   This file is part of the Open Porous Media project (OPM).
 
-  OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+  OPM is free software: you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
 
-  OPM is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+  OPM is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+  details.
 
-  You should have received a copy of the GNU General Public License
-  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU General Public License along
+  with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifndef RST_HEADER
 #define RST_HEADER
 
-#include <vector>
-#include <ctime>
-#include <cstddef>
-
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 
+#include <cstddef>
+#include <ctime>
+#include <utility>
+#include <vector>
+
 namespace Opm {
+
 class UnitSystem;
 
-namespace RestartIO {
+} // namespace Opm
 
-struct RstHeader {
-    RstHeader(const Runspec& runspec, const UnitSystem& unit_system, const std::vector<int>& intehead, const std::vector<bool>& logihead, const std::vector<double>& doubhead);
+namespace Opm::RestartIO {
+
+struct RstHeader
+{
+    RstHeader(const Runspec& runspec,
+              const UnitSystem& unit_system,
+              const std::vector<int>& intehead,
+              const std::vector<bool>& logihead,
+              const std::vector<double>& doubhead);
 
     Runspec runspec;
     int nx;
@@ -90,9 +100,10 @@ struct RstHeader {
     int nmfipr;
     int ngroup;
     int nwgmax;
-    int nwell_udq;
-    int ngroup_udq;
     int nfield_udq;
+    int ngroup_udq;
+    int nsegment_udq;
+    int nwell_udq;
     int num_action;
     int guide_rate_nominated_phase;
     int max_wlist;
@@ -131,17 +142,11 @@ struct RstHeader {
     double glift_rate_delta;
     double glift_min_eco_grad;
 
-
     std::time_t sim_time() const;
     std::pair<std::time_t, std::size_t> restart_info() const;
     int num_udq() const;
 };
 
+} // namespace Opm::RestartIO
 
-}
-}
-
-
-
-
-#endif
+#endif  // RST_HEADER

--- a/opm/output/eclipse/AggregateUDQData.hpp
+++ b/opm/output/eclipse/AggregateUDQData.hpp
@@ -96,6 +96,12 @@ public:
         return this->dUDG_;
     }
 
+    /// Retrieve values of segment level UDQs.  Nullopt if no such UDQs exist.
+    const std::optional<WindowedMatrix<double>>& getDUDS() const
+    {
+        return this->dUDS_;
+    }
+
     /// Retrieve values of well level UDQs.  Nullopt if no such UDQs exist.
     const std::optional<WindowedArray<double>>& getDUDW() const
     {
@@ -146,6 +152,13 @@ private:
     /// for each group level UDQ otherwise.
     std::optional<WindowedArray<double>> dUDG_{};
 
+    /// Numeric values of segment level UDQs.
+    ///
+    /// Nullopt if no such UDQs exist, (declared maximum number of
+    /// segments)-by-(declared maximum number of multi-segmented wells) for
+    /// each segment level UDQ otherwise.
+    std::optional<WindowedMatrix<double>> dUDS_{};
+
     /// Numeric values of well level UDQs.
     ///
     /// Nullopt if no such UDQs exist, declared maximum #wells elements for
@@ -168,6 +181,10 @@ private:
                                const std::size_t                ngmax,
                                const std::vector<const Group*>& groups,
                                const int                        expectedNumGroupUDQs);
+
+    void collectSegmentUDQValues(const std::vector<UDQInput>&    udqInput,
+                                 const UDQState&                 udqState,
+                                 const std::vector<std::string>& msWells);
 
     void collectWellUDQValues(const std::vector<UDQInput>&    udqInput,
                               const UDQState&                 udqState,

--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -283,6 +283,10 @@ namespace {
             rstFile.write("DUDG", dudg->data());
         }
 
+        if (const auto& duds = udqData.getDUDS(); duds.has_value()) {
+            rstFile.write("DUDS", duds->data());
+        }
+
         if (const auto& dudw = udqData.getDUDW(); dudw.has_value()) {
             rstFile.write("DUDW", dudw->data());
         }

--- a/opm/output/eclipse/UDQDims.cpp
+++ b/opm/output/eclipse/UDQDims.cpp
@@ -41,6 +41,9 @@ std::size_t Opm::UDQDims::totalNumUDQs() const
     return this->totalNumUDQs_;
 }
 
+// ---------------------------------------------------------------------------
+// Dimensions for UDA restart arrays (IUAD, IUAP, and IGPH)
+
 std::size_t Opm::UDQDims::numIUAD() const
 {
     return this->intehead(VI::intehead::NO_IUADS);
@@ -58,10 +61,16 @@ std::size_t Opm::UDQDims::numIUAP() const
     return this->intehead(VI::intehead::NO_IUAPS);
 }
 
+// ---------------------------------------------------------------------------
+// Dimensions for field level UDQ value restart array (DUDF)
+
 std::size_t Opm::UDQDims::numFieldUDQs() const
 {
     return this->intehead(VI::intehead::NO_FIELD_UDQS);
 }
+
+// ---------------------------------------------------------------------------
+// Dimensions for group level UDQ value restart array (DUDG)
 
 std::size_t Opm::UDQDims::maxNumGroups() const
 {
@@ -73,6 +82,27 @@ std::size_t Opm::UDQDims::numGroupUDQs() const
     return this->intehead(VI::intehead::NO_GROUP_UDQS);
 }
 
+// ---------------------------------------------------------------------------
+// Dimensions for segment level UDQ value restart array (DUDS)
+
+std::size_t Opm::UDQDims::maxNumMsWells() const
+{
+    return this->intehead(VI::intehead::NSWLMX);
+}
+
+std::size_t Opm::UDQDims::maxNumSegments() const
+{
+    return this->intehead(VI::intehead::NSEGMX);
+}
+
+std::size_t Opm::UDQDims::numSegmentUDQs() const
+{
+    return this->intehead(VI::intehead::NO_SEG_UDQS);
+}
+
+// ---------------------------------------------------------------------------
+// Dimensions for well level UDQ value restart array (DUDW)
+
 std::size_t Opm::UDQDims::maxNumWells() const
 {
     return this->intehead(VI::intehead::NWMAXZ);
@@ -82,6 +112,10 @@ std::size_t Opm::UDQDims::numWellUDQs() const
 {
     return this->intehead(VI::intehead::NO_WELL_UDQS);
 }
+
+// ===========================================================================
+// Private member functions
+// ===========================================================================
 
 void Opm::UDQDims::collectDimensions() const
 {

--- a/opm/output/eclipse/UDQDims.hpp
+++ b/opm/output/eclipse/UDQDims.hpp
@@ -33,29 +33,76 @@ class UDQConfig;
 
 namespace Opm {
 
+/// Collection of UDQ and UDA related dimension queries
+///
+/// Used to size various restart file output arrays.
 class UDQDims
 {
 public:
-    explicit UDQDims(const UDQConfig& config, const std::vector<int>& intehead);
+    /// Constructor
+    ///
+    /// \param[in] config Collection of run's UDQs.
+    ///
+    /// \param[in] intehead Current report step's INTEHEAD array.  Queried
+    /// for most dimension values.
+    explicit UDQDims(const UDQConfig&        config,
+                     const std::vector<int>& intehead);
 
-    static std::size_t entriesPerIUDQ() { return  3; }
-    static std::size_t entriesPerIUAD() { return  5; }
-    static std::size_t entriesPerZUDN() { return  2; }
+    /// Number of IUDQ elements per UDQ.
+    static std::size_t entriesPerIUDQ() { return 3; }
+
+    /// Number of IUAD elements per UDA.
+    static std::size_t entriesPerIUAD() { return 5; }
+
+    /// Number of ZUDN elments per UDQ.
+    static std::size_t entriesPerZUDN() { return 2; }
+
+    /// Number of ZUDL elments per UDQ.
     static std::size_t entriesPerZUDL() { return 16; }
 
+    /// Total number of UDQs in run of all types/categories.
     std::size_t totalNumUDQs() const;
+
+    /// Total number of UDAs in run.
     std::size_t numIUAD() const;
+
+    /// Number of potential group level injection phase UDAs.
+    ///
+    /// Zero if no UDAs in run, maximum number of groups otherwise.
     std::size_t numIGPH() const;
+
+    /// Number of well/group IDs involved in UDAs.
     std::size_t numIUAP() const;
 
+    /// Number of field level UDQs
     std::size_t numFieldUDQs() const;
 
+    /// Maximum number of groups in run, including FIELD
     std::size_t maxNumGroups() const;
+
+    /// Number of group level UDQs
     std::size_t numGroupUDQs() const;
 
+    /// Run's maximum number of multi-segmented wells
+    std::size_t maxNumMsWells() const;
+
+    /// Run's maximum number of segments per multi-segmented well
+    std::size_t maxNumSegments() const;
+
+    /// Number of segment level UDQs.
+    std::size_t numSegmentUDQs() const;
+
+    /// Run's maximum number of wells, multi-segmented or otherwise
     std::size_t maxNumWells() const;
+
+    /// Number of well level UDQs.
     std::size_t numWellUDQs() const;
 
+    /// Linear sequence of some array sizes.
+    ///
+    /// Retained for backwards compatibility but will be removed in the
+    /// future.
+    [[deprecated("The data vector is not aware of categories other than field, group, or well.  Use named accessors instead.")]]
     const std::vector<int>& data() const
     {
         if (! this->dimensionData_.has_value()) {
@@ -66,13 +113,25 @@ public:
     }
 
 private:
+    /// Total number of UDQs of all categories
     std::size_t totalNumUDQs_{};
+
+    /// Current report step's INTEHEAD array.  Backend for most size
+    /// queries.
     std::reference_wrapper<const std::vector<int>> intehead_;
 
+    /// Backing storage for original linear sequence of selected array sizes.
     mutable std::optional<std::vector<int>> dimensionData_;
 
+    /// Build original sequence of selected array sizes.
     void collectDimensions() const;
 
+    /// Query INTEHEAD for individual dimension item.
+    ///
+    /// \param[in] i index into INTEHEAD.  Should be one of the named items
+    /// in VectorItems/intehead.hpp.
+    ///
+    /// \returns Corresponding INTEHEAD item.
     std::size_t intehead(const std::vector<int>::size_type i) const;
 };
 

--- a/opm/output/eclipse/WindowedArray.hpp
+++ b/opm/output/eclipse/WindowedArray.hpp
@@ -71,12 +71,17 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         ///
         /// \param[in] n Number of windows.
         /// \param[in] sz Number of data items per window.
-        explicit WindowedArray(const NumWindows n, const WindowSize sz)
-            : x_         (n.value * sz.value)
+        explicit WindowedArray(const NumWindows n,
+                               const WindowSize sz,
+                               const T          initial = T{})
+            : x_         (n.value * sz.value, initial)
             , windowSize_(sz.value)
         {
-            if (sz.value == 0)
-                throw std::invalid_argument("Window array with windowsize==0 is not permitted");
+            if (sz.value == 0) {
+                throw std::invalid_argument {
+                    "Zero-sized windows are not permitted"
+                };
+            }
         }
 
         WindowedArray(const WindowedArray& rhs) = default;
@@ -184,14 +189,18 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         /// \param[in] nRows Number of rows.
         /// \param[in] nCols Number of columns.
         /// \param[in] sz Number of data items per (row,column) window.
-        explicit WindowedMatrix(const NumRows& nRows,
-                                const NumCols& nCols,
-                                const WindowSize& sz)
-            : data_   (NumWindows{ nRows.value * nCols.value }, sz)
+        explicit WindowedMatrix(const NumRows&    nRows,
+                                const NumCols&    nCols,
+                                const WindowSize& sz,
+                                const T           initial = T{})
+            : data_   (NumWindows{ nRows.value * nCols.value }, sz, initial)
             , numCols_(nCols.value)
         {
-            if (nCols.value == 0)
-                throw std::invalid_argument("Window matrix with columns==0 is not permitted");
+            if (nCols.value == 0) {
+                throw std::invalid_argument {
+                    "Zero-columned windowed matrices are not permitted"
+                };
+            }
         }
 
         /// Retrieve number of columns allocated for this matrix.


### PR DESCRIPTION
This PR adds support for outputting and reloading the `DUDS` restart file array which holds values of segment level UDQs (`SU*`) in an (#segments)-by-(# MS wells)-by-(#segment level UDQs) dense structure.  Undefined `SU*` values represented by the usual default `UDQ` restart value (`-3.0e+20`).

As a help to efficiency, we defer to class `UDQState` to export the UDQ values pertaining to all segments of a single MS well.  This is easier than providing an interface based on values for a single segment at a time.  On the reloading side, we introduce a new member function `UDQVectors::currentSegmentUDQValue()` which exposes a similar range of values for all segments of a single MS well.  While here, also rework the internals of `UDQVectors` to resemble the structure of RstState's UDQ support.