### PR TITLE
Bump embedded pybind11 version to enable numpy2 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,7 +423,8 @@ if (OPM_ENABLE_PYTHON)
   add_custom_target(copy_python ALL
     COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/python/install.py ${PROJECT_SOURCE_DIR}/python ${PROJECT_BINARY_DIR} 0)
 
-  file(COPY ${PROJECT_SOURCE_DIR}/python/README.md DESTINATION ${PROJECT_BINARY_DIR}/python)
+  file(COPY ${PROJECT_SOURCE_DIR}/python/README.md ${PROJECT_SOURCE_DIR}/python/MANIFEST.in
+       DESTINATION ${PROJECT_BINARY_DIR}/python)
 
   pybind11_add_module(opmcommon_python
                       ${PYTHON_CXX_SOURCE_FILES}

--- a/cmake/Modules/DownloadPyBind11.cmake
+++ b/cmake/Modules/DownloadPyBind11.cmake
@@ -1,6 +1,14 @@
 include(FetchContent)
-FetchContent_Declare(pybind11
-                     DOWNLOAD_EXTRACT_TIMESTAMP ON
-                     URL https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz
-                     URL_HASH SHA512=ed1512ff0bca3bc0a45edc2eb8c77f8286ab9389f6ff1d5cb309be24bc608abbe0df6a7f5cb18c8f80a3bfa509058547c13551c3cd6a759af708fd0cdcdd9e95)
+
+if(Python3_VERSION_MINOR LESS 8)
+  FetchContent_Declare(pybind11
+                       URL https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz
+                       URL_HASH SHA512=ed1512ff0bca3bc0a45edc2eb8c77f8286ab9389f6ff1d5cb309be24bc608abbe0df6a7f5cb18c8f80a3bfa509058547c13551c3cd6a759af708fd0cdcdd9e95)
+else()
+  FetchContent_Declare(pybind11
+                       DOWNLOAD_EXTRACT_TIMESTAMP ON
+                       URL https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.tar.gz
+                       URL_HASH SHA512=497c25b33b09a9c42f67131ab82e35d689e8ce089dd7639be997305ff9a6d502447b79c824508c455d559e61f0186335b54dd2771d903a7c1621833930622d1a)
+endif()
+
 FetchContent_MakeAvailable(pybind11)

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,1 @@
+include opm/*

--- a/python/generate-pypi-package.sh
+++ b/python/generate-pypi-package.sh
@@ -33,7 +33,6 @@ do
     # make step is necessary until the generated ParserKeywords/*.hpp are generated in the Python step
     make opmcommon_python -j${BUILD_JOBS}
     cd python
-    echo -e "include opm/*\ninclude opm/io/summary/__init__.py" > MANIFEST.in
     ${python_versions[$tag]} setup.py sdist bdist_wheel --plat-name manylinux2014_x86_64 --python-tag $tag
     ${python_versions[$tag]} -m auditwheel repair dist/*$tag*.whl
     cp dist/*$tag*.whl /tmp/opm-common/wheelhouse

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -29,6 +29,7 @@ setup(
                 'opm.io.ecl_state',
                 'opm.io.parser',
                 'opm.io.schedule',
+                'opm.io.sim',
                 'opm.io.summary',
                 'opm.io.ecl',
                 'opm.tools',


### PR DESCRIPTION
numpy2 is now the default in python repositories, and we need to bump the embedded pybind11 to support it.

The new version of pybind11 does however not support python < 3.8. We therefore use the old version for python 3.6 and 3.7, and the new version for >= 3.8.

Closes #2350
(edited by @blattms: added closes statement)