### PR TITLE
Don't Mark CheckDefined as Constexpr

### DIFF
--- a/opm/material/common/Valgrind.hpp
+++ b/opm/material/common/Valgrind.hpp
@@ -73,7 +73,7 @@ OPM_HOST_DEVICE inline bool IsRunning()
  *         occupied by the object.
  */
 template <class T>
-OPM_HOST_DEVICE constexpr inline bool CheckDefined([[maybe_unused]] const T& value)
+OPM_HOST_DEVICE inline bool CheckDefined([[maybe_unused]] const T& value)
 {
 #if !defined NDEBUG && HAVE_VALGRIND && !OPM_IS_INSIDE_DEVICE_FUNCTION
     auto tmp = VALGRIND_CHECK_MEM_IS_DEFINED(&value, sizeof(T));


### PR DESCRIPTION
The VALGRIND_CHECK_MEM_IS_DEFINED macro may use inline assembly and this is not `constexpr` friendly.  We will regain ability to evaluate this in a `constexpr` manner in C++20 when we get [`std::is_constant_evaluated()`](https://en.cppreference.com/w/cpp/types/is_constant_evaluated).

Fixes a local build failure on older versions of GCC/Valgrind (fallout from #4222).