### PR TITLE
Generalise Entity Matching for UDQ Assignment

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -33,6 +33,7 @@
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 
 #include <opm/input/eclipse/Schedule/Action/ActionContext.hpp>
+#include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
 #include <opm/input/eclipse/Schedule/Action/Actions.hpp>
 #include <opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
@@ -115,8 +116,9 @@ void msim::run(EclipseIO& io, bool report_only)
 }
 
 
-UDAValue msim::uda_val() {
- return UDAValue();
+UDAValue msim::uda_val()
+{
+    return UDAValue();
 }
 
 
@@ -131,7 +133,9 @@ void msim::post_step(data::Solution& /* sol */,
         return;
     }
 
-    Action::Context context(this->st, this->schedule[report_step].wlist_manager.get());
+    const auto context = Action::Context {
+        this->st, this->schedule[report_step].wlist_manager.get()
+    };
 
     for (const auto& action : actions.pending(this->action_state, std::chrono::system_clock::to_time_t(sim_time))) {
         auto result = action->eval(context);
@@ -195,7 +199,6 @@ void msim::run_step(const WellTestState& wtest_state,
 
         this->schedule.getUDQConfig(report_step - 1)
             .eval(report_step,
-                  this->schedule,
                   this->schedule.wellMatcher(report_step),
                   this->schedule.segmentMatcherFactory(report_step),
                   createRegionSetMatcherFactory(this->state),

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
@@ -237,10 +237,6 @@ namespace Opm {
         ///
         /// Assigns new UDQ values to both the summary and UDQ state objects.
         ///
-        /// \param[in] report_step Current report step.
-        ///
-        /// \param[in] sched Full dynamic input schedule.
-        ///
         /// \param[in] wm Well name pattern matcher.
         ///
         /// \param[in] create_segment_matcher Factory function for
@@ -252,9 +248,7 @@ namespace Opm {
         ///
         /// \param[in,out] udq_state Dynamic values for all known UDQs.
         /// Values pertaining to UDQs being assigned here will be updated.
-        void eval_assign(std::size_t           report_step,
-                         const Schedule&       sched,
-                         const WellMatcher&    wm,
+        void eval_assign(const WellMatcher&    wm,
                          SegmentMatcherFactory create_segment_matcher,
                          SummaryState&         st,
                          UDQState&             udq_state) const;
@@ -266,8 +260,6 @@ namespace Opm {
         /// objects.
         ///
         /// \param[in] report_step Current report step.
-        ///
-        /// \param[in] sched Full dynamic input schedule.
         ///
         /// \param[in] wm Well name pattern matcher.
         ///
@@ -284,7 +276,6 @@ namespace Opm {
         /// \param[in,out] udq_state Dynamic values for all known UDQs.
         /// Values pertaining to UDQs being assigned here will be updated.
         void eval(std::size_t             report_step,
-                  const Schedule&         sched,
                   const WellMatcher&      wm,
                   SegmentMatcherFactory   create_segment_matcher,
                   RegionSetMatcherFactory create_region_matcher,
@@ -513,15 +504,9 @@ namespace Opm {
         ///
         /// Assigns new UDQ values to both the summary and UDQ state objects.
         ///
-        /// \param[in] report_step Current report step.
-        ///
-        /// \param[in] schedule Full dynamic input schedule.
-        ///
         /// \param[in,out] context Pattern matchers and state objects.
         /// Values pertaining to UDQs being assigned here will be updated.
-        void eval_assign(std::size_t     report_step,
-                         const Schedule& sched,
-                         UDQContext&     context) const;
+        void eval_assign(UDQContext& context) const;
 
         /// Compute new values for all UDQs
         ///

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -2072,7 +2072,7 @@ UDQ
     UDQState udq_state(undefined_value);
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-    udq.eval(0, schedule, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
+    udq.eval(0, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
 
     BOOST_CHECK_EQUAL( st.get("FU_UADD"), 12);   // 10 + 2
 
@@ -2100,7 +2100,7 @@ DEFINE FU_PAR2 FU_PAR3 /
     st.update("FMWPR", 100);
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-    udq.eval(0, schedule, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
+    udq.eval(0, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
 
     BOOST_CHECK_EQUAL(st.get("FU_PAR2"), 100);
 }
@@ -2120,7 +2120,7 @@ DEFINE FU_PAR3 FU_PAR2 + 1/
     UDQState udq_state(undefined_value);
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-    udq.eval(0, schedule, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
+    udq.eval(0, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
 
     BOOST_CHECK_EQUAL(st.get("FU_PAR2"), undefined_value);
     BOOST_CHECK_EQUAL(st.get("FU_PAR3"), undefined_value);
@@ -2232,7 +2232,7 @@ DEFINE WUGASRA  750000 - WGLIR '*' /
     WellMatcher wm(std::move(wo));
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-    udq.eval(0, schedule, wm, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
+    udq.eval(0, wm, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
 
     const auto required_keys = [&udq]()
     {
@@ -2450,7 +2450,7 @@ DEFINE FU_VAR91 GOPR TEST  /
 
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-    udq.eval(0, schedule, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
+    udq.eval(0, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
 }
 
 BOOST_AUTO_TEST_CASE(UDQ_KEY_ERROR) {
@@ -2471,7 +2471,7 @@ UDQ
 
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-    BOOST_CHECK_THROW(udq.eval(0, schedule, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state), std::exception);
+    BOOST_CHECK_THROW(udq.eval(0, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state), std::exception);
 }
 
 BOOST_AUTO_TEST_CASE(UDQ_ASSIGN) {
@@ -2509,7 +2509,7 @@ UDQ
 
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-    udq.eval(0, schedule, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
+    udq.eval(0, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
     BOOST_CHECK_EQUAL(st.get("FU_VAR1"), 10);
 }
 
@@ -2552,7 +2552,7 @@ TSTEP
         const auto& udq = schedule.getUDQConfig(report_step);
         auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
         auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-        udq.eval(report_step, schedule, schedule.wellMatcher(report_step), segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
+        udq.eval(report_step, schedule.wellMatcher(report_step), segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
         auto fu_var1 = st.get("FU_VAR1");
         BOOST_CHECK_EQUAL(fu_var1, report_step + 1);
     }
@@ -2562,7 +2562,7 @@ TSTEP
         const auto& udq = schedule.getUDQConfig(report_step);
         auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
         auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-        udq.eval(report_step, schedule, schedule.wellMatcher(report_step), segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
+        udq.eval(report_step, schedule.wellMatcher(report_step), segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
         auto fu_var1 = st.get("FU_VAR1");
         BOOST_CHECK_EQUAL(fu_var1, report_step - 4);
     }
@@ -2572,7 +2572,7 @@ TSTEP
         const auto& udq = schedule.getUDQConfig(report_step);
         auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
         auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-        udq.eval(report_step, schedule, schedule.wellMatcher(report_step), segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
+        udq.eval(report_step, schedule.wellMatcher(report_step), segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
         auto fu_var1 = st.get("FU_VAR1");
         BOOST_CHECK_EQUAL(fu_var1, 0);
     }
@@ -2625,7 +2625,7 @@ UDQ
     const auto& udq = schedule.getUDQConfig(0);
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-    udq.eval(0, schedule, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
+    udq.eval(0, {}, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
     auto fu_var1 = st.get("FU_VAR1");
     auto fu_var2 = st.get("FU_VAR2");
     auto fu_var3 = st.get("FU_VAR3");
@@ -2672,7 +2672,7 @@ UDQ
 
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-    udq.eval(0, schedule, schedule.wellMatcher(0), segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
+    udq.eval(0, schedule.wellMatcher(0), segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
     auto fu_var1 = st.get("FU_VAR1");
     auto fu_var2 = st.get("FU_VAR2");
     auto fu_var3 = st.get("FU_VAR3");
@@ -2700,7 +2700,7 @@ UDQ
     const auto& udq = schedule.getUDQConfig(0);
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-    udq.eval(0, schedule, schedule.wellMatcher(0), segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
+    udq.eval(0, schedule.wellMatcher(0), segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
 
     auto fu_var1 = st.get("FU_VAR1");
     auto fu_var2 = st.get("FU_VAR2");
@@ -3014,7 +3014,7 @@ DEFINE WU_WBHP TU_FBHP[WOPR] UMIN WU_WBHP0 /
 
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
-    udq.eval(0, schedule, wm, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
+    udq.eval(0, wm, segmentMatcherFactory, regionSetMatcherFactory, st, udq_state);
 
     const double wu_wbhp1 = st.get_well_var("PROD1", "WU_WBHP");
     const double wu_wbhp2 = st.get_well_var("PROD2", "WU_WBHP");

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -434,7 +434,6 @@ first_sim(const Setup&   setup,
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
 
     udq.eval(report_step,
-             setup.schedule,
              setup.schedule.wellMatcher(report_step),
              segmentMatcherFactory,
              regionSetMatcherFactory,


### PR DESCRIPTION
This commit introduces more general entity matching for UDQ assignments.  This is in preparation of adding support for assignment statements within an ACTIONX block using the `"?"` selector to identify wells and/or groups.

We add new member functions
```
UDQSet UDQAssign::eval(entities, matcher) const
```
with `entities` being a vector of either well/group names or a vector of enumerated items such as the known segments of all MS wells and `matcher` being a call-back function that translates a selector to a vector of specific entities.  Those are, in turn, expected to be a subset of the input entities.  The result value is sized according to the input entities and only those entities identified by the `matcher` will have a defined value.

We reimplement the `UDQConfig`'s well and group assignment operations in terms of these new `UDQAssign::eval()` functions and in so doing simplify the interfaces of these.  They can now be fully implemented in terms of a `UDQContext` object so we no longer need the `Schedule` or `report_step` parameters.  We therefore remove these from `UDQConfig::eval()`.