### PR TITLE
Fix serialization of shared pointers

### DIFF
--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -147,6 +147,7 @@ public:
         m_ptrmap.clear();
         m_op = Operation::PACK;
         (*this)(data);
+        m_ptrmap.clear();
     }
 
     //! \brief Call this to serialize data.
@@ -164,6 +165,7 @@ public:
         m_ptrmap.clear();
         m_op = Operation::PACK;
         variadic_call(data...);
+        m_ptrmap.clear();
     }
 
     //! \brief Call this to de-serialize data.
@@ -176,6 +178,7 @@ public:
         m_ptrmap.clear();
         m_op = Operation::UNPACK;
         (*this)(data);
+        m_ptrmap.clear();
     }
 
     //! \brief Call this to de-serialize data.
@@ -188,6 +191,7 @@ public:
         m_ptrmap.clear();
         m_op = Operation::UNPACK;
         variadic_call(data...);
+        m_ptrmap.clear();
     }
 
     //! \brief Returns current position in buffer.

--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -22,6 +22,7 @@
 #define SERIALIZER_HPP
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
@@ -101,9 +102,9 @@ public:
     {
         if constexpr (is_ptr<T>::value) {
             if constexpr (detail::is_unique_ptr<T>::value) {
-                uniqueptr(data);
+                unique_ptr(data);
             } else {
-                ptr(data);
+                shared_ptr(data);
             }
         } else if constexpr (is_pair_or_tuple<T>::value) {
             tuple(data);
@@ -545,53 +546,47 @@ protected:
         T, std::void_t<decltype(std::declval<T>().serializeOp(std::declval<Serializer<Packer>&>()))>
     > : public std::true_type {};
 
-    //! \brief Handler for smart pointers.
+    //! \brief Handler for shared pointers.
     template<class PtrType>
-    void ptr(const PtrType& data)
+    void shared_ptr(const PtrType& data)
     {
         using T1 = typename PtrType::element_type;
-        void* data_ptr = reinterpret_cast<void*>(data.get());
+        std::uintptr_t data_ptr = reinterpret_cast<std::uintptr_t>(data.get());
         (*this)(data_ptr);
         if (!data_ptr)
             return;
-
         if (m_op == Operation::PACK || m_op == Operation::PACKSIZE) {
             if (m_ptrmap.count(data_ptr) == 0) {
                 (*this)(*data);
-                m_ptrmap[data_ptr] = nullptr;
+                m_ptrmap[data_ptr].reset();
             }
         } else {  // m_op == Operation::UNPACK
             if (m_ptrmap.count(data_ptr) == 0) {
-                const_cast<PtrType&>(data).reset(new T1);
-                m_ptrmap[data_ptr] = reinterpret_cast<void*>(& const_cast<PtrType&>(data));
+                const_cast<PtrType&>(data) = std::make_shared<T1>();
+                m_ptrmap[data_ptr] = std::static_pointer_cast<void>(data);
                 (*this)(*data);
             } else {
-                const_cast<PtrType&>(data) = *(reinterpret_cast<PtrType*>(m_ptrmap[data_ptr]));
+                const_cast<PtrType&>(data) = std::static_pointer_cast<T1>(m_ptrmap[data_ptr]);
             }
         }
     }
 
     template<class PtrType>
-    void uniqueptr(const PtrType& data)
+    void unique_ptr(const PtrType& data)
     {
         using T1 = typename PtrType::element_type;
-        void* data_ptr = reinterpret_cast<void*>(&(*data));
-        (*this)(data_ptr);
-        if (!data_ptr)
-            return;
 
-        if (m_op == Operation::PACK || m_op == Operation::PACKSIZE) {
-            if (m_ptrmap.count(data_ptr) == 0) {
+        if (m_op != Operation::UNPACK) {
+            (*this)(data ? 1 : 0);
+            if (data) {
                 (*this)(*data);
-                m_ptrmap[data_ptr] = nullptr;
             }
-        } else {  // m_op == Operation::UNPACK
-            if (m_ptrmap.count(data_ptr) == 0) {
-                const_cast<PtrType&>(data).reset(new T1);
-                m_ptrmap[data_ptr] = reinterpret_cast<void*>(& const_cast<PtrType&>(data));
+        } else {
+            int ptr = 0;
+            (*this)(ptr);
+            if (ptr == 1) {
+                const_cast<PtrType&>(data) = std::make_unique<T1>();
                 (*this)(*data);
-            } else {
-                throw std::runtime_error("Should never have to reconstruct more than one unique_ptr!");
             }
         }
     }
@@ -601,7 +596,7 @@ protected:
     size_t m_packSize = 0; //!< Required buffer size after PACKSIZE has been done
     size_t m_position = 0; //!< Current position in buffer
     std::vector<char> m_buffer; //!< Buffer for serialized data
-    std::map<void*, void*> m_ptrmap; //!< Map to keep track of which pointer data has been serialized and actual pointers during unpacking
+    std::map<std::uintptr_t, std::shared_ptr<void>> m_ptrmap; //!< Map to keep track of which pointer data has been serialized and actual pointers during unpacking
 };
 
 }


### PR DESCRIPTION
commit https://github.com/OPM/opm-common/commit/067d6d44460548e10610b5c753bd2db76bb1887f aimed to
keep the shared nature of shared pointers when deserializing.

the problem is that assigning multiple shared ptrs to the same
raw pointer does not enable any sharing, it only leads to multiple
deletions. fix this by properly holding a shared pointer in the map.

convert the adresses that is serialized to keep track of what pointers were
shared on the sender side to integers (uintptr_t) rather than serializing
them as void pointers. this is clearer and in principle more correct as
it is rather unclear how a serializer should handle a void pointer, and
it only worked by "accident" since std::is_pod_v happens to return true
for a void*.

while at it make sure to clear out pointer maps after pack/unpack operations for
memory savings (does not matter in reality since serializer objects are immediately destroyed,
but still..)