### PR TITLE
Recognise Leading Backslash as Wildcard Escape Sequence

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ASTNode.cpp
+++ b/opm/input/eclipse/Schedule/Action/ASTNode.cpp
@@ -280,6 +280,26 @@ Opm::Action::ASTNode::evalWellExpression(const Context& context) const
     return well_values;
 }
 
+namespace {
+    std::string normalisePattern(const std::string& patt)
+    {
+        if (patt.front() == '\\') {
+            // Trim leading '\' character since the 'patt' might be
+            // something like
+            //
+            //    '\*P*'
+            //
+            // which denotes all wells (typically) whose names contain at
+            // least one 'P' anywhere in the name.  Without the leading
+            // backslash, the pattern would match all well lists whose names
+            // begin with 'P'.
+            return patt.substr(1);
+        }
+
+        return patt;
+    }
+} // Anonymous namespace
+
 std::vector<std::string>
 Opm::Action::ASTNode::getWellList(const Context& context) const
 {
@@ -293,7 +313,7 @@ Opm::Action::ASTNode::getWellList(const Context& context) const
     wnames.reserve(wells.size());
 
     std::copy_if(wells.begin(), wells.end(), std::back_inserter(wnames),
-                 [&wpatt = this->arg_list.front()]
+                 [wpatt = normalisePattern(this->arg_list.front())]
                  (const auto& well) { return shmatch(wpatt, well); });
 
     return wnames;

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1293,16 +1293,24 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
 
     // There are many SCHEDULE keywords which operate on well names.  In
     // addition to fully qualified names like 'W1', there are shell-style
-    // wildcard patterns like 'W*'.  Similarly, you can request all wells in
-    // a well list '*WL'[1] and the well name '?', when used in an ACTIONX
-    // keyword block, matches all wells which trigger the condition in the
-    // same ACTIONX keyword.  This function is intended to be the final
-    // arbiter for well names matching these kinds of patterns.  The time
-    // step argument filters out wells which do not exist at that time level
-    // (i.e., zero-based report step index).
+    // wildcard patterns like 'W*' or 'PROD?'.  Similarly, you can request
+    // all wells in a well list '*WL'[1] and the well name '?', when used in
+    // an ACTIONX keyword block, matches all wells which trigger the
+    // condition in the same ACTIONX keyword[2].  This function is intended
+    // to be the final arbiter for well names matching these kinds of
+    // patterns.  The time step argument filters out wells which do not
+    // exist at that time level (i.e., zero-based report step index).
     //
     // [1]: The leading '*' in a WLIST name should not be treated as a
-    //      pattern matching wildcard.
+    //      pattern matching wildcard.  On the other hand, the pattern
+    //      '\*WL' matches all wells whose names end in 'WL'.  In this case,
+    //      the leading backslash "escapes" the initial asterisk, thus
+    //      disambiguating it as a normal wildcard.
+    //
+    // [2]: A leading '?' character can be escaped as '\?' in order to not
+    //      be misconstrued as the '?' pattern.  Thus, the pattern '\?????'
+    //      matches all wells whose names consist of exactly five
+    //      characters.
     std::vector<std::string>
     Schedule::wellNames(const std::string&              pattern,
                         const std::size_t               timeStep,


### PR DESCRIPTION
This PR adds support for using a leading backslash character (`\`) to disambiguate a leading wildcard (`*` or `?`) in a name pattern as being truly a wildcard.  In particular, this means that the ACTIONX condition

    WMCTL '\*RO*' = 0

will be satisfied for all shut wells with the character sequence 'RO' anywhere in the name and that

    WCONPROD
      '\*RO*' 'OPEN' 'GRAT'  2*  500.0   2*  90.0 /
    /

will apply to all wells with the same character sequence 'RO' anywhere in the name.  On the other hand, `'*RO*'` matches all well lists whose names begin with the characters 'RO'.  Similarly, `'\*H'` matches all wells whose names end in 'H' while `'*H'` matches the single well list '*H'.

This disambiguation also applies to the wildcard '?'.  A leading backslash enables `'\?????'` to match all wells whose names consist of exactly five characters whereas '?????' could be misconstrued as the '?' pattern in an ACTIONX block if we consider only the pattern's initial character.  The issue becomes particularly pronounced if we wish to match a well name consisting of a single character.

As of this PR, we support ACTIONX specifications of the form

    ACTIONX
    TESTW 25 1 /
    DAY > 10 AND /
    WMCTL '\*RO*' = 0 /
    /

    UDQ
      ASSIGN WU_TEST '?' 1 /
    /

    ENDACTIO

and well control specifications of the form

    WCONPROD
      '\*H'   'OPEN' 'GRAT'  2*  500.0  2*  90.0 /
      '\*RO*' 'OPEN' 'GRAT'  2*  500.0  2*  90.0 /
    /