### PR TITLE
Permit Operating on Defaulted MULT* Arrays

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -1632,10 +1632,15 @@ void FieldProps::handle_operation(const Section      section,
                     unique_name = tran_field_iter->second;
                 }
             }
-            else if (mustExist &&
+            else if (mustExist && !kw_info.multiplier &&
                      !(editSect && (unique_name == ParserKeywords::PORV::keywordName)) &&
                      (this->double_data.find(unique_name) == this->double_data.end()))
             {
+                // Note exceptions for the MULT* arrays (i.e., MULT[XYZ] and
+                // MULT[XYZ]-).  We always support operating on defaulted
+                // array values (i.e, all elements equal to one) in the case
+                // of those arrays, even if the operation is not assignment.
+
                 throw OpmInputError {
                     fmt::format("Target array {} must already "
                                 "exist when operated upon in {}.",

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -327,6 +327,51 @@ ADD
                       OpmInputError);
 }
 
+BOOST_AUTO_TEST_CASE(Multiply_Defaulted_MultX)
+{
+    const auto deck = Parser{}.parseString(R"(RUNSPEC
+OIL
+GAS
+WATER
+TABDIMS
+/
+DIMENS
+ 3 3 3 /
+GRID
+MULTIPLY
+ 'MULTX' 0.123 1 3 1 1 2 2 /
+ 'MULTX' 0.234 1 3 2 2 2 2 /
+ 'MULTX' 0.345 1 3 3 3 2 2 /
+/
+)");
+
+    // Note: 'grid' must be mutable in FieldPropsManager constructor.
+    auto grid = EclipseGrid { 3, 3, 3 };
+
+    const auto fpMgr = FieldPropsManager {
+        deck, Phases{true, true, true}, grid, TableManager{deck}
+    };
+
+    const auto& multX = fpMgr.get_double("MULTX");
+
+    const auto expect = std::vector {
+        1.0, 1.0, 1.0,
+        1.0, 1.0, 1.0,
+        1.0, 1.0, 1.0,
+
+        0.123, 0.123, 0.123,
+        0.234, 0.234, 0.234,
+        0.345, 0.345, 0.345,
+
+        1.0, 1.0, 1.0,
+        1.0, 1.0, 1.0,
+        1.0, 1.0, 1.0,
+    };
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(multX .begin(), multX .end(),
+                                  expect.begin(), expect.end());
+}
+
 BOOST_AUTO_TEST_CASE(GRID_RESET) {
     std::string deck_string = R"(
 REGIONS


### PR DESCRIPTION
The existence checks introduced in commit 90be095 (PR #4109) turned out to be a little too restrictive.  Recent experience suggests that we need to permit array operations like `ADD` or `MULTIPLY` on the `MULT*` arrays (`MULT[XYZ]` and `MULT[XYZ]-`) even if these arrays have not yet been explicitly defined in the input deck.

This commit re-enables those array operations for property arrays whose `multiplier` flag is `true`.