### PR TITLE
Don't Move From Object Twice

### DIFF
--- a/opm/output/eclipse/AggregateGroupData.cpp
+++ b/opm/output/eclipse/AggregateGroupData.cpp
@@ -910,15 +910,15 @@ void assignGroupInjectionTargets(const Opm::Group&        group,
                                  SGrpArray&               sGrp)
 {
     if (group.hasInjectionControl(Opm::Phase::GAS)) {
-        assignGroupGasInjectionTargets(group, sumState, std::forward<SGProp>(sgprop), sGrp);
+        assignGroupGasInjectionTargets(group, sumState, sgprop, sGrp);
     }
 
     if (group.hasInjectionControl(Opm::Phase::WATER)) {
-        assignGroupWaterInjectionTargets(group, sumState, std::forward<SGProp>(sgprop), sGrp);
+        assignGroupWaterInjectionTargets(group, sumState, sgprop, sGrp);
     }
 
     if (group.hasInjectionControl(Opm::Phase::OIL)) {
-        assignGroupOilInjectionTargets(group, sumState, std::forward<SGProp>(sgprop), sGrp);
+        assignGroupOilInjectionTargets(group, sumState, sgprop, sGrp);
     }
 }
 


### PR DESCRIPTION
We've had a long-standing problem in our linearisation logic for restart file well data.  We were calling `forward<>(obj)` repeatedly and the only reason this didn't blow up is that it captured a unit system by reference.  Use a guaranteed safe call instead.

While here, also fix a similar problem for the group data and split some long lines in preparation of altering the implementation of ACTIONX match sets.