### PR TITLE
changed: only keep keywords in sched_deck if there are actions

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -88,8 +88,22 @@ namespace Opm
     class Schedule {
     public:
         Schedule() = default;
-        ~Schedule() = default;
+
         explicit Schedule(std::shared_ptr<const Python> python_handle);
+
+        /*! \brief Construct a Schedule object from a deck.
+         *  \param deck Deck to construct Schedule from
+         *  \param fp Field property manager
+         *  \param runspec Run specification parameters to use
+         *  \param parseContext Parsing context
+         *  \param errors Error configuration
+         *  \param python Python interpreter to use
+         *  \param lowActionParsingStrictness Reduce parsing strictness for actions
+         *  \param keepKeywords Keep the schdule keywords even if there are no actions
+         *  \param output_interval Output interval to use
+         *  \param rst Restart state to use
+         *  \param tracer_config Tracer configuration to use
+         */
         Schedule(const Deck& deck,
                  const EclipseGrid& grid,
                  const FieldPropsManager& fp,
@@ -98,6 +112,7 @@ namespace Opm
                  ErrorGuard& errors,
                  std::shared_ptr<const Python> python,
                  const bool lowActionParsingStrictness = false,
+                 const bool keepKeywords = true,
                  const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr,
                  const TracerConfig* tracer_config = nullptr);
@@ -111,6 +126,7 @@ namespace Opm
                  T&& errors,
                  std::shared_ptr<const Python> python,
                  const bool lowActionParsingStrictness = false,
+                 const bool keepKeywords = true,
                  const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr,
                  const TracerConfig* tracer_config = nullptr);
@@ -121,6 +137,7 @@ namespace Opm
                  const Runspec &runspec,
                  std::shared_ptr<const Python> python,
                  const bool lowActionParsingStrictness = false,
+                 const bool keepKeywords = true,
                  const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr,
                  const TracerConfig* tracer_config = nullptr);
@@ -131,6 +148,7 @@ namespace Opm
                  ErrorGuard& errors,
                  std::shared_ptr<const Python> python,
                  const bool lowActionParsingStrictness = false,
+                 const bool keepKeywords = true,
                  const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr);
 
@@ -141,6 +159,7 @@ namespace Opm
                  T&& errors,
                  std::shared_ptr<const Python> python,
                  const bool lowActionParsingStrictness = false,
+                 const bool keepKeywords = true,
                  const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr);
 
@@ -148,6 +167,7 @@ namespace Opm
                  const EclipseState& es,
                  std::shared_ptr<const Python> python,
                  const bool lowActionParsingStrictness = false,
+                 const bool keepKeywords = true,
                  const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr);
 
@@ -156,6 +176,8 @@ namespace Opm
                  const EclipseState& es,
                  const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr);
+
+        ~Schedule() = default;
 
         static Schedule serializationTestObject();
 
@@ -541,6 +563,7 @@ namespace Opm
                                     const ScheduleGrid& grid,
                                     const std::unordered_map<std::string, double> * target_wellpi,
                                     const std::string& prefix,
+                                    const bool keepKeywords,
                                     const bool log_to_debug = false);
         void addACTIONX(const Action::ActionX& action);
         void addGroupToGroup( const std::string& parent_group, const std::string& child_group);

--- a/opm/input/eclipse/Schedule/ScheduleBlock.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleBlock.cpp
@@ -190,4 +190,9 @@ TSTEP
     output.write_string(tstep_string);
 }
 
+void ScheduleBlock::clearKeywords()
+{
+    m_keywords.clear();
+}
+
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/ScheduleBlock.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleBlock.hpp
@@ -70,6 +70,8 @@ public:
     bool operator==(const ScheduleBlock& other) const;
     static ScheduleBlock serializationTestObject();
 
+    void clearKeywords();
+
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {

--- a/opm/input/eclipse/Schedule/ScheduleDeck.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleDeck.cpp
@@ -128,8 +128,9 @@ ScheduleDeck::ScheduleDeck(time_point start_time, const Deck& deck, const Schedu
         if (context.rst_skip) {
             if (skiprest_include.count(keyword.name()) != 0)
                 this->m_blocks[0].push_back(keyword);
-        } else
+        } else {
             this->m_blocks.back().push_back(keyword);
+        }
     }
 }
 
@@ -178,7 +179,11 @@ namespace {
     }
 }
 
-void ScheduleDeck::add_block(ScheduleTimeType time_type, const time_point& t, ScheduleDeckContext& context, const KeywordLocation& location) {
+void ScheduleDeck::add_block(ScheduleTimeType time_type,
+                             const time_point& t,
+                             ScheduleDeckContext& context,
+                             const KeywordLocation& location)
+{
     context.last_time = t;
     if (context.rst_skip) {
         if (t < this->m_restart_time)
@@ -285,6 +290,11 @@ void ScheduleDeck::dump_deck(std::ostream&     os,
     for (const auto& block : this->m_blocks) {
         block.dump_deck(usys, output, current_time);
     }
+}
+
+void ScheduleDeck::clearKeywords(const std::size_t idx)
+{
+    m_blocks[idx].clearKeywords();
 }
 
 

--- a/opm/input/eclipse/Schedule/ScheduleDeck.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleDeck.hpp
@@ -79,6 +79,8 @@ namespace Opm {
 
         void dump_deck(std::ostream& os, const UnitSystem& usys) const;
 
+        void clearKeywords(const std::size_t idx);
+
     private:
         time_point m_restart_time;
         std::size_t m_restart_offset;

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(RUN) {
             }
             auto rst_view = std::make_shared<EclIO::RestartFileView>(std::move(rst), report_step);
             const auto rst_state = Opm::RestartIO::RstState::load(std::move(rst_view), state.runspec(), parser);
-            Schedule sched_rst(deck, state, python, false, {}, &rst_state);
+            Schedule sched_rst(deck, state, python, false, true, {}, &rst_state);
             const auto& rfti_well = sched_rst.getWell("RFTI", report_step);
             const auto& rftp_well = sched_rst.getWell("RFTP", report_step);
             BOOST_CHECK(rftp_well.getStatus() == Well::Status::SHUT);

--- a/tests/parser/ScheduleRestartTests.cpp
+++ b/tests/parser/ScheduleRestartTests.cpp
@@ -124,7 +124,7 @@ std::tuple<Schedule, Schedule, RestartIO::RstState> load_schedule_pair(const std
     auto rst_view = std::make_shared<EclIO::RestartFileView>(std::move(rst_file), restart_step);
     auto rst_state = RestartIO::RstState::load(std::move(rst_view), ecl_state.runspec(), parser);
     EclipseState ecl_state_restart(restart_deck);
-    Schedule restart_sched(restart_deck, ecl_state_restart, python, false, {}, &rst_state);
+    Schedule restart_sched(restart_deck, ecl_state_restart, python, false, true, {}, &rst_state);
 
     return {sched, restart_sched, std::move(rst_state)};
 }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -4488,7 +4488,7 @@ BOOST_AUTO_TEST_CASE(SKIPREST_VFP) {
     auto rst_file = std::make_shared<Opm::EclIO::ERst>(rst_filename);
     auto rst_view = std::make_shared<Opm::EclIO::RestartFileView>(std::move(rst_file), report_step);
     const auto rst = Opm::RestartIO::RstState::load(std::move(rst_view), es.runspec(), parser);
-    const auto sched = Schedule{ deck, es, python, false, {}, &rst };
+    const auto sched = Schedule{ deck, es, python, false, true, {}, &rst };
     BOOST_CHECK_NO_THROW( sched[3].vfpprod(5) );
 
     for (std::size_t index = 0; index < sched.size(); index++) {

--- a/tests/rst_test.cpp
+++ b/tests/rst_test.cpp
@@ -83,7 +83,7 @@ std::pair<Opm::EclipseState, Opm::Schedule> load_schedule(std::shared_ptr<const 
         return {
             std::piecewise_construct,
             std::forward_as_tuple(state),
-            std::forward_as_tuple(deck, state, python, false, std::nullopt, &rst)
+            std::forward_as_tuple(deck, state, python, false, true, std::nullopt, &rst)
         };
     } else
         return {


### PR DESCRIPTION
This becomes very significant with large schedules. This is probably too naive but I want to check fallout.