### PR TITLE
Use previous vfp table if default in historical runs

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -184,11 +184,13 @@ public:
 
         //! \brief Handle a WCONINJH keyword.
         //! \param record The deck record to use
+        //! \param vfp_table_nr The vfp table number
         //! \param bhp_def The default BHP limit in SI units
         //! \param is_producer True if well is a producer
         //! \param well_name Name of well
         //! \param loc Location of keyword for logging purpose
         void handleWCONINJH(const DeckRecord& record,
+                            const int vfp_table_nr,
                             const double bhp_def,
                             const bool is_producer,
                             const std::string& well_name,
@@ -301,12 +303,14 @@ public:
 
         //! \brief Handle WCONPROD keyword.
         //! \param alq_type ALQ type
+        //! \param vfp_table_nr The vfp table number
         //! \param bhp_def Default BHP target in SI units
         //! \param unit_system Unit system to use
         //! \param well Well name
         //! \param record Deck record to use
         //! \param location Location of keyword for logging purpose
         void handleWCONPROD(const std::optional<VFPProdTable::ALQ_TYPE>& alq_type,
+                            const int vfp_table_nr,
                             const double bhp_def,
                             const UnitSystem& unit_system,
                             const std::string& well,
@@ -315,10 +319,12 @@ public:
 
         //! \brief Handle WCONHIST keyword.
         //! \param alq_type ALQ type
+        //! \param vfp_table_nr The vfp table number
         //! \param bhp_def Default BHP limit in SI units
         //! \param unit_system Unit system to use
         //! \param record Deck record to use
         void handleWCONHIST(const std::optional<VFPProdTable::ALQ_TYPE>& alq_type,
+                            const int vfp_table_nr,
                             const double bhp_def,
                             const UnitSystem& unit_system,
                             const DeckRecord& record);
@@ -362,7 +368,7 @@ public:
         void init_rates( const DeckRecord& record );
 
         void init_history(const DeckRecord& record);
-        void init_vfp(const std::optional<VFPProdTable::ALQ_TYPE>& alq_type, const UnitSystem& unit_system, const DeckRecord& record);
+        void init_vfp(const std::optional<VFPProdTable::ALQ_TYPE>& alq_type, const int vfp_table_nr, const UnitSystem& unit_system, const DeckRecord& record);
 
         WellProductionProperties(const DeckRecord& record);
 

--- a/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
@@ -197,6 +197,7 @@ namespace Opm {
 
     void
     Well::WellInjectionProperties::handleWCONINJH(const DeckRecord& record,
+                                                  const int vfp_table_nr,
                                                   const double bhp_def,
                                                   const bool is_producer,
                                                   const std::string& well_name,
@@ -259,7 +260,7 @@ namespace Opm {
         this->controlMode = newControlMode;
         this->predictionMode = false;
 
-        this->VFPTableNumber = record.getItem("VFP_TABLE").get< int >(0);
+        this->VFPTableNumber = vfp_table_nr;
 
         this->rsRvInj = record.getItem("VAPOIL_C").getSIDouble(0);
         if (this->injectorType == InjectorType::OIL && this->rsRvInj > 0) {

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -103,6 +103,9 @@ void handleWCONHIST(HandlerContext& handlerContext)
             bool update_well = false;
 
             auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
+            if (record.getItem("VFP_TABLE").defaultApplied(0)) { // Default 1* use the privious set vfp table
+                table_nr = properties->VFPTableNumber;
+            }
 
             if (table_nr != 0) {
                 const auto& vfpprod = handlerContext.state().vfpprod;
@@ -128,6 +131,7 @@ void handleWCONHIST(HandlerContext& handlerContext)
             }
 
             properties->handleWCONHIST(alq_type,
+                                       table_nr,
                                        default_bhp,
                                        handlerContext.static_schedule().m_unit_system, record);
 
@@ -277,7 +281,9 @@ void handleWCONINJH(HandlerContext& handlerContext)
             }
 
             auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
-
+            if (record.getItem("VFP_TABLE").defaultApplied(0)) { // Default 1* use the privious set vfp table
+                table_nr = injection->VFPTableNumber;
+            }
             if (table_nr != 0) {
                 const auto& vfpinj = handlerContext.state().vfpinj;
                 if (!vfpinj.has(table_nr)) {
@@ -286,7 +292,7 @@ void handleWCONINJH(HandlerContext& handlerContext)
                 }
             }
 
-            injection->handleWCONINJH(record, default_bhp_limit,
+            injection->handleWCONINJH(record, table_nr, default_bhp_limit,
                                       well2.isProducer(), well_name,
                                       handlerContext.keyword.location());
 
@@ -346,7 +352,6 @@ void handleWCONPROD(HandlerContext& handlerContext)
             }
 
             auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
-
             if (table_nr != 0) {
                 const auto& vfpprod = handlerContext.state().vfpprod;
                 if (vfpprod.has(table_nr)) {
@@ -365,7 +370,7 @@ void handleWCONPROD(HandlerContext& handlerContext)
                                                                    ParserKeywords::WCONPROD::BHP::defaultValue.get<double>());
             }
 
-            properties->handleWCONPROD(alq_type, default_bhp_target,
+            properties->handleWCONPROD(alq_type, table_nr, default_bhp_target,
                                        handlerContext.static_schedule().m_unit_system,
                                        well_name, record, handlerContext.keyword.location());
 

--- a/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
@@ -93,8 +93,8 @@ namespace Opm {
     }
 
 
-    void Well::WellProductionProperties::init_vfp(const std::optional<VFPProdTable::ALQ_TYPE>& alq_type, const UnitSystem& unit_system_arg, const DeckRecord& record) {
-        this->VFPTableNumber = record.getItem("VFP_TABLE").defaultApplied(0) ? 0 : record.getItem("VFP_TABLE").get< int >(0);
+    void Well::WellProductionProperties::init_vfp(const std::optional<VFPProdTable::ALQ_TYPE>& alq_type, const int vfp_table_nr, const UnitSystem& unit_system_arg, const DeckRecord& record) {
+        this->VFPTableNumber = vfp_table_nr;
         if (alq_type) {
             const auto alq_dim = VFPProdTable::ALQDimension(*alq_type, unit_system_arg);
             const auto& alq_input = record.getItem("ALQ").get<UDAValue>(0);
@@ -164,6 +164,7 @@ namespace Opm {
 
 
     void Well::WellProductionProperties::handleWCONPROD(const std::optional<VFPProdTable::ALQ_TYPE>& alq_type,
+                                                        const int vfp_table_nr,
                                                         const double bhp_def,
                                                         const UnitSystem& unit_system_arg,
                                                         const std::string& well_name,
@@ -171,7 +172,7 @@ namespace Opm {
                                                         const KeywordLocation& location)
     {
         this->predictionMode = true;
-        this->init_vfp(alq_type, unit_system_arg, record);
+        this->init_vfp(alq_type, vfp_table_nr, unit_system_arg, record);
         this->init_rates(record);
 
         if (record.getItem("BHP").defaultApplied(0)) {
@@ -232,12 +233,13 @@ namespace Opm {
       default constructor and the handleWCONPROD() method.
     */
 void Well::WellProductionProperties::handleWCONHIST(const std::optional<VFPProdTable::ALQ_TYPE>& alq_type,
+                                                    const int vfp_table_nr,
                                                     const double bhp_def,
                                                     const UnitSystem& unit_system_arg,
                                                     const DeckRecord& record)
     {
         this->init_rates(record);
-        this->init_vfp(alq_type, unit_system_arg, record);
+        this->init_vfp(alq_type, vfp_table_nr, unit_system_arg, record);
         this->LiquidRate.update(0);
         this->ResVRate.update(0);
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -5476,6 +5476,147 @@ WCONPROD
     BOOST_CHECK(!sched[0].has_gpmaint());
 }
 
+BOOST_AUTO_TEST_CASE(WCONHIST_WCONINJH_VFP) {
+    const std::string deck_string = R"(
+START
+7 OCT 2020 /
+
+DIMENS
+  10 10 3 /
+
+GRID
+DXV
+  10*100.0 /
+DYV
+  10*100.0 /
+DZV
+  3*10.0 /
+
+DEPTHZ
+  121*2000.0 /
+
+PORO
+  300*0.3 /
+PERMX
+    300*1 /
+PERMY
+    300*0.1 /
+PERMZ
+    300*0.01 /
+
+SCHEDULE
+
+VFPPROD
+-- table_num, datum_depth, flo, wfr, gfr, pressure, alq, unit, table_vals
+42 7.0E+03 LIQ WCT GOR THP ' ' METRIC BHP /
+1.0 / flo axis
+0.0 1.0 / THP axis
+0.0 / WFR axis
+0.0 / GFR axis
+0.0 / ALQ axis
+-- Table itself: thp_idx wfr_idx gfr_idx alq_idx <vals>
+1 1 1 1 0.0 /
+2 1 1 1 1.0 /
+
+VFPPROD
+-- table_num, datum_depth, flo, wfr, gfr, pressure, alq, unit, table_vals
+43 7.0E+03 LIQ WCT GOR THP 'GRAT' METRIC BHP /
+1.0 / flo axis
+0.0 1.0 / THP axis
+0.0 / WFR axis
+0.0 / GFR axis
+0.0 / ALQ axis
+-- Table itself: thp_idx wfr_idx gfr_idx alq_idx <vals>
+1 1 1 1 0.0 /
+2 1 1 1 1.0 /
+
+VFPINJ
+-- Table Depth  Rate   TAB  UNITS  BODY
+-- ----- ----- ----- ----- ------ -----
+       5  32.9   WAT   THP METRIC   BHP /
+-- Rate axis
+1 3 5 /
+-- THP axis
+7 11 /
+-- Table data with THP# <values 1-num_rates>
+1 1.5 2.5 3.5 /
+2 4.5 5.5 6.5 /
+
+WELSPECS -- 0
+  'P1' 'G' 10 10 2005 'LIQ' /
+  'P2' 'G' 10 10 2005 'LIQ' /
+/
+
+COMPDAT
+  'P1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+  'P2'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+/
+
+WCONHIST
+  'P1' 'OPEN' 'RESV'  0.0 0.0  0.0  42 10/
+  'P2' 'OPEN' 'RESV'  0.0 0.0  0.0  43 100/
+/
+
+TSTEP
+ 1/
+
+WCONHIST
+  'P1' 'OPEN' 'RESV'  0.0 0.0  0.0  1* 20/
+  'P2' 'OPEN' 'RESV'  0.0 0.0  0.0  0 200/
+/
+
+TSTEP
+ 1/
+
+WCONINJH
+  'P1' 'WAT' 'OPEN'  0.0 2* 1*/
+  'P2' 'WAT' 'OPEN'  0.0 2* 5 /
+/
+
+TSTEP
+ 1/
+
+WCONINJH
+  'P1' 'WAT' 'OPEN'  0.0 2* 0 /
+  'P2' 'WAT' 'OPEN'  0.0 2* 1* /
+/
+)";
+    const auto deck = Parser{}.parseString(deck_string);
+    const auto es    = EclipseState{ deck };
+    auto       sched = Schedule{ deck, es };
+
+    // step 0
+    {
+        const auto& well1 = sched.getWell("P1", 0);
+        const auto& well2 = sched.getWell("P2", 0);
+        BOOST_CHECK_EQUAL(well1.vfp_table_number(), 42);
+        BOOST_CHECK_EQUAL(well2.vfp_table_number(), 43);
+    }
+
+    // step 1
+    {
+        const auto& well1 = sched.getWell("P1", 1);
+        const auto& well2 = sched.getWell("P2", 1);
+        BOOST_CHECK_EQUAL(well1.vfp_table_number(), 42);
+        BOOST_CHECK_EQUAL(well2.vfp_table_number(), 0);
+    }
+
+    // step 2
+    {
+        const auto& well1 = sched.getWell("P1", 2);
+        const auto& well2 = sched.getWell("P2", 2);
+        BOOST_CHECK_EQUAL(well1.vfp_table_number(), 0);
+        BOOST_CHECK_EQUAL(well2.vfp_table_number(), 5);
+    }
+
+    // step 3
+    {
+        const auto& well1 = sched.getWell("P1", 3);
+        const auto& well2 = sched.getWell("P2", 3);
+        BOOST_CHECK_EQUAL(well1.vfp_table_number(), 0);
+        BOOST_CHECK_EQUAL(well2.vfp_table_number(), 5);
+    }
+}
 
 BOOST_AUTO_TEST_CASE(SUMTHIN_IN_SUMMARY) {
     const auto deck = Parser{}.parseString(R"(RUNSPEC

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -590,8 +590,9 @@ namespace {
             Opm::UnitSystem unit_system(Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC);
             auto deck = parser.parseString(input);
             const auto& record = deck["WCONHIST"].back().getRecord(0);
+            auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
             Opm::Well::WellProductionProperties hist(unit_system, "W");
-            hist.handleWCONHIST(alq_type,
+            hist.handleWCONHIST(alq_type, table_nr, 
                                 Opm::ParserKeywords::FBHPDEF::TARGET_BHP::defaultValue * unit::barsa,
                                 unit_system, record);
 
@@ -645,8 +646,9 @@ namespace {
             auto deck = parser.parseString(input);
             const auto& kwd     = deck["WCONPROD"].back();
             const auto&  record = kwd.getRecord(0);
+            auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
             Opm::Well::WellProductionProperties pred(unit_system, "W");
-            pred.handleWCONPROD(alq_type,
+            pred.handleWCONPROD(alq_type, table_nr,
                                 Opm::ParserKeywords::FBHPDEF::TARGET_BHP::defaultValue * unit::barsa,
                                 unit_system, "WELL", record, {});
 

--- a/tests/test_rst.cpp
+++ b/tests/test_rst.cpp
@@ -983,7 +983,7 @@ BOOST_AUTO_TEST_CASE(Historic_Period)
         };
 
         auto prop = op1.getProductionProperties();
-        prop.handleWCONHIST(std::nullopt, 101325.0, Opm::UnitSystem::newMETRIC(),
+        prop.handleWCONHIST(std::nullopt, 0, 101325.0, Opm::UnitSystem::newMETRIC(),
                             deck.get<Opm::ParserKeywords::WCONHIST>().back().getRecord(0));
 
         const auto ctrl = prop.controls(Opm::SummaryState { Opm::TimeService::now(), state.header.udq_undefined }, state.header.udq_undefined);
@@ -1003,7 +1003,7 @@ BOOST_AUTO_TEST_CASE(Historic_Period)
         };
 
         auto prop = op1.getProductionProperties();
-        prop.handleWCONHIST(std::nullopt, 101325.0, Opm::UnitSystem::newMETRIC(),
+        prop.handleWCONHIST(std::nullopt, 0, 101325.0, Opm::UnitSystem::newMETRIC(),
                             deck.get<Opm::ParserKeywords::WCONHIST>().back().getRecord(0));
 
         const auto ctrl = prop.controls(Opm::SummaryState { Opm::TimeService::now(), state.header.udq_undefined }, state.header.udq_undefined);
@@ -1053,7 +1053,7 @@ BOOST_AUTO_TEST_CASE(Historic_Period_WHistCtl)
         };
 
         auto prop = op1.getProductionProperties();
-        prop.handleWCONHIST(std::nullopt, 101325.0, Opm::UnitSystem::newMETRIC(),
+        prop.handleWCONHIST(std::nullopt, 0, 101325.0, Opm::UnitSystem::newMETRIC(),
                             deck.get<Opm::ParserKeywords::WCONHIST>().back().getRecord(0));
 
         const auto ctrl = prop.controls(Opm::SummaryState { Opm::TimeService::now(), state.header.udq_undefined }, state.header.udq_undefined);
@@ -1073,7 +1073,7 @@ BOOST_AUTO_TEST_CASE(Historic_Period_WHistCtl)
         };
 
         auto prop = op1.getProductionProperties();
-        prop.handleWCONHIST(std::nullopt, 101325.0, Opm::UnitSystem::newMETRIC(),
+        prop.handleWCONHIST(std::nullopt, 0, 101325.0, Opm::UnitSystem::newMETRIC(),
                             deck.get<Opm::ParserKeywords::WCONHIST>().back().getRecord(0));
 
         const auto ctrl = prop.controls(Opm::SummaryState { Opm::TimeService::now(), state.header.udq_undefined }, state.header.udq_undefined);


### PR DESCRIPTION
For WCONHIST and WCONINJH default vfp table is the previous one 