### PR TITLE
fixed: test-suites needs a name

### DIFF
--- a/tests/test_CopyablePtr.cpp
+++ b/tests/test_CopyablePtr.cpp
@@ -47,7 +47,7 @@ struct B {
 };
 } // namespace
 
-BOOST_AUTO_TEST_SUITE ()
+BOOST_AUTO_TEST_SUITE (CopyablePtr)
 
 BOOST_AUTO_TEST_CASE (copyable)
 {

--- a/tests/test_calculateCellVol.cpp
+++ b/tests/test_calculateCellVol.cpp
@@ -30,7 +30,7 @@
 
 //using namespace Opm;
 
-BOOST_AUTO_TEST_SUITE ()
+BOOST_AUTO_TEST_SUITE (CalculateCellVolume)
 
 BOOST_AUTO_TEST_CASE (calc_cellvol)
 {

--- a/tests/test_cubic.cpp
+++ b/tests/test_cubic.cpp
@@ -45,7 +45,7 @@
 #include <opm/common/utility/numeric/MonotCubicInterpolator.hpp>
 using namespace Opm;
 
-BOOST_AUTO_TEST_SUITE ()
+BOOST_AUTO_TEST_SUITE (Cubic)
 
 BOOST_AUTO_TEST_CASE (cubic)
 {


### PR DESCRIPTION
building as c++-20 this causes errors

I started investigating the changes needed for building as c++-20. This is a simple thing that needs addressing.