### PR TITLE
ROCKOPTS item 2

### DIFF
--- a/opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
@@ -68,6 +68,7 @@ public:
     bool active() const;
     const std::vector<RockConfig::RockComp>& comp() const;
     const std::string& rocknum_property() const;
+    bool store() const;
     std::size_t num_rock_tables() const;
     Hysteresis hysteresis_mode() const;
     bool water_compaction() const;
@@ -82,6 +83,7 @@ public:
         serializer(m_comp);
         serializer(num_property);
         serializer(num_tables);
+        serializer(m_store);
         serializer(m_water_compaction);
         serializer(hyst_mode);
         serializer(m_dispersion);
@@ -92,6 +94,7 @@ private:
     std::vector<RockComp> m_comp;
     std::string num_property;
     std::size_t num_tables = 0;
+    bool m_store = false;
     bool m_water_compaction = false;
     Hysteresis hyst_mode = Hysteresis::REVERS;
     bool m_dispersion = false;

--- a/tests/parser/SimulationConfigTest.cpp
+++ b/tests/parser/SimulationConfigTest.cpp
@@ -364,7 +364,7 @@ ROCK
    3  0.3 /
 
 ROCKOPTS
-   2* SATNUM  /
+   1* STORE SATNUM  /
 
 )";
     Opm::Parser parser;
@@ -373,6 +373,7 @@ ROCKOPTS
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, TableManager());
     RockConfig rc(deck, fp);
     BOOST_CHECK_EQUAL(rc.rocknum_property(), "SATNUM");
+    BOOST_CHECK_EQUAL(rc.store(), true);
     const auto& comp = rc.comp();
     BOOST_CHECK_EQUAL(comp.size(), 3U);
 }
@@ -388,7 +389,7 @@ TABDIMS
 PROPS
 
 ROCKOPTS
-  1* 1* SATNUM /
+  1* NOSTORE SATNUM /
 
 ROCK
 123.4 0.40E-05 /
@@ -405,6 +406,7 @@ ROCK
     const auto rc = RockConfig { deck, fp };
 
     BOOST_CHECK_EQUAL(rc.rocknum_property(), "SATNUM");
+    BOOST_CHECK_EQUAL(rc.store(), false);
 
     const auto& comp = rc.comp();
     BOOST_REQUIRE_EQUAL(comp.size(), std::size_t{3});


### PR DESCRIPTION
This PR allows for parsing ROCKOPTS item 2 with options STORE or NOSTORE (default).
Needed in https://github.com/OPM/opm-simulators/pull/5785