### PR TITLE
convertECL supports input files with lowercase extensions

### DIFF
--- a/test_util/convertECL.cpp
+++ b/test_util/convertECL.cpp
@@ -294,7 +294,7 @@ int main(int argc, char **argv)
     std::string rootN = filename.substr(0,p);
     std::string extension = filename.substr(p,l-p);
     std::transform(extension.begin(), extension.end(), extension.begin(),
-                 [](unsigned char ckey){ return ::toupper(ckey);});  
+                 [](unsigned char ckey){ return std::toupper(ckey);});  
     std::string resFile;
 
 

--- a/test_util/convertECL.cpp
+++ b/test_util/convertECL.cpp
@@ -293,7 +293,8 @@ int main(int argc, char **argv)
 
     std::string rootN = filename.substr(0,p);
     std::string extension = filename.substr(p,l-p);
-    std::transform(extension.begin(), extension.end(), extension.begin(), ::toupper);  
+    std::transform(extension.begin(), extension.end(), extension.begin(),
+                 [](unsigned char ckey){ return ::toupper(ckey);});  
     std::string resFile;
 
 

--- a/test_util/convertECL.cpp
+++ b/test_util/convertECL.cpp
@@ -4,7 +4,7 @@
 #include <iomanip>
 #include <iostream>
 #include <type_traits>
-
+#include <cctype>
 #include <opm/io/eclipse/EclFile.hpp>
 #include <opm/io/eclipse/ERst.hpp>
 #include <opm/io/eclipse/EclOutput.hpp>
@@ -293,6 +293,7 @@ int main(int argc, char **argv)
 
     std::string rootN = filename.substr(0,p);
     std::string extension = filename.substr(p,l-p);
+    std::transform(extension.begin(), extension.end(), extension.begin(), ::toupper);  
     std::string resFile;
 
 


### PR DESCRIPTION
fixed a bug that `convertECL` could not identify files with lowercase extensions.