### PR TITLE
fixed: cannot forward these entities

### DIFF
--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -22,7 +22,10 @@
 #ifndef OPM_ECLIPSE_WRITER_HPP
 #define OPM_ECLIPSE_WRITER_HPP
 
+#include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
+
 #include <opm/output/data/Solution.hpp>
+#include <opm/output/eclipse/RestartValue.hpp>
 
 #include <map>
 #include <memory>
@@ -34,9 +37,7 @@ namespace Opm {
 
 class EclipseGrid;
 class EclipseState;
-struct NNCdata;
 class RestartKey;
-class RestartValue;
 class Schedule;
 class SummaryConfig;
 class SummaryState;

--- a/opm/output/eclipse/RestartIO.hpp
+++ b/opm/output/eclipse/RestartIO.hpp
@@ -25,6 +25,7 @@
 #define RESTART_IO_HPP
 
 #include <opm/output/eclipse/AggregateAquiferData.hpp>
+#include <opm/output/eclipse/RestartValue.hpp>
 
 #include <optional>
 #include <string>
@@ -34,8 +35,6 @@ namespace Opm {
 
     class EclipseGrid;
     class EclipseState;
-    class RestartKey;
-    class RestartValue;
     class Schedule;
     class UDQState;
     class SummaryState;


### PR DESCRIPTION
they are involved in std::vector parameters with default (empty) values. causes issues when building as c++-20.