### PR TITLE
Fix Latent Divide By Zero Error

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -2044,7 +2044,8 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         }
 
         if (report_step == 0) {
-            return this->m_static.rst_config.write_rst_file.value();
+            return this->m_static.rst_config.write_rst_file.has_value()
+                && *this->m_static.rst_config.write_rst_file;
         }
 
         const auto previous_restart_output_step =

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -2036,11 +2036,16 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
 
     bool Schedule::must_write_rst_file(const std::size_t report_step) const
     {
-        if (this->m_static.output_interval.has_value())
-            return this->m_static.output_interval.value() % report_step;
+        if (this->m_static.output_interval.has_value() &&
+            (*this->m_static.output_interval > 0) &&
+            (report_step > 0))
+        {
+            return (report_step % *this->m_static.output_interval) == 0;
+        }
 
-        if (report_step == 0)
+        if (report_step == 0) {
             return this->m_static.rst_config.write_rst_file.value();
+        }
 
         const auto previous_restart_output_step =
             this->restart_output.lastRestartEventBefore(report_step);


### PR DESCRIPTION
If `report_step` is zero, then the current master sources might end up generating a division by zero.  This problem was not noticed by the reviewer when this code was introduced in commit 0eb1b95fc (PR #2347) and has escaped all review until now.

As far as I can tell the `output_interval` isn't really used and the real fix might just be to remove the feature altogether, but that's a larger API change that's better handled in follow-up work.  For now, just ensure that we don't divide by zero and that we implement more or less what the option's intended to do.