### PR TITLE
[fix] Added missing include needed for g++-14

### DIFF
--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -19,6 +19,7 @@
 #ifndef OPM_IO_ESMRY_HPP
 #define OPM_IO_ESMRY_HPP
 
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <iosfwd>


### PR DESCRIPTION
Back-port of PR #4256 for OPM 2024.10 Release.