### PR TITLE
Retire OPM_?WEL Arrays

### DIFF
--- a/opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -123,17 +123,12 @@ namespace Opm {
         2. You can optionally ask the RestartIO::save() function to save the
            solution in double precision.
 
-        3. The RestartIO::save() function will save opm specific vector OPM_IWEL
-           and OPM_XWEL.
-
       ecl_compatible_restart = true:
 
         1. The 'extra' fields in the RestartValue are silently ignored.
 
         2. If request double precision solution data that is silently ignored,
            it will be float.
-
-        3. The OPM_IWEL and OPM_XWEL vectors will not be written.
 
       Observe that the solution data in the RestartValue is passed
       unconditionally to the solution section in the restart file, so if you
@@ -144,10 +139,9 @@ namespace Opm {
 
 
 
-    class IOConfig {
-
+    class IOConfig
+    {
     public:
-
         IOConfig() = default;
         explicit IOConfig(const Deck&);
         explicit IOConfig(const std::string& input_path);

--- a/opm/output/eclipse/LoadRestart.cpp
+++ b/opm/output/eclipse/LoadRestart.cpp
@@ -694,115 +694,6 @@ namespace {
         }
     }
 
-    void checkWellVectorSizes(const std::vector<int>&                   opm_iwel,
-                              const std::vector<double>&                opm_xwel,
-                              const std::vector<Opm::data::Rates::opt>& phases,
-                              const std::vector<Opm::Well>&            sched_wells)
-    {
-        const auto expected_xwel_size =
-            std::accumulate(sched_wells.begin(), sched_wells.end(),
-                            std::size_t(0),
-                [&phases](const std::size_t acc, const Opm::Well& w)
-                -> std::size_t
-            {
-                return acc
-                    + 3 + phases.size()
-                    + (w.getConnections().size()
-                        * (phases.size() + Opm::data::Connection::restart_size));
-            });
-
-        if (opm_xwel.size() != expected_xwel_size) {
-            throw std::runtime_error {
-                "Mismatch between OPM_XWEL and deck; "
-                "OPM_XWEL size was " + std::to_string(opm_xwel.size()) +
-                ", expected " + std::to_string(expected_xwel_size)
-            };
-        }
-
-        if (opm_iwel.size() != sched_wells.size()) {
-            throw std::runtime_error {
-                "Mismatch between OPM_IWEL and deck; "
-                "OPM_IWEL size was " + std::to_string(opm_iwel.size()) +
-                ", expected " + std::to_string(sched_wells.size())
-            };
-        }
-    }
-
-    Opm::data::Wells
-    restore_wells_opm(const ::Opm::EclipseState&         es,
-                      const ::Opm::EclipseGrid&          grid,
-                      const ::Opm::Schedule&             schedule,
-                      const Opm::EclIO::RestartFileView& rst_view)
-    {
-        if (! (rst_view.hasKeyword<int>   ("OPM_IWEL") &&
-               rst_view.hasKeyword<double>("OPM_XWEL")))
-        {
-            return {};
-        }
-
-        const auto& opm_iwel = rst_view.getKeyword<int>   ("OPM_IWEL");
-        const auto& opm_xwel = rst_view.getKeyword<double>("OPM_XWEL");
-
-        using rt = Opm::data::Rates::opt;
-
-        const auto& sched_wells = schedule.getWells(rst_view.simStep());
-        std::vector<rt> phases;
-        {
-            const auto& phase = es.runspec().phases();
-
-            if (phase.active(Opm::Phase::WATER)) { phases.push_back(rt::wat); }
-            if (phase.active(Opm::Phase::OIL))   { phases.push_back(rt::oil); }
-            if (phase.active(Opm::Phase::GAS))   { phases.push_back(rt::gas); }
-        }
-
-        checkWellVectorSizes(opm_iwel, opm_xwel, phases, sched_wells);
-
-        Opm::data::Wells wells;
-        auto opm_xwel_data = opm_xwel.begin();
-        auto opm_iwel_data = opm_iwel.begin();
-
-        for (const auto& sched_well : sched_wells) {
-            auto& well = wells[ sched_well.name() ];
-
-            well.bhp         = *opm_xwel_data;  ++opm_xwel_data;
-            well.thp         = *opm_xwel_data;  ++opm_xwel_data;
-            well.temperature = *opm_xwel_data;  ++opm_xwel_data;
-            well.control     = *opm_iwel_data;  ++opm_iwel_data;
-
-            for (const auto& phase : phases) {
-                well.rates.set(phase, *opm_xwel_data);
-                ++opm_xwel_data;
-            }
-
-            for (const auto& sc : sched_well.getConnections()) {
-                const auto i = sc.getI(), j = sc.getJ(), k = sc.getK();
-
-                if (!grid.cellActive(i, j, k) || sc.state() == Opm::Connection::State::SHUT) {
-                    opm_xwel_data += Opm::data::Connection::restart_size + phases.size();
-                    continue;
-                }
-
-                well.connections.emplace_back();
-                auto& connection = well.connections.back();
-
-                connection.index          = grid.getGlobalIndex(i, j, k);
-                connection.pressure       = *opm_xwel_data++;
-                connection.reservoir_rate = *opm_xwel_data++;
-                connection.cell_pressure = *opm_xwel_data++;
-                connection.cell_saturation_water = *opm_xwel_data++;
-                connection.cell_saturation_gas = *opm_xwel_data++;
-                connection.effective_Kh = *opm_xwel_data++;
-
-                for (const auto& phase : phases) {
-                    connection.rates.set(phase, *opm_xwel_data);
-                    ++opm_xwel_data;
-                }
-            }
-        }
-
-        return wells;
-    }
-
     template <typename AssignCumulative>
     void restoreConnCumulatives(const WellVectors::Window<double>& xcon,
                                 AssignCumulative&&                 asgn)
@@ -1167,11 +1058,11 @@ namespace {
     }
 
     Opm::data::Wells
-    restore_wells_ecl(const ::Opm::EclipseState&                   es,
-                      const ::Opm::EclipseGrid&                    grid,
-                      const ::Opm::Schedule&                       schedule,
-                      Opm::SummaryState&                           smry,
-                      std::shared_ptr<Opm::EclIO::RestartFileView> rst_view)
+    restore_wells(const ::Opm::EclipseState&                   es,
+                  const ::Opm::EclipseGrid&                    grid,
+                  const ::Opm::Schedule&                       schedule,
+                  Opm::SummaryState&                           smry,
+                  std::shared_ptr<Opm::EclIO::RestartFileView> rst_view)
     {
         auto soln = ::Opm::data::Wells{};
 
@@ -1604,10 +1495,7 @@ namespace Opm { namespace RestartIO  {
 
         xr.convertToSI(es.getUnits());
 
-        auto xw = rst_view->hasKeyword<double>("OPM_XWEL")
-            ? restore_wells_opm(es, grid, schedule, *rst_view)
-            : restore_wells_ecl(es, grid, schedule, summary_state, rst_view);
-
+        auto xw = restore_wells(es, grid, schedule, summary_state, rst_view);
         auto xgrp_nwrk = restore_grp_nwrk(schedule, es.getUnits(), rst_view);
 
         auto aquifers = hasAquifers(*rst_view)

--- a/opm/output/eclipse/RestartValue.cpp
+++ b/opm/output/eclipse/RestartValue.cpp
@@ -17,16 +17,24 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <set>
-#include <utility>
-
 #include <opm/output/eclipse/RestartValue.hpp>
+
+#include <algorithm>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace Opm {
 
     namespace {
 
-        const std::set<std::string> reserved_keys = {"LOGIHEAD", "INTEHEAD" ,"DOUBHEAD", "IWEL", "XWEL","ICON", "XCON" , "OPM_IWEL" , "OPM_XWEL", "ZWEL"};
+        const std::set<std::string> reserved_keys {
+            "LOGIHEAD", "INTEHEAD", "DOUBHEAD",
+            "IWEL", "XWEL", "ZWEL",
+            "ICON", "XCON",
+        };
 
     }
 

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -596,8 +596,6 @@ BOOST_AUTO_TEST_CASE(ECL_FORMATTED)
 
                 BOOST_CHECK_MESSAGE(rst.hasKey("SWAT"), "Restart file must have SWAT vector");
                 BOOST_CHECK_MESSAGE(!rst.hasKey("EXTRA"), "Restart file must NOT have EXTRA vector");
-                BOOST_CHECK_MESSAGE(!rst.hasKey("OPM_IWEL"), "Restart file must NOT have OPM_IWEL vector");
-                BOOST_CHECK_MESSAGE(!rst.hasKey("OPM_XWEL"), "Restart file must NOT have OPM_XWEL vector");
             }
         }
     }


### PR DESCRIPTION
These no longer serve any purpose as all of their contents are available in the regular restart arrays&ndash;notably `IWEL` and `[SX]WEL`.