### PR TITLE
Simplify Using VSCode Editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@
 .project
 .settings/*
 
+# VSCode
+.vs
+.vscode
+
 # QtCreator project settings
 CMakeLists.txt.user*
 


### PR DESCRIPTION
The VSCode editor likes to put files in a .vs or .vscode directory. Exclude all such files from version control.