### PR TITLE
Split UDA Restart File Loading out to Helper Functions

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQActive.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQActive.cpp
@@ -16,144 +16,283 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <opm/io/eclipse/rst/state.hpp>
+
 #include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>
+
+#include <opm/io/eclipse/rst/state.hpp>
+#include <opm/io/eclipse/rst/udq.hpp>
+
+#include <opm/input/eclipse/EclipseState/Phase.hpp>
+
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
+
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 #include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
 
 #include <fmt/format.h>
 
-namespace Opm {
+namespace {
+    template <typename RstUDARecord>
+    void loadRstWellUDAs(const RstUDARecord&                     record,
+                         const std::vector<int>&                 wgIndex,
+                         const Opm::UDAValue&                    uda,
+                         const std::vector<std::string>&         wellNames,
+                         std::vector<Opm::UDQActive::RstRecord>& udaRecords)
+    {
+        const auto* localWgIndex = &wgIndex[record.wg_offset + 0];
 
-std::vector<UDQActive::RstRecord> UDQActive::load_rst(const UnitSystem& units,
-                                                      const UDQConfig& udq_config,
-                                                      const RestartIO::RstState& rst_state,
-                                                      const std::vector<std::string>& well_names,
-                                                      const std::vector<std::string>& group_names)
-{
-    std::vector<RstRecord> records;
-    const auto& rst_active = rst_state.udq_active;
-
-    for (const auto& record : rst_active.iuad) {
-        const auto& udq_input = udq_config[record.input_index];
-        UDAValue uda(udq_input.keyword(), units.uda_dim(record.control));
-        for (std::size_t use_index = 0; use_index < record.use_count; use_index++) {
-            std::size_t wg_index = rst_active.wg_index[record.wg_offset + use_index];
-
-            if (UDQ::well_control(record.control))
-                records.emplace_back(record.control, uda, well_names[wg_index]);
-            else {
-                const auto& group = group_names[wg_index + 1];
-                if (UDQ::is_group_production_control(record.control))
-                    records.emplace_back(record.control, uda, group);
-                else
-                    records.emplace_back(record.control, uda, group, rst_active.ig_phase[wg_index]);
-            }
+        for (auto i = 0*record.use_count; i < record.use_count; ++i) {
+            udaRecords.emplace_back(record.control, uda, wellNames[localWgIndex[i]]);
         }
     }
-    return records;
+
+    template <typename RstUDARecord, typename WGIndexOp>
+    void loadGroupRstUDA(const RstUDARecord&             record,
+                         const std::vector<int>&         wgIndex,
+                         const std::vector<std::string>& groupNames,
+                         WGIndexOp&&                     wgIndexOp)
+    {
+        using namespace std::string_literals;
+
+        const auto* localWgIndex = &wgIndex[record.wg_offset + 0];
+
+        for (auto i = 0*record.use_count; i < record.use_count; ++i) {
+            wgIndexOp(localWgIndex[i], groupNames[localWgIndex[i] + 1]);
+        }
+    }
+
+    template <typename RstUDARecord>
+    void loadRstGroupProdUDAs(const RstUDARecord&                     record,
+                              const std::vector<int>&                 wgIndex,
+                              const Opm::UDAValue&                    uda,
+                              const std::vector<std::string>&         groupNames,
+                              std::vector<Opm::UDQActive::RstRecord>& udaRecords)
+    {
+        loadGroupRstUDA(record, wgIndex, groupNames,
+                        [control = record.control, &uda, &udaRecords]
+                        ([[maybe_unused]] const std::size_t phaseIdx,
+                         const std::string&                 group)
+        {
+            udaRecords.emplace_back(control, uda, group);
+        });
+    }
+
+    template <typename RstUDARecord>
+    void loadRstGroupInjUDAs(const RstUDARecord&                     record,
+                             const std::vector<int>&                 wgIndex,
+                             const std::vector<Opm::Phase>&          igPhase,
+                             const Opm::UDAValue&                    uda,
+                             const std::vector<std::string>&         groupNames,
+                             std::vector<Opm::UDQActive::RstRecord>& udaRecords)
+    {
+        loadGroupRstUDA(record, wgIndex, groupNames,
+                        [control = record.control, &uda, &igPhase, &udaRecords]
+                        (const std::size_t  phaseIdx,
+                         const std::string& group)
+        {
+            udaRecords.emplace_back(control, uda, group, igPhase[phaseIdx]);
+        });
+    }
+} // Anonymous namespace
+
+// ===========================================================================
+
+Opm::UDQActive::OutputRecord::OutputRecord()
+    : input_index { 0 }
+    , control     { UDAControl::WCONPROD_ORAT }
+    , uda_code    { 0 }
+    , use_count   { 1 }
+{}
+
+Opm::UDQActive::OutputRecord::OutputRecord(const std::string& udq_arg,
+                                           const std::size_t  input_index_arg,
+                                           const std::size_t  use_index_arg,
+                                           const std::string& wgname_arg,
+                                           const UDAControl   control_arg)
+    : udq         { udq_arg }
+    , input_index { input_index_arg }
+    , use_index   { use_index_arg }
+    , control     { control_arg }
+    , uda_code    { UDQ::udaCode(control_arg) }
+    , use_count   { 1 }
+    , wgname      { wgname_arg }
+{}
+
+bool Opm::UDQActive::OutputRecord::operator==(const OutputRecord& other) const
+{
+    return (this->udq == other.udq)
+        && (this->input_index == other.input_index)
+        && (this->use_index == other.use_index)
+        && (this->wgname == other.wgname)
+        && (this->control == other.control)
+        && (this->uda_code == other.uda_code)
+        && (this->use_count == other.use_count)
+        ;
 }
 
-UDQActive UDQActive::serializationTestObject()
+// ---------------------------------------------------------------------------
+
+Opm::UDQActive::InputRecord::InputRecord()
+    : input_index { 0 }
+    , control     { UDAControl::WCONPROD_ORAT }
+{}
+
+Opm::UDQActive::InputRecord::InputRecord(const std::size_t  input_index_arg,
+                                         const std::string& udq_arg,
+                                         const std::string& wgname_arg,
+                                         const UDAControl   control_arg)
+    : input_index { input_index_arg }
+    , udq         { udq_arg }
+    , wgname      { wgname_arg }
+    , control     { control_arg }
+{}
+
+bool Opm::UDQActive::InputRecord::operator==(const InputRecord& other) const
+{
+    return (this->input_index == other.input_index)
+        && (this->udq == other.udq)
+        && (this->wgname == other.wgname)
+        && (this->control == other.control)
+        ;
+}
+
+// ---------------------------------------------------------------------------
+
+Opm::UDQActive Opm::UDQActive::serializationTestObject()
 {
     UDQActive result;
+
     result.input_data = {{1, "test1", "test2", UDAControl::WCONPROD_ORAT}};
     result.output_data = {{"test1", 1, 2, "test2", UDAControl::WCONPROD_ORAT}};
 
     return result;
 }
 
-UDQActive::operator bool() const {
-    return this->input_data.size() > 0;
-}
+std::vector<Opm::UDQActive::RstRecord>
+Opm::UDQActive::load_rst(const UnitSystem&               units,
+                         const UDQConfig&                udq_config,
+                         const RestartIO::RstState&      rst_state,
+                         const std::vector<std::string>& well_names,
+                         const std::vector<std::string>& group_names)
+{
+    auto udaRecords = std::vector<RstRecord> {};
 
+    const auto& rst_active = rst_state.udq_active;
+    const auto& wgIndex = rst_active.wg_index;
 
-std::string UDQActive::OutputRecord::wg_name()  const {
-    return this->wgname;
-}
+    for (const auto& record : rst_active.iuad) {
+        const auto uda = UDAValue {
+            udq_config[record.input_index].keyword(),
+            units.uda_dim(record.control)
+        };
 
-std::string UDQActive::udq_hash(const std::string& udq, UDAControl control) {
-  return udq + std::to_string(static_cast<int64_t>(control));
-}
-
-std::string UDQActive::wg_hash(const std::string& wgname, UDAControl control) {
-    return wgname + std::to_string(static_cast<int64_t>(control));
-}
-
-/*
-  We go through the current list of input records and compare with the supplied
-  arguments (uda, wgnamem, control). There are seven possible outcomes:
-
-    0. The uda variable is not defined (defaulted target/limit): fast return.
-
-    1. The uda variable is a double and no uda usage has been registered so far:
-       fast return.
-
-    2. The uda variable is a double, and the (wgname,control) combination is
-       found in the input data; this implies that uda has been used previously
-       for this particular (wgname, control) combination: We remove that record
-       from the input_data.
-
-    3. The uda variable is a string and we find that particular (udq, wgname,
-       control) combination in the input data: No changes
-
-    4. The uda variable is a string; but another udq was used for this (wgname,
-       control) combination: We erase the previous entry and add a new entry.
-
-    5. The uda variable is a string and we do not find this (wgname, control)
-       combination in the previous records: We add a new record.
-
-    6. The uda variable is a double, and the (wgname, control) combination has
-       not been encountered before: return 0
-
-*/
-int UDQActive::update(const UDQConfig& udq_config, const UDAValue& uda, const std::string& wgname, UDAControl control) {
-    // Alternative 0
-    if (!uda.is_defined())
-        return 0;
-
-    // Alternative 1
-    if (uda.is<double>() && this->input_data.empty())
-        return 0;
-
-    if (uda.is<std::string>()) {
-        if (!udq_config.has_keyword(uda.get<std::string>()))
-            throw std::logic_error(fmt::format("Missing ASSIGN/DEFINE for UDQ {} can not be used as UDA for {} for {}", uda.get<std::string>(), UDQ::controlName(control), wgname));
-    }
-
-    for (auto iter = this->input_data.begin(); iter != this->input_data.end(); ++iter) {
-        const auto& record = *iter;
-        if ((record.wgname == wgname) && (record.control == control)) {
-            if (uda.is<double>()) {
-                // Alternative 2
-                this->input_data.erase(iter);
-                this->output_data.clear();
-                return 1;
-            } else {
-                const std::string& udq = uda.get<std::string>();
-                if (record.udq == udq)
-                    // Alternative 3
-                    return 0;
-                else {
-                    // Alternative 4
-                    this->input_data.erase(iter);
-                    this->output_data.clear();
-                    break;
-                }
-            }
+        if (UDQ::well_control(record.control)) {
+            loadRstWellUDAs(record, wgIndex, uda, well_names, udaRecords);
+        }
+        else if (UDQ::is_group_production_control(record.control)) {
+            loadRstGroupProdUDAs(record, wgIndex, uda, group_names, udaRecords);
+        }
+        else {
+            loadRstGroupInjUDAs(record, wgIndex, rst_active.ig_phase,
+                                uda, group_names, udaRecords);
         }
     }
 
-    // Alternative 4 & 5
-    if (uda.is<std::string>()) {
-        const std::string& udq = uda.get<std::string>();
-        const auto& udq_input = udq_config[udq];
-        auto udq_index = udq_input.index.insert_index;
-        this->input_data.emplace_back( udq_index, udq, wgname, control );
+    return udaRecords;
+}
+
+Opm::UDQActive::operator bool() const
+{
+    return ! this->input_data.empty();
+}
+
+// We go through the current list of input records and compare with the supplied
+// arguments (uda, wgnamem, control).  There are seven possible outcomes:
+//
+//   0. The uda variable is not defined (defaulted target/limit): fast return.
+//
+//   1. The uda variable is a double and no uda usage has been registered so far:
+//      fast return.
+//
+//   2. The uda variable is a double, and the (wgname,control) combination
+//      is found in the input data; this implies that uda has been used
+//      previously for this particular (wgname, control) combination: We
+//      remove that record from the input_data.
+//
+//   3. The uda variable is a string and we find that particular (udq,
+//      wgname, control) combination in the input data: No changes
+//
+//   4. The uda variable is a string; but another udq was used for this
+//      (wgname, control) combination: We replace the previous entry.
+//
+//   5. The uda variable is a string and we do not find this (wgname,
+//      control) combination in the previous records: We add a new record.
+//
+//   6. The uda variable is a double, and the (wgname, control) combination
+//      has not been encountered before: return 0
+int Opm::UDQActive::update(const UDQConfig&   udq_config,
+                           const UDAValue&    uda,
+                           const std::string& wgname,
+                           const UDAControl   control)
+{
+    // Alternative 0
+    if (!uda.is_defined()) {
+        return 0;
+    }
+
+    const auto isString = uda.is<std::string>();
+    const auto quantity = isString ? uda.get<std::string>() : std::string{};
+
+    // Alternative 1
+    if (!isString && this->input_data.empty()) {
+        return 0;
+    }
+
+    if (isString && !udq_config.has_keyword(quantity)) {
+        throw std::logic_error {
+            fmt::format("User defined quantity {} is not known and cannot "
+                        "be used as a user defined argument in {} for {}\n"
+                        "Missing ASSIGN or DEFINE for this UDQ?",
+                        quantity, UDQ::controlName(control), wgname)
+        };
+    }
+
+    for (auto record = this->input_data.begin();
+         record != this->input_data.end(); ++record)
+    {
+        if ((record->wgname != wgname) || (record->control != control)) {
+            continue;
+        }
+
+        if (isString && (record->udq == quantity)) {
+            // Alternative 3
+            return 0;
+        }
+
+        this->input_data.erase(record);
         this->output_data.clear();
+
+        if (isString) {
+            // Alternative 4
+            break;
+        }
+
+        // Alternative 2
+        return 1;
+    }
+
+    // Alternatives 4 & 5
+    if (isString) {
+        const auto udq_index = udq_config[quantity].index.insert_index;
+
+        this->input_data.emplace_back(udq_index, quantity, wgname, control);
+        this->output_data.clear();
+
         return 1;
     }
 
@@ -161,66 +300,88 @@ int UDQActive::update(const UDQConfig& udq_config, const UDAValue& uda, const st
     return 0;
 }
 
-
-const std::vector<UDQActive::OutputRecord>& UDQActive::iuad() const {
+const std::vector<Opm::UDQActive::OutputRecord>& Opm::UDQActive::iuad() const
+{
     if (this->output_data.empty()) {
-        for (const auto& input_record : this->input_data) {
-            const auto& udq = input_record.udq;
-            const auto& control = input_record.control;
-            auto it = std::find_if(this->output_data.begin(), this->output_data.end(),
-                                  [&udq, &control](const auto& output_record)
-                                  {
-                                      return output_record.udq == udq && output_record.control == control;
-                                  });
-            if (it != this->output_data.end()) {
-                ++it->use_count;
-            } else {
-                this->output_data.emplace_back(input_record.udq, input_record.input_index,
-                                               0, input_record.wgname, input_record.control);
-            }
-        }
-
-        if (!this->output_data.empty()) {
-            for (std::size_t index = 1; index < output_data.size(); index++) {
-                const auto& prev_record = this->output_data[index - 1];
-                this->output_data[index].use_index = prev_record.use_index + prev_record.use_count;
-            }
-        }
+        this->constructOutputRecords();
     }
 
     return this->output_data;
 }
 
-std::vector<UDQActive::InputRecord> UDQActive::iuap() const {
-    std::vector<UDQActive::InputRecord> iuap_data;
+std::vector<Opm::UDQActive::InputRecord> Opm::UDQActive::iuap() const
+{
+    auto iuap_data = std::vector<UDQActive::InputRecord>{};
+
     auto input_rcpy = this->input_data;
-    while (!input_rcpy.empty()) {
-        //store next active control (new control)
-        auto inp_rec = input_rcpy.begin();
-        auto cur_rec = *inp_rec;
-        iuap_data.push_back(*inp_rec);
+    while (! input_rcpy.empty()) {
+        // Store next active control (new control).
+        //
+        // Recall: We must not take a reference to the new element here
+        // since push_back() below may reallocate.  In that case, all
+        // element references are invalidated.
+        const auto cur_rec =
+            iuap_data.emplace_back(input_rcpy.front());
+
+        // Find and store active controls with same control and UDQ.
         auto it = input_rcpy.erase(input_rcpy.begin());
-        //find and store active controls with same control and udq
-        //auto it = input_rcpy.begin();
         while (it != input_rcpy.end()) {
             if ((it->control == cur_rec.control) && (it->udq == cur_rec.udq)) {
                 iuap_data.push_back(*it);
                 it = input_rcpy.erase(it);
             }
             else {
-                it++;
+                ++it;
             }
         }
     }
+
     return iuap_data;
 }
 
-
-bool UDQActive::operator==(const UDQActive& data) const {
-    return this->input_data == data.input_data &&
-           this->output_data == data.output_data;
+bool Opm::UDQActive::operator==(const UDQActive& data) const
+{
+    return (this->input_data  == data.input_data)
+        && (this->output_data == data.output_data)
+        ;
 }
 
+// ---------------------------------------------------------------------------
+// Private member functions of class Opm::UDAQactive
+// ---------------------------------------------------------------------------
 
+void Opm::UDQActive::constructOutputRecords() const
+{
+    for (const auto& input_record : this->input_data) {
+        auto it = std::find_if(this->output_data.begin(), this->output_data.end(),
+                               [&input_record](const auto& output_record)
+                               {
+                                   return (output_record.udq     == input_record.udq)
+                                       && (output_record.control == input_record.control);
+                               });
+
+        if (it != this->output_data.end()) {
+            ++it->use_count;
+        }
+        else {
+            // Recall: Constructor gives use_count = 1 in this case.
+            this->output_data.emplace_back(input_record.udq,
+                                           input_record.input_index,
+                                           /* use_index = */ 0,
+                                           input_record.wgname,
+                                           input_record.control);
+        }
+    }
+
+    if (! this->output_data.empty()) {
+        // Recalculate IUAP start indices.
+        auto useIndex = std::size_t{0};
+
+        for (auto& record : this->output_data) {
+            record.use_index = useIndex;
+
+            useIndex += record.use_count;
+        }
+    }
 }
 

--- a/opm/input/eclipse/Schedule/UDQ/UDQActive.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQActive.hpp
@@ -17,91 +17,162 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef UDQ_USAGE_HPP
 #define UDQ_USAGE_HPP
 
+#include <opm/input/eclipse/EclipseState/Phase.hpp>
+
+#include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
+
+#include <opm/input/eclipse/Deck/UDAValue.hpp>
+
+#include <cstddef>
 #include <cstdlib>
 #include <optional>
 #include <string>
 #include <vector>
 
-#include <opm/input/eclipse/Deck/UDAValue.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
-#include <opm/input/eclipse/EclipseState/Phase.hpp>
-
 namespace Opm {
 
-class UDAValue;
 class UDQConfig;
 class UnitSystem;
 
-namespace RestartIO {
+} // namespace Opm
+
+namespace Opm::RestartIO {
     struct RstState;
-}
+} // namespace Opm::RestartIO
 
-class UDQActive {
+namespace Opm {
+
+/// Internalised representation of all UDAs in a simulation run
+class UDQActive
+{
 public:
-
-    struct RstRecord {
-
-        RstRecord(UDAControl control_arg, UDAValue value_arg,
+    /// Single UDA created from restart file information
+    struct RstRecord
+    {
+        /// Constructor
+        ///
+        /// Creates a general UDA from restart file information.
+        ///
+        /// \param[in] control_arg Which item/limit of which constraint
+        /// keyword (e.g., WCONPROD or GCONPROD) for which this UDA supplies
+        /// the numeric value.
+        ///
+        /// \param[in] value_arg UDA value loaded from restart file.
+        /// Typically a UDQ name with associate unit conversion operators.
+        ///
+        /// \param[in] wgname_arg Well or group name affected by this UDA.
+        RstRecord(const UDAControl   control_arg,
+                  const UDAValue     value_arg,
                   const std::string& wgname_arg)
-            : control(control_arg)
-            , value(value_arg)
-            , wgname(wgname_arg)
-        {};
+            : control { control_arg }
+            , value   { value_arg }
+            , wgname  { wgname_arg }
+        {}
 
-        RstRecord(UDAControl control_arg, UDAValue value_arg,
-                  const std::string& wgname_arg, Phase phase)
-            : RstRecord(control_arg, value_arg, wgname_arg)
+        /// Constructor
+        ///
+        /// Creates a group level UDA for an injection limit.
+        ///
+        /// \param[in] control_arg Which item/limit of GCONINJE for which
+        /// this UDA supplies the numeric value.
+        ///
+        /// \param[in] value_arg UDA value loaded from restart file.
+        /// Typically a UDQ name with associate unit conversion operators.
+        ///
+        /// \param[in] wgname_arg Group name affected by this UDA.
+        ///
+        /// \param[in] phase Injected phase.
+        RstRecord(const UDAControl   control_arg,
+                  const UDAValue     value_arg,
+                  const std::string& wgname_arg,
+                  const Phase        phase)
+            : RstRecord { control_arg, value_arg, wgname_arg }
         {
             this->ig_phase = phase;
-        };
+        }
 
+        /// Item/limit of constraint keyword for which this UDA supplies the
+        /// numeric value.
         UDAControl control;
+
+        /// UDA value.
+        ///
+        /// Typically a UDQ name and associate unit conversion operators.
         UDAValue value;
+
+        /// Name of well/group affected by this UDA.
         std::string wgname;
-        std::optional<Phase> ig_phase;
+
+        /// Injected phase in group level injection.
+        ///
+        /// Nullopt unless the control is a GCONINJE item.
+        std::optional<Phase> ig_phase{};
     };
 
-
-
-    class OutputRecord{
+    /// Single UDA with use counts and IUAP start offsets for restart file
+    /// output purposes.
+    ///
+    /// This information is intended to go mostly unaltered into the IUAD
+    /// restart file array.
+    class OutputRecord
+    {
     public:
-        OutputRecord() :
-            input_index(0),
-            control(UDAControl::WCONPROD_ORAT),
-            uda_code(0),
-            use_count(1)
-        {}
+        /// Default constructor.
+        ///
+        /// Creates an invalid OutputRecord which is mostly usable as a
+        /// target for a deserialisation operation.
+        OutputRecord();
 
-        OutputRecord(const std::string& udq_arg, std::size_t input_index_arg, std::size_t use_index_arg, const std::string& wgname_arg, UDAControl control_arg) :
-            udq(udq_arg),
-            input_index(input_index_arg),
-            use_index(use_index_arg),
-            control(control_arg),
-            uda_code(UDQ::udaCode(control_arg)),
-            use_count(1),
-            wgname(wgname_arg)
-        {}
+        /// Constructor
+        ///
+        /// \param[in] udq_arg Name of UDQ from which this UDA derives its
+        /// numeric value.
+        ///
+        /// \param[in] input_index_arg Zero-based index in order of
+        /// appearance of the UDQ use for this UDA.
+        ///
+        /// \param[in] use_index_arg IUAP array start offset.
+        ///
+        /// \param[in] wgname_arg Name of well or group affected by this
+        /// UDA.
+        ///
+        /// \param[in] control_arg Constraint keyword and item/limit for
+        /// which this UDA supplies the numeric value.
+        OutputRecord(const std::string& udq_arg,
+                     const std::size_t  input_index_arg,
+                     const std::size_t  use_index_arg,
+                     const std::string& wgname_arg,
+                     const UDAControl   control_arg);
 
-        bool operator==(const OutputRecord& other) const  {
-            if ((this->udq == other.udq) &&
-                (this->input_index == other.input_index) &&
-                (this->use_index == other.use_index) &&
-                (this->wgname == other.wgname) &&
-                (this->control == other.control) &&
-                (this->uda_code == other.uda_code) &&
-                (this->use_count == other.use_count))
-                return true;
-            return false;
+        /// Equality predicate.
+        ///
+        /// \param[in] other Object against which \code *this \endcode will be
+        /// tested for equality.
+        ///
+        /// \return Whether or not \code *this \endcode is the same as \p
+        /// other.
+        bool operator==(const OutputRecord& other) const;
+
+        /// Inequality predicate.
+        ///
+        /// \param[in] other Object against which \code *this \endcode will be
+        /// tested for inequality.
+        ///
+        /// \return Whether or not \code *this \endcode is different from \p
+        /// other.
+        bool operator!=(const OutputRecord& other) const
+        {
+            return ! (*this == other);
         }
 
-        bool operator!=(const OutputRecord& other) const  {
-            return !(*this == other);
-        }
-
+        /// Convert between byte array and object representation.
+        ///
+        /// \tparam Serializer Byte array conversion protocol.
+        ///
+        /// \param[in,out] serializer Byte array conversion object.
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
@@ -114,40 +185,84 @@ public:
             serializer(use_count);
         }
 
+        /// Name of UDQ from which this UDA derives its numeric value.
         std::string udq;
+
+        /// Zero-based index in order of appearance of the UDQ use for this
+        /// UDA.
         std::size_t input_index;
+
+        /// IUAP array start offset.
         std::size_t use_index = 0;
-        UDAControl  control;
-        int uda_code;
-        std::string wg_name() const;
-        std::size_t use_count;
-    private:
-        // The wgname is need in the update process, but it should
-        // not be exported out.
-        std::string wgname;
-    };
 
-    class InputRecord {
-    public:
-        InputRecord() :
-            input_index(0),
-            control(UDAControl::WCONPROD_ORAT)
-        {}
+        /// Constraint keyword and item/limit for which this UDA supplies
+        /// the numeric value.
+        UDAControl control;
 
-        InputRecord(std::size_t input_index_arg, const std::string& udq_arg, const std::string& wgname_arg, UDAControl control_arg) :
-            input_index(input_index_arg),
-            udq(udq_arg),
-            wgname(wgname_arg),
-            control(control_arg)
-        {}
+        /// Restart file integer representation of \c control.
+        int uda_code{};
 
-        bool operator==(const InputRecord& other) const {
-            return this->input_index == other.input_index &&
-                   this->udq == other.udq &&
-                   this->wgname == other.wgname &&
-                   this->control == other.control;
+        /// Name of well/group affected by this UDA.
+        ///
+        /// Misleading if the use count is greater than one.
+        const std::string& wg_name() const
+        {
+            return this->wgname;
         }
 
+        /// Number of times this UDA is mentioned in this particular
+        /// combination of constraint keyword and item/limit.  Effectively,
+        /// how many wells/groups use this UDA for the same purpose.
+        std::size_t use_count{};
+
+    private:
+        /// Name of well/group affected by this UDA.
+        ///
+        /// Misleading if the use count is greater than one.
+        std::string wgname{};
+    };
+
+    /// Internalised representation of a UDA from the input file
+    class InputRecord
+    {
+    public:
+        /// Default constructor.
+        ///
+        /// Creates an invalid input record that is mostly useful as a
+        /// target for a deserialisation operation.
+        InputRecord();
+
+        /// Constructor.
+        ///
+        /// \param[in] input_index_arg Zero-based index in order of
+        /// appearance of the UDQ used for this UDA.  Needed for restart
+        /// file output purposes.
+        ///
+        /// \param[in] udq_arg Name of UDQ used for this UDA.
+        ///
+        /// \param[in] wgname_arg Name of well/group affected by this UDA.
+        ///
+        /// \param[in] control_arg Keyword and item/limit for which this UDA
+        /// supplies the numeric value.
+        InputRecord(const std::size_t  input_index_arg,
+                    const std::string& udq_arg,
+                    const std::string& wgname_arg,
+                    const UDAControl   control_arg);
+
+        /// Equality predicate.
+        ///
+        /// \param[in] other Object against which \code *this \endcode will be
+        /// tested for equality.
+        ///
+        /// \return Whether or not \code *this \endcode is the same as \p
+        /// other.
+        bool operator==(const InputRecord& other) const;
+
+        /// Convert between byte array and object representation.
+        ///
+        /// \tparam Serializer Byte array conversion protocol.
+        ///
+        /// \param[in,out] serializer Byte array conversion object.
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
@@ -157,26 +272,112 @@ public:
             serializer(control);
         }
 
+        /// Zero-based index in order of appearance of the UDQ use for this
+        /// UDA.  Needed for restart file output purposes.
         std::size_t input_index;
+
+        /// Name of the UDQ used in this UDA.
         std::string udq;
+
+        /// Well or group affected by this UDA.
         std::string wgname;
+
+        /// Constraint keyword and item/limit for which this UDA supplies
+        /// the numeric value.
         UDAControl control;
     };
 
+    /// Create a serialisation test object.
     static UDQActive serializationTestObject();
+
+    /// Default constructor.
+    ///
+    /// Creates an empty collection of UDAs.  Resulting collection is usable
+    /// as a target for a deserialisation operation, or as a container of
+    /// new UDAs through calls to the update() member function.
     UDQActive() = default;
-    static std::vector<RstRecord> load_rst(const UnitSystem& units,
-                                           const UDQConfig& udq_config,
-                                           const RestartIO::RstState& rst_state,
-                                           const std::vector<std::string>& well_names,
-                                           const std::vector<std::string>& group_names);
-    int update(const UDQConfig& udq_config, const UDAValue& uda, const std::string& wgname, UDAControl control);
+
+    /// Load UDAs from restart file.
+    ///
+    /// \param[in] units
+    ///
+    /// \param[in] udq_config Simulation run's collection of user defined
+    /// quantities.
+    ///
+    /// \param[in] rst_state Restart file information.
+    ///
+    /// \param[in] well_names Run's wells at restart point.
+    ///
+    /// \param[in] group_names Run's groups at restart point.
+    static std::vector<RstRecord>
+    load_rst(const UnitSystem&               units,
+             const UDQConfig&                udq_config,
+             const RestartIO::RstState&      rst_state,
+             const std::vector<std::string>& well_names,
+             const std::vector<std::string>& group_names);
+
+    /// Amend collection of input UDAs to account for a new entry
+    ///
+    /// Does nothing if the UDA is numeric.  Adds a new record if none
+    /// exists for the particular combination of (UDA, well/group name, and
+    /// constraint keyword item).  Removes a record if the UDA value is
+    /// numeric and previously used a UDQ specification.  Replaces a record
+    /// if a different UDA was used for the same combination of well/group
+    /// name and keyword/item.
+    ///
+    /// \param[in] udq_config Simulation run's collection of user defined
+    /// quantities.
+    ///
+    /// \param[in] uda Numeric or string UDA value entered for a single
+    /// limit/item in a constraint keyword.
+    ///
+    /// \param[in] wgname Well/group name affected by \p uda.
+    ///
+    /// \param[in] control Constraint keyword and associate item/limit for
+    /// which \p uda supplies the numeric value.
+    ///
+    /// \return Whether or not internal data structures were altered.  One
+    /// (1) if changes were made, and zero (0) otherwise.
+    int update(const UDQConfig&   udq_config,
+               const UDAValue&    uda,
+               const std::string& wgname,
+               const UDAControl   control);
+
+    /// UDA existence predicate
+    ///
+    /// \return Whether or not there are any UDAs registered in this
+    /// collection.
     explicit operator bool() const;
+
+    /// Retrieve current set of UDAs, condensed by use counts and IUAP
+    /// offsets.
+    ///
+    /// Intended for restart file output purposes only.
     const std::vector<OutputRecord>& iuad() const;
+
+    /// Retrieve current set of UDAs from which to form IUAP restart file
+    /// array.
+    ///
+    /// Intendend for restart file output purposes only.
+    ///
+    /// \note This function's role could possibly be served by iuad() as
+    /// well.  If so, that's a future performance benefit since we won't
+    /// have to form a new vector<> on every call to the function.
     std::vector<InputRecord> iuap() const;
 
+    /// Equality predicate.
+    ///
+    /// \param[in] data Object against which \code *this \endcode will be
+    /// tested for equality.
+    ///
+    /// \return Whether or not \code *this \endcode is the same as \p data.
     bool operator==(const UDQActive& data) const;
 
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
@@ -185,16 +386,22 @@ public:
     }
 
 private:
-    std::string udq_hash(const std::string& udq, UDAControl control);
-    std::string wg_hash(const std::string& wgname, UDAControl control);
-    int add(const UDQConfig& udq_config, const std::string& udq, const std::string& wgname, UDAControl control);
-    int update_input(const UDQConfig& udq_config, const UDAValue& uda, const std::string& wgname, UDAControl control);
-    int drop(const std::string& wgname, UDAControl control);
+    /// Current set of UDAs entered in the input source.
+    std::vector<InputRecord> input_data{};
 
-    std::vector<InputRecord> input_data;
-    std::vector<OutputRecord> mutable output_data;
+    /// Current set of UDAs condensed by use counts and IUAP start pointers.
+    ///
+    /// Intended for restart file output as the IUAD vector.  Cleared if
+    /// input_data changes.  Formed in constructOutputRecords().
+    ///
+    /// Marked 'mutable' because we may need to construct this from the
+    /// 'const' iuad() member function.
+    mutable std::vector<OutputRecord> output_data{};
+
+    /// Form output_data structure from input_data.
+    void constructOutputRecords() const;
 };
 
-}
+} // namespace Opm
 
-#endif
+#endif // UDQ_USAGE_HPP


### PR DESCRIPTION
This is mostly to exploit commonalities between the group level production and injection cases, and to prepare for adding support for field level UDAs.

While here, add Doxygen-style documentation to the `UDQActive` members, remove unused/unimplemented member functions (e.g., `udq_hash()`, `wg_hash()`, `update_input()`) and reorder the logic in `UDQActive::update()` in order to reduce levels of nesting.