### PR TITLE
Allow region operator on global 3D fields (poor man's version) 

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -1453,7 +1453,7 @@ void FieldProps::handle_operateR(const DeckKeyword& keyword)
             if (!all_active) {
                 const auto message =
                     fmt::format(R"(Region operation on 3D field {} with global storage will not update inactive cells.
-Note that this might cause problems for PINCH option 4 or 5 beging ALL.)", target_kw);
+Note that this might cause problems for PINCH option 4 or 5 being ALL.)", target_kw);
 
                 OpmLog::warning(Log::fileMessage(keyword.location(), message));
             }
@@ -1528,7 +1528,7 @@ void FieldProps::handle_region_operation(const DeckKeyword& keyword)
                 if (!all_active) {
                     const auto message =
                         fmt::format(R"(Region operation on 3D field {} with global storage will not update inactive cells.
-Note that this might cause problems for PINCH option 4 or 5 beging ALL.)", target_kw);
+Note that this might cause problems for PINCH option 4 or 5 being ALL.)", target_kw);
 
                     OpmLog::warning(Log::fileMessage(keyword.location(), message));
                 }

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -1866,7 +1866,7 @@ void FieldProps::init_porv(Fieldprops::FieldData<double>& porv)
     }
 
     for (const auto& mregp: this->multregp) {
-        const auto& index_list = this->region_index(mregp.region_name, mregp.region_value).first;
+        const auto index_list = this->region_index(mregp.region_name, mregp.region_value).first;
         for (const auto& cell_index : index_list)
             porv_data[cell_index.active_index] *= mregp.multiplier;
     }

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -755,7 +755,7 @@ private:
 
     std::string region_name(const DeckItem& region_item) const;
 
-    std::vector<Box::cell_index>
+    std::pair<std::vector<Box::cell_index>,bool>
     region_index(const std::string& region_name, int region_value);
 
     void handle_OPERATE(const DeckKeyword& keyword, Box box);

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -2276,7 +2276,7 @@ OPERATE
 }
 
 BOOST_AUTO_TEST_CASE(GLOBAL_SUPPORTED) {
-    // Operations involving two keywords cannot update a global keyword.
+    // Test COPY with global MULTZ
     const std::string valid_copy { R"(
 GRID
 

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -2295,6 +2295,25 @@ COPY
 
 )" };
 
+    // Test COPY with global MULTZ with inactive cells
+    const std::string valid_copy_inactive { R"(
+GRID
+
+PORO
+   3*0 21*0.10 3*0/
+
+ACTNUM
+   9*1 9*0 9*1 /
+
+MULTZ
+ 27*1.0 /
+
+COPY
+   MULTZ MULTX /
+/
+
+)" };
+
     // Test EQUALREG on global MULTZ
     const std::string valid_region { R"(
 GRID
@@ -2340,6 +2359,21 @@ EQUALREG
 )" };
     {
         const auto& fp = make_fp(valid_copy);
+
+        const auto& multz_fp = fp.get_double_field_data("MULTZ");
+        const auto& multz_status = multz_fp.global_value_status;
+        const auto& multz_data = multz_fp.global_data;
+        const auto& multx_data = fp.get_global_double("MULTX");
+
+        BOOST_CHECK(multz_data);
+        BOOST_CHECK_EQUAL(multz_data->size(), multx_data.size());
+
+        for(auto i = std::size_t(0); i < multz_data->size(); ++i)
+            if ((*multz_status)[i] != value::status::uninitialized)
+                BOOST_CHECK_EQUAL((*multz_data)[i], multx_data[i]);
+    }
+    {
+        const auto& fp = make_fp(valid_copy_inactive);
 
         const auto& multz_fp = fp.get_double_field_data("MULTZ");
         const auto& multz_status = multz_fp.global_value_status;

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -2291,7 +2291,7 @@ OPERATE
 )" };
 
     BOOST_CHECK_THROW(make_fp(invalid_copy), std::logic_error);
-    BOOST_CHECK_THROW(make_fp(invalid_region), OpmInputError);
+    BOOST_CHECK_THROW(make_fp(invalid_region), std::logic_error);
     BOOST_CHECK_THROW(make_fp(invalid_operate), std::logic_error);
 }
 BOOST_AUTO_TEST_CASE(GLOBAL_SUPPORTED) {

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -2252,25 +2252,6 @@ COPY
 
 )" };
 
-    // Cannot update a global keyword with xxxxREG operations
-    const std::string invalid_region { R"(
-GRID
-
-PORO
-   27*0.10 /
-
-ACTNUM
-   9*1 9*0 9*1 /
-
-MULTZ
- 27*1.0 /
-
-EQUALREG
-   MULTZ  2.0 1 /
-/
-
-)" };
-
     // Cannot update a global keyword with the OPERATE keyword
     const std::string invalid_operate { R"(
 GRID
@@ -2291,9 +2272,9 @@ OPERATE
 )" };
 
     BOOST_CHECK_THROW(make_fp(invalid_copy), std::logic_error);
-    BOOST_CHECK_THROW(make_fp(invalid_region), std::logic_error);
     BOOST_CHECK_THROW(make_fp(invalid_operate), std::logic_error);
 }
+
 BOOST_AUTO_TEST_CASE(GLOBAL_SUPPORTED) {
     // Operations involving two keywords cannot update a global keyword.
     const std::string valid_copy { R"(
@@ -2314,19 +2295,90 @@ COPY
 
 )" };
 
-    const auto& fp = make_fp(valid_copy);
+    // Test EQUALREG on global MULTZ
+    const std::string valid_region { R"(
+GRID
 
-    const auto& multz_fp = fp.get_double_field_data("MULTZ");
-    const auto& multz_status = multz_fp.global_value_status;
-    const auto& multz_data = multz_fp.global_data;
-    const auto& multx_data = fp.get_global_double("MULTX");
+PORO
+   27*0.10 /
 
-    BOOST_CHECK(multz_data);
-    BOOST_CHECK_EQUAL(multz_data->size(), multx_data.size());
-    
-    for(auto i = std::size_t(0); i < multz_data->size(); ++i)
-        if ((*multz_status)[i] != value::status::uninitialized)
-            BOOST_CHECK_EQUAL((*multz_data)[i], multx_data[i]);
+ACTNUM
+   9*1 9*0 9*1 /
+
+MULTZ
+ 27*1.0 /
+
+FLUXNUM
+   27*1 /
+
+EQUALREG
+   MULTZ 2.0 1 F/
+/
+
+)" };
+
+    // Test EQUALREG on global MULTZ with inactive cells
+    const std::string valid_region_inactive { R"(
+GRID
+
+PORO
+   3*0.0 21*0.10 3*0.0/
+
+ACTNUM
+   9*1 9*0 9*1 /
+
+MULTZ
+ 27*1.0 /
+
+FLUXNUM
+   27*1 /
+
+EQUALREG
+   MULTZ 2.0 1 F/
+/
+
+)" };
+    {
+        const auto& fp = make_fp(valid_copy);
+
+        const auto& multz_fp = fp.get_double_field_data("MULTZ");
+        const auto& multz_status = multz_fp.global_value_status;
+        const auto& multz_data = multz_fp.global_data;
+        const auto& multx_data = fp.get_global_double("MULTX");
+
+        BOOST_CHECK(multz_data);
+        BOOST_CHECK_EQUAL(multz_data->size(), multx_data.size());
+
+        for(auto i = std::size_t(0); i < multz_data->size(); ++i)
+            if ((*multz_status)[i] != value::status::uninitialized)
+                BOOST_CHECK_EQUAL((*multz_data)[i], multx_data[i]);
+    }
+    {
+        const auto& fp = make_fp(valid_region);
+
+        const auto& multz_data = fp.get_global_double("MULTZ");
+        std::vector<double> multz_expected = {
+            2, 2, 2, 2, 2, 2, 2, 2, 2,
+            1, 1, 1, 1, 1, 1, 1, 1, 1,
+            2, 2, 2, 2, 2, 2, 2, 2, 2};
+
+        for(auto i = std::size_t(0); i < multz_data.size(); ++i)
+            BOOST_CHECK_EQUAL(multz_data[i], multz_expected[i]);
+    }
+
+    {
+        const auto& fp = make_fp(valid_region_inactive);
+
+        const auto& multz_data = fp.get_global_double("MULTZ");
+        std::vector<double> multz_expected = {
+            0, 0, 0, 2, 2, 2, 2, 2, 2,
+            1, 1, 1, 1, 1, 1, 1, 1, 1,
+            2, 2, 2, 2, 2, 2, 0, 0, 0};
+
+        for(auto i = std::size_t(0); i < multz_data.size(); ++i)
+            if (i > 2 && i < 24)
+                BOOST_CHECK_EQUAL(multz_data[i], multz_expected[i]);
+    }
 }
 
 


### PR DESCRIPTION
For region operations we only make sure that global arrays have correct values for active cells.

This means that values get lost for inactive cells of the regions. In this case we at least issue a warning.

This is the last PR that I factor out from #4181 