### PR TITLE
Compositional well

### DIFF
--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -394,7 +394,7 @@ struct SummaryConfigContext {
     bool is_well_comp(const std::string& keyword)
     {
         static const auto well_comp_kw = keyword_set {
-             "WXMF", "WYMF", "WZMF", "WCGMR", "WCOMR"
+             "WAMF", "WXMF", "WYMF", "WZMF", "WCGMR", "WCOMR"
         };
 
         return is_in_set(well_comp_kw, keyword);

--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -394,7 +394,7 @@ struct SummaryConfigContext {
     bool is_well_comp(const std::string& keyword)
     {
         static const auto well_comp_kw = keyword_set {
-             "WAMF", "WXMF", "WYMF", "WZMF", "WCGMR", "WCOMR"
+             "WAMF", "WXMF", "WYMF", "WZMF", "WCGMR", "WCOMR",
         };
 
         return is_in_set(well_comp_kw, keyword);

--- a/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -311,6 +311,7 @@ bool ScheduleState::operator==(const ScheduleState& other) const {
         && this->bhp_defaults.get() == other.bhp_defaults.get()
         && this->source.get() == other.source.get()
         && this->wells == other.wells
+        && this->inj_streams == other.inj_streams
         && this->groups == other.groups
         && this->vfpprod == other.vfpprod
         && this->vfpinj == other.vfpinj

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -201,6 +201,10 @@ namespace Opm {
                 return (ptr != nullptr);
             }
 
+            void update(const K& key, std::shared_ptr<T> value) {
+                this->m_data[key] = value;
+            }
+
 
             void update(T object) {
                 auto key = object.name();
@@ -509,6 +513,9 @@ namespace Opm {
         // constant flux aquifers
         std::unordered_map<int, SingleAquiferFlux> aqufluxs;
         BCProp bcprop;
+        // injection streams for compostional STREAM injection using WINJGAS 
+        map_member<std::string, std::vector<double>> inj_streams;
+
         std::unordered_map<std::string, double> target_wellpi;
         std::optional<NextStep> next_tstep;
 
@@ -546,6 +553,7 @@ namespace Opm {
             serializer(wells);
             serializer(aqufluxs);
             serializer(bcprop);
+            serializer(inj_streams);
             serializer(target_wellpi);
             serializer(this->next_tstep);
             serializer(m_start_time);

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -202,9 +202,8 @@ namespace Opm {
             }
 
             void update(const K& key, std::shared_ptr<T> value) {
-                this->m_data[key] = value;
+                this->m_data.insert_or_assign(key, std::move(value));
             }
-
 
             void update(T object) {
                 auto key = object.name();

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -234,6 +234,7 @@ public:
         void handleWTMULT(Well::WELTARGCMode cmode, double factor);
 
         void setGasInjComposition(const std::vector<double>& composition);
+        const std::vector<double>& gasInjComposition() const;
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -575,7 +576,6 @@ public:
     double inj_temperature() const;
     bool hasInjTemperature() const;
     void setWellInjTemperature(const double temp);
-    void setGasInjComposition(const std::vector<double>& composition);
     bool hasInjected( ) const;
     bool hasProduced( ) const;
     bool updateHasInjected( );

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -164,6 +164,9 @@ public:
 
         double rsRvInj;
 
+        // injection stream compostion for compositional simulation
+        std::optional<std::vector<double>> gas_inj_composition{};
+
         bool operator==(const WellInjectionProperties& other) const;
         bool operator!=(const WellInjectionProperties& other) const;
 
@@ -230,6 +233,8 @@ public:
         void update_uda(const UDQConfig& udq_config, UDQActive& udq_active, UDAControl control, const UDAValue& value);
         void handleWTMULT(Well::WELTARGCMode cmode, double factor);
 
+        void setGasInjComposition(const std::vector<double>& composition);
+
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
@@ -248,6 +253,7 @@ public:
             serializer(injectorType);
             serializer(controlMode);
             serializer(rsRvInj);
+            serializer(gas_inj_composition);
         }
     };
 
@@ -569,6 +575,7 @@ public:
     double inj_temperature() const;
     bool hasInjTemperature() const;
     void setWellInjTemperature(const double temp);
+    void setGasInjComposition(const std::vector<double>& composition);
     bool hasInjected( ) const;
     bool hasProduced( ) const;
     bool updateHasInjected( );

--- a/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
@@ -509,5 +509,11 @@ namespace Opm {
         gas_inj_composition = composition;
     }
 
+    const std::vector<double>& Well::WellInjectionProperties::gasInjComposition() const {
+        if (!gas_inj_composition.has_value()) {
+            throw std::invalid_argument("Gas injection composition not set");
+        }
+        return gas_inj_composition.value();
+    }
 
 }

--- a/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
@@ -60,7 +60,8 @@ namespace Opm {
           injectionControls(0),
           injectorType(InjectorType::WATER),
           controlMode(InjectorCMode::CMODE_UNDEFINED),
-          rsRvInj(0.0)
+          rsRvInj(0.0),
+          gas_inj_composition(std::nullopt)
     {
     }
 
@@ -82,6 +83,7 @@ namespace Opm {
         result.injectorType = InjectorType::OIL;
         result.controlMode = InjectorCMode::BHP;
         result.rsRvInj = 11;
+        result.gas_inj_composition = std::vector<double>{1.0, 2.0, 3.0};
 
         return result;
     }
@@ -284,7 +286,8 @@ namespace Opm {
             (injectionControls == other.injectionControls) &&
             (injectorType == other.injectorType) &&
             (controlMode == other.controlMode) &&
-            (rsRvInj == other.rsRvInj))
+            (rsRvInj == other.rsRvInj) &&
+            (gas_inj_composition == other.gas_inj_composition))
             return true;
         else
             return false;
@@ -324,6 +327,7 @@ namespace Opm {
             << "injector type: "    << InjectorType2String(wp.injectorType) << ", "
             << "control mode: "     << WellInjectorCMode2String(wp.controlMode) << " , "
             << "rs/rv concentration: " << wp.rsRvInj << " }";
+            // TODO: add gas_inj_composition
     }
 
 
@@ -344,6 +348,7 @@ namespace Opm {
         controls.vfp_table_number = this->VFPTableNumber;
         controls.prediction_mode = this->predictionMode;
         controls.rs_rv_inj = this->rsRvInj;
+        // TODO: should we add gas_inj_composition here?
 
         return controls;
     }
@@ -498,6 +503,10 @@ namespace Opm {
             default:
                 std::invalid_argument(fmt::format("Invalid target {} supplied to WTMULT", WellWELTARGCMode2String(cmode)));
         }
+    }
+
+    void Well::WellInjectionProperties::setGasInjComposition(const std::vector<double>& composition) {
+        gas_inj_composition = composition;
     }
 
 

--- a/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
@@ -327,7 +327,6 @@ namespace Opm {
             << "injector type: "    << InjectorType2String(wp.injectorType) << ", "
             << "control mode: "     << WellInjectorCMode2String(wp.controlMode) << " , "
             << "rs/rv concentration: " << wp.rsRvInj << " }";
-            // TODO: add gas_inj_composition
     }
 
 
@@ -348,7 +347,6 @@ namespace Opm {
         controls.vfp_table_number = this->VFPTableNumber;
         controls.prediction_mode = this->predictionMode;
         controls.rs_rv_inj = this->rsRvInj;
-        // TODO: should we add gas_inj_composition here?
 
         return controls;
     }

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -445,6 +445,25 @@ void handleWCYCLE(HandlerContext& handlerContext)
     handlerContext.state().wcycle.update(std::move(new_config));
 }
 
+void handleWELLSTRE(HandlerContext& handlerContext)
+{
+    auto& inj_streams = handlerContext.state().inj_streams;
+    for (const auto& record : handlerContext.keyword) {
+        const std::string& stream_name = record.getItem("STREAM").getTrimmedString(0);
+        const auto& compostion = record.getItem("COMPOSITIONS").getData<double>();
+        // TODO: we need to check the number of the values in the composition is the same as the number of components
+
+        const double sum = std::accumulate(compostion.begin(), compostion.end(), 0.0);
+        if (std::abs(sum - 1.0) > std::numeric_limits<double>::epsilon()) {
+            std::string msg = fmt::format("The sum of the composition values for stream '{}' is not 1.0, but {}.", stream_name, sum);
+            throw OpmInputError(msg, handlerContext.keyword.location());
+        }
+        auto composition_ptr = std::make_shared<std::vector<double>>(std::move(compostion));
+        inj_streams.update(stream_name, composition_ptr);
+    }
+
+}
+
 void handleWELOPEN(HandlerContext& handlerContext)
 {
     const auto& keyword = handlerContext.keyword;
@@ -524,6 +543,41 @@ void handleWELOPEN(HandlerContext& handlerContext)
 
             handlerContext.state().events().addEvent(ScheduleEvents::COMPLETION_CHANGE);
         }
+    }
+}
+
+void handleWINJGAS(HandlerContext& HandlerContext)
+{
+    for (const auto& record : HandlerContext.keyword) {
+        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const auto well_names = HandlerContext.wellNames(wellNamePattern, false);
+        const std::string& fluid_nature = record.getItem("FLUID").getTrimmedString(0);
+        // TODO: technically, only the firt two characters are significant
+        // TODO: we need to test it out whether only the first two characters matter
+        if (fluid_nature != "STREAM") {
+            std::string msg = fmt::format("The fluid nature '{}' is not supported in WINJGAS keyword.", fluid_nature);
+            throw OpmInputError(msg, HandlerContext.keyword.location());
+        }
+        const std::string& stream_name = record.getItem("STREAM").getTrimmedString(0);
+        // TODO: we do not handle other records for now
+
+        // we make sure the stream is defined in WELLSTRE keyword
+        const auto& inj_streams = HandlerContext.state().inj_streams;
+        if (!inj_streams.has(stream_name)) {
+            std::string msg = fmt::format("The stream '{}' is not defined in WELLSTRE keyword.", stream_name);
+            throw OpmInputError(msg, HandlerContext.keyword.location());
+        }
+
+        auto well2 = HandlerContext.state().wells.get(well_names[0]);
+        // if (well2.isProducer()) {
+        //     std::string msg = fmt::format("The well '{}' is a producer, not an injector.", well_names[0]);
+        //     throw OpmInputError(msg, HandlerContext.keyword.location());
+        // }
+        auto injection = std::make_shared<Well::WellInjectionProperties>(well2.getInjectionProperties());
+
+        // TODO: should we make it a injection event?
+        const auto& inj_stream = inj_streams.get(stream_name);
+        injection->setGasInjComposition(inj_stream);
     }
 }
 
@@ -943,13 +997,17 @@ getWellHandlers()
         { "WCONINJE", &handleWCONINJE },
         { "WCONINJH", &handleWCONINJH },
         { "WCONPROD", &handleWCONPROD },
+
         { "WCYCLE",   &handleWCYCLE   },
+
         { "WELOPEN" , &handleWELOPEN  },
+        { "WELLSTRE", &handleWELLSTRE },
         { "WELSPECS", &handleWELSPECS },
         { "WELSPECL", &handleWELSPECL },
         { "WELTARG" , &handleWELTARG  },
         { "WELTRAJ" , &handleWELTRAJ  },
         { "WHISTCTL", &handleWHISTCTL },
+        { "WINJGAS",  &handleWINJGAS  },
         { "WLIST"   , &handleWLIST    },
         { "WPAVE"   , &handleWPAVE    },
         { "WPAVEDEP", &handleWPAVEDEP },

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -576,11 +576,6 @@ void handleWINJGAS(HandlerContext& handlerContext)
 
         for (const auto& well_name : well_names) {
             auto well2 = handlerContext.state().wells.get(well_name);
-            if (well2.isProducer()) {
-                const std::string msg = fmt::format(
-                        "The well '{}' is a producer, not an injector, can not be specified with WINJGAS.", well_name);
-                throw OpmInputError(msg, handlerContext.keyword.location());
-            }
             auto injection = std::make_shared<Well::WellInjectionProperties>(well2.getInjectionProperties());
 
             const auto& inj_stream = inj_streams.get(stream_name);

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/W/WELLSTRE
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/W/WELLSTRE
@@ -10,16 +10,11 @@
       "value_type": "STRING"
     },
     {
-        "item": 2,
-        "name": "XMOLE1",
-        "value_type": "DOUBLE",
-        "dimension": "1"
-      },
-      {
-        "item": 3,
-        "name": "XMOLE2",
-        "value_type": "DOUBLE",
-        "dimension": "1"
-      }
+      "item": 2,
+      "name": "COMPOSITIONS",
+      "value_type": "DOUBLE",
+      "dimension": "1",
+      "size_type": "ALL"
+    }
   ]
 }

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/W/WELL_PROBE_COMP
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/W/WELL_PROBE_COMP
@@ -4,6 +4,7 @@
     "SUMMARY"
   ],
   "deck_names": [
+    "WAMF",
     "WXMF",
     "WYMF",
     "WZMF",

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -992,7 +992,7 @@ protected:
         // p_l and p_v are the same here, in the future, there might be slightly more complicated scenarios when capillary
         // pressure joins
 
-        constexpr size_t num_deri = numComponents;
+        constexpr size_t num_deri = InputEval::numVars; // numComponents;
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             std::vector<double> deri(num_deri, 0.);
             // derivatives from P

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -80,7 +80,7 @@ public:
      *
      */
     template <class FluidState>
-    static void solve(FluidState& fluid_state,
+    static bool solve(FluidState& fluid_state,
                       const std::string& twoPhaseMethod,
                       Scalar flash_tolerance,
                       const EOSType& eos_type,
@@ -116,6 +116,8 @@ public:
 
         // we update the derivatives in fluid_state
         updateDerivatives_(fluid_state_scalar, fluid_state, eos_type, is_single_phase);
+
+        return is_single_phase;
     } //end solve
 
     /*!

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -994,7 +994,7 @@ protected:
         // p_l and p_v are the same here, in the future, there might be slightly more complicated scenarios when capillary
         // pressure joins
 
-        constexpr size_t num_deri = InputEval::numVars; // numComponents;
+        constexpr size_t num_deri = InputEval::numVars;
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             std::vector<double> deri(num_deri, 0.);
             // derivatives from P


### PR DESCRIPTION
This PR is providing some necessary elements for the compositional simulation with wells. It mostly including the following elements, 

1. parsing the schedule keywords WINJGAS and WELLSTRE
2. making PTFlash::solve() can handle arbitrary number of derivatives from the input AD variables. 
3. adding WAMF in the summary keywords

The PR can be reviewed and merged by itself without the downstream PR https://github.com/OPM/opm-simulators/pull/6042 . 