### PR TITLE
Revise Depth Correction Algorithm for WBPn

### DIFF
--- a/opm/input/eclipse/Schedule/Well/PAvgCalculator.cpp
+++ b/opm/input/eclipse/Schedule/Well/PAvgCalculator.cpp
@@ -743,14 +743,18 @@ void PAvgCalculator<Scalar>::accumulateLocalContributions(const Sources& sources
     this->accumCTF_.prepareAccumulation();
     this->accumPV_.prepareAccumulation();
 
-    const auto connDP =
-        this->connectionPressureOffset(sources, controls, gravity, refDepth);
+    const auto connDensity =
+        this->connectionDensity(sources, controls, gravity);
 
     if (controls.open_connections()) {
-        this->accumulateLocalContribOpen(sources, controls, connDP);
+        this->accumulateLocalContribOpen(sources, controls,
+                                         gravity, refDepth,
+                                         connDensity);
     }
     else {
-        this->accumulateLocalContribAll(sources, controls, connDP);
+        this->accumulateLocalContribAll(sources, controls,
+                                        gravity, refDepth,
+                                        connDensity);
     }
 }
 
@@ -788,8 +792,7 @@ addConnection(const GridDims&   cellIndexMap,
 
     this->inputConn_.push_back(this->connections_.size());
 
-    this->connections_.emplace_back(conn.CF(), conn.depth(),
-                                    localCellPos->second);
+    this->connections_.emplace_back(conn.CF(), localCellPos->second);
 
     if (conn.dir() == Connection::Direction::X) {
         this->addNeighbours_X(cellIndexMap, setupHelperMap);
@@ -955,7 +958,9 @@ template <typename ConnIndexMap, typename CTFPressureWeightFunction>
 void PAvgCalculator<Scalar>::
 accumulateLocalContributions(const Sources&             sources,
                              const PAvg&                controls,
-                             const std::vector<Scalar>& connDP,
+                             const Scalar               gravity,
+                             const Scalar               refDepth,
+                             const std::vector<Scalar>& connDensity,
                              ConnIndexMap               connIndex,
                              CTFPressureWeightFunction  ctfPressWeight)
 {
@@ -972,13 +977,15 @@ accumulateLocalContributions(const Sources&             sources,
     // Intermediate, per connection results pertaining to CTF-weighted sum.
     auto accumCTF_c = Accumulator{};
 
-    auto addContrib = [&sources, &ctfPressWeight, &accumCTF_c, this]
-        (const ContrIndexType i, const Scalar dp, PressureTermHandler handler)
+    auto addContrib = [gravity, refDepth, &sources, &ctfPressWeight, &accumCTF_c, this]
+        (const ContrIndexType i, const Scalar density, PressureTermHandler handler)
     {
-        using Item = typename PAvgDynamicSourceData<Scalar>::template SourceDataSpan<const Scalar>::Item;
+        using Item = typename PAvgDynamicSourceData<Scalar>::
+            template SourceDataSpan<const Scalar>::Item;
 
         const auto src = sources.wellBlocks()[this->contributingCells_[i]];
-        const auto p   = src[Item::Pressure] + dp;
+        const auto p   = src[Item::Pressure] +
+            pressureOffset(density, src[Item::Depth], gravity, refDepth);
 
         // Use std::invoke() to simplify the calling syntax here.
         std::invoke(handler, accumCTF_c    , ctfPressWeight(src), p);
@@ -990,7 +997,7 @@ accumulateLocalContributions(const Sources&             sources,
         std::pair { &PAvgConnection::diagNeighbours, &Accumulator::addDiagonal },
     };
 
-    const auto nconn = connDP.size();
+    const auto nconn = connDensity.size();
     for (auto connID = 0*nconn; connID < nconn; ++connID) {
         accumCTF_c.prepareAccumulation();
         accumCTF_c.prepareContribution();
@@ -998,12 +1005,12 @@ accumulateLocalContributions(const Sources&             sources,
         const auto& conn = this->connections_[connIndex(connID)];
 
         // 1) Connecting cell
-        addContrib(conn.cell, connDP[connID], &Accumulator::addCentre);
+        addContrib(conn.cell, connDensity[connID], &Accumulator::addCentre);
 
         // 2) Connecting cell's neighbours.
         for (const auto& [neighbours, handler] : handlers) {
             for (const auto& neighIdx : conn.*neighbours) {
-                addContrib(neighIdx, connDP[connID], handler);
+                addContrib(neighIdx, connDensity[connID], handler);
             }
         }
 
@@ -1023,14 +1030,17 @@ template <typename ConnIndexMap>
 void PAvgCalculator<Scalar>::
 accumulateLocalContributions(const Sources&             sources,
                              const PAvg&                controls,
-                             const std::vector<Scalar>& connDP,
+                             const Scalar               gravity,
+                             const Scalar               refDepth,
+                             const std::vector<Scalar>& connDensity,
                              ConnIndexMap&&             connIndex)
 {
     if (controls.inner_weight() < 0.0) {
         // F1 < 0 => pore-volume weighting of individual cell contributions,
         // no weighting when commiting term.
 
-        this->accumulateLocalContributions(sources, controls, connDP,
+        this->accumulateLocalContributions(sources, controls,
+                                           gravity, refDepth, connDensity,
                                            std::forward<ConnIndexMap>(connIndex),
                                            [](const auto& src)
                                            {
@@ -1045,9 +1055,11 @@ accumulateLocalContributions(const Sources&             sources,
         // F1 >= 0 => unit weighting of individual cell contributions,
         // F1-weighting when committing term.
 
-        this->accumulateLocalContributions(sources, controls, connDP,
+        this->accumulateLocalContributions(sources, controls,
+                                           gravity, refDepth, connDensity,
                                            std::forward<ConnIndexMap>(connIndex),
-                                           [](const auto&) { return 1.0; });
+                                           [](const auto&)
+                                           { return static_cast<Scalar>(1.0); });
     }
 }
 
@@ -1055,11 +1067,14 @@ template<class Scalar>
 void PAvgCalculator<Scalar>::
 accumulateLocalContribOpen(const Sources&             sources,
                            const PAvg&                controls,
-                           const std::vector<Scalar>& connDP)
+                           const Scalar               gravity,
+                           const Scalar               refDepth,
+                           const std::vector<Scalar>& connDensity)
 {
-    assert (connDP.size() == this->openConns_.size());
+    assert (connDensity.size() == this->openConns_.size());
 
-    this->accumulateLocalContributions(sources, controls, connDP,
+    this->accumulateLocalContributions(sources, controls,
+                                       gravity, refDepth, connDensity,
                                        [this](const auto i)
                                        { return this->openConns_[i]; });
 }
@@ -1068,52 +1083,46 @@ template<class Scalar>
 void PAvgCalculator<Scalar>::
 accumulateLocalContribAll(const Sources&             sources,
                           const PAvg&                controls,
-                          const std::vector<Scalar>& connDP)
+                          const Scalar               gravity,
+                          const Scalar               refDepth,
+                          const std::vector<Scalar>& connDensity)
 {
-    assert (connDP.size() == this->connections_.size());
+    assert (connDensity.size() == this->connections_.size());
 
-    this->accumulateLocalContributions(sources, controls, connDP,
+    this->accumulateLocalContributions(sources, controls,
+                                       gravity, refDepth, connDensity,
                                        [](const auto i) { return i; });
 }
 
 template<class Scalar>
 template <typename ConnIndexMap>
 std::vector<Scalar> PAvgCalculator<Scalar>::
-connectionPressureOffsetWell(const std::size_t nconn,
-                             const Sources&    sources,
-                             const Scalar      gravity,
-                             const Scalar      refDepth,
-                             ConnIndexMap      connIndex) const
+connectionDensityWell(const std::size_t nconn,
+                      const Sources&    sources,
+                      ConnIndexMap      connIndex) const
 {
-    auto dp = std::vector<Scalar>(nconn);
+    auto connDensity = std::vector<Scalar>(nconn);
 
-    auto density = [&sources, this](const auto connIx)
-    {
-        using Item = typename PAvgDynamicSourceData<Scalar>::template SourceDataSpan<const Scalar>::Item;
+    using Item = typename PAvgDynamicSourceData<Scalar>::
+        template SourceDataSpan<const Scalar>::Item;
 
-        return sources.wellConns()[this->inputConn_[connIx]][Item::MixtureDensity];
-    };
+    const auto& src = sources.wellConns();
 
     for (auto connID = 0*nconn; connID < nconn; ++connID) {
-        const auto connIx = connIndex(connID);
-        const auto depth  = this->connections_[connIx].depth;
-
-        dp[connID] = pressureOffset(density(connIx), depth, gravity, refDepth);
+        connDensity[connID] = src[this->inputConn_[connIndex(connID)]][Item::MixtureDensity];
     }
 
-    return dp;
+    return connDensity;
 }
 
 template<class Scalar>
 template <typename ConnIndexMap>
 std::vector<Scalar> PAvgCalculator<Scalar>::
-connectionPressureOffsetRes(const std::size_t nconn,
-                            const Sources&    sources,
-                            const Scalar      gravity,
-                            const Scalar      refDepth,
-                            ConnIndexMap      connIndex) const
+connectionDensityRes(const std::size_t nconn,
+                     const Sources&    sources,
+                     ConnIndexMap      connIndex) const
 {
-    auto dp = std::vector<Scalar>(nconn);
+    auto connDensity = std::vector<Scalar>(nconn);
 
     const auto neighList = std::array {
         &PAvgConnection::rectNeighbours,
@@ -1124,7 +1133,8 @@ connectionPressureOffsetRes(const std::size_t nconn,
 
     auto includeDensity = [this, &sources, &density](const ContrIndexType i)
     {
-        using Item = typename PAvgDynamicSourceData<Scalar>::template SourceDataSpan<const Scalar>::Item;
+        using Item = typename PAvgDynamicSourceData<Scalar>::
+            template SourceDataSpan<const Scalar>::Item;
 
         const auto src = sources.wellBlocks()[this->contributingCells_[i]];
 
@@ -1144,18 +1154,17 @@ connectionPressureOffsetRes(const std::size_t nconn,
             }
         }
 
-        dp[connID] = pressureOffset(value(density), conn.depth, gravity, refDepth);
+        connDensity[connID] = value(density);
     }
 
-    return dp;
+    return connDensity;
 }
 
 template<class Scalar>
 std::vector<Scalar> PAvgCalculator<Scalar>::
-connectionPressureOffset(const Sources& sources,
-                         const PAvg&    controls,
-                         const Scalar   gravity,
-                         const Scalar   refDepth) const
+connectionDensity(const Sources& sources,
+                  const PAvg&    controls,
+                  const Scalar   gravity) const
 {
     const auto nconn = controls.open_connections()
         ? this->openConns_.size()
@@ -1167,7 +1176,7 @@ connectionPressureOffset(const Sources& sources,
         // No depth correction.  Either because the run explicitly requests
         // NONE for this or all wells, or because gravity effects are turned
         // off (gravity == 0) globally; possibly due to the NOGRAV keyword.
-        // Unexpected case such as denormalised or non-finite values of
+        // Unexpected cases such as denormalised or non-finite values of
         // 'gravity' go here too.
 
         return std::vector<Scalar>(nconn, 0.0);
@@ -1175,15 +1184,13 @@ connectionPressureOffset(const Sources& sources,
 
     if (controls.depth_correction() == PAvg::DepthCorrection::RES) {
         if (! controls.open_connections()) {
-            return this->connectionPressureOffsetRes(nconn, sources, gravity, refDepth,
-                                                     [](const auto i) { return i; });
+            return this->connectionDensityRes(nconn, sources,
+                                              [](const auto i) { return i; });
         }
 
-        return this->connectionPressureOffsetRes(nconn, sources, gravity, refDepth,
-                                                 [this](const auto i)
-                                                 {
-                                                     return this->openConns_[i];
-                                                 });
+        return this->connectionDensityRes(nconn, sources,
+                                          [this](const auto i)
+                                          { return this->openConns_[i]; });
     }
 
     if (controls.depth_correction() != PAvg::DepthCorrection::WELL) {
@@ -1194,15 +1201,13 @@ connectionPressureOffset(const Sources& sources,
     }
 
     if (! controls.open_connections()) {
-        return this->connectionPressureOffsetWell(nconn, sources, gravity, refDepth,
-                                                  [](const auto i) { return i; });
+        return this->connectionDensityWell(nconn, sources,
+                                           [](const auto i) { return i; });
     }
 
-    return this->connectionPressureOffsetWell(nconn, sources, gravity, refDepth,
-                                              [this](const auto i)
-                                              {
-                                                  return this->openConns_[i];
-                                              });
+    return this->connectionDensityWell(nconn, sources,
+                                       [this](const auto i)
+                                       { return this->openConns_[i]; });
 }
 
 // ---------------------------------------------------------------------------

--- a/opm/input/eclipse/Schedule/Well/PAvgCalculator.cpp
+++ b/opm/input/eclipse/Schedule/Well/PAvgCalculator.cpp
@@ -665,6 +665,13 @@ void PAvgCalculator<Scalar>::pruneInactiveWBPCells(const std::vector<bool>& isAc
         this->contributingCells_.swap(newWBPCells);
     }
 
+    // Identify the well cells.  These must be excluded from the neighbour
+    // lists when accumulating per-cell/per-connection contributions.
+    auto isWellCell = std::vector<bool>(allIx.size(), false);
+    for (const auto& conn : this->connections_) {
+        isWellCell[conn.cell] = true;
+    }
+
     // Filter connections_ down to active cells only.
     this->pruneInactiveConnections(isActive);
 
@@ -691,8 +698,9 @@ void PAvgCalculator<Scalar>::pruneInactiveWBPCells(const std::vector<bool>& isAc
             auto newNeigbour = std::vector<ContrIndexType>{};
             newNeigbour.reserve((conn.*neighbours).size());
 
+            // Final neighbourship includes active, non-well cells only.
             for (const auto& neighbour : conn.*neighbours) {
-                if (isActive[neighbour]) {
+                if (isActive[neighbour] && !isWellCell[neighbour]) {
                     newNeigbour.push_back(newIndex[neighbour]);
                 }
             }

--- a/opm/input/eclipse/Schedule/Well/PAvgDynamicSourceData.hpp
+++ b/opm/input/eclipse/Schedule/Well/PAvgDynamicSourceData.hpp
@@ -39,12 +39,13 @@ public:
     /// contiguous range of elements.
     ///
     /// \tparam T Element type.  Const or non-const as needed.  Typically \c
-    ///   double or \code const double \endcode.
-    template<typename T>
+    ///   Scalar or \code const Scalar \endcode.
+    template <typename T>
     class SourceDataSpan
     {
     private:
         friend class PAvgDynamicSourceData<Scalar>;
+
     public:
         /// Supported items of dynamic data per source location
         enum class Item
@@ -52,6 +53,7 @@ public:
             Pressure,           //< Dynamic pressure value
             MixtureDensity,     //< Dynamic mixture density
             PoreVol,            //< Dynamic pore volume
+            Depth,              //< Constant depth location
 
             // ----------------------------------------
 

--- a/tests/test_PAvgCalculator.cpp
+++ b/tests/test_PAvgCalculator.cpp
@@ -715,6 +715,18 @@ namespace {
         }
     }
 
+    void assignCellDepth(const std::vector<double>& depth,
+                         Setup&                     cse)
+    {
+        using Span = std::remove_cv_t<
+            std::remove_reference_t<decltype(cse.blockSource[0])>>;
+        using Item = typename Span::Item;
+
+        for (auto block = 0*depth.size(); block < depth.size(); ++block) {
+            cse.blockSource[cse.wbpCells[block]].set(Item::Depth, depth[block]);
+        }
+    }
+
     void assignConnPress(const std::vector<double>& connPress,
                          Setup&                     cse)
     {
@@ -726,7 +738,9 @@ namespace {
             cse.connSource[conn]
                 .set(Item::Pressure, connPress[conn])
                 .set(Item::PoreVol, 0.5)
-                .set(Item::MixtureDensity, 0.1);
+                .set(Item::MixtureDensity, 0.1)
+                .set(Item::Depth, 0.0) // Unused
+                ;
         }
     }
 
@@ -736,6 +750,12 @@ namespace {
             85.0,  90.0,  95.0,
             90.0, 100.0, 110.0,
             90.0, 100.0, 120.0,
+        }, cse);
+
+        assignCellDepth({
+            2002.5, 2002.5, 2002.5,
+            2002.5, 2002.5, 2002.5,
+            2002.5, 2002.5, 2002.5,
         }, cse);
 
         assignConnPress({80.0}, cse);
@@ -762,6 +782,23 @@ namespace {
             44.5, 54.5, 64.5,
         }, cse);
 
+        assignCellDepth({
+            // K=0
+            2000.5, 2000.5, 2000.5,
+            2000.5, 2000.5, 2000.5,
+            2000.5, 2000.5, 2000.5,
+
+            // K=1
+            2001.5, 2001.5, 2001.5,
+            2001.5, 2001.5, 2001.5,
+            2001.5, 2001.5, 2001.5,
+
+            // K=2
+            2002.5, 2002.5, 2002.5,
+            2002.5, 2002.5, 2002.5,
+            2002.5, 2002.5, 2002.5,
+        }, cse);
+
         assignConnPress({35.0, 37.0, 39.0}, cse);
     }
 
@@ -785,6 +822,23 @@ namespace {
             1315.0,  1258.0,  1326.0,
             1268.0,  1253.0,  1259.0,
             1295.0,  1281.0,  1269.0,
+        }, cse);
+
+        assignCellDepth({
+            // K=0
+            2000.5, 2000.5, 2000.5,
+            2000.5, 2000.5, 2000.5,
+            2000.5, 2000.5, 2000.5,
+
+            // K=1
+            2001.5, 2001.5, 2001.5,
+            2001.5, 2001.5, 2001.5,
+            2001.5, 2001.5, 2001.5,
+
+            // K=2
+            2002.5, 2002.5, 2002.5,
+            2002.5, 2002.5, 2002.5,
+            2002.5, 2002.5, 2002.5,
         }, cse);
 
         assignConnPress({1222.0, 1232.0, 1242.0}, cse);
@@ -1311,6 +1365,41 @@ namespace {
             0.170, 0.110, 0.170,
         };
     }
+
+    std::vector<double> cellDepth()
+    {
+        return {
+            // K=2
+            2002.5, 2002.5, 2002.5,
+            2002.5, 2002.5, 2002.5,
+            2002.5, 2002.5, 2002.5,
+
+            // K=3
+            2003.5, 2003.5, 2003.5,
+            2003.5, 2003.5, 2003.5,
+            2003.5, 2003.5, 2003.5,
+
+            // K=4
+            2004.5, 2004.5, 2004.5,
+            2004.5, 2004.5, 2004.5,
+            2004.5, 2004.5, 2004.5,
+
+            // K=5
+            2005.5, 2005.5, 2005.5,
+            2005.5, 2005.5, 2005.5,
+            2005.5, 2005.5, 2005.5,
+
+            // K=6
+            2006.5, 2006.5, 2006.5,
+            2006.5, 2006.5, 2006.5,
+            2006.5, 2006.5, 2006.5,
+
+            // K=7
+            2007.5, 2007.5, 2007.5,
+            2007.5, 2007.5, 2007.5,
+            2007.5, 2007.5, 2007.5,
+        };
+    }
 } // Anonymous namespace
 
 BOOST_AUTO_TEST_SUITE(Open_Shut)
@@ -1328,19 +1417,24 @@ namespace {
             using Item = typename Span::Item;
 
             const auto cellPress = pressureField();
+            const auto depth = cellDepth();
 
             for (auto block = 0*cellPress.size(); block < cellPress.size(); ++block) {
                 this->blockSource[this->wbpCells[block]]
                     .set(Item::Pressure, cellPress[block])
                     .set(Item::PoreVol, 1.25)
-                    .set(Item::MixtureDensity, 0.1);
+                    .set(Item::MixtureDensity, 0.1)
+                    .set(Item::Depth, depth[block])
+                    ;
             }
 
             for (auto conn = 0*this->wbpConns.size(); conn < this->wbpConns.size(); ++conn) {
                 this->connSource[conn]
                     .set(Item::Pressure, 1222.0)
                     .set(Item::PoreVol, 1.25)
-                    .set(Item::MixtureDensity, 0.1);
+                    .set(Item::MixtureDensity, 0.1)
+                    .set(Item::Depth, 0.0) // Unused
+                    ;
             }
         }
     };
@@ -1407,19 +1501,24 @@ namespace {
 
             const auto cellPress = pressureField();
             const auto poreVol = poreVolume();
+            const auto depth = cellDepth();
 
             for (auto block = 0*cellPress.size(); block < cellPress.size(); ++block) {
                 this->blockSource[this->wbpCells[block]]
                     .set(Item::Pressure, cellPress[block])
                     .set(Item::PoreVol, poreVol[block])
-                    .set(Item::MixtureDensity, 0.1);
+                    .set(Item::MixtureDensity, 0.1)
+                    .set(Item::Depth, depth[block])
+                    ;
             }
 
             for (auto conn = 0*this->wbpConns.size(); conn < this->wbpConns.size(); ++conn) {
                 this->connSource[conn]
                     .set(Item::Pressure, 1222.0)
                     .set(Item::PoreVol, 1.25)
-                    .set(Item::MixtureDensity, 0.1);
+                    .set(Item::MixtureDensity, 0.1)
+                    .set(Item::Depth, 0.0) // Unused
+                    ;
             }
         }
     };
@@ -1490,12 +1589,15 @@ namespace {
             const auto cellPress = pressureField();
             const auto poreVol = poreVolume();
             const auto mixDens = mixtureDensity();
+            const auto depth = cellDepth();
 
             for (auto block = 0*cellPress.size(); block < cellPress.size(); ++block) {
                 this->blockSource[this->wbpCells[block]]
                     .set(Item::Pressure, cellPress[block])
                     .set(Item::PoreVol, poreVol[block])
-                    .set(Item::MixtureDensity, mixDens[block]);
+                    .set(Item::MixtureDensity, mixDens[block])
+                    .set(Item::Depth, depth[block])
+                    ;
             }
 
             const auto wellBoreDens = std::vector {
@@ -1506,7 +1608,9 @@ namespace {
                 this->connSource[conn]
                     .set(Item::Pressure, 1222.0)
                     .set(Item::PoreVol, 1.25)
-                    .set(Item::MixtureDensity, wellBoreDens[conn]);
+                    .set(Item::MixtureDensity, wellBoreDens[conn])
+                    .set(Item::Depth, 0.0) // Unused
+                    ;
             }
         }
     };
@@ -1682,12 +1786,15 @@ namespace {
             const auto cellPress = pressureField();
             const auto poreVol = poreVolume();
             const auto mixDens = mixtureDensity();
+            const auto depth = cellDepth();
 
             for (auto block = 0*cellPress.size(); block < cellPress.size(); ++block) {
                 this->blockSource[this->wbpCells[block]]
                     .set(Item::Pressure, cellPress[block])
                     .set(Item::PoreVol, poreVol[block])
-                    .set(Item::MixtureDensity, mixDens[block]);
+                    .set(Item::MixtureDensity, mixDens[block])
+                    .set(Item::Depth, depth[block])
+                    ;
             }
 
             const auto wellBoreDens = std::vector {
@@ -1698,7 +1805,9 @@ namespace {
                 this->connSource[conn]
                     .set(Item::Pressure, 1222.0)
                     .set(Item::PoreVol, 1.25)
-                    .set(Item::MixtureDensity, wellBoreDens[conn]);
+                    .set(Item::MixtureDensity, wellBoreDens[conn])
+                    .set(Item::Depth, 0.0) // Unused
+                    ;
             }
         }
     };
@@ -1732,3 +1841,188 @@ BOOST_AUTO_TEST_CASE(All_Specified)
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(DepthCorrection_Horizontal_Well)
+
+namespace {
+    namespace Horizontal {
+
+        // Octave: 1234 + fix(100 * rand([5, 3, 2]))
+        std::vector<double> pressureField()
+        {
+            return {
+                // K=2
+                // I=3        I=4           I=5           I=6           I=7
+                1.28300e+03,  1.27900e+03,  1.27800e+03,  1.31800e+03,  1.33200e+03, // J= 8
+                1.24100e+03,  1.32000e+03,  1.26800e+03,  1.29100e+03,  1.28600e+03, // J= 9
+                1.25800e+03,  1.26000e+03,  1.28300e+03,  1.25100e+03,  1.26600e+03, // J=10
+
+                // K=3
+                // I=3        I=4           I=5           I=6           I=7
+                1.32400e+03,  1.32700e+03,  1.24800e+03,  1.27600e+03,  1.25100e+03, // J= 8
+                1.31500e+03,  1.26100e+03,  1.28900e+03,  1.29400e+03,  1.29100e+03, // J= 9
+                1.25200e+03,  1.27600e+03,  1.31300e+03,  1.25600e+03,  1.27500e+03, // J=10
+            };
+        }
+
+        // Octave: fix(1e6 * (123.4 + 56.7*rand([5, 3, 2]))) / 1e6
+        std::vector<double> poreVolume()
+        {
+            return {
+                // K=2
+                // I=3        I=4           I=5           I=6           I=7
+                1.79996e+02,  1.29890e+02,  1.37383e+02,  1.24440e+02,  1.26011e+02, // J= 8
+                1.76635e+02,  1.78395e+02,  1.50687e+02,  1.53171e+02,  1.66701e+02, // J= 9
+                1.65692e+02,  1.33692e+02,  1.27440e+02,  1.25164e+02,  1.72015e+02, // J=10
+
+                // K=3
+                // I=3        I=4           I=5           I=6           I=7
+                1.62943e+02,  1.53786e+02,  1.63148e+02,  1.39431e+02,  1.32052e+02, // J= 8
+                1.74940e+02,  1.62589e+02,  1.57609e+02,  1.63935e+02,  1.78005e+02, // J= 9
+                1.73528e+02,  1.78178e+02,  1.38307e+02,  1.62020e+02,  1.37216e+02, // J=10
+            };
+        }
+
+        // Octave: 0.1 + fix(10 * rand([5, 3, 2])) / 100
+        std::vector<double> mixtureDensity()
+        {
+            return {
+                // K=2
+                // I=3        I=4           I=5           I=6           I=7
+                1.60000e-01,  1.70000e-01,  1.60000e-01,  1.20000e-01,  1.80000e-01, // J= 8
+                1.20000e-01,  1.50000e-01,  1.40000e-01,  1.10000e-01,  1.30000e-01, // J= 9
+                2.00000e-01,  1.20000e-01,  1.00000e-01,  1.10000e-01,  1.30000e-01, // J=10
+
+                // K=3
+                // I=3        I=4           I=5           I=6           I=7
+                1.50000e-01,  1.80000e-01,  1.60000e-01,  1.80000e-01,  1.10000e-01, // J= 8
+                1.40000e-01,  1.00000e-01,  1.10000e-01,  1.10000e-01,  1.20000e-01, // J= 9
+                1.30000e-01,  1.30000e-01,  1.80000e-01,  1.90000e-01,  1.20000e-01, // J=10
+            };
+        }
+
+        std::vector<double> cellDepth()
+        {
+            return {
+                // K=2
+                // I=3        I=4           I=5           I=6           I=7
+                2.00150e+03,  2.00150e+03,  2.00150e+03,  2.00150e+03,  2.00150e+03, // J= 8
+                2.00150e+03,  2.00150e+03,  2.00150e+03,  2.00150e+03,  2.00150e+03, // J= 9
+                2.00150e+03,  2.00150e+03,  2.00150e+03,  2.00150e+03,  2.00150e+03, // J=10
+
+                // K=3
+                // I=3        I=4           I=5           I=6           I=7
+                2.00250e+03,  2.00250e+03,  2.00250e+03,  2.00250e+03,  2.00250e+03, // J= 8
+                2.00250e+03,  2.00250e+03,  2.00250e+03,  2.00250e+03,  2.00250e+03, // J= 9
+                2.00250e+03,  2.00250e+03,  2.00250e+03,  2.00250e+03,  2.00250e+03, // J=10
+            };
+        }
+
+    } // namespace Horizontal
+
+    struct Setup : public CalculatorSetup
+    {
+        Setup()
+            : CalculatorSetup { shoeBox({10, 10, 3}), horizontalProducer_X({10, 10, 3}, 2, 5) }
+        {
+            using Span = std::remove_cv_t<
+                std::remove_reference_t<decltype(this->blockSource[0])>>;
+
+            using Item = typename Span::Item;
+
+            const auto cellPress = Horizontal::pressureField();
+            const auto poreVol = Horizontal::poreVolume();
+            const auto mixDens = Horizontal::mixtureDensity();
+            const auto depth = Horizontal::cellDepth();
+
+            for (auto block = 0*cellPress.size(); block < cellPress.size(); ++block) {
+                this->blockSource[this->wbpCells[block]]
+                    .set(Item::Pressure, cellPress[block])
+                    .set(Item::PoreVol, poreVol[block])
+                    .set(Item::MixtureDensity, mixDens[block])
+                    .set(Item::Depth, depth[block])
+                    ;
+            }
+
+            const auto wellBoreDens = std::vector {
+                0.1, 0.125, 0.15, 0.175, 0.2,
+            };
+
+            for (auto conn = 0*this->wbpConns.size(); conn < this->wbpConns.size(); ++conn) {
+                this->connSource[conn]
+                    .set(Item::Pressure, 1222.0)
+                    .set(Item::PoreVol, 1.25)
+                    .set(Item::MixtureDensity, wellBoreDens[conn])
+                    .set(Item::Depth, 0.0) // Unused
+                    ;
+            }
+        }
+    };
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(TopOfFormation)
+{
+    // Producer connected in X direction in columns 3:7 of row (:,9,3)
+    // meaning cells (3,9,3), (4,9,3), (5,9,3), (6,9,3), and (7,9,3).
+    Setup cse{};
+
+    const auto controls = AveragingControls::DepthCorrection::well_open();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2000.0; // BHP reference depth.  Depth correction in layers 2..3.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculatorResult<double>::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1285.266048437499, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1274.980575312500, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1280.123311874999, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1281.529122624999, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(MiddleOfFormation)
+{
+    // Producer connected in X direction in columns 3:7 of row (:,9,3)
+    // meaning cells (3,9,3), (4,9,3), (5,9,3), (6,9,3), and (7,9,3).
+    Setup cse{};
+
+    const auto controls = AveragingControls::DepthCorrection::well_open();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2001.5; // BHP reference depth.  Depth correction in layer 3.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculatorResult<double>::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1287.656419374999, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1277.370946249999, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1282.513682812499, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1283.919493562499, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(BottomOfFormation)
+{
+    // Producer connected in X direction in columns 3:7 of row (:,9,3)
+    // meaning cells (3,9,3), (4,9,3), (5,9,3), (6,9,3), and (7,9,3).
+    Setup cse{};
+
+    const auto controls = AveragingControls::DepthCorrection::well_open();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2003.0; // BHP reference depth.  Depth correction in layers 2..3.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculatorResult<double>::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1290.046790312499, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1279.761317187499, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1284.904053749999, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1286.309864499999, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // DepthCorrection_Horizontal_Well


### PR DESCRIPTION
The original approach accumulated a per-connection average pressure and then adjusted this to the reference depth using the associated mixture density.  This is mostly okay for normal, vertical wells but biases the result for horizontal connections.  This revised approach uses the common mixture density, but corrects each cell pressure individually based on that cell's centre depth before aggregating the per-connection contributions.

To this end, re-purpose the original `connectionPressureOffset()` member function to compute the mixture density and affect depth correction as part of handling each individual contribution in `accumulateLocalContributions()`.  As a simple, though possibly wasteful, way to get the cell centre depth, defer this calculation to another `DynamicSourceData` item. Doing so increases the amount of information that must be collected per source location by one third (33.3%) and since this information is actually constant we might be able to collect the information just once instead of on each call to `accumulateLocalContributions()`.

For now we nevertheless opt for simplicity while being cognizant that we might have to optimise this implementation in the future.

While here, also exclude well cells from neighbourship contributions of other well cells.  Those cells might unduly bias the WBPn measurement, especially for deviated/horizontal wells in which the connections' direction of intersection change rapidly over a short interval.