### PR TITLE
fixed: check for and don't try to add an empty unit

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -177,7 +177,9 @@ namespace Opm {
                 this->add_assign(udq, rst_state.header.report_step);
             }
 
-            this->add_unit(udq.name, udq.unit);
+            if (!udq.unit.empty()) {
+                this->add_unit(udq.name, udq.unit);
+            }
         }
     }
 


### PR DESCRIPTION
leads to deref of empty string.
fixes debug_iter failure in ScheduleRestartTests