### PR TITLE
add ability to add source term from code

### DIFF
--- a/opm/input/eclipse/Schedule/Source.hpp
+++ b/opm/input/eclipse/Schedule/Source.hpp
@@ -89,6 +89,12 @@ public:
 
     void updateSource(const DeckRecord& record);
 
+    //! \brief Add a source term for a grid cell.
+    void addSourceCell(const SourceCell& cell)
+    {
+        m_cells.push_back(cell);
+    }
+
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {


### PR DESCRIPTION
I am working on a machine learning application using flow. While I mostly managed to do this without modifying the opm code, there is one exception. The approach used is what is known as CoSTA - Corrected Source Term Approach.
This involves adding an extra source term to the system of equations. As this is provided provided by the neural network from python I need to be able to also generate the Source for this from code without having a DeckRecord to pass in. Thus I need this simple addition to the Source API.