### PR TITLE
Give meaningful error for out-of-range well perforations in ACTIONX.

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/GridDims.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/GridDims.cpp
@@ -29,6 +29,8 @@
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
+#include <fmt/format.h>
+
 #include <array>
 #include <stdexcept>
 #include <vector>
@@ -126,7 +128,8 @@ namespace Opm {
     void GridDims::assertGlobalIndex(std::size_t globalIndex) const
     {
         if (globalIndex >= getCartesianSize())
-            throw std::invalid_argument("input global index above valid range");
+            throw std::invalid_argument(fmt::format("Input global index {} above valid range (1, ..., {}).",
+                                                    globalIndex, getCartesianSize()));
     }
 
     void GridDims::assertIJK(const std::size_t i,
@@ -134,7 +137,8 @@ namespace Opm {
                              const std::size_t k) const
     {
         if (i >= getNX() || j >= getNY() || k >= getNZ())
-            throw std::invalid_argument("input IJK index above valid range");
+            throw std::invalid_argument(fmt::format("Input IJK index ({}, {}, {}) not part of grid with dimensions {} x {} x {}.",
+                                                    i + 1, j + 1, k + 1, getNX(), getNY(),getNZ()));
     }
 
     // keyword must be DIMENS or SPECGRID

--- a/opm/input/eclipse/Parser/ParseContext.cpp
+++ b/opm/input/eclipse/Parser/ParseContext.cpp
@@ -133,6 +133,7 @@ namespace Opm {
         this->addKey(SCHEDULE_WELL_IN_FIELD_GROUP, InputErrorAction::WARN);
         this->addKey(SCHEDULE_COMPSEGS_INVALID, InputErrorAction::THROW_EXCEPTION);
         this->addKey(SCHEDULE_COMPSEGS_NOT_SUPPORTED, InputErrorAction::THROW_EXCEPTION);
+        this->addKey(SCHEDULE_COMPDAT_INVALID, InputErrorAction::THROW_EXCEPTION);
         addKey(SCHEDULE_INVALID_NAME, InputErrorAction::THROW_EXCEPTION);
     }
 
@@ -408,4 +409,6 @@ namespace Opm {
 
     const std::string ParseContext::SCHEDULE_COMPSEGS_INVALID = "SCHEDULE_COMPSEG_INVALID";
     const std::string ParseContext::SCHEDULE_COMPSEGS_NOT_SUPPORTED = "SCHEDULE_COMPSEGS_NOT_SUPPORTED";
+
+    const std::string ParseContext::SCHEDULE_COMPDAT_INVALID = "SCHEDULE_COMPDAT_INVALID";
 }

--- a/opm/input/eclipse/Parser/ParseContext.hpp
+++ b/opm/input/eclipse/Parser/ParseContext.hpp
@@ -365,6 +365,7 @@ class KeywordLocation;
         const static std::string SCHEDULE_COMPSEGS_INVALID;
         const static std::string SCHEDULE_COMPSEGS_NOT_SUPPORTED;
 
+        const static std::string SCHEDULE_COMPDAT_INVALID;
         /*
           The SIMULATOR_KEYWORD_ errormodes are for the situation where the
           parser recognizes, and correctly parses a keyword, but we know that

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -466,7 +466,8 @@ namespace Opm
                            std::set<std::string>* compsegs_wells = nullptr);
 
         void internalWELLSTATUSACTIONXFromPYACTION(const std::string& well_name, std::size_t report_step, const std::string& wellStatus);
-        void prefetchPossibleFutureConnections(const ScheduleGrid& grid, const DeckKeyword& keyword);
+        void prefetchPossibleFutureConnections(const ScheduleGrid& grid, const DeckKeyword& keyword,
+                                               const ParseContext& parseContext, ErrorGuard& errors);
         void store_wgnames(const DeckKeyword& keyword);
         std::vector<std::string> wellNames(const std::string& pattern,
                                            const HandlerContext& context,


### PR DESCRIPTION
Previously we threw an exception that was poorly handled by the logging system. The user e.g. saw:
```
Reading from: BLA.INC line 2

Error: An error occurred while creating the reservoir schedule
Internal error: input IJK index above valid range

Error: Unrecoverable errors while loading input: input IJK index above valid range
```
With this commit we use the ParseContext to give a more meaningful error message like:
```
Error: Problem with COMPDAT in ACTIONX
In BLA.INC line 19
Cell (83, 273, 47) of well EX_WA is not part of the grid (Input IJK index (83, 273, 47) not part of grid with dimensions 169x359x46.).

Error: Problem with keyword COMPDAT
In BLA.INC line 19
Problem with COMPDAT in ACTIONX
In BLA.INC line 19
Cell (83, 273, 47) of well EX_WA is not part of the grid (Input IJK index (83, 273, 47) not part of grid with dimensions 169 x 359 x 46.).

Error: Unrecoverable errors while loading input: Problem with keyword COMPDAT
In BLA.INC line 19
Problem with COMPDAT in ACTIONX
In BLA.INC line 19
Cell (83, 273, 47) of well EX_WA is not part of the grid (Input IJK index (83, 273, 47) not part of grid with dimensions 169 x 359 x 46.).
```
