### PR TITLE
Polish Parts of ACTIONX Implementation

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ActionAST.hpp
+++ b/opm/input/eclipse/Schedule/Action/ActionAST.hpp
@@ -17,57 +17,99 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef ActionAST_HPP
 #define ActionAST_HPP
+
+#include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
 
 #include <memory>
 #include <string>
 #include <unordered_set>
 #include <vector>
 
-#include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
-
-namespace Opm {
-namespace Action {
+namespace Opm::Action {
 
 class Context;
 class ASTNode;
 
+} // namespace Opm::Action
 
-/*
-  The Action::AST class implements a tree with the result of the parsing of the
-  ACTIONX condition. The AST does not contain any context, that is supplied with
-  a Action::Context instace when calling the eval() methoid is called.
-*/
+namespace Opm::Action {
 
-class AST{
+/// Expression evaluation tree of a full ACTIONX condition block.
+///
+/// There is no additional context such as current summary vector values or
+/// a set of active wells.  This must be supplied through an Action::Context
+/// instace when invoking the eval() member function.
+
+class AST
+{
 public:
+    /// Default constructor.
+    ///
+    /// Creates an empty object with no internal condition.  Mostly useful
+    /// as a target for an object deserialisation process.
     AST() = default;
+
+    /// Constructor.
+    ///
+    /// Forms the internal expression tree by parsing a sequence of text
+    /// tokens.
+    ///
+    /// \param[in] tokens Tokenised textual representation of an ACTIONX
+    /// condition block.
     explicit AST(const std::vector<std::string>& tokens);
 
+    /// Create a serialisation test object.
     static AST serializationTestObject();
 
+    /// Evaluate the expression tree at current dynamic state.
+    ///
+    /// \param[in] context Current summary vectors and wells
+    ///
+    /// \return Condition value.  A 'true' result means the condition is
+    /// satisfied while a 'false' result means the condition is not
+    /// satisfied.  Any wells for which the expression is true will be
+    /// included in the result set.  A 'false' result has no matching wells.
     Result eval(const Context& context) const;
 
+    /// Equality predicate.
+    ///
+    /// \param[in] data Object against which \code *this \endcode will
+    /// be tested for equality.
+    ///
+    /// \return Whether or not \code *this \endcode is the same as \p data.
     bool operator==(const AST& data) const;
 
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
         serializer(condition);
     }
+
+    /// Export all summary vectors needed to evaluate the expression tree.
+    ///
+    /// \param[in,out] required_summary Named summary vectors.  Upon
+    /// completion, any additional summary vectors needed to evaluate the
+    /// full condition block of the current AST object will be included in
+    /// this set.
     void required_summary(std::unordered_set<std::string>& required_summary) const;
 
 private:
-    /*
-      The use of a pointer here is to be able to create this class with only a
-      forward declaration of the ASTNode class. Would have prefered to use a
-      unique_ptr, but that requires writing custom destructors - the use of a
-      shared_ptr does not imply any shared ownership of the ASTNode.
-    */
+    // The pointer type enables creating this class with only a forward
+    // declaration of the ASTNode class.  Would have prefered to use a
+    // unique_ptr<>, but that requires writing custom destructors.  Despite
+    // the shared_ptr<>, there is no shared ownership of the ASTNode.
+
+    /// Internalised condition object in expression tree form.
     std::shared_ptr<ASTNode> condition;
 };
-}
-}
-#endif
+
+} // namespace Opm::Action
+
+#endif // ActionAST_HPP

--- a/opm/input/eclipse/Schedule/Action/ActionX.hpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.hpp
@@ -17,76 +17,185 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef ActionX_HPP_
 #define ActionX_HPP_
 
-#include <ctime>
-#include <string>
-#include <unordered_map>
-#include <unordered_set>
-#include <vector>
-
-#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionAST.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
 #include <opm/input/eclipse/Schedule/Action/Condition.hpp>
 
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 
+#include <cstddef>
+#include <ctime>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 namespace Opm {
-class DeckKeyword;
 class WellMatcher;
 class Actdims;
+} // namespace Opm
 
-namespace RestartIO {
+namespace Opm::RestartIO {
 struct RstAction;
-}
+} // namespace Opm::RestartIO
 
-
-namespace Action {
+namespace Opm::Action {
 class State;
+} // namespace Opm::Action
 
-/*
-  The ActionX class internalizes the ACTIONX keyword. This keyword represents a
-  small in-deck programming language for the SCHEDULE section. In the deck the
-  ACTIONX keyword comes together with a 'ENDACTIO' kewyord and then a list of
-  regular keywords in the between. The principle is then that ACTIONX represents
-  a condition, and when that condition is satisfied the keywords are applied. In
-  the example below the ACTIONX keyword defines a condition whether well OPX has
-  watercut above 0.75, when the condition is met the WELOPEN keyword is applied
-  - and the well is shut.
+namespace Opm::Action {
 
-  ACTIONX
-     'NAME'  /
-     WWCT OPX > 0.50 /
-  /
+// The ActionX class internalizes the ACTIONX keyword. This keyword represents a
+// small in-deck programming language for the SCHEDULE section. In the deck the
+// ACTIONX keyword comes together with a 'ENDACTIO' kewyord and then a list of
+// regular keywords in-between. The principle is then that ACTIONX represents
+// a condition, and when that condition is satisfied the keywords are applied. In
+// the example below the ACTIONX keyword defines a condition on well OPX having
+// watercut above 0.75. When the condition is met the WELOPEN keyword is applied,
+// shutting the well.
+//
+//   ACTIONX
+//      'NAME'  /
+//      WWCT OPX > 0.50 /
+//   /
+//
+//   WELOPEN
+//      'OPX'  OPEN /
+//   /
+//
+//   ENDACTIO
 
-  WELOPEN
-     'OPX'  OPEN /
-  /
-
-  ENDACTION
-
-
-*/
-
-class ActionX {
+class ActionX
+{
 public:
+    /// Keyword validity predicate.
+    ///
+    /// \param[in] keyword Name of SCHEDULE section keyword.
+    ///
+    /// \return Whether or not the current implementation supports using \p
+    /// keyword in an ACTIONX block.
+    static bool valid_keyword(const std::string& keyword);
+
+    /// Default constructor.
+    ///
+    /// Creates an invalid object that is only usable as a target for a
+    /// deserialisation process.
     ActionX();
-    ActionX(const std::string& name, size_t max_run, double max_wait, std::time_t start_time);
-    ActionX(const std::string& name, size_t max_run, double max_wait,
-            std::time_t start_time,
-            const std::vector<Condition>&& conditions,
-            const std::vector<std::string>&& tokens);
+
+    /// Constructor.
+    ///
+    /// Creates an invalid object without any triggering conditions.  Mostly
+    /// usable as an error state.
+    ///
+    /// \param[in] name Name of action object.  Typically from first record
+    /// of ACTIONX keyword.
+    ///
+    /// \param[in] max_run Maximum number of times this action can
+    /// run/trigger.  A value of zero is treated as an unlimited number of
+    /// runs.
+    ///
+    /// \param[in] min_wait Minimum wait time, in seconds, between two
+    /// successful triggerings of this action object.
+    ///
+    /// \param[in] start_time Point in time at which this action object is
+    /// created.  Typically the simulated time at the start of the report
+    /// step at which an ACTIONX keyword is encountered.  The first wait
+    /// time is relative to this start time.
+    ActionX(const std::string& name,
+            std::size_t max_run,
+            double min_wait,
+            std::time_t start_time);
+
+    /// Constructor.
+    ///
+    /// Creates an invalid object that is mostly usable as an error state.
+    /// Delegates to four argument constructor.
+    ///
+    /// \param[in] record First record of an ACTIONX keyword.
+    ///
+    /// \param[in] start_time Point in time at which this action object is
+    /// created.  Typically the simulated time at the start of the report
+    /// step at which an ACTIONX keyword is encountered.  The first wait
+    /// time is relative to this start time.
     ActionX(const DeckRecord& record, std::time_t start_time);
+
+    /// Constructor.
+    ///
+    /// Forms the ActionX object based on restart file information.
+    ///
+    /// \param[in] rst_action Restart file representation of an ACTIONX
+    /// block.
     explicit ActionX(const RestartIO::RstAction& rst_action);
 
+    /// Constructor.
+    ///
+    /// Internalises the triggering condition into an expression tree and
+    /// records minimum wait time and maximum run counts.  Associate
+    /// SCHEDULE keywords to run when the action triggers must be included
+    /// through addKeyword() calls.
+    ///
+    /// \param[in] name Name of action object.  Typically from first record
+    /// of ACTIONX keyword.
+    ///
+    /// \param[in] max_run Maximum number of times this action can
+    /// run/trigger.  A value of zero is treated as an unlimited number of
+    /// runs.
+    ///
+    /// \param[in] min_wait Minimum wait time, in seconds, between two
+    /// successful triggerings of this action object.
+    ///
+    /// \param[in] start_time Point in time at which this action object is
+    /// created.  Typically the simulated time at the start of the report
+    /// step at which an ACTIONX keyword is encountered.  The first wait
+    /// time is relative to this start time.
+    ///
+    /// \param[in] conditions Partially formed individual statements of the
+    /// triggering conditions for this action.  For restart file output
+    /// purposes.
+    ///
+    /// \param[in] tokens Textual representation of condition block.  Will be
+    /// used to form the internal expression tree representation of the
+    /// triggering condition.
+    ActionX(const std::string& name,
+            std::size_t max_run,
+            double min_wait,
+            std::time_t start_time,
+            std::vector<Condition>&& conditions,
+            const std::vector<std::string>& tokens);
+
+    /// Create a serialisation test object.
     static ActionX serializationTestObject();
 
+    /// Include SCHEDULE section keyword in block executed when action triggers.
+    ///
+    /// \param[in] kw SCHEDULE section keyword.
     void addKeyword(const DeckKeyword& kw);
+
+    /// Query whether or not the current ActionX object is ready to run.
+    ///
+    /// Will typically consider at least the object's current run count and
+    /// wait times.
+    ///
+    /// \param[in] state Dynamic run count and run time.
+    ///
+    /// \param[in] sim_time Simulated time since simulation start.
+    ///
+    /// \return Whether or not this ActionX object is ready to run.
     bool ready(const State& state, std::time_t sim_time) const;
-    Action::Result eval(const Action::Context& context) const;
+
+    /// Evaluate the action's conditions at current dynamic state
+    ///
+    /// \param[in] context Current summary vectors and wells
+    ///
+    /// \return Condition value.  A 'true' result means the condition is
+    /// satisfied while a 'false' result means the condition is not
+    /// satisfied.  Any wells for which the expression is true will be
+    /// included in the result set.  A 'false' result has no matching
+    /// wells.
+    Result eval(const Context& context) const;
 
     /// Retrive list of well names used in action block WELPI keywords
     ///
@@ -98,26 +207,73 @@ public:
     /// \return List of well names used in this action's WELPI keywords, if
     /// any.  List returned in sorted order defined by \p well_matcher.
     std::vector<std::string> wellpi_wells(const WellMatcher& well_matcher, const std::vector<std::string>& matching_wells) const;
-    void required_summary(std::unordered_set<std::string>& required_summary) const;
-    std::string name() const { return this->m_name; }
-    size_t max_run() const { return this->m_max_run; }
-    double min_wait() const { return this->m_min_wait; }
-    std::size_t id() const;
-    void update_id(std::size_t id);
-    std::time_t start_time() const { return this->m_start_time; }
-    std::vector<DeckKeyword>::const_iterator begin() const;
-    std::vector<DeckKeyword>::const_iterator end() const;
-    static bool valid_keyword(const std::string& keyword);
 
-    /*
-      The conditions() and keyword_strings() methods, and their underlying data
-      members are only present to support writing formatted restart files.
-    */
-    const std::vector<Condition>& conditions() const;
+    /// Export all summary vectors needed to evaluate the conditions of the
+    /// current ActionX object.
+    ///
+    /// \param[in,out] required_summary Named summary vectors.  Upon
+    /// completion, any additional summary vectors needed to evaluate full
+    /// condition block of the current ActionX object will be included in
+    /// this set.
+    void required_summary(std::unordered_set<std::string>& required_summary) const;
+
+    /// Retrieve name of action object.
+    std::string name() const { return this->m_name; }
+
+    /// Retrieve maximum number of times this action can run/trigger.
+    std::size_t max_run() const { return this->m_max_run; }
+
+    /// Retrieve minimum wait time, in seconds of simulated time, between
+    /// action triggers.
+    double min_wait() const { return this->m_min_wait; }
+
+    /// Retrieve distinguishing numeric ID of this action object.
+    std::size_t id() const { return this->m_id; }
+
+    /// Assign distinguishing numeric ID of this action object.
+    ///
+    /// Typically invoked only if encountering an ACTIONX keyword naming the
+    /// same action object as an earlier ACTIONX keyword.
+    void update_id(std::size_t id);
+
+    /// Retrieve point in time at which this action object is created.
+    ///
+    /// Typically the simulated time at the start of the report step at
+    /// which an ACTIONX keyword is encountered.  The first wait time is
+    /// relative to this start time.
+    std::time_t start_time() const { return this->m_start_time; }
+
+    /// Start of action block SCHEDULE keyword sequence.
+    auto begin() const { return this->keywords.begin(); }
+
+    /// End of action block SCHEDULE keyword sequence.
+    auto end() const { return this->keywords.end(); }
+
+    /// Intermediate representation of triggering conditions for restart
+    /// file output purposes.
+    const std::vector<Condition>& conditions() const
+    {
+        return this->m_conditions;
+    }
+
+    /// Textual representation of action block SCHEDULE keywords.
+    ///
+    /// For restart file output purposes.
     std::vector<std::string> keyword_strings() const;
 
+    /// Equality predicate.
+    ///
+    /// \param[in] data Object against which \code *this \endcode will
+    /// be tested for equality.
+    ///
+    /// \return Whether or not \code *this \endcode is the same as \p data.
     bool operator==(const ActionX& data) const;
 
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
@@ -132,26 +288,63 @@ public:
     }
 
 private:
-    std::string m_name;
-    size_t m_max_run = 0;
+    /// Action name.
+    std::string m_name{};
+
+    /// Maximum number of times this action can run/trigger.
+    std::size_t m_max_run = 0;
+
+    /// Minimum wait time, in seconds of simulated time, between action
+    /// triggers.
     double m_min_wait = 0.0;
+
+    /// Point in time at which this action object is created.  Typically the
+    /// simulated time at the start of the report step at which an ACTIONX
+    /// keyword is encountered.  The first wait time is relative to this
+    /// start time.
     std::time_t m_start_time;
+
+    /// Triggering condition for this action object.
+    AST condition{};
+
+    /// Distinguishing numeric ID of this action object.
+    ///
+    /// Incremented each time the action object is redefined, typically
+    /// because a new ACTIONX keyword with the same name is encountered.
+    ///
+    /// Note: Typically a small number in any real simulation run, so we
+    /// might be able to use a (nominally) smaller data type here--e.g.,
+    /// unsigned int or maybe even unsigned char.
     std::size_t m_id = 0;
 
-    std::vector<DeckKeyword> keywords;
-    Action::AST condition;
-    std::vector<Condition> m_conditions;
+    /// Sequence of keywords to execute when the action condition triggers.
+    std::vector<DeckKeyword> keywords{};
+
+    /// List of triggering conditions for this action object.
+    ///
+    /// For restart file output purposes only.
+    std::vector<Condition> m_conditions{};
 };
 
-/// \brief Parse ActionX keyword.
-/// \param kw The keyword representation of ActionX
-/// \param actdims Dimensions for ActionX as specified in the deck.
-/// \param start_time The first time that the ActionX should be evaluated
-/// \return A tuple of the ActionX created and a vector that contains for each error experienced
-///         during parsing the string indicating the type of error and the error string itself.
-std::tuple<ActionX, std::vector<std::pair<std::string, std::string>>>
+/// \brief Parse condition block of ACTIONX keyword.
+///
+/// \param[in] kw Keyword representation of ActionX.
+///
+/// \param[in] actdims Dimensions for ActionX as specified in the deck.
+///
+/// \param[in] start_time Point in time at which this action object is
+/// created.  Typically the simulated time at the start of the report step
+/// at which an ACTIONX keyword is encountered.
+///
+/// \return A partially formed ActionX object containing its fully
+/// internalised condition block, and a list of any error conditions--pairs
+/// of error categories and descriptive messages--encountered while parsing
+/// the ACTIONX condition block.  If there are no parse errors--i.e., when
+/// get<1>(t) is empty, then the ActionX object can be completed by calling
+/// its addKeyword() member function to form the actual action block.
+std::pair<ActionX, std::vector<std::pair<std::string, std::string>>>
 parseActionX(const DeckKeyword& kw, const Actdims& actimds, std::time_t start_time);
 
-}
-}
-#endif /* WELL_HPP_ */
+} // namespace Opm::Action
+
+#endif // ActionX_HPP_


### PR DESCRIPTION
In particular,

* Add Doxygen-style documentation
* Prefer `//`-style comments
* Make objects `const` where possible
* Prefer in-place construction&ndash;e.g., `vector<>::emplace_back()`
* Prefer initialisation lists to constructor body
* Remove unneeded `Action::` namespace prefixes