### PR TITLE
Don't Needlessly Copy Well/Group Names

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQContext.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQContext.cpp
@@ -207,7 +207,7 @@ namespace Opm {
         return it->second;
     }
 
-    std::vector<std::string> UDQContext::wells() const
+    const std::vector<std::string>& UDQContext::wells() const
     {
         return this->well_matcher.wells();
     }
@@ -217,7 +217,7 @@ namespace Opm {
         return this->well_matcher.wells(pattern);
     }
 
-    std::vector<std::string> UDQContext::groups() const
+    const std::vector<std::string>& UDQContext::groups() const
     {
         return this->summary_state.groups();
     }

--- a/opm/input/eclipse/Schedule/UDQ/UDQContext.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQContext.hpp
@@ -89,9 +89,9 @@ namespace Opm {
 
         const UDQFunctionTable& function_table() const;
 
-        std::vector<std::string> wells() const;
+        const std::vector<std::string>& wells() const;
         std::vector<std::string> wells(const std::string& pattern) const;
-        std::vector<std::string> groups() const;
+        const std::vector<std::string>& groups() const;
         SegmentSet segments() const;
         SegmentSet segments(const std::vector<std::string>& set_descriptor) const;
 


### PR DESCRIPTION
The no-argument overloads of member functions

 * [`WellMatcher::wells()`](https://github.com/OPM/opm-common/blob/c82b52776a13ea3085212e4c4dcc9201847d86d9/opm/input/eclipse/Schedule/Well/WellMatcher.hpp#L129-L130)
 * [`SummaryState::groups()`](https://github.com/OPM/opm-common/blob/c82b52776a13ea3085212e4c4dcc9201847d86d9/opm/input/eclipse/Schedule/SummaryState.hpp#L130)

return references to `const`.  Don't convert these to independent objects on the caller's behalf.  If the caller wants independent objects, they can create such objects at the call site.