### PR TITLE
Add Restart File Support for Field Level UDAs

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1457,11 +1457,12 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/eclipse/VectorItems/aquifer.hpp
         opm/output/eclipse/VectorItems/connection.hpp
         opm/output/eclipse/VectorItems/group.hpp
-        opm/output/eclipse/VectorItems/network.hpp
         opm/output/eclipse/VectorItems/intehead.hpp
         opm/output/eclipse/VectorItems/logihead.hpp
         opm/output/eclipse/VectorItems/msw.hpp
+        opm/output/eclipse/VectorItems/network.hpp
         opm/output/eclipse/VectorItems/tabdims.hpp
+        opm/output/eclipse/VectorItems/udq.hpp
         opm/output/eclipse/VectorItems/well.hpp
         opm/output/eclipse/ActiveIndexByColumns.hpp
         opm/output/eclipse/AggregateActionxData.hpp

--- a/opm/input/eclipse/Schedule/UDQ/UDQActive.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQActive.hpp
@@ -402,6 +402,17 @@ private:
     void constructOutputRecords() const;
 };
 
+// ===========================================================================
+
+/// Predicate for field level UDAs
+///
+/// \param[in] record IUAD restart file UDA record
+///
+/// \return Whether or not \p record applies at the field level.  In other
+/// words, whether or not the \p record is a UDA in GCONPROD or GCONINJE
+/// that applies to the FIELD group.
+bool isFieldUDA(const UDQActive::OutputRecord& record);
+
 } // namespace Opm
 
 #endif // UDQ_USAGE_HPP

--- a/opm/io/eclipse/rst/udq.cpp
+++ b/opm/io/eclipse/rst/udq.cpp
@@ -22,6 +22,7 @@
 #include <opm/common/utility/Visitor.hpp>
 
 #include <opm/output/eclipse/UDQDims.hpp>
+#include <opm/output/eclipse/VectorItems/udq.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -245,38 +246,61 @@ void Opm::RestartIO::RstUDQ::ensureValidNameIndex() const
 Opm::RestartIO::RstUDQActive::
 RstRecord::RstRecord(const UDAControl  c,
                      const std::size_t i,
+                     const UDAKind     k,
                      const std::size_t u1,
                      const std::size_t u2)
     : control    (c)
     , input_index(i)
     , use_count  (u1)
     , wg_offset  (u2)
+    , isFieldUDA (k == UDAKind::Field)
 {}
+
+namespace {
+    Opm::RestartIO::RstUDQActive::RstRecord::UDAKind udaKind(const int k)
+    {
+        using InKind  = Opm::RestartIO::Helpers::VectorItems::IUad::Value::UDAKind;
+        using OutKind = Opm::RestartIO::RstUDQActive::RstRecord::UDAKind;
+
+        switch (k) {
+        case InKind::Regular: return OutKind::Regular;
+        case InKind::Field:   return OutKind::Field;
+        }
+
+        throw std::invalid_argument {
+            fmt::format("Unknown UDA Kind {}", k)
+        };
+    }
+}
 
 Opm::RestartIO::RstUDQActive::
 RstUDQActive(const std::vector<int>& iuad_arg,
              const std::vector<int>& iuap,
              const std::vector<int>& igph)
     : wg_index { iuap }
-    , ig_phase (igph.size(), Phase::OIL)
 {
+    using Ix = Opm::RestartIO::Helpers::VectorItems::IUad::index;
+
+    this->iuad.reserve(iuad_arg.size() / UDQDims::entriesPerIUAD());
+
     for (auto offset = 0*iuad_arg.size();
          offset < iuad_arg.size();
          offset += UDQDims::entriesPerIUAD())
     {
         const auto* uda = &iuad_arg[offset];
 
-        this->iuad.emplace_back(UDQ::udaControl(uda[0]),
-                                uda[1] - 1,
-                                uda[3],
-                                uda[4] - 1);
+        this->iuad.emplace_back(UDQ::udaControl(uda[Ix::UDACode]),
+                                uda[Ix::UDQIndex] - 1,
+                                udaKind(uda[Ix::Kind]),
+                                uda[Ix::UseCount],
+                                uda[Ix::Offset] - 1);
     }
 
-    std::transform(this->wg_index.begin(),
-                   this->wg_index.end(),
+    std::transform(this->wg_index.begin(), this->wg_index.end(),
                    this->wg_index.begin(),
-                   [](const int wgObjectID) { return wgObjectID - 1; });
+                   [](const int wgIdx) { return wgIdx - 1; });
 
+    this->ig_phase.assign(igph.size(), Phase::OIL);
     std::transform(igph.begin(), igph.end(), this->ig_phase.begin(),
                    [](const int phase)
                    {

--- a/opm/io/eclipse/rst/udq.hpp
+++ b/opm/io/eclipse/rst/udq.hpp
@@ -500,25 +500,88 @@ private:
     void ensureValidNameIndex() const;
 };
 
+/// Collection of UDAs loaded from restart file
 struct RstUDQActive
 {
+    /// One single UDA
     struct RstRecord
     {
-        RstRecord(UDAControl c, std::size_t i, std::size_t u1, std::size_t u2);
+        enum class UDAKind : int {
+            /// UDA is of a regular kind that applies either to a well or a
+            /// non-field group.
+            Regular,
 
-        UDAControl  control;
+            /// UDA applies to the field level.
+            Field,
+        };
+
+        /// Constructor.
+        ///
+        /// Convenience only as this enables using vector<>::emplace_back().
+        ///
+        /// \param[in] c Control keyword and item
+        ///
+        /// \param[in] i Input index.  Zero-based order in which the UDQ was
+        /// entered.
+        ///
+        /// \param[in] k Type of this UDA.
+        ///
+        /// \param[in] u1 Use count.  Number of times this UDA is used in
+        /// this particular way (same keyword and control item, e.g., for
+        /// different wells or groups).
+        ///
+        /// \param[in] u2 IUAP start offset.
+        RstRecord(UDAControl  c,
+                  std::size_t i,
+                  UDAKind     k,
+                  std::size_t u1,
+                  std::size_t u2);
+
+        /// Control keyword and associate item for this UDA.
+        UDAControl control;
+
+        /// Input index.  Zero-based order in which the UDQ was entered.
         std::size_t input_index;
+
+        /// Use count.  Number of times this UDA is used in this particular
+        /// way (same keyword and control item, e.g., for different wells or
+        /// groups).
         std::size_t use_count;
+
+        /// IUAP start offset.
         std::size_t wg_offset;
+
+        /// Flag for whether or not this UDA applies at the field level.
+        bool isFieldUDA;
     };
 
+    /// Default constructor.
+    ///
+    /// Represents an empty collection.
     RstUDQActive() = default;
+
+    /// Constructor.
+    ///
+    /// Forms UDA collection from restart file information.
+    ///
+    /// \param[in] iuad.  Restart file IUAD array.
+    ///
+    /// \param[in] iuap.  Restart file IUAP array.  Wells/groups affected by
+    /// each UDA.
+    ///
+    /// \param[in] igph.  Restart file IGPH array.  Injection phases for
+    /// groups.
     RstUDQActive(const std::vector<int>& iuad,
                  const std::vector<int>& iuap,
                  const std::vector<int>& igph);
 
-    std::vector<RstRecord> iuad{};
+    /// Wells/groups affected by each UDA.
     std::vector<int> wg_index{};
+
+    /// Exploded items of each UDA.
+    std::vector<RstRecord> iuad{};
+
+    /// Injection phases for groups.
     std::vector<Phase> ig_phase{};
 };
 

--- a/opm/output/eclipse/AggregateUDQData.hpp
+++ b/opm/output/eclipse/AggregateUDQData.hpp
@@ -32,6 +32,7 @@
 namespace Opm {
     class Group;
     class Schedule;
+    class UDQActive;
     class UDQConfig;
     class UDQDims;
     class UDQInput;
@@ -118,7 +119,7 @@ private:
     ///
     /// 5 integers pr UDQ that is used for various well and group controls.
     /// Nullopt if no UDAs.
-    std::optional<WindowedArray<int>> iUAD_;
+    std::optional<WindowedArray<int>> iUAD_{};
 
     /// Aggregate 'ZUDN' array (Character) for all UDQ data.
     ///
@@ -134,12 +135,12 @@ private:
     ///
     /// 3 - zeroes - as of current understanding.  Nullopt if no injection
     /// phase is determined by a UDA for any group.
-    std::optional<WindowedArray<int>> iGPH_;
+    std::optional<WindowedArray<int>> iGPH_{};
 
     /// Aggregate 'IUAP' array for all UDQ data
     ///
     /// 1 integer pr UDQ constraint used.  Nullopt if no UDAs.
-    std::optional<WindowedArray<int>> iUAP_;
+    std::optional<WindowedArray<int>> iUAP_{};
 
     /// Numeric values of field level UDQs.
     ///
@@ -191,6 +192,34 @@ private:
                               const std::size_t               nwmax,
                               const std::vector<std::string>& wells,
                               const int                       expectedNumWellUDQs);
+
+    /// Form IUAD array for runs featuring UDAs
+    ///
+    /// \param[in] udqActive Run's current UDA collection.
+    ///
+    /// \param[in] expectNumIUAD Expected number of UDAs.  For consistency
+    /// checking.
+    void collectIUAD(const UDQActive&  udqActive,
+                     const std::size_t expectNumIUAD);
+
+    /// Form IUAP array for runs featuring UDAs.
+    ///
+    /// \param[in] wgIndex Precalculated IUAP array.  Copied into iUAP_.
+    ///
+    /// \param[in] expectNumIUAP Expected IUAP size.  For consistency
+    /// checking.
+    void collectIUAP(const std::vector<int>& wgIndex,
+                     const std::size_t       expectNumIUAP);
+
+    /// Form IGPH group level injection phase array for runs featuring UDAs.
+    ///
+    /// \param[in] phase_vector Precalculated injection phase array.  Copied
+    /// into iGPH_.
+    ///
+    /// \param[in] expectNumIGPH Expected IGPH size.  For consistency
+    /// checking.
+    void collectIGPH(const std::vector<int>& phase_vector,
+                     const std::size_t       expectNumIGPH);
 };
 
 } // Opm::RestartIO::Helpers

--- a/opm/output/eclipse/VectorItems/udq.hpp
+++ b/opm/output/eclipse/VectorItems/udq.hpp
@@ -1,0 +1,56 @@
+/*
+  Copyright (c) 2024 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_OUTPUT_ECLIPSE_VECTOR_UDQ_HPP
+#define OPM_OUTPUT_ECLIPSE_VECTOR_UDQ_HPP
+
+#include <vector>
+
+namespace Opm::RestartIO::Helpers::VectorItems {
+
+    namespace IUad {
+        enum index : std::vector<int>::size_type {
+            UDACode  = 0, // Integer code for keyword/item combination.
+            UDQIndex = 1, // UDQ insertion index (one-based)
+            Kind     = 2, // UDA Kind.  1 => Regular, 2 => Field.
+            UseCount = 3, // Number of times this UDA is used in this
+                          // way--i.e., number of wells (or groups) for
+                          // which this UDA supplies this particular limit
+                          // in this particular keyword.
+            Offset   = 4, // One-based start offset in IUAP for this UDA.
+        };
+
+        namespace Value {
+            enum UDAKind : int {
+                Regular = 1, // UDA applies to a well or a non-field group.
+                Field   = 2, // UDA applies to the field group.
+            };
+        } // namespace Value
+    } // namespace IUad
+
+    namespace ZUdn {
+        enum index : std::vector<const char*>::size_type {
+            Keyword = 0, // UDQ name
+            Unit    = 1, // UDQ Unit
+        };
+    } // namespace ZUdn
+
+} // Opm::RestartIO::Helpers::VectorItems
+
+#endif // OPM_OUTPUT_ECLIPSE_VECTOR_UDQ_HPP


### PR DESCRIPTION
In particular, this commit amends the logic for saving and reloading the IUAD and IUAP restart file arrays to account for the differences in how UDAs apply to the 'FIELD' group in the GCONPROD and GCONINJE keywords.  Notably, IUAD[2] is two (2) for field level UDAs, and we store two copies of the number one (1) into IUAP for each field level UDA.

While here, move the `ig_phase()` and `iuap_data()` helper functions into their appropriate namespaces and remove the logic which detected, and excluded field level UDAs from consideration in INTEHEAD.