### PR TITLE
Remove Unused (and Expensive) Well/Group Functions

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1130,45 +1130,6 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
         return this->snapshots[timeStep].groups.has(groupName);
     }
 
-    std::vector< const Group* > Schedule::getChildGroups2(const std::string& group_name,
-                                                          std::size_t timeStep) const
-    {
-        const auto& sched_state = this->snapshots[timeStep];
-        const auto& group = sched_state.groups.get(group_name);
-
-        std::vector<const Group*> child_groups;
-        std::transform(group.groups().begin(), group.groups().end(),
-                       std::back_inserter(child_groups),
-                       [this, timeStep](const auto& child_name)
-                       {
-                           return std::addressof(this->getGroup(child_name, timeStep));
-                       });
-
-        return child_groups;
-    }
-
-    std::vector< Well > Schedule::getChildWells2(const std::string& group_name, std::size_t timeStep) const {
-        const auto& sched_state = this->snapshots[timeStep];
-        const auto& group = sched_state.groups.get(group_name);
-
-        std::vector<Well> wells;
-
-        if (group.groups().size()) {
-            for (const auto& child_name : group.groups()) {
-                const auto& child_wells = this->getChildWells2(child_name, timeStep);
-                wells.insert(wells.end(), child_wells.begin(), child_wells.end());
-            }
-        } else {
-            std::transform(group.wells().begin(), group.wells().end(),
-                           std::back_inserter(wells),
-                           [this, timeStep](const auto& well_name) -> decltype(auto)
-                           {
-                               return this->getWell(well_name, timeStep);
-                           });
-        }
-        return wells;
-    }
-
     /*
       This function will return a list of wells which have changed
       *structurally* in the last report_step; wells where only production

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -262,8 +262,6 @@ namespace Opm {
         void clear_event(ScheduleEvents::Events, std::size_t report_step);
         void applyWellProdIndexScaling(const std::string& well_name, const std::size_t reportStep, const double scalingFactor);
 
-        std::vector<const Group*> getChildGroups2(const std::string& group_name, std::size_t timeStep) const;
-        std::vector<Well> getChildWells2(const std::string& group_name, std::size_t timeStep) const;
         WellProducerCMode getGlobalWhistctlMmode(std::size_t timestep) const;
 
         const UDQConfig& getUDQConfig(std::size_t timeStep) const;

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -461,56 +461,11 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     BOOST_CHECK_EQUAL(field_ptr->name(), "FIELD");
 }
 
-namespace {
-
-bool has_well( const std::vector<Well>& wells, const std::string& well_name)
+BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrderedGRUPTREE)
 {
-    return std::any_of(wells.begin(), wells.end(),
-                       [&well_name](const auto& well) { return well.name() == well_name; });
-}
+    const auto schedule = make_schedule(createDeckWithWellsOrderedGRUPTREE());
+    const auto group_names = schedule.groupNames("P*", 0);
 
-} // Anonymous namespace
-
-BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrderedGRUPTREE) {
-    const auto& schedule = make_schedule( createDeckWithWellsOrderedGRUPTREE() );
-
-    BOOST_CHECK_THROW( schedule.getChildWells2( "NO_SUCH_GROUP" , 0 ), std::exception);
-    {
-        auto field_wells = schedule.getChildWells2("FIELD" , 0);
-        BOOST_CHECK_EQUAL( field_wells.size() , 4U);
-
-        BOOST_CHECK( has_well( field_wells, "DW_0" ));
-        BOOST_CHECK( has_well( field_wells, "CW_1" ));
-        BOOST_CHECK( has_well( field_wells, "BW_2" ));
-        BOOST_CHECK( has_well( field_wells, "AW_3" ));
-    }
-
-    {
-        auto platform_wells = schedule.getChildWells2("PLATFORM" , 0);
-        BOOST_CHECK_EQUAL( platform_wells.size() , 4U);
-
-        BOOST_CHECK( has_well( platform_wells, "DW_0" ));
-        BOOST_CHECK( has_well( platform_wells, "CW_1" ));
-        BOOST_CHECK( has_well( platform_wells, "BW_2" ));
-        BOOST_CHECK( has_well( platform_wells, "AW_3" ));
-    }
-
-    {
-        auto child_wells1 = schedule.getChildWells2("CG1" , 0);
-        BOOST_CHECK_EQUAL( child_wells1.size() , 2U);
-
-        BOOST_CHECK( has_well( child_wells1, "DW_0" ));
-        BOOST_CHECK( has_well( child_wells1, "CW_1" ));
-    }
-
-    {
-        auto parent_wells2 = schedule.getChildWells2("PG2" , 0);
-        BOOST_CHECK_EQUAL( parent_wells2.size() , 2U);
-
-        BOOST_CHECK( has_well( parent_wells2, "BW_2" ));
-        BOOST_CHECK( has_well( parent_wells2, "AW_3" ));
-    }
-    auto group_names = schedule.groupNames("P*", 0);
     BOOST_CHECK( std::find(group_names.begin(), group_names.end(), "PG1") != group_names.end() );
     BOOST_CHECK( std::find(group_names.begin(), group_names.end(), "PG2") != group_names.end() );
     BOOST_CHECK( std::find(group_names.begin(), group_names.end(), "PLATFORM") != group_names.end() );


### PR DESCRIPTION
Client code should not call these, but instead prefer to look up individual objects by name.