### PR TITLE
Activate WLIST for use in Pyaction

### DIFF
--- a/opm/input/eclipse/Schedule/Action/PyAction.cpp
+++ b/opm/input/eclipse/Schedule/Action/PyAction.cpp
@@ -47,7 +47,7 @@ bool PyAction::valid_keyword(const std::string& keyword) {
         "METRIC", "MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-",
         "NEXT", "NEXTSTEP",
         "WCONINJE", "WCONPROD", "WECON", "WEFAC", "WELOPEN", "WELTARG", "WGRUPCON",
-        "WELSEGS", "WELSPECS", "WSEGVALV", "WTEST", "WTMULT"
+        "WELSEGS", "WELSPECS", "WSEGVALV", "WLIST", "WTEST", "WTMULT"
     };
     return pyaction_allowed_list.find(keyword) != pyaction_allowed_list.end();
 }


### PR DESCRIPTION
This PR depends on https://github.com/OPM/opm-simulators/pull/5836 and https://github.com/OPM/opm-tests/pull/1273.

With this PR, the keyword WLIST is activated for the use in a Pyaction.