### PR TITLE
Move WELTARG CMode Formatting to Implementation File

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WellEnums.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellEnums.cpp
@@ -27,6 +27,15 @@
 
 #include <fmt/format.h>
 
+template<>
+struct fmt::formatter<Opm::WellWELTARGCMode> : fmt::formatter<int>
+{
+    auto format(const Opm::WellWELTARGCMode& cmode, format_context& context) const
+    {
+        return fmt::formatter<int>::format(static_cast<int>(cmode), context);
+    }
+};
+
 namespace Opm {
 
 std::string WellStatus2String(WellStatus enumValue)

--- a/opm/input/eclipse/Schedule/Well/WellEnums.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellEnums.hpp
@@ -22,7 +22,6 @@
 
 #include <iosfwd>
 #include <string>
-#include <fmt/format.h>
 
 namespace Opm {
 
@@ -126,14 +125,5 @@ std::string WellGasInflowEquation2String(WellGasInflowEquation enumValue);
 WellGasInflowEquation WellGasInflowEquationFromString(const std::string& stringValue);
 
 } // Namespace Opm
-
-template<>
-struct fmt::formatter<Opm::WellWELTARGCMode> : fmt::formatter<int>
-{
-  auto format(const Opm::WellWELTARGCMode& cmode, format_context& context) const {
-    return fmt::formatter<int>::format(static_cast<int>(cmode), context);
-  }
-};
-
 
 #endif


### PR DESCRIPTION
That way, out-of-tree users of `WellEnums.hpp` won't have to have libfmt installed in a central location.