### PR TITLE
Avoid converting surface rate to SI twice

### DIFF
--- a/opm/input/eclipse/Schedule/eval_uda.cpp
+++ b/opm/input/eclipse/Schedule/eval_uda.cpp
@@ -49,7 +49,7 @@ namespace UDA {
 
 
 double eval_well_uda_rate(const UDAValue& value, const std::string& well, const SummaryState& st, double udq_default, InjectorType wellType, const UnitSystem& unitSystem) {
-    double raw_rate = eval_well_uda(value, well, st, udq_default);
+    const auto raw_rate = value.is<double>() ? value.get<double>() : eval_well_uda(value, well, st, udq_default);
     return injection::rateToSI(raw_rate, wellType, unitSystem);
 }
 
@@ -75,10 +75,7 @@ double eval_group_uda(const UDAValue& value, const std::string& group, const Sum
 
 
 double eval_group_uda_rate(const UDAValue& value, const std::string& name, const SummaryState& st, double udq_undefined, Phase phase, const UnitSystem& unitSystem) {
-    if (value.is<double>())
-        return injection::rateToSI(value.get<double>(), phase, unitSystem);
-
-    double raw_rate = eval_group_uda(value, name, st, udq_undefined);
+    const auto raw_rate = value.is<double>() ? value.get<double>() : eval_group_uda(value, name, st, udq_undefined);
     return injection::rateToSI(raw_rate, phase, unitSystem);
 }
 


### PR DESCRIPTION
Back-ports PR #4268 to the release branch as this fixes a problem and should be in the 2024.10 release.