### PR TITLE
Some janitoring

### DIFF
--- a/external/resinsight/LibCore/cvfAssert.cpp
+++ b/external/resinsight/LibCore/cvfAssert.cpp
@@ -45,13 +45,9 @@ namespace cvf {
 
 
 // User actions (interactive responses)
-#if 0
-static const int USERACTION_CONTINUE    = 0;
-#endif
 #ifdef WIN32
+static const int USERACTION_CONTINUE    = 0;
 static const int USERACTION_DEBUGBREAK  = 1;
-#endif
-#if 0
 static const int USERACTION_ABORT       = 2;
 #endif
 
@@ -111,7 +107,7 @@ Assert::FailAction AssertHandlerConsole::handleAssert(const char* fileName, int 
 
 #ifdef _MSC_VER
 #if (_MSC_VER >= 1600)
-    if (::IsDebuggerPresent()) 
+    //if (::IsDebuggerPresent())
 #endif
 	{
         __debugbreak();

--- a/opm/input/eclipse/Deck/DeckView.hpp
+++ b/opm/input/eclipse/Deck/DeckView.hpp
@@ -44,8 +44,8 @@ public:
         using reference = const DeckKeyword&;
         using value_type = DeckKeyword;
 
-        const DeckKeyword& operator*()  { return this->inner->get(); }
-        const DeckKeyword* operator->() { return &this->inner->get(); }
+        const DeckKeyword& operator*() const { return this->inner->get(); }
+        const DeckKeyword* operator->() const { return &this->inner->get(); }
 
         Iterator& operator++()    { ++this->inner; return *this; }
         Iterator  operator++(int) { auto tmp = *this; ++this->inner; return tmp; }
@@ -53,8 +53,8 @@ public:
         Iterator& operator--()    { --this->inner; return *this; }
         Iterator  operator--(int) { auto tmp = *this; --this->inner; return tmp; }
 
-        Iterator::difference_type operator-(const Iterator &other) { return this->inner - other.inner; }
-        Iterator operator+(Iterator::difference_type shift) { Iterator tmp = *this; tmp.inner += shift; return tmp;}
+        Iterator::difference_type operator-(const Iterator &other) const { return this->inner - other.inner; }
+        Iterator operator+(Iterator::difference_type shift) const { Iterator tmp = *this; tmp.inner += shift; return tmp;}
 
         friend bool operator== (const Iterator& a, const Iterator& b) { return a.inner == b.inner; };
         friend bool operator<= (const Iterator& a, const Iterator& b) { return a.inner <= b.inner; };

--- a/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -330,22 +330,22 @@ namespace Opm {
                 ! ignoreMultiplierRecord(record.nnc_behaviour);
             };
 
-            multiplier = this->template applyMultiplierDifferentRegion(regMaps,
-                                                                       multiplier,
-                                                                       regionId1,
-                                                                       regionId2,
-                                                                       applyMultiplier,
-                                                                       regPairFoundDifferent);
+            multiplier = this->applyMultiplierDifferentRegion(regMaps,
+                                                              multiplier,
+                                                              regionId1,
+                                                              regionId2,
+                                                              applyMultiplier,
+                                                              regPairFoundDifferent);
             // same region. Note that a pair where both region indices are the same is special.
             // For connections between it and all other regions the multipliers
             // will not override otherwise explicitly specified (as pairs with
             // different ids) multipliers, but accumulated to these.
-            multiplier = this->template applyMultiplierSameRegion(regMaps,
-                                                                  multiplier,
-                                                                  regionId1,
-                                                                  regionId2,
-                                                                  applyMultiplier,
-                                                                  regPairFoundSame);
+            multiplier = this->applyMultiplierSameRegion(regMaps,
+                                                         multiplier,
+                                                         regionId1,
+                                                         regionId2,
+                                                         applyMultiplier,
+                                                         regPairFoundSame);
         }
 
         return multiplier;
@@ -392,22 +392,22 @@ namespace Opm {
                 return (regPairPos != regMap.end());
             };
 
-            multiplier = this->template applyMultiplierSameRegion(regMaps,
-                                                                  multiplier,
-                                                                  regionId1,
-                                                                  regionId2,
-                                                                  applyMultiplier,
-                                                                  regPairFound);
+            multiplier = this->applyMultiplierSameRegion(regMaps,
+                                                         multiplier,
+                                                         regionId1,
+                                                         regionId2,
+                                                         applyMultiplier,
+                                                         regPairFound);
             // same region. Note that a pair where both region indices are the same is special.
             // For connections between it and all other regions the multipliers
             // will not override otherwise explicitly specified (as pairs with
             // different ids) multipliers, but accumulated to these.
-            multiplier = this->template applyMultiplierDifferentRegion(regMaps,
-                                                                       multiplier,
-                                                                       regionId1,
-                                                                       regionId2,
-                                                                       applyMultiplier,
-                                                                       regPairFound);
+            multiplier = this->applyMultiplierDifferentRegion(regMaps,
+                                                              multiplier,
+                                                              regionId1,
+                                                              regionId2,
+                                                              applyMultiplier,
+                                                              regPairFound);
         }
 
         return multiplier;

--- a/opm/input/eclipse/Schedule/Well/PAvgCalculator.cpp
+++ b/opm/input/eclipse/Schedule/Well/PAvgCalculator.cpp
@@ -200,7 +200,7 @@ public:
     /// \return \code *this \endcode
     WeightedRunningAverage& add(const T& x, const W& w = W{1})
     {
-        this->sum_    += w * x;
+        this->sum_    += static_cast<T>(w * x);
         this->weight_ += w;
 
         return *this;


### PR DESCRIPTION
- mark some member functions (operators) const
- cleanup some preprocessor stuff in resinsight code
- remove unnecessary template qualifiers
- add an explicit static cast in case compiler selects the wrong operator*