### PR TITLE
fixed: out-of-bounds indexing in FieldProps

### DIFF
--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -368,6 +368,11 @@ namespace Opm {
         this->field_props.reset_actnum(new_actnum);
     }
 
+    void EclipseState::set_active_indices(const std::vector<int>& indices)
+    {
+        this->field_props.set_active_indices(indices);
+    }
+
     void EclipseState::pruneDeactivatedAquiferConnections(const std::vector<std::size_t>& deactivated_cells) {
         if (this->aquifer_config.hasAnalyticalAquifer())
             this->aquifer_config.pruneDeactivatedAquiferConnections(deactivated_cells);

--- a/opm/input/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.hpp
@@ -134,6 +134,7 @@ namespace Opm {
 
         void prune_global_for_schedule_run();
         void reset_actnum(const std::vector<int>& new_actnum);
+        void set_active_indices(const std::vector<int>& indices);
         void pruneDeactivatedAquiferConnections(const std::vector<std::size_t>& deactivated_cells);
         void loadRestartAquifers(const RestartIO::RstAquifer& aquifers);
         // TODO: it is possible that the aquifer are opened through SCHEDULE and not specified in the SOLUTION section

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -522,7 +522,10 @@ public:
     };
 
     /// Normal constructor for FieldProps.
-    FieldProps(const Deck& deck, const Phases& phases, EclipseGrid& grid, const TableManager& table_arg,
+    FieldProps(const Deck& deck,
+               const Phases& phases,
+               EclipseGrid& grid,
+               const TableManager& table_arg,
                const std::size_t ncomps);
 
     /// Special case constructor used to process ACTNUM only.
@@ -707,6 +710,8 @@ public:
 
     void deleteMINPVV();
 
+    void set_active_indices(const std::vector<int>& indices);
+
 private:
     void processMULTREGP(const Deck& deck);
     void scanGRIDSection(const GRIDSection& grid_section);
@@ -815,6 +820,7 @@ private:
     Phases m_phases;
     SatFuncControls m_satfuncctrl;
     std::vector<int> m_actnum;
+    std::unordered_map<int,int> m_active_index;
     std::vector<double> cell_volume;
     std::vector<double> cell_depth;
     const std::string m_default_region;

--- a/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -184,6 +184,12 @@ void FieldPropsManager::prune_global_for_schedule_run()
     this->fp->prune_global_for_schedule_run();
 }
 
+
+void FieldPropsManager::set_active_indices(const std::vector<int>& indices)
+{
+    fp->set_active_indices(indices);
+}
+
 void apply_action(const Fieldprops::ScalarOperation& op,
                   const std::vector<double>& action_data,
                   std::vector<double>& data,

--- a/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -251,6 +251,8 @@ public:
 
     void prune_global_for_schedule_run();
 
+    void set_active_indices(const std::vector<int>& indices);
+
 private:
     /*
       Return the keyword values as a std::vector<>. All elements in the return


### PR DESCRIPTION
this happens when grid processing removed cells (pinch, minpv, ..). in particular the actnum in the grid_ptr member (ie EclipseState::getInputGrid()) does not reflect the additional inactive cells, and thus the active_index in the Box are not the same as those in the FieldData (which has been modified in the call to FieldProps::reset_actnum). this causes oob indexing in handle_schedule_keywords / multiply_deck.

this is a minimal fix to fix the oob indexing. there might be more dragons hidden in the output where the inconsistent actnum from the input grid is used.

---

This PR back-ports #4293 to the release branch for the OPM 2024.10 release.