### PR TITLE
Add non-zero default tolerance to mergeTables

### DIFF
--- a/opm/output/eclipse/Tables.cpp
+++ b/opm/output/eclipse/Tables.cpp
@@ -1877,7 +1877,7 @@ namespace { namespace SatFunc {
             // tables having sorted phase saturation values (required by ECL
             // format).
             std::vector<TableElement>
-            mergeTables(const std::vector<DerivedKroFunction>& t, const double tolerance = 0.0)
+            mergeTables(const std::vector<DerivedKroFunction>& t, const double tolerance = 1.0e-6)
             {
                 auto ret = std::vector<TableElement>{};
 
@@ -2006,7 +2006,7 @@ namespace { namespace SatFunc {
                     tbl.emplace_back(sg, krog, So_off);
                 }
 
-                const auto mrg = mergeTables(tbl, 1.0e-14);
+                const auto mrg = mergeTables(tbl);
 
                 for (auto& col : ret) { col.reserve(mrg.size()); }
 


### PR DESCRIPTION
To avoid near-duplicate saturation nodes in .INIT output of relperm/pc