### PR TITLE
Remove RVW from needed SOLUTION vectors to allow for restart of gas-water cases

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -283,7 +283,6 @@ static const std::unordered_map<std::string, keyword_info<double>> double_keywor
                                                                                       {"TEMPI",    keyword_info<double>{}.unit_string("Temperature")},
                                                                                       {"RS",       keyword_info<double>{}.unit_string("GasDissolutionFactor")},
                                                                                       {"RV",       keyword_info<double>{}.unit_string("OilDissolutionFactor")},
-                                                                                      {"RVW",      keyword_info<double>{}.unit_string("OilDissolutionFactor")}
                                                                                       };
 
 static const std::unordered_map<std::string, keyword_info<double>> composition_keywords = {{"XMF", keyword_info<double>{}},


### PR DESCRIPTION
We dont output RVW if --enable-opm-rst-file=false. This will make it possible to restart even if RVW is not written to file.This is analog to what we do for RSW. An alternative fix is to add RVW (and RSW) to the restart file even if --enable-opm-rst-file=false, then we should also add RSW to this list. 