### PR TITLE
Add exception for convergence monitoring

### DIFF
--- a/opm/common/Exceptions.hpp
+++ b/opm/common/Exceptions.hpp
@@ -44,6 +44,14 @@ public:
     {}
 };
 
+class ConvergenceMonitorFailure : public NumericalProblem
+{
+public:
+    explicit ConvergenceMonitorFailure(const std::string &message)
+        : NumericalProblem(message)
+    {}
+};
+
 class MaterialLawProblem : public NumericalProblem
 {
 public:


### PR DESCRIPTION
Adding an exception for the convergence monitoring being introduced in https://github.com/OPM/opm-simulators/pull/5590.
The exception is used to raise a convergence monitoring error, such that the timestep is chopped.