### PR TITLE
ACTIONX: mark GRUPTARG, GSATINJE, GSATPROD and TEST as unsupported

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ActionX.cpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.cpp
@@ -119,8 +119,6 @@ bool ActionX::valid_keyword(const std::string& keyword)
         "WPIMULT",
         "WSEGVALV",
         "WTEST", "WTMULT",
-
-        "TEST",
     };
 
     return actionx_allowed_list.find(keyword) != actionx_allowed_list.end();

--- a/opm/input/eclipse/Schedule/Action/ActionX.cpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.cpp
@@ -104,8 +104,7 @@ bool ActionX::valid_keyword(const std::string& keyword)
 
         "GCONINJE", "GCONPROD", "GCONSUMP",
         "GLIFTOPT",
-        "GRUPNET", "GRUPTARG", "GRUPTREE",
-        "GSATINJE", "GSATPROD",
+        "GRUPNET", "GRUPTREE",
 
         "MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-",
         "NEXT", "NEXTSTEP",


### PR DESCRIPTION
- Remove GRUPTARG, GSATINJE and GSATPROD from list of supported keywords by ActionX since they are not supported by flow, see: https://github.com/OPM/opm-simulators/blob/96132fefcf0275a7d6b87de6a5b6e4cc0cb25ed7/opm/simulators/utils/UnsupportedFlowKeywords.cpp#L248, https://github.com/OPM/opm-simulators/blob/96132fefcf0275a7d6b87de6a5b6e4cc0cb25ed7/opm/simulators/utils/UnsupportedFlowKeywords.cpp#L249 and https://github.com/OPM/opm-simulators/blob/96132fefcf0275a7d6b87de6a5b6e4cc0cb25ed7/opm/simulators/utils/UnsupportedFlowKeywords.cpp#L256
- Remove TEST since this is not a keyword