### PR TITLE
Add Missing UDA Dimension for GCONPROD GRAT Limit

### DIFF
--- a/opm/input/eclipse/Units/UnitSystem.cpp
+++ b/opm/input/eclipse/Units/UnitSystem.cpp
@@ -1485,6 +1485,7 @@ namespace {
 
         case UDAControl::WCONPROD_GRAT:
         case UDAControl::WELTARG_GRAT:
+        case UDAControl::GCONPROD_GAS_TARGET:
         case UDAControl::WCONPROD_LIFT:   // @TODO@ Get this working also for ALQ types other than GRAT
         case UDAControl::WELTARG_LIFT:
             return this->getDimension(UnitSystem::measure::gas_surface_rate);


### PR DESCRIPTION
Appears to have been simply forgotten when this function was first added in commit d8d6749337 (PR #2620).  Without this we fail loading a restarted simulation run with UDAs for GCONPROD's GRAT limit and issue a diagnostic of the form
> ```
> Internal error: No dimension for UDA control 'GCONPROD_GRAT'
> ```