### PR TITLE
Decouple Action::State From Action::Result

### DIFF
--- a/opm/input/eclipse/Schedule/Action/State.cpp
+++ b/opm/input/eclipse/Schedule/Action/State.cpp
@@ -17,101 +17,166 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <vector>
-#include <algorithm>
-#include <stdexcept>
-
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
-#include <opm/input/eclipse/Schedule/Action/ActionX.hpp>
-#include <opm/input/eclipse/Schedule/Action/Actions.hpp>
+
 #include <opm/io/eclipse/rst/state.hpp>
 
-namespace Opm {
-namespace Action {
+#include <opm/input/eclipse/Schedule/Action/ActionX.hpp>
+#include <opm/input/eclipse/Schedule/Action/Actions.hpp>
 
-State::action_id State::make_id(const ActionX& action) {
-    return std::make_pair(action.name(), action.id());
-}
+#include <algorithm>
+#include <cstddef>
+#include <ctime>
+#include <map>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
+#include <fmt/format.h>
 
-std::size_t State::run_count(const ActionX& action) const {
-    auto count_iter = this->run_state.find(this->make_id(action));
-    if (count_iter == this->run_state.end())
-        return 0;
-
-    return count_iter->second.run_count;
-}
-
-std::time_t State::run_time(const ActionX& action) const {
-    auto state = this->run_state.at(this->make_id(action));
-    return state.last_run;
-}
-
-
-void State::add_run(const ActionX& action, std::time_t run_time, Result result) {
-    const auto& id  = this->make_id(action);
-    auto count_iter = this->run_state.find(id);
-    if (count_iter == this->run_state.end())
-        this->run_state.insert( std::make_pair(id, run_time) );
-    else
-        count_iter->second.add_run(run_time);
-
-    this->last_result.insert_or_assign(action.name(), std::move(result));
-}
-
-void State::add_run(const PyAction& action, bool result) {
-    this->m_python_result.insert_or_assign( action.name(), result );
-}
-
-
-std::optional<Result> State::result(const std::string& action) const {
-    auto iter = this->last_result.find(action);
-    if (iter == this->last_result.end())
-        return std::nullopt;
-
-    return iter->second;
-}
-
-
-std::optional<bool> State::python_result(const std::string& action) const {
-    auto iter = this->m_python_result.find(action);
-    if (iter == this->m_python_result.end())
-        return std::nullopt;
-
-    return iter->second;
-}
-
-
-
-/*
-  When restoring from restart file we initialize the number of times it has run
-  and the last run time. From the evaluation only the 'true' evaluation is
-  restored, not the well/group set.
-*/
-void State::load_rst(const Actions& action_config, const RestartIO::RstState& rst_state) {
-    for (const auto& rst_action : rst_state.actions) {
-        if (rst_action.run_count > 0) {
-            const auto& action = action_config[rst_action.name];
-            this->add_run(action, rst_action.last_run.value(), Action::Result{ true });
-        }
+namespace {
+    std::pair<std::string, std::size_t>
+    makeID(const Opm::Action::ActionX& action)
+    {
+        return { action.name(), action.id() };
     }
 }
 
-
-bool State::operator==(const State& other) const {
-    return this->run_state == other.run_state &&
-           this->last_result == other.last_result &&
-           this->m_python_result == other.m_python_result;
+bool Opm::Action::State::MatchSet::hasWell(const std::string& well) const
+{
+    // Note: this->wells_ is typically unsorted, so use linear search.
+    return std::find(this->wells_.begin(), this->wells_.end(), well)
+        != this->wells_.end();
 }
 
+Opm::Action::State::MatchSet
+Opm::Action::State::MatchSet::serializationTestObject()
+{
+    using namespace std::string_literals;
 
-State State::serializationTestObject() {
+    auto mset = MatchSet{};
+
+    mset.wells_.assign({ "P1"s, "P2"s, "I"s });
+
+    return mset;
+}
+
+bool Opm::Action::State::MatchSet::operator==(const MatchSet& that) const
+{
+    return this->wells_ == that.wells_;
+}
+
+// ---------------------------------------------------------------------------
+
+std::size_t Opm::Action::State::run_count(const ActionX& action) const
+{
+    auto count_iter = this->run_state.find(makeID(action));
+
+    return (count_iter == this->run_state.end())
+        ? std::size_t{0} : count_iter->second.run_count;
+}
+
+std::time_t Opm::Action::State::run_time(const ActionX& action) const
+{
+    auto statePos = this->run_state.find(makeID(action));
+    if (statePos == this->run_state.end()) {
+        throw std::invalid_argument {
+            fmt::format("Action {} has never run", action.name())
+        };
+    }
+
+    return statePos->second.last_run;
+}
+
+void Opm::Action::State::add_run(const ActionX&    action,
+                                 const std::time_t run_time,
+                                 const Result&     result)
+{
+    {
+        const auto& [statePos, inserted] = this->run_state
+            .emplace(makeID(action), run_time);
+
+        if (! inserted) {
+            statePos->second.add_run(run_time);
+        }
+    }
+
+    if (! result) { return; }
+
+    if (auto wellRange = result.wells(); ! wellRange.empty()) {
+        const auto resultInsert = this->last_result
+            .emplace(std::piecewise_construct,
+                     std::forward_as_tuple(action.name()),
+                     std::forward_as_tuple());
+
+        resultInsert.first->second.wells_ = std::move(wellRange);
+    }
+}
+
+void Opm::Action::State::add_run(const PyAction& action, const bool result)
+{
+    this->m_python_result.insert_or_assign(action.name(), result);
+}
+
+const Opm::Action::State::MatchSet*
+Opm::Action::State::result(const std::string& action) const
+{
+    auto iter = this->last_result.find(action);
+
+    return (iter == this->last_result.end())
+        ? nullptr : &iter->second;
+}
+
+std::optional<bool>
+Opm::Action::State::python_result(const std::string& action) const
+{
+    auto iter = this->m_python_result.find(action);
+    if (iter == this->m_python_result.end()) {
+        return std::nullopt;
+    }
+
+    return iter->second;
+}
+
+// When restoring from restart file we initialize the number of times it has
+// run and the last run time.  From the evaluation only the 'true'
+// evaluation is restored, not the well/group set.
+void Opm::Action::State::load_rst(const Actions&             action_config,
+                                  const RestartIO::RstState& rst_state)
+{
+    for (const auto& rst_action : rst_state.actions) {
+        if (! (rst_action.run_count > 0)) {
+            continue;
+        }
+
+        this->add_run(action_config[rst_action.name],
+                      rst_action.last_run.value(),
+                      Action::Result{ true });
+    }
+}
+
+bool Opm::Action::State::operator==(const State& other) const
+{
+    return (this->m_python_result == other.m_python_result)
+        && (this->run_state == other.run_state)
+        && (this->last_result == other.last_result)
+        ;
+}
+
+Opm::Action::State Opm::Action::State::serializationTestObject()
+{
     State st;
-    st.run_state.insert(std::make_pair( std::make_pair("ACTION", 100), RunState::serializationTestObject()));
-    st.last_result.insert( std::make_pair("ACTION", Result::serializationTestObject()));
-    st.m_python_result.insert( std::make_pair("PYACTION", false) );
-    return st;
-}
 
-}
+    st.run_state.emplace(std::piecewise_construct,
+                         std::forward_as_tuple(std::string{"ACTION"}, 100),
+                         std::forward_as_tuple(RunState::serializationTestObject()));
+
+    st.last_result.emplace("ACTION", MatchSet::serializationTestObject());
+    st.m_python_result.emplace("PYACTION", false);
+
+    return st;
 }

--- a/opm/output/eclipse/AggregateWellData.cpp
+++ b/opm/output/eclipse/AggregateWellData.cpp
@@ -1466,8 +1466,8 @@ namespace {
 
             // Loop over actions to assign action name for relevant wells
             for (const auto& action : actions) {
-                const auto& result = action_state.result(action.name());
-                if (result.has_value() && result->has_well(well.name())) {
+                const auto* result = action_state.result(action.name());
+                if ((result != nullptr) && result->hasWell(well.name())) {
                     zWell[Ix::ActionX] = action.name();
                 }
             }

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -1024,37 +1024,38 @@ BOOST_AUTO_TEST_CASE(ActionState)
     Action::Result res3(true, {"W3"});
 
     BOOST_CHECK_EQUAL(0U, st.run_count(action1));
-    BOOST_CHECK_THROW( st.run_time(action1), std::out_of_range);
+    BOOST_CHECK_THROW( st.run_time(action1), std::invalid_argument);
 
     st.add_run(action1, 100, res1);
     BOOST_CHECK_EQUAL(1U, st.run_count(action1));
     BOOST_CHECK_EQUAL(100, st.run_time(action1));
-    auto r1 = st.result("NAME");
-    BOOST_CHECK(r1.value() == res1);
+    const auto* r1 = st.result("NAME");
+    BOOST_REQUIRE(r1 != nullptr);
+    BOOST_CHECK(r1->hasWell("W1"));
 
     st.add_run(action1, 1000, res2);
     BOOST_CHECK_EQUAL(2U, st.run_count(action1));
     BOOST_CHECK_EQUAL(1000, st.run_time(action1));
-    auto r2 = st.result("NAME");
-    BOOST_CHECK(r2.value() == res2);
+    const auto* r2 = st.result("NAME");
+    BOOST_REQUIRE(r2 != nullptr);
+    BOOST_CHECK(r2->hasWell("W2"));
 
     BOOST_CHECK_EQUAL(0U, st.run_count(action2));
-    BOOST_CHECK_THROW( st.run_time(action2), std::out_of_range);
+    BOOST_CHECK_THROW(st.run_time(action2), std::invalid_argument);
 
     st.add_run(action2, 100, res3);
     BOOST_CHECK_EQUAL(1U, st.run_count(action2));
     BOOST_CHECK_EQUAL(100, st.run_time(action2));
-    auto r3 = st.result("NAME");
-    BOOST_CHECK(r3.value() == res3);
+    const auto* r3 = st.result("NAME");
+    BOOST_REQUIRE(r3 != nullptr);
+    BOOST_CHECK(r3->hasWell("W3"));
 
     st.add_run(action2, 1000, res1);
     BOOST_CHECK_EQUAL(2U, st.run_count(action2));
     BOOST_CHECK_EQUAL(1000, st.run_time(action2));
 
-
-    auto res = st.result("NAME-HIDDEN");
-    BOOST_CHECK(!res.has_value());
-
+    const auto* res = st.result("NAME-HIDDEN");
+    BOOST_CHECK(res == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(MANUAL4_QUOTE)


### PR DESCRIPTION
This PR introduces a separate storage layer for matching entities&ndash;typically wells&ndash;in the `Action::State` object.  This is in preparation of making `Action::Result` more general, and that will make the `Result` object harder to serialize.  The new `Action::State::MatchSet` type has the usual serialization support, but is expected to be limited to wells, since that's what's needed for restart file output purposes.

We switch the internals of `Action::State` to storing `MatchSet`s instead and `Action::State::result()` will now return a pointer to a `MatchSet` instead of an `optional<Action::Result>`.  Update callers accordingly.

While here, switch `Action::State::run_count()` to use `map<>::find()` instead of `map<>::at()` since the former enables controlling which exception type gets thrown as well as the diagnostic message.