### PR TITLE
Refactor ErrorGuard, adding formattedErrors() function.

### DIFF
--- a/opm/input/eclipse/Parser/ErrorGuard.hpp
+++ b/opm/input/eclipse/Parser/ErrorGuard.hpp
@@ -21,6 +21,7 @@
 #ifndef ERROR_GUARD_HPP
 #define ERROR_GUARD_HPP
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -35,15 +36,17 @@ public:
     explicit operator bool() const { return !this->error_list.empty(); }
 
     /*
-      Observe that this desctructor has a somewhat special semantics. If there
+      Observe that this destructor has somewhat special semantics. If there
       are errors in the error list it will print all warnings and errors on
-      stderr and throw std::runtime_error.
+      stderr with the dump() method, and then call std::exit(1).
     */
     ~ErrorGuard();
     void terminate() const;
-    std::string dump() const;
+    void dump() const;
+    std::string formattedErrors() const;
 
 private:
+    std::size_t maxMessageWidth() const;
 
     std::vector<std::pair<std::string, std::string>> error_list;
     std::vector<std::pair<std::string, std::string>> warning_list;


### PR DESCRIPTION
Refactoring after #4305.

The dump() function is now back to only dumping to stderr. In this class it is used by terminate(), possibly via the destructor. Use in other classes should be unnnecessary, I considered making it private but decided not to for convenience of debugging.

The formattedErrors() messages are no longer reformatted by a regexp, but keep their original style (see below).

Example of output:
```
Unrecoverable errors while loading input:

The GRID section must be followed by EDIT or PROPS instead of GRID
In file /Users/atgeirr/opm/src/opm-tests/spe1/SPE1CASE2_WRONGORDER.DATA, line 108

The GRID section must be followed by EDIT or PROPS instead of GRID
In file /Users/atgeirr/opm/src/opm-tests/spe1/SPE1CASE2_WRONGORDER.DATA, line 110

The PROPS section must be followed by REGIONS or SOLUTION instead of GRID
In file /Users/atgeirr/opm/src/opm-tests/spe1/SPE1CASE2_WRONGORDER.DATA, line 255

The GRID section must be followed by EDIT or PROPS instead of SOLUTION
In file /Users/atgeirr/opm/src/opm-tests/spe1/SPE1CASE2_WRONGORDER.DATA, line 257
```
The above is from the DBG file, on stdout it is the same except with the prefix `Error:` and a bold red font.

This requires downstream update, which is incoming.