### PR TITLE
changed: store a pointer to the static unit system instead of a copy per well

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -40,6 +40,7 @@
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleStatic.hpp>
 #include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/WriteRestartFileEvents.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
@@ -335,6 +336,20 @@ namespace Opm
             this->template pack_unpack_map<int, VFPInjTable>(serializer);
             this->template pack_unpack_map<std::string, Group>(serializer);
             this->template pack_unpack_map<std::string, Well>(serializer);
+
+            // If we are deserializing we need to setup the pointer to the
+            // unit system since this is process specific. This is safe
+            // because we set the same value in all well instances.
+            // We do some redundant assignments as these are shared_ptr's
+            // with multiple pointers to any given instance, but it is not
+            // significant so let's keep it simple.
+            if (!serializer.isSerializing()) {
+                for (auto& snapshot : snapshots) {
+                    for (auto& well : snapshot.wells) {
+                        well.second->updateUnitSystem(&m_static.m_unit_system);
+                    }
+                }
+            }
         }
 
         template <typename T, class Serializer>

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -574,6 +574,9 @@ public:
                                    std::vector<bool>& scalingApplicable);
     const PAvg& pavg() const;
 
+    //! \brief Used by schedule deserialization.
+    void updateUnitSystem(const UnitSystem* usys) { unit_system = usys; }
+
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
@@ -585,7 +588,6 @@ public:
         serializer(headJ);
         serializer(ref_depth);
         serializer(wpave_ref_depth);
-        serializer(unit_system);
         serializer(udq_undefined);
         serializer(status);
         serializer(drainage_radius);
@@ -640,7 +642,7 @@ private:
     bool automatic_shutin{false};
     int pvt_table{};
     GasInflowEquation gas_inflow = GasInflowEquation::STD;  // Will NOT be loaded/assigned from restart file
-    UnitSystem unit_system;
+    const UnitSystem* unit_system{nullptr};
     double udq_undefined{};
     WellType wtype{};
     WellGuideRate guide_rate{};


### PR DESCRIPTION
this becomes significant in large schedules with lots of well data