### PR TITLE
Guard against zero pore volume numerical aquifer cells

### DIFF
--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
@@ -123,6 +123,12 @@ namespace Opm {
         }
     }
 
+    void NumericalAquifers::applyMinPV(const EclipseGrid& grid) {
+        for (auto& [id, aq] : this->m_aquifers) {
+            aq.applyMinPV(grid);
+        }
+    }
+
     bool NumericalAquifers::operator==(const NumericalAquifers& other) const {
         return (this->m_aquifers == other.m_aquifers)
             && (this->m_num_records == other.m_num_records);

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <limits>
 #include <unordered_set>
 #include <utility>
 #include <stdexcept>

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
@@ -50,6 +50,7 @@ namespace Opm {
         using AQUNUM=ParserKeywords::AQUNUM;
         if ( !deck.hasKeyword<AQUNUM>() ) return;
 
+        constexpr auto EPSILON = std::numeric_limits<double>::epsilon();
         std::unordered_set<std::size_t> cells;
         // there might be multiple keywords of keyword AQUNUM, it is not totally
         // clear about the rules here. For now, we take care of all the keywords
@@ -62,6 +63,15 @@ namespace Opm {
                                              aqu_cell.I + 1, aqu_cell.J + 1, aqu_cell.K + 1);
                     throw OpmInputError(error, keyword->location());
                 } else {
+                    if (const auto id = aqu_cell.aquifer_id; !this->hasAquifer(id)) {
+                        this->m_aquifers.insert(std::make_pair(id, SingleNumericalAquifer{id}));
+                    }
+                    if (aqu_cell.cellVolume() < EPSILON) {
+                        const auto[I, J, K] = grid.getIJK(aqu_cell.global_index);
+                        OpmLog::warning(fmt::format("Bulk volume in numerical aquifer {} cell ({}, {}, {}) below threshold (~ {:.5e}). Cell is removed from the simulation.",
+                                        aqu_cell.aquifer_id, I + 1, J + 1, K + 1, EPSILON));
+                        continue;
+                    }
                     this->addAquiferCell(aqu_cell);
                     cells.insert(aqu_cell.global_index);
                 }
@@ -74,10 +84,6 @@ namespace Opm {
 
     void NumericalAquifers::addAquiferCell(const NumericalAquiferCell& aqu_cell) {
         const size_t id = aqu_cell.aquifer_id;
-        if (!this->hasAquifer(id)) {
-            this->m_aquifers.insert(std::make_pair(id, SingleNumericalAquifer{id}));
-        }
-
         auto& aquifer = this->m_aquifers.at(id);
         aquifer.addAquiferCell(aqu_cell);
     }

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
@@ -57,6 +57,8 @@ namespace Opm {
 
         std::unordered_map<size_t, AquiferCellProps> aquiferCellProps() const;
 
+        void applyMinPV(const EclipseGrid& grid);
+
         void initConnections(const Deck& deck, const EclipseGrid& grid);
         void postProcessConnections(const EclipseGrid& grid, const std::vector<int>& actnum);
 

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
@@ -29,8 +29,6 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <fmt/format.h>
-#include <algorithm>
-#include <limits>
 #include <unordered_set>
 
 namespace Opm {
@@ -97,8 +95,11 @@ namespace Opm {
 
     std::vector<NNCdata> SingleNumericalAquifer::aquiferCellNNCs() const {
         std::vector<NNCdata> nncs;
+        if (this->cells_.empty())
+            return nncs;
+
         // aquifer cells are connected to each other through NNCs to form the aquifer
-        for (int i = 0; i < static_cast<int>(this->cells_.size()) - 1; ++i) { // int needed if this->cells_ is empty..
+        for (size_t i = 0; i < this->cells_.size() - 1; ++i) {
             const double trans1 = this->cells_[i].transmissiblity();
             const double trans2 = this->cells_[i + 1].transmissiblity();
             const double tran = 1. / (1. / trans1 + 1. / trans2);
@@ -116,7 +117,7 @@ namespace Opm {
     std::vector<NNCdata>
     SingleNumericalAquifer::aquiferConnectionNNCs(const EclipseGrid& grid, const FieldPropsManager& fp) const {
        std::vector<NNCdata> nncs;
-        if (this->cells_.size() == 0)
+        if (this->cells_.empty())
             return nncs;
         // aquifer connections are connected to aquifer cells through NNCs
         const std::vector<double>& ntg = fp.get_double("NTG");

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
@@ -59,6 +59,8 @@ namespace Opm {
         size_t numConnections() const;
         const NumericalAquiferCell* getCellPrt(size_t index) const;
 
+        void applyMinPV(const EclipseGrid& grid);
+
         std::unordered_map<size_t, AquiferCellProps> aquiferCellProps() const;
 
         std::vector<NNCdata> aquiferCellNNCs() const;

--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -151,9 +151,11 @@ namespace Opm {
         this->assignRunTitle(deck);
         this->reportNumberOfActivePhases();
 
-        this->conveyNumericalAquiferEffects();
         if (field_props.has_double("MINPVV")) {
             this->m_inputGrid.setMINPVV(field_props.get_global_double("MINPVV"));
+        }
+        this->conveyNumericalAquiferEffects();
+        if (field_props.has_double("MINPVV")) {
             field_props.deleteMINPVV();
         }
         this->initLgrs(deck);
@@ -425,7 +427,10 @@ namespace Opm {
             return;
         }
 
-        const auto& numerical_aquifer = this->aquifer_config.numericalAquifers();
+        //const auto& numerical_aquifer = this->aquifer_config.numericalAquifers();
+        auto& numerical_aquifer = this->aquifer_config.mutableNumericalAquifers();
+
+        numerical_aquifer.applyMinPV(this->m_inputGrid);
 
         // Update field_props for numerical aquifer cells and set the
         // transmissiblity related to aquifer cells to zero.

--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -427,7 +427,6 @@ namespace Opm {
             return;
         }
 
-        //const auto& numerical_aquifer = this->aquifer_config.numericalAquifers();
         auto& numerical_aquifer = this->aquifer_config.mutableNumericalAquifers();
 
         numerical_aquifer.applyMinPV(this->m_inputGrid);


### PR DESCRIPTION
Current master eventually fails due to dividing by zero when trying to compute the CNV error for any numerical aquifer cells with zero porosity. 