### PR TITLE
Record ACTIONX Wells Affected by WELPI Separately

### DIFF
--- a/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
+++ b/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
@@ -31,12 +31,13 @@ namespace Opm {
 
 struct SimulatorUpdate
 {
-    static SimulatorUpdate serializationTestObject() {
-      SimulatorUpdate simulatorUpdate;
-      simulatorUpdate.tran_update = false;
-      simulatorUpdate.well_structure_changed = false;
-      simulatorUpdate.affected_wells = {"test"};
-      return simulatorUpdate;
+    static SimulatorUpdate serializationTestObject()
+    {
+        SimulatorUpdate simulatorUpdate;
+        simulatorUpdate.tran_update = true;
+        simulatorUpdate.well_structure_changed = true;
+        simulatorUpdate.affected_wells = {"test"};
+        return simulatorUpdate;
     }
 
     template<class Serializer>
@@ -47,36 +48,47 @@ struct SimulatorUpdate
         serializer(well_structure_changed);
     }
 
-    // Wells affected by ACTIONX and for which the simulator needs to
-    // reapply rates and state from the newly updated Schedule object.
-    std::unordered_set<std::string> affected_wells;
+    /// Wells affected by ACTIONX and for which the simulator needs to
+    /// reapply rates and state from the newly updated Schedule object.
+    std::unordered_set<std::string> affected_wells{};
 
-    // If one of the transmissibility multiplier keywords has been invoked
-    // as an ACTIONX keyword the simulator needs to recalculate the
-    // transmissibility.
+    /// Whether or not a transmissibility multiplier keyword was invoked in
+    /// an ACTIONX block.
+    ///
+    /// If so, the simulator needs to recalculate the transmissibilities.
     bool tran_update{false};
 
     /// Whether or not well structure changed in processing an ACTIONX
-    /// block.  Typically because of a keyword like WELSPECS, COMPDAT,
-    /// and/or WELOPEN.
+    /// block.
+    ///
+    /// Typically because of a keyword like WELSPECS, COMPDAT, and/or
+    /// WELOPEN.
     bool well_structure_changed{false};
 
-    void append(SimulatorUpdate& otherSimUpdate) {
-      this->tran_update = otherSimUpdate.tran_update or this->tran_update;
-      this->well_structure_changed = otherSimUpdate.well_structure_changed or this->well_structure_changed;
-      affected_wells.insert(otherSimUpdate.affected_wells.begin(), otherSimUpdate.affected_wells.end());
+    void append(const SimulatorUpdate& otherSimUpdate)
+    {
+        this->tran_update = this->tran_update || otherSimUpdate.tran_update;
+
+        this->well_structure_changed = this->well_structure_changed
+            || otherSimUpdate.well_structure_changed;
+
+        this->affected_wells.insert(otherSimUpdate.affected_wells.begin(),
+                                    otherSimUpdate.affected_wells.end());
     }
 
-    void reset() {
-      tran_update = false;
-      well_structure_changed = false;
-      affected_wells.clear();
+    void reset()
+    {
+        this->tran_update = false;
+        this->well_structure_changed = false;
+        this->affected_wells.clear();
     }
 
-    bool operator==(const SimulatorUpdate& data) const {
-    return tran_update == data.tran_update &&
-           well_structure_changed == data.well_structure_changed &&
-           affected_wells == data.affected_wells;
+    bool operator==(const SimulatorUpdate& that) const
+    {
+        return (this->tran_update == that.tran_update)
+            && (this->well_structure_changed == that.well_structure_changed)
+            && (this->affected_wells == that.affected_wells)
+            ;
     }
 };
 

--- a/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
+++ b/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
@@ -37,6 +37,7 @@ struct SimulatorUpdate
         simulatorUpdate.tran_update = true;
         simulatorUpdate.well_structure_changed = true;
         simulatorUpdate.affected_wells = {"test"};
+        simulatorUpdate.welpi_wells.insert("I-45");
         return simulatorUpdate;
     }
 
@@ -44,6 +45,7 @@ struct SimulatorUpdate
     void serializeOp(Serializer& serializer)
     {
         serializer(affected_wells);
+        serializer(welpi_wells);
         serializer(tran_update);
         serializer(well_structure_changed);
     }
@@ -51,6 +53,10 @@ struct SimulatorUpdate
     /// Wells affected by ACTIONX and for which the simulator needs to
     /// reapply rates and state from the newly updated Schedule object.
     std::unordered_set<std::string> affected_wells{};
+
+    /// Wells affected only by WELPI for which the simulator needs to update
+    /// its internal notion of the connection transmissibility factors.
+    std::unordered_set<std::string> welpi_wells{};
 
     /// Whether or not a transmissibility multiplier keyword was invoked in
     /// an ACTIONX block.
@@ -74,6 +80,9 @@ struct SimulatorUpdate
 
         this->affected_wells.insert(otherSimUpdate.affected_wells.begin(),
                                     otherSimUpdate.affected_wells.end());
+
+        this->welpi_wells.insert(otherSimUpdate.welpi_wells.begin(),
+                                 otherSimUpdate.welpi_wells.end());
     }
 
     void reset()
@@ -81,6 +90,7 @@ struct SimulatorUpdate
         this->tran_update = false;
         this->well_structure_changed = false;
         this->affected_wells.clear();
+        this->welpi_wells.clear();
     }
 
     bool operator==(const SimulatorUpdate& that) const
@@ -88,6 +98,7 @@ struct SimulatorUpdate
         return (this->tran_update == that.tran_update)
             && (this->well_structure_changed == that.well_structure_changed)
             && (this->affected_wells == that.affected_wells)
+            && (this->welpi_wells == that.welpi_wells)
             ;
     }
 };

--- a/opm/input/eclipse/Schedule/HandlerContext.cpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.cpp
@@ -47,6 +47,13 @@ void HandlerContext::affected_well(const std::string& well_name)
     }
 }
 
+void HandlerContext::welpi_well(const std::string& well_name)
+{
+    if (sim_update != nullptr) {
+        sim_update->welpi_wells.insert(well_name);
+    }
+}
+
 void HandlerContext::record_tran_change()
 {
     if (sim_update) {

--- a/opm/input/eclipse/Schedule/HandlerContext.hpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.hpp
@@ -82,6 +82,9 @@ public:
     //! \brief Mark that a well has changed.
     void affected_well(const std::string& well_name);
 
+    //! \brief Mark that a well is affected by WELPI.
+    void welpi_well(const std::string& well_name);
+
     //! \brief Mark that transmissibilities must be recalculated.
     void record_tran_change();
 

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -185,7 +185,7 @@ void handleWELPIRuntime(HandlerContext& handlerContext)
             handlerContext.state().target_wellpi
                 .insert_or_assign(well_name, targetPI);
 
-            handlerContext.affected_well(well_name);
+            handlerContext.welpi_well(well_name);
         }
     }
 }

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -1448,8 +1448,8 @@ TSTEP
         const auto& well = sched.getWell("PROD1", 0);
         const auto& sim_update = sched.applyAction(0, action1, action_result.wells(),
                                                    std::unordered_map<std::string,double>{{"PROD1", well.convertDeckPI(500)}});
-        BOOST_CHECK_EQUAL( sim_update.affected_wells.count("PROD1"), 1);
-        BOOST_CHECK_EQUAL( sim_update.affected_wells.size(), 1);
+        BOOST_CHECK_EQUAL( sim_update.welpi_wells.count("PROD1"), 1);
+        BOOST_CHECK_EQUAL( sim_update.welpi_wells.size(), 1);
     }
     {
         const auto& target_wellpi = sched[0].target_wellpi;


### PR DESCRIPTION
This way, the simulator layer has more information by which to decide if applying a CTF update is safe/sufficient or if it needs to fully rebuild its internal representation of the simulation wells.