### PR TITLE
Quell c++-20 warnings

### DIFF
--- a/opm/common/utility/MemPacker.hpp
+++ b/opm/common/utility/MemPacker.hpp
@@ -31,6 +31,9 @@ namespace Opm {
 namespace Serialization {
 namespace detail {
 
+template <typename T>
+constexpr bool is_pod_v = std::is_standard_layout_v<T> && std::is_trivial_v<T>;
+
 //! \brief Abstract struct for packing which is (partially) specialized for specific types.
 template <bool pod, class T>
 struct Packing
@@ -176,7 +179,7 @@ struct MemPacker {
     template<class T>
     std::size_t packSize(const T& data) const
     {
-        return detail::Packing<std::is_pod_v<T>,T>::packSize(data);
+        return detail::Packing<detail::is_pod_v<T>,T>::packSize(data);
     }
 
     //! \brief Calculates the pack size for an array.
@@ -186,7 +189,7 @@ struct MemPacker {
     template<class T>
     std::size_t packSize(const T* data, std::size_t n) const
     {
-        static_assert(std::is_pod_v<T>, "Array packing not supported for non-pod data");
+        static_assert(detail::is_pod_v<T>, "Array packing not supported for non-pod data");
         return detail::Packing<true,T>::packSize(data, n);
     }
 
@@ -200,7 +203,7 @@ struct MemPacker {
               std::vector<char>& buffer,
               std::size_t& position) const
     {
-        detail::Packing<std::is_pod_v<T>,T>::pack(data, buffer, position);
+        detail::Packing<detail::is_pod_v<T>,T>::pack(data, buffer, position);
     }
 
     //! \brief Pack an array.
@@ -215,7 +218,7 @@ struct MemPacker {
               std::vector<char>& buffer,
               std::size_t& position) const
     {
-        static_assert(std::is_pod_v<T>, "Array packing not supported for non-pod data");
+        static_assert(detail::is_pod_v<T>, "Array packing not supported for non-pod data");
         detail::Packing<true,T>::pack(data, n, buffer, position);
     }
 
@@ -229,7 +232,7 @@ struct MemPacker {
                 const std::vector<char>& buffer,
                 std::size_t& position) const
     {
-        detail::Packing<std::is_pod_v<T>,T>::unpack(data, buffer, position);
+        detail::Packing<detail::is_pod_v<T>,T>::unpack(data, buffer, position);
     }
 
     //! \brief Unpack an array.
@@ -244,7 +247,7 @@ struct MemPacker {
                 const std::vector<char>& buffer,
                 std::size_t& position) const
     {
-        static_assert(std::is_pod_v<T>, "Array packing not supported for non-pod data");
+        static_assert(detail::is_pod_v<T>, "Array packing not supported for non-pod data");
         detail::Packing<true,T>::unpack(data, n, buffer, position);
     }
 };

--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -80,6 +80,9 @@ struct is_unique_ptr : std::false_type {};
 template <typename T>
 struct is_unique_ptr<std::unique_ptr<T>> : std::true_type {};
 
+template <typename T>
+constexpr bool is_pod_v = std::is_standard_layout_v<T> && std::is_trivial_v<T>;
+
 } // namespace detail
 
 /*! \brief Class for (de-)serializing.
@@ -213,7 +216,7 @@ protected:
     template <typename Vector>
     void vector(const Vector& data)
     {
-        if constexpr (std::is_pod_v<typename Vector::value_type>) {
+        if constexpr (detail::is_pod_v<typename Vector::value_type>) {
           if (m_op == Operation::PACKSIZE) {
               (*this)(data.size());
               if (data.size() > 0) {
@@ -278,7 +281,7 @@ protected:
     {
         using T = typename Array::value_type;
 
-        if constexpr (std::is_pod_v<T>) {
+        if constexpr (detail::is_pod_v<T>) {
             if (m_op == Operation::PACKSIZE)
                 m_packSize += m_packer.packSize(data.data(), data.size());
             else if (m_op == Operation::PACK)

--- a/opm/material/checkFluidSystem.hpp
+++ b/opm/material/checkFluidSystem.hpp
@@ -62,8 +62,8 @@ class HairSplittingFluidState
     : protected BaseFluidState
 {
 public:
-    enum { numPhases = FluidSystem::numPhases };
-    enum { numComponents = FluidSystem::numComponents };
+    static constexpr int numPhases = FluidSystem::numPhases;
+    static constexpr int numComponents = FluidSystem::numComponents;
 
     typedef ScalarT Scalar;
 
@@ -277,8 +277,8 @@ void checkFluidSystem()
 
     // make sure the fluid system provides the number of phases and
     // the number of components
-    enum { numPhases = FluidSystem::numPhases };
-    enum { numComponents = FluidSystem::numComponents };
+    static constexpr int numPhases = FluidSystem::numPhases;
+    static constexpr int numComponents = FluidSystem::numComponents;
 
     typedef HairSplittingFluidState<RhsEval, FluidSystem> FluidState;
     FluidState fs;

--- a/opm/material/common/quad.hpp
+++ b/opm/material/common/quad.hpp
@@ -121,10 +121,12 @@ struct is_scalar<quad>
     : public integral_constant<bool, true>
 {};
 
+#if __cplusplus < 202002L
 template <>
 struct is_pod<quad>
     : public integral_constant<bool, true>
 {};
+#endif
 
 template <>
 struct is_signed<quad>

--- a/opm/material/constraintsolvers/CompositionFromFugacities.hpp
+++ b/opm/material/constraintsolvers/CompositionFromFugacities.hpp
@@ -48,7 +48,7 @@ namespace Opm {
 template <class Scalar, class FluidSystem, class Evaluation = Scalar>
 class CompositionFromFugacities
 {
-    enum { numComponents = FluidSystem::numComponents };
+    static constexpr int numComponents = FluidSystem::numComponents;
 
 public:
     typedef Dune::FieldVector<Evaluation, numComponents> ComponentVector;

--- a/opm/material/constraintsolvers/NcpFlash.hpp
+++ b/opm/material/constraintsolvers/NcpFlash.hpp
@@ -86,8 +86,8 @@ namespace Opm {
 template <class Scalar, class FluidSystem>
 class NcpFlash
 {
-    enum { numPhases = FluidSystem::numPhases };
-    enum { numComponents = FluidSystem::numComponents };
+    static constexpr int numPhases = FluidSystem::numPhases;
+    static constexpr int numComponents = FluidSystem::numComponents;
 
     enum {
         p0PvIdx = 0,
@@ -559,9 +559,9 @@ protected:
         }
         // mole fractions
         else {
-            assert(pvIdx < numPhases + numPhases*numComponents);
-            unsigned phaseIdx = (pvIdx - numPhases)/numComponents;
-            unsigned compIdx = (pvIdx - numPhases)%numComponents;
+            assert(pvIdx < numPhases + numPhases * numComponents);
+            unsigned phaseIdx = (pvIdx - numPhases) / numComponents;
+            unsigned compIdx = (pvIdx - numPhases) % numComponents;
             fluidState.setMoleFraction(phaseIdx, compIdx, value);
         }
     }

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -61,17 +61,13 @@ namespace Opm {
 template <class Scalar, class FluidSystem>
 class PTFlash
 {
-    enum { numPhases = FluidSystem::numPhases };
-    enum { numComponents = FluidSystem::numComponents };
+    static constexpr int numPhases = FluidSystem::numPhases;
+    static constexpr int numComponents = FluidSystem::numComponents;
     enum { oilPhaseIdx = FluidSystem::oilPhaseIdx};
     enum { gasPhaseIdx = FluidSystem::gasPhaseIdx};
-    enum { numMiscibleComponents = FluidSystem::numMiscibleComponents};
-    enum { numMisciblePhases = FluidSystem::numMisciblePhases}; //oil, gas
-    enum {
-        numEq =
-        numMisciblePhases+
-        numMisciblePhases*numMiscibleComponents
-    };
+    static constexpr int numMiscibleComponents = FluidSystem::numMiscibleComponents;
+    static constexpr int numMisciblePhases = FluidSystem::numMisciblePhases; //oil, gas
+    static constexpr int numEq = numMisciblePhases + numMisciblePhases * numMiscibleComponents;
 
 public:
     /*!


### PR DESCRIPTION
- use constexpr instead of anonymous enums
- avoid use of std::is_pod_v - it is deprecated in c++-20. instead implement it ourself in terms of std::is_trivial && std::is_standard_layout