### PR TITLE
fixed: use constexpr formats and/or mark format strings runtime

### DIFF
--- a/opm/common/OpmLog/KeywordLocation.cpp
+++ b/opm/common/OpmLog/KeywordLocation.cpp
@@ -24,7 +24,7 @@
 namespace Opm {
 
 std::string KeywordLocation::format(const std::string& msg_fmt) const {
-    return fmt::format(msg_fmt,
+    return fmt::format(fmt::runtime(msg_fmt),
                        fmt::arg("keyword", this->keyword),
                        fmt::arg("file", this->filename),
                        fmt::arg("line", this->lineno));

--- a/opm/common/utility/OpmInputError.cpp
+++ b/opm/common/utility/OpmInputError.cpp
@@ -30,7 +30,7 @@ namespace {
 
 template<typename ... Args>
 std::string formatImpl(const std::string& msg_format, const KeywordLocation& loc, const Args& ...arguments) {
-    return fmt::format(msg_format,
+    return fmt::format(fmt::runtime(msg_format),
         arguments...,
         fmt::arg("keyword", loc.keyword),
         fmt::arg("file", loc.filename),

--- a/opm/input/eclipse/Parser/Parser.cpp
+++ b/opm/input/eclipse/Parser/Parser.cpp
@@ -67,6 +67,7 @@
 #include <stack>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <regex>
 #include <utility>
 #include <vector>
@@ -1830,7 +1831,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
 
         bool validKwIdx = curKwIdx < deck.size();
         if( !validKwIdx || deck[curKwIdx].name() != "RUNSPEC" ) {
-            std::string msg = "The first keyword of a valid deck must be RUNSPEC (is {})\n";
+            constexpr std::string_view msg = "The first keyword of a valid deck must be RUNSPEC (is {})\n";
             auto curKeyword = deck[0];
             topLevelErrors.push_back(Log::fileMessage(curKeyword.location(),
                                                       fmt::format(msg,
@@ -1848,7 +1849,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                     const auto& parserKeyword =
                         parser.getParserKeywordFromDeckName( curKeywordName );
                     if (ensureKeywordSectionAffiliation && !parserKeyword.isValidSection(curSectionName)) {
-                        std::string msg =
+                        constexpr std::string_view msg =
                             "The keyword '{}' is located in the '{}' section where it is invalid";
                         errorGuard.addError(errorKey,
                                             Log::fileMessage(location,

--- a/opm/material/densead/EvaluationFormat.hpp
+++ b/opm/material/densead/EvaluationFormat.hpp
@@ -50,7 +50,7 @@ struct fmt::formatter<Opm::DenseAd::Evaluation<ValueT,numDerivs,staticSize>>
         std::vector<ValueT> tmp(e.size());
         for (int i = 0; i < e.size(); ++i)
             tmp[i] = e.derivative(i);
-        return fmt::format_to(ctx.out(), "v: "+ spec +" / d: [" + spec +"]",
+        return fmt::format_to(ctx.out(), fmt::runtime("v: "+ spec +" / d: [" + spec +"]"),
                               e.value(), fmt::join(tmp, ", "));
     }
 };


### PR DESCRIPTION
fmt wants to do compile time validation of format strings under c++-20. mark formatting strings constexpr where possible, and mark formats runtime to disable validation where not possible.