### PR TITLE
convertECL supports converting .LGR to .FLGR and vice versa

### DIFF
--- a/test_util/convertECL.cpp
+++ b/test_util/convertECL.cpp
@@ -232,6 +232,7 @@ int main(int argc, char **argv)
         {".UNRST" , ".FUNRST" },
         {".RFT"   , ".FRFT"   },
         {".ESMRY" , ".FESMRY" },
+        {".LGR"  , ".FLGR"},
     };
 
     const std::map<std::string, std::string> to_binary {
@@ -243,6 +244,7 @@ int main(int argc, char **argv)
         {".FUNRST" , ".UNRST" },
         {".FRFT"   , ".RFT"   },
         {".FESMRY" , ".ESMRY" },
+        {".FLGR"  , ".LGR"},
     };
 
     std::string output_fname{};


### PR DESCRIPTION
Adds the ability to convert standard output format LGR to FLGR.