### PR TITLE
fixed: make isTabulated constexpr and explicit use from base class

### DIFF
--- a/opm/material/components/Air.hpp
+++ b/opm/material/components/Air.hpp
@@ -50,6 +50,8 @@ class Air : public Component<Scalar, Air<Scalar> >
     typedef ::Opm::IdealGas<Scalar> IdealGas;
 
 public:
+    using Component<Scalar, Air<Scalar>>::isTabulated;
+
     /*!
      * \brief Returns true iff the liquid phase is assumed to be compressible
      */

--- a/opm/material/components/Component.hpp
+++ b/opm/material/components/Component.hpp
@@ -45,7 +45,7 @@ class Component
 public:
     typedef ScalarT Scalar;
 
-    static const bool isTabulated = false;
+    static constexpr bool isTabulated = false;
 
     /*!
      * \brief A default routine for initialization, not needed for components and must not be called.

--- a/opm/material/components/H2O.hpp
+++ b/opm/material/components/H2O.hpp
@@ -71,6 +71,8 @@ class H2O : public Component<Scalar, H2O<Scalar> >
     static const Scalar Rs; // specific gas constant of water
 
 public:
+    using Component<Scalar, H2O<Scalar>>::isTabulated;
+
     /*!
      * \brief A human readable name for the water.
      */

--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -57,7 +57,7 @@ class TabulatedComponent
 public:
     typedef ScalarT Scalar;
 
-    static const bool isTabulated = true;
+    static constexpr bool isTabulated = true;
 
     /*!
      * \brief Initialize the tables.


### PR DESCRIPTION
fixes debug build of test_components. I can't precisely answer why this did not trigger in release builds but.. Regressed in e3f737b8c2a9ef613759ad57dbb3aa7293265c90