### PR TITLE
Refactor Action::State and Action::Value

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ASTNode.cpp
+++ b/opm/input/eclipse/Schedule/Action/ASTNode.cpp
@@ -191,12 +191,19 @@ Opm::Action::ASTNode::evalComparison(const Context& context) const
 
     // Special casing of MONTH comparisons where in addition to symbolic
     // month names we can compare with numeric month indices.  When
-    // conducting such comparisons, the numeric value should be rounded
-    // before comparison.  This means that for example
+    // conducting such comparisons, the numeric value month value should be
+    // compared to the *nearest integer* value of the right-hand side--in
+    // other words the numeric month value should be rounded to the nearest
+    // integer before comparison.  This means that for example
     //
     //   MNTH = 4.3
     //
-    // should evaluate to true for the month of April (month index = 4).
+    // should evaluate to true for the month of April (month index = 4) and
+    // that
+    //
+    //   MNTH = 10.8
+    //
+    // should evaluate to true for the month of November (month index = 11).
     if (this->children.front().func_type == FuncType::time_month) {
         const auto& rhs = this->children[1];
 

--- a/opm/input/eclipse/Schedule/Action/ASTNode.cpp
+++ b/opm/input/eclipse/Schedule/Action/ASTNode.cpp
@@ -29,9 +29,12 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <iterator>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>
@@ -40,18 +43,18 @@
 namespace {
     std::string strip_quotes(const std::string& s)
     {
-        if (s.front() == '\'') {
-            return s.substr(1, s.size() - 2);
-        }
-        else {
+        if (s.front() != '\'') {
             return s;
         }
+
+        return s.substr(1, s.size() - 2);
     }
 
     std::vector<std::string>
     strip_quotes(const std::vector<std::string>& quoted_strings)
     {
-        std::vector<std::string> strings;
+        std::vector<std::string> strings{};
+        strings.reserve(quoted_strings.size());
 
         std::transform(quoted_strings.begin(), quoted_strings.end(),
                        std::back_inserter(strings),
@@ -80,7 +83,7 @@ Opm::Action::ASTNode::ASTNode(const double value)
 
 Opm::Action::ASTNode::ASTNode(const TokenType                 type_arg,
                               const FuncType                  func_type_arg,
-                              const std::string&              func_arg,
+                              std::string_view                func_arg,
                               const std::vector<std::string>& arg_list_arg)
     : type     (type_arg)
     , func_type(func_type_arg)
@@ -104,6 +107,52 @@ Opm::Action::ASTNode::serializationTestObject()
     return result;
 }
 
+void Opm::Action::ASTNode::add_child(const ASTNode& child)
+{
+    this->children.push_back(child);
+}
+
+Opm::Action::Result
+Opm::Action::ASTNode::eval(const Context& context) const
+{
+    if (this->empty()) {
+        throw std::invalid_argument {
+            "ASTNode::eval() should not reach leaf nodes"
+        };
+    }
+
+    if ((this->type == TokenType::op_or) ||
+        (this->type == TokenType::op_and))
+    {
+        return this->evalLogicalOperation(context);
+    }
+
+    return this->evalComparison(context);
+}
+
+void Opm::Action::ASTNode::
+required_summary(std::unordered_set<std::string>& required_summary) const
+{
+    if (this->type == TokenType::ecl_expr) {
+        required_summary.insert(this->func);
+    }
+
+    for (const auto& node : this->children) {
+        node.required_summary(required_summary);
+    }
+}
+
+bool Opm::Action::ASTNode::operator==(const ASTNode& that) const
+{
+    return (this->type == that.type)
+        && (this->func_type == that.func_type)
+        && (this->func == that.func)
+        && (this->arg_list == that.arg_list)
+        && (this->number == that.number)
+        && (this->children == that.children)
+        ;
+}
+
 std::size_t Opm::Action::ASTNode::size() const
 {
     return this->children.size();
@@ -114,17 +163,60 @@ bool Opm::Action::ASTNode::empty() const
     return this->size() == 0;
 }
 
-void Opm::Action::ASTNode::add_child(const ASTNode& child)
+// ===========================================================================
+// Private member functions
+// ===========================================================================
+
+Opm::Action::Result
+Opm::Action::ASTNode::evalLogicalOperation(const Context& context) const
 {
-    this->children.push_back(child);
+    auto result = Result { this->type == TokenType::op_and };
+
+    for (const auto& child : this->children) {
+        if (this->type == TokenType::op_or) {
+            result |= child.eval(context);
+        }
+        else {
+            result &= child.eval(context);
+        }
+    }
+
+    return result;
+}
+
+Opm::Action::Result
+Opm::Action::ASTNode::evalComparison(const Context& context) const
+{
+    auto v2 = Value {};
+
+    // Special casing of MONTH comparisons where in addition to symbolic
+    // month names we can compare with numeric month indices.  When
+    // conducting such comparisons, the numeric value should be rounded
+    // before comparison.  This means that for example
+    //
+    //   MNTH = 4.3
+    //
+    // should evaluate to true for the month of April (month index = 4).
+    if (this->children.front().func_type == FuncType::time_month) {
+        const auto& rhs = this->children[1];
+
+        v2 = (rhs.type == TokenType::number)
+            ? Value { std::round(rhs.number) }
+            : rhs.nodeValue(context);
+    }
+    else {
+        v2 = this->children[1].nodeValue(context);
+    }
+
+    return this->children.front().nodeValue(context).eval_cmp(this->type, v2);
 }
 
 Opm::Action::Value
-Opm::Action::ASTNode::value(const Action::Context& context) const
+Opm::Action::ASTNode::nodeValue(const Context& context) const
 {
-    if (! this->children.empty()) {
+    if (! this->empty()) {
         throw std::invalid_argument {
-            "value() method should only reach leafnodes"
+            "nodeValue() method should only reach leaf nodes"
         };
     }
 
@@ -136,120 +228,79 @@ Opm::Action::ASTNode::value(const Action::Context& context) const
         return Value { context.get(this->func) };
     }
 
-    // The matching code is special case to handle one-argument cases with
-    // well patterns like 'P*'.
-    if ((this->arg_list.size() == 1) &&
-        (this->arg_list.front().find("*") != std::string::npos))
-    {
-        if (this->func_type != FuncType::well) {
-            throw std::logic_error {
-                ": attempted to action-evaluate list not of type well."
-            };
-        }
-
-        const auto& well_arg = this->arg_list[0];
-
-        auto well_values = Value{};
-        auto wnames = std::vector<std::string>{};
-
-        if ((well_arg.front() == '*') && (well_arg.size() > 1)) {
-            const auto& wlm = context.wlist_manager();
-            wnames = wlm.wells(well_arg);
-        }
-        else {
-            const auto& wells = context.wells(this->func);
-            std::copy_if(wells.begin(), wells.end(), std::back_inserter(wnames),
-                        [&well_arg](const auto& well)
-                        {
-                            return shmatch(well_arg, well);
-                        });
-        }
-
-        for (const auto& wname : wnames) {
-            well_values.add_well(wname, context.get(this->func, wname));
-        }
-
-        return well_values;
+    if (this->argListIsPattern()) {
+        return this->evalListExpression(context);
     }
     else {
-        const auto arg_key = fmt::format("{}", fmt::join(this->arg_list, ":"));
-        const auto scalar_value = context.get(this->func, arg_key);
-
-        if (this->func_type == FuncType::well) {
-            return Value { this->arg_list.front(), scalar_value };
-        }
-
-        return Value { scalar_value };
+        return this->evalScalarExpression(context);
     }
 }
 
-Opm::Action::Result
-Opm::Action::ASTNode::eval(const Action::Context& context) const
+Opm::Action::Value
+Opm::Action::ASTNode::evalListExpression(const Context& context) const
 {
-    if (this->empty()) {
-        throw std::invalid_argument {
-            "ASTNode::eval() should not reach leafnodes"
+    if (this->func_type != FuncType::well) {
+        throw std::logic_error {
+            ": attempted to action-evaluate list not of type well."
         };
     }
 
-    if ((this->type == TokenType::op_or) ||
-        (this->type == TokenType::op_and))
-    {
-        auto result = Result { this->type == TokenType::op_and };
-
-        for (const auto& child : this->children) {
-            if (this->type == TokenType::op_or) {
-                result |= child.eval(context);
-            }
-            else {
-                result &= child.eval(context);
-            }
-        }
-
-        return result;
-    }
-
-    auto v2 = Value {};
-
-    // Special casing of MONTH comparisons where in addition symbolic month
-    // names we can compare with numeric months, in the case of numeric
-    // months the numerical value should be rounded before comparison - i.e.
-    //
-    //   MNTH = 4.3
-    //
-    // should evaluate to true for the month of April (4).
-    if (this->children.front().func_type == FuncType::time_month) {
-        const auto& rhs = this->children[1];
-
-        v2 = (rhs.type == TokenType::number)
-            ? Value { std::round(rhs.number) }
-            : rhs.value(context);
-    }
-    else {
-        v2 = this->children[1].value(context);
-    }
-
-    return this->children.front().value(context).eval_cmp(this->type, v2);
+    return this->evalWellExpression(context);
 }
 
-bool Opm::Action::ASTNode::operator==(const ASTNode& data) const
+Opm::Action::Value
+Opm::Action::ASTNode::evalScalarExpression(const Context& context) const
 {
-    return (type == data.type)
-        && (func_type == data.func_type)
-        && (func == data.func)
-        && (arg_list == data.arg_list)
-        && (number == data.number)
-        && (children == data.children)
-        ;
+    const auto arg_key = fmt::format("{}", fmt::join(this->arg_list, ":"));
+    const auto scalar_value = context.get(this->func, arg_key);
+
+    if (this->func_type != FuncType::well) {
+        return Value { scalar_value };
+    }
+
+    return Value { this->arg_list.front(), scalar_value };
 }
 
-void Opm::Action::ASTNode::required_summary(std::unordered_set<std::string>& required_summary) const
+Opm::Action::Value
+Opm::Action::ASTNode::evalWellExpression(const Context& context) const
 {
-    if (this->type == TokenType::ecl_expr) {
-        required_summary.insert(this->func);
+    auto well_values = Value{};
+
+    for (const auto& wname : this->getWellList(context)) {
+        well_values.add_well(wname, context.get(this->func, wname));
     }
 
-    for (const auto& node : this->children) {
-        node.required_summary(required_summary);
+    return well_values;
+}
+
+std::vector<std::string>
+Opm::Action::ASTNode::getWellList(const Context& context) const
+{
+    if (this->argListIsWellList()) {
+        return context.wlist_manager().wells(this->arg_list.front());
     }
+
+    const auto& wells = context.wells(this->func);
+
+    auto wnames = std::vector<std::string>{};
+    wnames.reserve(wells.size());
+
+    std::copy_if(wells.begin(), wells.end(), std::back_inserter(wnames),
+                 [&wpatt = this->arg_list.front()]
+                 (const auto& well) { return shmatch(wpatt, well); });
+
+    return wnames;
+}
+
+bool Opm::Action::ASTNode::argListIsPattern() const
+{
+    return (this->arg_list.size() == 1)
+        && (this->arg_list.front().find("*") != std::string::npos);
+}
+
+bool Opm::Action::ASTNode::argListIsWellList() const
+{
+    const auto& well_arg = this->arg_list.front();
+
+    return (well_arg.size() > 1) && (well_arg.front() == '*');
 }

--- a/opm/input/eclipse/Schedule/Action/ASTNode.hpp
+++ b/opm/input/eclipse/Schedule/Action/ASTNode.hpp
@@ -20,48 +20,139 @@
 #ifndef ASTNODE_HPP
 #define ASTNODE_HPP
 
-#include <opm/input/eclipse/Schedule/Action/ActionContext.hpp>
-
-#include "ActionValue.hpp"
+#include <opm/input/eclipse/Schedule/Action/ActionValue.hpp>
 
 #include <cstddef>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <vector>
 
-namespace Opm { namespace Action {
+namespace Opm::Action {
+    class Context;
+} // namespace Opm::Action
 
-class ActionContext;
-class WellSet;
+namespace Opm::Action {
 
+/// Node in ACTIONX condition expression abstract syntax tree
+///
+/// Might for instance represent the conjunction ('AND') in a condition of
+/// the form
+///
+///    FGOR > 432.1 AND /
+///    (WMCTL 'PROD*' = 1 OR /
+///     GWIR < GUWIRMIN) /
+///
+/// In this case, the direct children would be the 'FGOR' condition and the
+/// grouped disjunction '(WMCTL OR GWIR)'.
 class ASTNode
 {
 public:
+    /// Default constructor
+    ///
+    /// Creates an AST node representing an error condition.  Exists mostly
+    /// for serialisation purposes.
     ASTNode();
+
+    /// Constructor
+    ///
+    /// Creates an AST node representing an expression, a relation, a
+    /// grouping, or a value.
+    ///
+    /// \param[in] type_arg Kind of AST node.
     explicit ASTNode(TokenType type_arg);
+
+    /// Constructor
+    ///
+    /// Creates a leaf-level AST node representing a numeric value.
+    ///
+    /// \param[in] value Numeric value in leaf-level AST node.
     explicit ASTNode(double value);
+
+    /// Constructor
+    ///
+    /// Creates an AST node representing an expression, a relation, a
+    /// grouping, or a value.  Records any applicable function name along
+    /// with arguments--e.g., a list of well names--upon which to invoke the
+    /// function.
+    ///
+    /// \param[in] type_arg Kind of AST node.
+    ///
+    /// \param[in] func_type_arg Function category of this AST node.
+    ///
+    /// \param[in] func_arg Which function (i.e., summary vector or UDQ) to
+    /// evaluate at this AST node.  Pass an empty string if there is no
+    /// function.  Common examples include FGOR, WOPR, or GGLR.
+    ///
+    /// \param[in] arg_list_arg Any additional arguments to the \p func_arg
+    /// function.  Might for instance be a list of well or group names.
     explicit ASTNode(TokenType type_arg,
                      FuncType func_type_arg,
-                     const std::string& func_arg,
+                     std::string_view func_arg,
                      const std::vector<std::string>& arg_list_arg);
 
-    static ASTNode serializationTestObject();
-
-    Action::Result eval(const Action::Context& context) const;
-    Action::Value value(const Action::Context& context) const;
-
-    void required_summary(std::unordered_set<std::string>& required_summary) const;
-
-    bool operator==(const ASTNode& data) const;
-
+    /// Kind of AST node.
     TokenType type;
+
+    /// Function category of this AST node.
     FuncType func_type;
+
+    /// Which function to evaluate at this AST node.  Empty string for no
+    /// function.  Typically a summary vector name otherwise.
     std::string func;
 
+    /// Create a serialisation test object.
+    static ASTNode serializationTestObject();
+
+    /// Parent a node to current AST node.
+    ///
+    /// Note: The order of add_child() calls may matter.  For instance, if
+    /// the current node represents a binary operator such addition or a
+    /// logical comparison--see the \c type member--then child nodes will be
+    /// treated left-to-right in the order of add_child() calls.  This is
+    /// especially important for comparisons like '<', subtraction, or
+    /// division.
+    ///
+    /// \param[in] child Expression node which will be parented to the
+    /// current AST node object.
     void add_child(const ASTNode& child);
+
+    /// Evaluate logical expression
+    ///
+    /// \param[in] context Current summary vector values and well query
+    /// object.
+    ///
+    /// \return Expression value.  Any wells for which the expression is
+    /// true will be included in the result set.
+    Result eval(const Context& context) const;
+
+    /// Export all summary vectors needed to compute values for the
+    /// current collection of user defined quantities.
+    ///
+    /// \param[in,out] required_summary Named summary vectors.  Upon
+    /// completion, any additional summary vectors needed to evaluate the
+    /// current condition will be included in this set.
+    void required_summary(std::unordered_set<std::string>& required_summary) const;
+
+    /// Equality predicate.
+    ///
+    /// \param[in] that Object against which \code *this \endcode will
+    /// be tested for equality.
+    ///
+    /// \return Whether or not \code *this \endcode is the same as \p other.
+    bool operator==(const ASTNode& that) const;
+
+    /// Number of child nodes of this AST node.
     std::size_t size() const;
+
+    /// Query whether or not this AST node has any child nodes.
     bool empty() const;
 
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
@@ -74,15 +165,121 @@ public:
     }
 
 private:
+    // Note: data member order here is dictated by initialisation list in
+    // four-argument constructor.
+
+    /// Additional arguments upon which to invoke the \c func function.
+    /// Might, for instance, be a list of well or group names.
     std::vector<std::string> arg_list{};
+
+    /// Numeric value of a scalar AST node.
     double number {0.0};
 
-    // To have a member std::vector<ASTNode> inside the ASTNode class is
-    // supposedly borderline undefined behaviour; it compiles without
-    // warnings and works.  Good for enough for me.
+    // Note: a data member of type std::vector<ASTNode> inside class ASTNode
+    // is well defined in C++17 or later, but may look surprising to the
+    // uninitiated.
+
+    /// Child nodes of this AST node.
     std::vector<ASTNode> children{};
+
+    /// Evaluate a conjunction/disjunction ('AND'/'OR') node.
+    ///
+    /// This is a top-level entry point for eval().
+    ///
+    /// \param[in] context Current summary vector values and well query
+    /// object.
+    ///
+    /// \return Expression value.  Any wells for which the expression is
+    /// true will be included in the result set.
+    Result evalLogicalOperation(const Context& context) const;
+
+    /// Evaluate a leaf-level comparison ('<', '=', '>=' &c) node.
+    ///
+    /// This is a top-level entry point for eval() when the node itself is a
+    /// leaf-level condition.
+    ///
+    /// \param[in] context Current summary vector values and well query
+    /// object.
+    ///
+    /// \return Expression value.  Any wells for which the expression is
+    /// true will be included in the result set.
+    Result evalComparison(const Context& context) const;
+
+    /// Compute numeric value of leaf node and collect associated entities.
+    ///
+    /// Must only be called for leaf nodes--i.e., nodes for which there are
+    /// no child nodes.
+    ///
+    /// \param[in] context Current summary vector values and well query
+    /// object.
+    ///
+    /// \return Numeric value of a function applied to a sequence of
+    /// arguments.  Also includes names of any wells mentioned in the
+    /// function argument list.
+    Value nodeValue(const Context& context) const;
+
+    /// Compute numeric value of leaf node when argument list is a name
+    /// pattern.
+    ///
+    /// Must only be called for leaf nodes--i.e., nodes for which there are
+    /// no child nodes.
+    ///
+    /// \param[in] context Current summary vector values and well query
+    /// object.
+    ///
+    /// \return Numeric value of a function applied to a sequence of
+    /// arguments.  Also includes names of any wells matching the pattern in
+    /// the function argument list.
+    Value evalListExpression(const Context& context) const;
+
+    /// Compute numeric value of leaf node when argument list is a single
+    /// name.
+    ///
+    /// Must only be called for leaf nodes--i.e., nodes for which there are
+    /// no child nodes.
+    ///
+    /// \param[in] context Current summary vector values and well query
+    /// object.
+    ///
+    /// \return Numeric value of a function applied to a sequence of
+    /// arguments.  Also includes the name the well mentioned in the
+    /// function argument list.
+    Value evalScalarExpression(const Context& context) const;
+
+    /// Compute numeric value of leaf node when argument list is a well name
+    /// pattern.
+    ///
+    /// Must only be called for leaf nodes--i.e., nodes for which there are
+    /// no child nodes.
+    ///
+    /// \param[in] context Current summary vector values and well query
+    /// object.
+    ///
+    /// \return Numeric value of a function applied to a sequence of
+    /// arguments.  Also includes names of any wells matching the pattern in
+    /// the function argument list.
+    Value evalWellExpression(const Context& context) const;
+
+    /// Compute list of well names matching a name pattern.
+    ///
+    /// \param[in] context Current summary vector values and well query
+    /// object.
+    ///
+    /// \return Names of all wells matching the well name pattern in \code
+    /// arg_list.front() \endcode, irrespective of whether the pattern is a
+    /// well template, a well list, or a well list template.
+    std::vector<std::string> getWellList(const Context& context) const;
+
+    /// Query whether or not the front of the function argument list (\code
+    /// arg_list.front() \endcode) is a name pattern.
+    bool argListIsPattern() const;
+
+    /// Query whether or not the front of the function argument list (\code
+    /// arg_list.front() \endcode) is the name of a well list or a well list
+    /// template (pattern).
+    bool argListIsWellList() const;
 };
 
-}} // namespace Opm::Action
+} // namespace Opm::Action
 
 #endif // ASTNODE_HPP

--- a/opm/input/eclipse/Schedule/Action/ActionValue.hpp
+++ b/opm/input/eclipse/Schedule/Action/ActionValue.hpp
@@ -23,64 +23,190 @@
 #include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
 
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
-namespace Opm { namespace Action {
+namespace Opm::Action {
 
+/// Lexical token in ACTIONX condition expression
 enum class TokenType
 {
-    number,        //  0
-    ecl_expr,      //  1
-    open_paren,    //  2
-    close_paren,   //  3
-    op_gt,         //  4
-    op_ge,         //  5
-    op_lt,         //  6
-    op_le,         //  7
-    op_eq,         //  8
-    op_ne,         //  9
-    op_and,        // 10
-    op_or,         // 11
-    end,           // 12
-    error,         // 13
+    /// Token is a literal number (e.g., 42 or -2.718e2)
+    number, // 0
+
+    /// Token is an expression--e.g., a function invocation or an arithmetic
+    /// combination of functions and values.
+    ecl_expr, // 1
+
+    /// Token is an opening parenthesis (i.e. "(")
+    open_paren, // 2
+
+    /// Token is a closing parenthesis (i.e., ")")
+    close_paren, // 3
+
+    /// Token is a greater-than operator (i.e., ">" or ".GT.")
+    op_gt, // 4
+
+    /// Token is a greater-than-or-equal-to operator (i.e., ">=" or ".GE.")
+    op_ge, // 5
+
+    /// Token is a less-than operator (i.e., "<" or ".LT.")
+    op_lt, // 6
+
+    /// Token is a less-than-or-equal-to operator (i.e., "<=" or ".LE.")
+    op_le, // 7
+
+    /// Token is an equality operator (i.e., "=" or ".EQ.")
+    op_eq, // 8
+
+    /// Token is a not-equal operator (i.e., "!=" or ".NE.")
+    op_ne, // 9
+
+    /// Token is the logical conjunction ("AND")
+    op_and, // 10
+
+    /// Token is the logical disjunction ("OR")
+    op_or, // 11
+
+    /// Token is the end-of-record (forward slash, "/")
+    end, // 12
+
+    /// Parse error state.
+    error, // 13
 };
 
+/// Function category of an ACTION condition sub-expression
 enum class FuncType
 {
-    none,
-    time,
-    time_month,
-    region,
-    field,
-    group,
-    well,
-    well_segment,
-    well_connection,
-    Well_lgr,
-    aquifer,
-    block,
+    /// No applicable function
+    none, // 0
+
+    /// Function is derived time quantity--e.g., the DAY or the YEAR--of the
+    /// current simulated TIME.
+    time, // 1
+
+    /// Function is the month ("MNTH") of the current simulated TIME.
+    time_month, // 2
+
+    /// Function applies to the region level (e.g., ROPR)
+    region, // 3
+
+    /// Function applies to the field level (e.g., FGOR)
+    field, // 4
+
+    /// Function applies to the group level (e.g., GOPRS)
+    group, // 5
+
+    /// Function applies to the well level (e.g., WWCT)
+    well, // 6
+
+    /// Function applies to the segment level (e.g., SOFR)
+    well_segment,  // 7
+
+    /// Function applies to the well connection level (e.g., CPR)
+    well_connection, // 8
+
+    /// Function applies to wells in an LGR.  Not really supported.
+    Well_lgr, // 9
+
+    /// Function applies to the aquifer level (e.g., AAQP)
+    aquifer, // 10
+
+    /// Function applies to the block/cell level (e.g., BDENO)
+    block, // 11
 };
 
+/// Numeric value of an AST sub-expression
 class Value
 {
 public:
-    explicit Value(double value);
-    Value(const std::string& wname, double value);
+    /// Default constructor.
+    ///
+    /// Resulting object is meaningful only if calling code later invokes
+    /// the add_well() member function.
     Value() = default;
 
+    /// Constructor.
+    ///
+    /// Creates a scalar Value object.
+    ///
+    /// \param[in] value Numeric value of scalar Value object.
+    explicit Value(double value);
+
+    /// Constructor.
+    ///
+    /// Creates a non-scalar Value object associated to a single well.
+    Value(std::string_view wname, double value);
+
+    /// Compare current Value to another Value.
+    ///
+    /// \param[in] op Comparison operator.  Must be one of
+    ///     * TokenType::op_eq (==)
+    ///     * TokenType::op_ge (>=)
+    ///     * TokenType::op_le (<=)
+    ///     * TokenType::op_ne (!=)
+    ///     * TokenType::op_gt (>)
+    ///     * TokenType::op_lt (<)
+    ///   Function eval_cmp() will throw an exception of type
+    ///   std::invalid_argument unless \p op is one of these operators.
+    ///
+    /// \param[in] rhs Value object against which \code *this \endcode will
+    /// be compared through \p op.  Should be a scalar value.  The \p rhs
+    /// object will be used on the right-hand side of the comparison
+    /// operator while \code *this \endcode will be used on the left-hand
+    /// side of \p op.  Function eval_cmp() will throw an exception of type
+    /// std::invalid_argument if \p rhs is not a scalar Value object.
+    ///
+    /// \return Result of comparison "*this op rhs".  If \code *this
+    /// \endcode is non-scalar, then any wells for which the comparison
+    /// holds will be included in the result set.
     Result eval_cmp(TokenType op, const Value& rhs) const;
-    void add_well(const std::string& well, double value);
+
+    /// Incorporate well level function value into Value object.
+    ///
+    /// Will throw an exception of type std::invalid_argument if \code *this
+    /// \endcode was created as a scalar object.
+    ///
+    /// \param[in] well Named well for which to incorporate a function
+    /// value.
+    ///
+    /// \param[in] value Numeric function value for \p well.
+    void add_well(std::string_view well, double value);
+
+    /// Retrieve scalar function value.
+    ///
+    /// Will throw an exception of type std::invalid_argument if \code *this
+    /// \endcode was not created as a scalar object.
     double scalar() const;
 
 private:
-    double scalar_value{};
-    double is_scalar{false};
-    std::vector<std::pair<std::string, double>> well_values{};
+    /// Numeric value of scalar Value object.
+    ///
+    /// Meaningful only if \c is_scalar_ flag is true.
+    double scalar_value_{};
 
-    Result eval_cmp_wells(TokenType op, double rhs) const;
+    /// Whether or not current Value represents a scalar.
+    double is_scalar_{false};
+
+    /// Collection of function values associated to individual wells.
+    std::vector<std::pair<std::string, double>> well_values_{};
+
+    /// Compare current list of well values to another Value
+    ///
+    /// \param[in] op Comparison operator.
+    ///
+    /// \param[in] rhs Numerical value against which the current values will
+    /// be compared through \p op.  The \p rhs value will be used on the
+    /// right-hand side of the comparison operator while the current well
+    /// values will be used on the left-hand side of \p op.
+    ///
+    /// \return Result of comparison "X op rhs" for all well values 'X'.
+    /// True if the comparison holds for at least one well.  Any wells for
+    /// which the comparison holds will be included in the result set.
+    Result evalWellComparisons(TokenType op, double rhs) const;
 };
 
-}} // namespace Opm::Action
+} // namespace Opm::Action
 
 #endif // ACTION_VALUE_HPP


### PR DESCRIPTION
This is in preparation of making the set of entities matching a "true" condition more general.  While here, also split nested conditional out to separate helper functions for readability and switch to taking `string_view` parameters where possible.  Finally, add Doxygen-style documentation to both classes and remove `Action::` namespace prefix where appropriate.