### PR TITLE
Really limit processing of deck to actnum to determine active cells.

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -1619,7 +1619,8 @@ void FieldProps::handle_OPERATE(const DeckKeyword& keyword, Box box)
 
 void FieldProps::handle_operation(const Section      section,
                                   const DeckKeyword& keyword,
-                                  Box                box)
+                                  Box                box,
+                                  const bool         onlyACTNUM)
 {
     // Keyword handler for ADD, EQUALS, MAXVALUE, MINVALUE, and MULTIPLY.
     //
@@ -1654,6 +1655,10 @@ void FieldProps::handle_operation(const Section      section,
     for (const auto& record : keyword) {
         const auto target_kw = Fieldprops::keywords::
             get_keyword_from_alias(record.getItem(0).getTrimmedString(0));
+
+        if (onlyACTNUM && target_kw != "ACTNUM") {
+            continue;
+        }
 
         box.update(record);
 
@@ -1829,12 +1834,13 @@ void FieldProps::handle_COPY(const DeckKeyword& keyword,
 
 void FieldProps::handle_keyword(const Section      section,
                                 const DeckKeyword& keyword,
-                                Box&               box)
+                                Box&               box,
+                                const bool         onlyACTNUM)
 {
     const auto& name = keyword.name();
 
     if (Fieldprops::keywords::oper_keywords.count(name) == 1) {
-        this->handle_operation(section, keyword, box);
+        this->handle_operation(section, keyword, box, onlyACTNUM);
     }
 
     else if (name == ParserKeywords::OPERATE::keywordName) {
@@ -2070,7 +2076,7 @@ void FieldProps::scanGRIDSectionOnlyACTNUM(const GRIDSection& grid_section)
             this->handle_int_keyword(Fieldprops::keywords::GRID::int_keywords.at(name), keyword, box);
         }
         else if ((name == "EQUALS") || (Fieldprops::keywords::box_keywords.count(name) == 1)) {
-            this->handle_keyword(Section::GRID, keyword, box);
+            this->handle_keyword(Section::GRID, keyword, box, true);
         }
     }
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -768,7 +768,8 @@ private:
     region_index(const std::string& region_name, int region_value);
 
     void handle_OPERATE(const DeckKeyword& keyword, Box box);
-    void handle_operation(Section section, const DeckKeyword& keyword, Box box);
+    void handle_operation(Section section, const DeckKeyword& keyword, Box box,
+                          const bool onlyACTNUM = false);
     void handle_operateR(const DeckKeyword& keyword);
     void handle_region_operation(const DeckKeyword& keyword);
     void handle_COPY(const DeckKeyword& keyword, Box box, bool region);
@@ -779,7 +780,8 @@ private:
     double get_beta(const std::string& func_name, const std::string& target_array, double raw_beta);
     double get_alpha(const std::string& func_name, const std::string& target_array, double raw_alpha);
 
-    void handle_keyword(Section section, const DeckKeyword& keyword, Box& box);
+    void handle_keyword(Section section, const DeckKeyword& keyword, Box& box,
+                        const bool onlyACTNUM = false);
     void handle_double_keyword(Section section,
                                const Fieldprops::keywords::keyword_info<double>& kw_info,
                                const DeckKeyword& keyword,


### PR DESCRIPTION
When setting up the EclipseGrid, we create a temporary FieldProps object for getting the ACTNUM array. Somehow we processed all EQUALS statements in the GRID section for this. This seems overkill here.

Hence we now only honor EQUALS ACTNUM to save some processing.

Not relevant for the manual.