### PR TITLE
 For testing: Use 3 as default for MINNPCOL

### DIFF
--- a/opm/input/eclipse/share/keywords/900_OPM/M/MINNPCOL
+++ b/opm/input/eclipse/share/keywords/900_OPM/M/MINNPCOL
@@ -8,7 +8,7 @@
     {
       "name": "VALUE",
       "value_type": "INT",
-      "default": 6
+      "default": 3
     }
   ]
 }


### PR DESCRIPTION
I think it is time to think about removing MINNPCOL. Setting the default to 3 should make it more or less redundant.  