### PR TITLE
Some serialization cleanup

### DIFF
--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -354,7 +354,7 @@ protected:
             for (size_t i = 0; i < size; ++i) {
                 typename Map::value_type entry;
                 (*this)(entry);
-                data_mut.insert(entry);
+                data_mut.insert(std::move(entry));
             }
         } else {
             (*this)(data.size());

--- a/opm/input/eclipse/EclipseState/EndpointScaling.hpp
+++ b/opm/input/eclipse/EclipseState/EndpointScaling.hpp
@@ -47,13 +47,7 @@ class EndpointScaling {
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
-            if (serializer.isSerializing())
-                serializer(options.to_ulong());
-            else {
-                unsigned long bits = 0;
-                serializer(bits);
-                options = std::bitset<4>(bits);
-            }
+            serializer(options);
         }
 
     private:

--- a/opm/input/eclipse/Schedule/Group/GuideRate.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.hpp
@@ -150,23 +150,7 @@ public:
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
-        if (serializer.isSerializing()) {
-            serializer(values.size());
-            for (const auto& [key, value] : values) {
-              serializer(key);
-              serializer(*value);
-            }
-        } else {
-            std::size_t size = 0;
-            serializer(size);
-            for (size_t i = 0; i < size; ++i) {
-                std::string key;
-                serializer(key);
-                auto val = values.emplace(key, std::make_unique<GRValState>());
-                if (val.first != values.end())
-                    serializer(*val.first->second);
-            }
-        }
+        serializer(values);
         serializer(injection_group_values);
         serializer(potentials);
         serializer(guide_rates_expired);

--- a/opm/input/eclipse/Schedule/Well/WellTestState.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestState.hpp
@@ -260,27 +260,8 @@ public:
     void serializeOp(Serializer& serializer)
     {
         serializer(this->wells);
-        if (serializer.isSerializing()) {
-            std::size_t size = this->completions.size();
-            serializer(size);
-            for (auto& [well, comp_map] : this->completions) {
-                serializer(well);
-                serializer(comp_map);
-            }
-        } else {
-            std::size_t size = 0;
-            serializer(size);
-            for (std::size_t i=0; i < size; i++) {
-                std::string well;
-                std::unordered_map<int, ClosedCompletion> comp_map;
-
-                serializer(well);
-                serializer(comp_map);
-                this->completions.emplace(well, std::move(comp_map));
-            }
-        }
+        serializer(this->completions);
     }
-
 
     static WellTestState serializationTestObject();
     bool operator==(const WellTestState& other) const;


### PR DESCRIPTION
No reason to manually handle maps, bitsets or (with a small fix) unique_ptrs.