### PR TITLE
Write group limits to restart even if not controlled

### DIFF
--- a/opm/input/eclipse/Schedule/Group/Group.cpp
+++ b/opm/input/eclipse/Schedule/Group/Group.cpp
@@ -905,7 +905,7 @@ Group::ExceedAction Group::ExceedActionFromString( const std::string& stringValu
 
 Group::ExceedAction Group::ExceedActionFromInt( const int value ) {
 
-    if (value < 0) return ExceedAction::NONE;
+    if (value <= 0) return ExceedAction::NONE;
     if (value == 4) return ExceedAction::RATE;
 
     throw std::invalid_argument(fmt::format("Unknown ExceedAction state integer: {}", value));

--- a/opm/output/eclipse/AggregateGroupData.cpp
+++ b/opm/output/eclipse/AggregateGroupData.cpp
@@ -788,29 +788,25 @@ void assignGroupGasInjectionTargets(const Opm::Group&        group,
     const auto& prop = group.injectionProperties(Opm::Phase::GAS);
     const auto  cntl = group.injectionControls(Opm::Phase::GAS, sumState);
 
-    if (group.has_control(Opm::Phase::GAS, Opm::Group::InjectionCMode::RATE) &&
-        (prop.surface_max_rate.is_numeric() || (cntl.surface_max_rate > 0.0)))
+    if (prop.surface_max_rate.is_numeric() || (cntl.surface_max_rate > 0.0))
     {
         sGrp[Ix::gasSurfRateLimit] = sgprop(M::gas_surface_rate, cntl.surface_max_rate);
         sGrp[Ix::gasSurfRateLimit_2] = sGrp[Ix::gasSurfRateLimit];
     }
 
-    if (group.has_control(Opm::Phase::GAS, Opm::Group::InjectionCMode::RESV) &&
-        (prop.resv_max_rate.is_numeric() || (cntl.resv_max_rate > 0.0)))
+    if (prop.resv_max_rate.is_numeric() || (cntl.resv_max_rate > 0.0))
     {
         sGrp[Ix::gasResRateLimit] = sgprop(M::rate, cntl.resv_max_rate);
         sGrp[Ix::gasResRateLimit_2] = sGrp[Ix::gasResRateLimit];
     }
 
-    if (group.has_control(Opm::Phase::GAS, Opm::Group::InjectionCMode::REIN) &&
-        (prop.target_reinj_fraction.is_numeric() || (cntl.target_reinj_fraction > 0.0)))
+    if (prop.target_reinj_fraction.is_numeric() || (cntl.target_reinj_fraction > 0.0))
     {
         sGrp[Ix::gasReinjectionLimit] = cntl.target_reinj_fraction;
         sGrp[Ix::gasReinjectionLimit_2] = sGrp[Ix::gasReinjectionLimit];
     }
 
-    if (group.has_control(Opm::Phase::GAS, Opm::Group::InjectionCMode::VREP) &&
-        (prop.target_void_fraction.is_numeric() || (cntl.target_void_fraction > 0.0)))
+    if (prop.target_void_fraction.is_numeric() || (cntl.target_void_fraction > 0.0))
     {
         sGrp[Ix::gasVoidageLimit] = cntl.target_void_fraction;
         sGrp[Ix::gasVoidageLimit_2] = sGrp[Ix::gasVoidageLimit];
@@ -831,29 +827,25 @@ void assignGroupWaterInjectionTargets(const Opm::Group&        group,
     const auto& prop = group.injectionProperties(Opm::Phase::WATER);
     const auto  cntl = group.injectionControls(Opm::Phase::WATER, sumState);
 
-    if (group.has_control(Opm::Phase::WATER, Opm::Group::InjectionCMode::RATE) &&
-        (prop.surface_max_rate.is_numeric() || (cntl.surface_max_rate > 0.0)))
+    if (prop.surface_max_rate.is_numeric() || (cntl.surface_max_rate > 0.0))
     {
         sGrp[Ix::waterSurfRateLimit] = sgprop(M::liquid_surface_rate, cntl.surface_max_rate);
         sGrp[Ix::waterSurfRateLimit_2] = sGrp[Ix::waterSurfRateLimit];
     }
 
-    if (group.has_control(Opm::Phase::WATER, Opm::Group::InjectionCMode::RESV) &&
-        (prop.resv_max_rate.is_numeric() || (cntl.resv_max_rate > 0.0)))
+    if (prop.resv_max_rate.is_numeric() || (cntl.resv_max_rate > 0.0))
     {
         sGrp[Ix::waterResRateLimit] = sgprop(M::rate, cntl.resv_max_rate);
         sGrp[Ix::waterResRateLimit_2] = sGrp[Ix::waterResRateLimit];
     }
 
-    if (group.has_control(Opm::Phase::WATER, Opm::Group::InjectionCMode::REIN) &&
-        (prop.target_reinj_fraction.is_numeric() || (cntl.target_reinj_fraction > 0.0)))
+    if (prop.target_reinj_fraction.is_numeric() || (cntl.target_reinj_fraction > 0.0))
     {
         sGrp[Ix::waterReinjectionLimit] = cntl.target_reinj_fraction;
         sGrp[Ix::waterReinjectionLimit_2] = sGrp[Ix::waterReinjectionLimit];
     }
 
-    if (group.has_control(Opm::Phase::WATER, Opm::Group::InjectionCMode::VREP) &&
-        (prop.target_void_fraction.is_numeric() || (cntl.target_void_fraction > 0.0)))
+    if (prop.target_void_fraction.is_numeric() || (cntl.target_void_fraction > 0.0))
     {
         sGrp[Ix::waterVoidageLimit] = cntl.target_void_fraction;
         sGrp[Ix::waterVoidageLimit_2] = sGrp[Ix::waterVoidageLimit];
@@ -874,29 +866,25 @@ void assignGroupOilInjectionTargets(const Opm::Group&        group,
     const auto& prop = group.injectionProperties(Opm::Phase::OIL);
     const auto  cntl = group.injectionControls(Opm::Phase::OIL, sumState);
 
-    if (group.has_control(Opm::Phase::OIL, Opm::Group::InjectionCMode::RATE) &&
-        (prop.surface_max_rate.is_numeric() || (cntl.surface_max_rate > 0.0)))
+    if (prop.surface_max_rate.is_numeric() || (cntl.surface_max_rate > 0.0))
     {
         sGrp[Ix::oilSurfRateLimit] = sgprop(M::liquid_surface_rate, cntl.surface_max_rate);
         sGrp[Ix::oilSurfRateLimit_2] = sGrp[Ix::oilSurfRateLimit];
     }
 
-    if (group.has_control(Opm::Phase::OIL, Opm::Group::InjectionCMode::RESV) &&
-        (prop.resv_max_rate.is_numeric() || (cntl.resv_max_rate > 0.0)))
+    if (prop.resv_max_rate.is_numeric() || (cntl.resv_max_rate > 0.0))
     {
         sGrp[Ix::oilResRateLimit] = sgprop(M::rate, cntl.resv_max_rate);
         sGrp[Ix::oilResRateLimit_2] = sGrp[Ix::oilResRateLimit];
     }
 
-    if (group.has_control(Opm::Phase::OIL, Opm::Group::InjectionCMode::REIN) &&
-        (prop.target_reinj_fraction.is_numeric() || (cntl.target_reinj_fraction > 0.0)))
+    if (prop.target_reinj_fraction.is_numeric() || (cntl.target_reinj_fraction > 0.0))
     {
         sGrp[Ix::oilReinjectionLimit] = cntl.target_reinj_fraction;
         sGrp[Ix::oilReinjectionLimit_2] = sGrp[Ix::oilReinjectionLimit];
     }
 
-    if (group.has_control(Opm::Phase::OIL, Opm::Group::InjectionCMode::VREP) &&
-        (prop.target_void_fraction.is_numeric() || (cntl.target_void_fraction > 0.0)))
+    if (prop.target_void_fraction.is_numeric() || (cntl.target_void_fraction > 0.0))
     {
         sGrp[Ix::oilVoidageLimit] = cntl.target_void_fraction;
         sGrp[Ix::oilVoidageLimit_2] = sGrp[Ix::oilVoidageLimit];
@@ -934,29 +922,25 @@ void assignGroupProductionTargets(const Opm::Group&        group,
     const auto& prop = group.productionProperties();
     const auto  cntl = group.productionControls(sumState);
 
-    if (group.has_control(Opm::Group::ProductionCMode::ORAT) &&
-        (prop.oil_target.is_numeric() || (cntl.oil_target > 0.0)))
+    if (prop.oil_target.is_numeric() || (cntl.oil_target > 0.0))
     {
         sGrp[Ix::OilRateLimit] = sgprop(M::liquid_surface_rate, cntl.oil_target);
         sGrp[Ix::OilRateLimit_2] = sGrp[Ix::OilRateLimit];  // ORAT control
     }
 
-    if (group.has_control(Opm::Group::ProductionCMode::WRAT) &&
-        (prop.water_target.is_numeric() || (cntl.water_target > 0.0)))
+    if (prop.water_target.is_numeric() || (cntl.water_target > 0.0))
     {
         sGrp[Ix::WatRateLimit] = sgprop(M::liquid_surface_rate, cntl.water_target);
         sGrp[Ix::WatRateLimit_2] = sGrp[Ix::WatRateLimit];  // WRAT control
     }
 
-    if (group.has_control(Opm::Group::ProductionCMode::GRAT) &&
-        (prop.gas_target.is_numeric() || (cntl.gas_target > 0.0)))
+    if (prop.gas_target.is_numeric() || (cntl.gas_target > 0.0))
     {
         sGrp[Ix::GasRateLimit] = sgprop(M::gas_surface_rate, cntl.gas_target);
         sGrp[Ix::GasRateLimit_2] = sGrp[Ix::GasRateLimit]; // GRAT control
     }
 
-    if (group.has_control(Opm::Group::ProductionCMode::LRAT) &&
-        (prop.liquid_target.is_numeric() || (cntl.liquid_target > 0.0)))
+    if (prop.liquid_target.is_numeric() || (cntl.liquid_target > 0.0))
     {
         sGrp[Ix::LiqRateLimit] = sgprop(M::liquid_surface_rate, cntl.liquid_target);
         sGrp[Ix::LiqRateLimit_2] = sGrp[Ix::LiqRateLimit];  // LRAT control


### PR DESCRIPTION
Background: Restoring all limits from restart appears required to get the correct group information. In particular, a production group controlled by a higher-level group is currently restored as GroupType::NONE, causing differences in the .UNRST output of the restart run. 