### PR TITLE
Let ErrorGuard::dump return an error string for logging.

### DIFF
--- a/opm/input/eclipse/Parser/ErrorGuard.cpp
+++ b/opm/input/eclipse/Parser/ErrorGuard.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <iomanip>
 #include <numeric>
+#include <regex>
 
 namespace Opm {
 
@@ -35,7 +36,9 @@ namespace Opm {
     }
 
 
-    void ErrorGuard::dump() const {
+    std::string ErrorGuard::dump() const {
+        // error messages to log before exiting
+        std::string error_msgs;
         auto maxit = [](const auto acc, const auto& pair)
                      {
                          return std::max(acc, pair.first.size());
@@ -53,11 +56,19 @@ namespace Opm {
         }
 
         if (!this->error_list.empty()) {
+            std::regex file_regex("\n\\w*In file(.*)line (.*)");
             std::cerr << std::endl << std::endl << "Errors:" << std::endl;
-            for (const auto& pair : this->error_list)
+
+            for (const auto& pair : this->error_list) {
+                error_msgs += std::string("       ") + pair.first + ": " +
+                    std::regex_replace(pair.second, file_regex, " at:$1line: $2") +
+                    std::string("\n");
                 std::cerr << std::left << "  " << std::setw(width) << pair.first << ": " << pair.second << std::endl;
+            }
             std::cerr << std::endl;
         }
+
+        return error_msgs;
     }
 
 

--- a/opm/input/eclipse/Parser/ErrorGuard.cpp
+++ b/opm/input/eclipse/Parser/ErrorGuard.cpp
@@ -24,6 +24,8 @@
 #include <numeric>
 #include <regex>
 
+#include <fmt/format.h>
+
 namespace Opm {
 
     void ErrorGuard::addError(const std::string& errorKey, const std::string& msg) {
@@ -56,14 +58,14 @@ namespace Opm {
         }
 
         if (!this->error_list.empty()) {
-            std::regex file_regex("\n\\w*In file(.*)line (.*)");
+            const std::regex file_regex("\n\\w*In file(.*)line (.*)");
             std::cerr << std::endl << std::endl << "Errors:" << std::endl;
 
-            for (const auto& pair : this->error_list) {
-                error_msgs += std::string("       ") + pair.first + ": " +
-                    std::regex_replace(pair.second, file_regex, " at:$1line: $2") +
-                    std::string("\n");
-                std::cerr << std::left << "  " << std::setw(width) << pair.first << ": " << pair.second << std::endl;
+            for (const auto& [error_key, error_msg] : this->error_list) {
+                error_msgs += fmt::format("       {}; {}\n", error_key,
+                                          std::regex_replace(error_msg, file_regex,
+                                                             " at:$1line: $2")) ;
+                std::cerr << std::left << "  " << std::setw(width) << error_key << ": " << error_msg << std::endl;
             }
             std::cerr << std::endl;
         }

--- a/opm/input/eclipse/Parser/ErrorGuard.hpp
+++ b/opm/input/eclipse/Parser/ErrorGuard.hpp
@@ -41,7 +41,7 @@ public:
     */
     ~ErrorGuard();
     void terminate() const;
-    void dump() const;
+    std::string dump() const;
 
 private:
 


### PR DESCRIPTION
This is needed to let errors in the topology show up in the log files, too.

Currently, those are only printed to cerr and the simulator will end with the following line that also appears in the log file: "Error: Unrecoverable errors while loading input:"

Unfortunately, this line (and the log files) will not contain any usable error message and there no other message about the error in the log files.

With this commit we let ErrorGuard::dump return a string with all errors. Those are slightly reformatted to have error message and file information on one line. This string will be used in opm-simulators to print something meaningful to the log files.