### PR TITLE
fixed: list opm.io.summary package in setup.py

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -29,6 +29,7 @@ setup(
                 'opm.io.ecl_state',
                 'opm.io.parser',
                 'opm.io.schedule',
+                'opm.io.summary',
                 'opm.io.ecl',
                 'opm.tools',
                 'opm.util'


### PR DESCRIPTION
This has been forgotten at some point. Causes warnings while packaging.