### PR TITLE
Improve LGR, NNC and dual porosity support

### DIFF
--- a/opm/io/eclipse/EGrid.cpp
+++ b/opm/io/eclipse/EGrid.cpp
@@ -3,9 +3,8 @@
 
    This file is part of the Open Porous Media project (OPM).
 
-   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
    OPM is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -29,621 +28,628 @@
 #include <fstream>
 #include <iterator>
 #include <numeric>
-#include <string>
 #include <stdexcept>
+#include <string>
 
 
-namespace Opm { namespace EclIO {
-
-using NNCentry = std::tuple<int, int, int, int, int, int, float>;
-
-EGrid::EGrid(const std::string& filename, const std::string& grid_name)
-    : EclFile(filename), inputFileName { filename }, m_grid_name {grid_name}
+namespace Opm
 {
-    initFileName = inputFileName.parent_path() / inputFileName.stem();
-
-    if (this->formattedInput())
-        initFileName += ".FINIT";
-    else
-        initFileName += ".INIT";
-
-    std::string lgrname = "global";
-
-    m_nncs_loaded = false;
-    actnum_array_index = -1;
-    nnc1_array_index = -1;
-    nnc2_array_index = -1;
-    coordsys_array_index = -1;
-    m_radial = false;
-    m_mapaxes_loaded = false;
-    double length_factor = 1.0;
-
-    int hostnum_index = -1;
-
-    for (size_t n = 0; n < array_name.size(); n++) {
-
-        if (array_name[n] == "ENDLGR")
-            lgrname = "global";
-
-        if (array_name[n] == "LGR") {
-            auto lgr = this->get<std::string>(n);
-            lgrname = lgr[0];
-            lgr_names.push_back(lgr[0]);
-        }
-
-        if (array_name[n] == "NNCHEAD"){
-            auto nnchead = this->get<int>(n);
-
-            if (nnchead[1] == 0)
-               lgrname = "global";
-            else
-               lgrname = lgr_names[nnchead[1] - 1];
-        }
-
-        if (array_name[n] == "MAPUNITS"){
-            auto mapunits = this->get<std::string>(n);
-            m_mapunits = mapunits[0];
-            if (m_mapunits == "METRES")
-                length_factor = 1.0;
-            else if (m_mapunits == "FEET")
-                length_factor = 0.3048;
-            else if (m_mapunits == "CM")
-                length_factor = 0.01;
-            else{
-                std::string message = "Unit system " + m_mapunits + " not supported for MAPUNITS";
-                OPM_THROW(std::invalid_argument, message);
-            }
-        }
-
-        if (array_name[n] == "MAPAXES"){
-            const auto& mapAx = this->get<float>(n);
-            std::transform(mapAx.begin(), mapAx.end(), this->m_mapaxes.begin(),
-                           [length_factor](const float elm) { return elm * length_factor; });
-            mapaxes_init();
-            m_mapaxes_loaded = true;
-        }
-
-        if (lgrname == grid_name) {
-            if (array_name[n] == "GRIDHEAD") {
-                auto gridhead = get<int>(n);
-                nijk[0] = gridhead[1];
-                nijk[1] = gridhead[2];
-                nijk[2] = gridhead[3];
-
-                numres = (gridhead.size() > 24)
-                    ? gridhead[24] : 1;
-
-                m_radial = (gridhead.size() > 26)
-                    && (gridhead[26] > 0);
-            }
-
-            if (array_name[n] == "COORD")
-                coord_array_index = n;
-            else if (array_name[n] == "COORDSYS")
-                coordsys_array_index = n;
-            else if (array_name[n] == "ZCORN")
-                zcorn_array_index = n;
-            else if (array_name[n] == "ACTNUM")
-                actnum_array_index= n;
-            else if (array_name[n] == "NNC1")
-                nnc1_array_index = n;
-            else if (array_name[n] == "NNC2")
-                nnc2_array_index = n;
-            else if (array_name[n] == "HOSTNUM")
-                hostnum_index = n;
-        }
-
-        if ((lgrname == "global") && (array_name[n] == "GRIDHEAD")) {
-            auto gridhead = get<int>(n);
-            host_nijk[0] = gridhead[1];
-            host_nijk[1] = gridhead[2];
-            host_nijk[2] = gridhead[3];
-        }
-
-    }
-
-    if (coordsys_array_index == -1){
-        for (int l = 0; l < nijk[2]; l ++)
-            res[l] = 0;
-    } else {
-        auto coordsys = get<int>(coordsys_array_index);
-
-        for (int r = 0; r < numres; r++){
-            int l1 = coordsys[r*6 + 0];
-            int l2 = coordsys[r*6 + 1];
-
-            for (int l = l1 -1; l < l2; l++)
-                res[l] = r;
-        }
-    }
-
-    if (actnum_array_index != -1) {
-        auto actnum = this->get<int>(actnum_array_index);
-        nactive = 0;
-        for (size_t i = 0; i < actnum.size(); i++) {
-            if (actnum[i] > 0) {
-                act_index.push_back(nactive);
-                glob_index.push_back(i);
-                nactive++;
-            } else {
-               act_index.push_back(-1);
-            }
-        }
-    } else {
-        int nCells = nijk[0] * nijk[1] * nijk[2];
-        act_index.resize(nCells);
-        glob_index.resize(nCells);
-        std::iota(act_index.begin(), act_index.end(), 0);
-        std::iota(glob_index.begin(), glob_index.end(), 0);
-    }
-
-    if (hostnum_index > -1){
-        auto hostnum = getImpl(hostnum_index, INTE, inte_array, "integer");
-        host_cells.reserve(hostnum.size());
-
-        std::transform(hostnum.begin(), hostnum.end(),
-                       std::back_inserter(host_cells),
-                       [](const auto& val)
-                       {
-                           return val - 1;
-                       });
-    }
-}
-
-std::vector<std::array<int, 3>> EGrid::hostCellsIJK()
+namespace EclIO
 {
-    std::vector<std::array<int, 3>> res_vect;
-    res_vect.reserve(host_cells.size());
 
-    for (auto val : host_cells){
-        std::array<int, 3> tmp;
-        tmp[2] = val / (host_nijk[0] * host_nijk[1]);
-        int rest = val % (host_nijk[0] * host_nijk[1]);
+    using NNCentry = std::tuple<int, int, int, int, int, int, float>;
 
-        tmp[1] = rest / host_nijk[0];
-        tmp[0] = rest % host_nijk[0];
+    EGrid::EGrid(const std::string& filename, const std::string& grid_name)
+        : EclFile(filename)
+        , inputFileName {filename}
+        , m_grid_name {grid_name}
+    {
+        initFileName = inputFileName.parent_path() / inputFileName.stem();
 
-        res_vect.push_back(tmp);
-    }
-
-    return res_vect;
-}
-
-std::vector<NNCentry> EGrid::get_nnc_ijk()
-{
-    if (!m_nncs_loaded)
-        load_nnc_data();
-
-    std::vector<NNCentry> res_vect;
-    res_vect.reserve(nnc1_array.size());
-
-    for (size_t n=0; n< nnc1_array.size(); n++){
-        auto ijk1 = ijk_from_global_index(nnc1_array[n] - 1);
-        auto ijk2 = ijk_from_global_index(nnc2_array[n] - 1);
-
-        if (transnnc_array.size() > 0)
-            res_vect.push_back({ijk1[0], ijk1[1], ijk1[2], ijk2[0], ijk2[1], ijk2[2], transnnc_array[n]});
+        if (this->formattedInput())
+            initFileName += ".FINIT";
         else
-            res_vect.push_back({ijk1[0], ijk1[1], ijk1[2], ijk2[0], ijk2[1], ijk2[2], -1.0 });
-    }
+            initFileName += ".INIT";
 
-    return res_vect;
-}
+        std::string lgrname = "global";
 
+        m_nncs_loaded = false;
+        actnum_array_index = -1;
+        nnc1_array_index = -1;
+        nnc2_array_index = -1;
+        coordsys_array_index = -1;
+        m_radial = false;
+        m_mapaxes_loaded = false;
+        double length_factor = 1.0;
 
-void EGrid::load_grid_data()
-{
-    coord_array = getImpl(coord_array_index, REAL, real_array, "float");
-    zcorn_array = getImpl(zcorn_array_index, REAL, real_array, "float");
-}
+        int hostnum_index = -1;
 
-void EGrid::load_nnc_data()
-{
-    if ((nnc1_array_index > -1) && (nnc2_array_index > -1)) {
+        for (size_t n = 0; n < array_name.size(); n++) {
 
-        nnc1_array = getImpl(nnc1_array_index, Opm::EclIO::INTE, inte_array, "inte");
-        nnc2_array = getImpl(nnc2_array_index, Opm::EclIO::INTE, inte_array, "inte");
+            if (array_name[n] == "ENDLGR")
+                lgrname = "global";
 
-        if ((std::filesystem::exists(initFileName)) && (nnc1_array.size() > 0)){
-            Opm::EclIO::EInit init(initFileName.generic_string());
-
-            auto init_dims = init.grid_dimension(m_grid_name);
-            int init_nactive = init.activeCells(m_grid_name);
-
-            if (init_dims != nijk){
-                std::string message = "Dimensions of Egrid differ from dimensions found in init file. ";
-                std::string grid_str = std::to_string(nijk[0]) + "x" + std::to_string(nijk[1]) + "x" + std::to_string(nijk[2]);
-                std::string init_str = std::to_string(init_dims[0]) + "x" + std::to_string(init_dims[1]) + "x" + std::to_string(init_dims[2]);
-                message = message + "Egrid: " + grid_str + ". INIT file: " + init_str;
-                OPM_THROW(std::invalid_argument, message);
+            if (array_name[n] == "LGR") {
+                auto lgr = this->get<std::string>(n);
+                lgrname = lgr[0];
+                lgr_names.push_back(lgr[0]);
             }
 
-            if (init_nactive != nactive){
-                std::string message = "Number of active cells are different in Egrid and Init file.";
-                message = message + " Egrid: " + std::to_string(nactive) + ". INIT file: " + std::to_string(init_nactive);
-                OPM_THROW(std::invalid_argument, message);
+            if (array_name[n] == "NNCHEAD") {
+                auto nnchead = this->get<int>(n);
+
+                if (nnchead[1] == 0)
+                    lgrname = "global";
+                else
+                    lgrname = lgr_names[nnchead[1] - 1];
             }
 
-            auto trans_data = init.getInitData<float>("TRANNNC", m_grid_name);
-
-            if (trans_data.size() != nnc1_array.size()){
-                std::string message = "inconsistent size of array TRANNNC in init file. ";
-                message = message + " Size of NNC1 and NNC2: " + std::to_string(nnc1_array.size());
-                message = message + " Size of TRANNNC: " + std::to_string(trans_data.size());
-                OPM_THROW(std::invalid_argument, message);
+            if (array_name[n] == "MAPUNITS") {
+                auto mapunits = this->get<std::string>(n);
+                m_mapunits = mapunits[0];
+                if (m_mapunits == "METRES")
+                    length_factor = 1.0;
+                else if (m_mapunits == "FEET")
+                    length_factor = 0.3048;
+                else if (m_mapunits == "CM")
+                    length_factor = 0.01;
+                else {
+                    std::string message = "Unit system " + m_mapunits + " not supported for MAPUNITS";
+                    OPM_THROW(std::invalid_argument, message);
+                }
             }
 
-            transnnc_array = trans_data;
+            if (array_name[n] == "MAPAXES") {
+                const auto& mapAx = this->get<float>(n);
+                std::transform(mapAx.begin(), mapAx.end(), this->m_mapaxes.begin(), [length_factor](const float elm) {
+                    return elm * length_factor;
+                });
+                mapaxes_init();
+                m_mapaxes_loaded = true;
+            }
+
+            if (lgrname == grid_name) {
+                if (array_name[n] == "GRIDHEAD") {
+                    auto gridhead = get<int>(n);
+                    nijk[0] = gridhead[1];
+                    nijk[1] = gridhead[2];
+                    nijk[2] = gridhead[3];
+
+                    numres = (gridhead.size() > 24) ? gridhead[24] : 1;
+
+                    m_radial = (gridhead.size() > 26) && (gridhead[26] > 0);
+                }
+
+                if (array_name[n] == "COORD")
+                    coord_array_index = n;
+                else if (array_name[n] == "COORDSYS")
+                    coordsys_array_index = n;
+                else if (array_name[n] == "ZCORN")
+                    zcorn_array_index = n;
+                else if (array_name[n] == "ACTNUM")
+                    actnum_array_index = n;
+                else if (array_name[n] == "NNC1")
+                    nnc1_array_index = n;
+                else if (array_name[n] == "NNC2")
+                    nnc2_array_index = n;
+                else if (array_name[n] == "HOSTNUM")
+                    hostnum_index = n;
+            }
+
+            if ((lgrname == "global") && (array_name[n] == "GRIDHEAD")) {
+                auto gridhead = get<int>(n);
+                host_nijk[0] = gridhead[1];
+                host_nijk[1] = gridhead[2];
+                host_nijk[2] = gridhead[3];
+            }
         }
 
-        m_nncs_loaded = true;
-    }
-}
-
-int EGrid::global_index(int i, int j, int k) const
-{
-    if (i < 0 || i >= nijk[0] || j < 0 || j >= nijk[1] || k < 0 || k >= nijk[2]) {
-        OPM_THROW(std::invalid_argument, "i, j or/and k out of range");
-    }
-
-    return i + j * nijk[0] + k * nijk[0] * nijk[1];
-}
-
-
-int EGrid::active_index(int i, int j, int k) const
-{
-    int n = i + j * nijk[0] + k * nijk[0] * nijk[1];
-
-    if (i < 0 || i >= nijk[0] || j < 0 || j >= nijk[1] || k < 0 || k >= nijk[2]) {
-        OPM_THROW(std::invalid_argument, "i, j or/and k out of range");
-    }
-
-    return act_index[n];
-}
-
-
-std::array<int, 3> EGrid::ijk_from_active_index(int actInd) const
-{
-    if (actInd < 0 || actInd >= nactive) {
-        OPM_THROW(std::invalid_argument, "active index out of range");
-    }
-
-    int _glob = glob_index[actInd];
-
-    std::array<int, 3> result;
-    result[2] = _glob / (nijk[0] * nijk[1]);
-
-    int rest = _glob % (nijk[0] * nijk[1]);
-
-    result[1] = rest / nijk[0];
-    result[0] = rest % nijk[0];
-
-    return result;
-}
-
-
-std::array<int, 3> EGrid::ijk_from_global_index(int globInd) const
-{
-    if (globInd < 0 || globInd >= nijk[0] * nijk[1] * nijk[2]) {
-        OPM_THROW(std::invalid_argument, "global index out of range");
-    }
-
-    std::array<int, 3> result;
-    result[2] = globInd / (nijk[0] * nijk[1]);
-
-    int rest = globInd % (nijk[0] * nijk[1]);
-
-    result[1] = rest / nijk[0];
-    result[0] = rest % nijk[0];
-
-    return result;
-}
-
-void EGrid::mapaxes_transform(double& x, double& y) const {
-    double tmpx = x;
-    x = origin[0] + tmpx * unit_x[0] + y * unit_y[0];
-    y = origin[1] + tmpx * unit_x[1] + y * unit_y[1];
-}
-
-void EGrid::mapaxes_init()
-{
-    origin = {m_mapaxes[2], m_mapaxes[3]};
-    unit_x = {m_mapaxes[4] - m_mapaxes[2], m_mapaxes[5] - m_mapaxes[3]};
-    unit_y = {m_mapaxes[0] - m_mapaxes[2], m_mapaxes[1] - m_mapaxes[3]};
-
-    auto norm_x = 1.0 / std::hypot(unit_x[0], unit_x[1]);
-    auto norm_y = 1.0 / std::hypot(unit_y[0], unit_y[1]);
-
-    unit_x[0] *= norm_x;
-    unit_x[1] *= norm_x;
-    unit_y[0] *= norm_y;
-    unit_y[1] *= norm_y;
-}
-
-void EGrid::getCellCorners(const std::array<int, 3>& ijk,
-                           std::array<double, 8>& X,
-                           std::array<double, 8>& Y,
-                           std::array<double, 8>& Z)
-{
-    if (coord_array.empty())
-        load_grid_data();
-
-    std::vector<int> zind;
-    std::vector<int> pind;
-
-    int res_shift = res.at(ijk[2])*(nijk[0]+1)*(nijk[1]+1)*6;
-    
-   // calculate indices for grid pillars in COORD arrray
-    pind.push_back(res_shift + ijk[1]*(nijk[0]+1)*6 + ijk[0]*6);
-    pind.push_back(pind[0] + 6);
-    pind.push_back(pind[0] + (nijk[0]+1)*6);
-    pind.push_back(pind[2] + 6);
-
-    // get depths from zcorn array in ZCORN array
-    zind.push_back(ijk[2]*nijk[0]*nijk[1]*8 + ijk[1]*nijk[0]*4 + ijk[0]*2);
-    zind.push_back(zind[0] + 1);
-    zind.push_back(zind[0] + nijk[0]*2);
-    zind.push_back(zind[2] + 1);
-
-    for (int n = 0; n < 4; n++)
-        zind.push_back(zind[n] + nijk[0]*nijk[1]*4);
-
-    for (int n = 0; n < 8; n++)
-        Z[n] = zcorn_array[zind[n]];
-
-    for (int  n = 0; n < 4; n++) {
-        double xt;
-        double yt;
-        double xb;
-        double yb;
-
-        double zt = coord_array[pind[n] + 2];
-        double zb = coord_array[pind[n] + 5];
-
-        if (m_radial) {
-            xt = coord_array[pind[n]] * cos(coord_array[pind[n] + 1] / 180.0 * M_PI);
-            yt = coord_array[pind[n]] * sin(coord_array[pind[n] + 1] / 180.0 * M_PI);
-            xb = coord_array[pind[n] + 3] * cos(coord_array[pind[n] + 4] / 180.0 * M_PI);
-            yb = coord_array[pind[n] + 3] * sin(coord_array[pind[n] + 4] / 180.0 * M_PI);
+        if (coordsys_array_index == -1) {
+            for (int l = 0; l < nijk[2]; l++)
+                res[l] = 0;
         } else {
+            auto coordsys = get<int>(coordsys_array_index);
+
+            for (int r = 0; r < numres; r++) {
+                int l1 = coordsys[r * 6 + 0];
+                int l2 = coordsys[r * 6 + 1];
+
+                for (int l = l1 - 1; l < l2; l++)
+                    res[l] = r;
+            }
+        }
+
+        if (actnum_array_index != -1) {
+            auto actnum = this->get<int>(actnum_array_index);
+            nactive = 0;
+            for (size_t i = 0; i < actnum.size(); i++) {
+                if (actnum[i] > 0) {
+                    act_index.push_back(nactive);
+                    glob_index.push_back(i);
+                    nactive++;
+                } else {
+                    act_index.push_back(-1);
+                }
+            }
+        } else {
+            int nCells = nijk[0] * nijk[1] * nijk[2];
+            act_index.resize(nCells);
+            glob_index.resize(nCells);
+            std::iota(act_index.begin(), act_index.end(), 0);
+            std::iota(glob_index.begin(), glob_index.end(), 0);
+        }
+
+        if (hostnum_index > -1) {
+            auto hostnum = getImpl(hostnum_index, INTE, inte_array, "integer");
+            host_cells.reserve(hostnum.size());
+
+            std::transform(hostnum.begin(), hostnum.end(), std::back_inserter(host_cells), [](const auto& val) {
+                return val - 1;
+            });
+        }
+    }
+
+    std::vector<std::array<int, 3>> EGrid::hostCellsIJK()
+    {
+        std::vector<std::array<int, 3>> res_vect;
+        res_vect.reserve(host_cells.size());
+
+        for (auto val : host_cells) {
+            std::array<int, 3> tmp;
+            tmp[2] = val / (host_nijk[0] * host_nijk[1]);
+            int rest = val % (host_nijk[0] * host_nijk[1]);
+
+            tmp[1] = rest / host_nijk[0];
+            tmp[0] = rest % host_nijk[0];
+
+            res_vect.push_back(tmp);
+        }
+
+        return res_vect;
+    }
+
+    std::vector<NNCentry> EGrid::get_nnc_ijk()
+    {
+        if (!m_nncs_loaded)
+            load_nnc_data();
+
+        std::vector<NNCentry> res_vect;
+        res_vect.reserve(nnc1_array.size());
+
+        for (size_t n = 0; n < nnc1_array.size(); n++) {
+            auto ijk1 = ijk_from_global_index(nnc1_array[n] - 1);
+            auto ijk2 = ijk_from_global_index(nnc2_array[n] - 1);
+
+            if (transnnc_array.size() > 0)
+                res_vect.push_back({ijk1[0], ijk1[1], ijk1[2], ijk2[0], ijk2[1], ijk2[2], transnnc_array[n]});
+            else
+                res_vect.push_back({ijk1[0], ijk1[1], ijk1[2], ijk2[0], ijk2[1], ijk2[2], -1.0});
+        }
+
+        return res_vect;
+    }
+
+
+    void EGrid::load_grid_data()
+    {
+        coord_array = getImpl(coord_array_index, REAL, real_array, "float");
+        zcorn_array = getImpl(zcorn_array_index, REAL, real_array, "float");
+    }
+
+    void EGrid::load_nnc_data()
+    {
+        if ((nnc1_array_index > -1) && (nnc2_array_index > -1)) {
+
+            nnc1_array = getImpl(nnc1_array_index, Opm::EclIO::INTE, inte_array, "inte");
+            nnc2_array = getImpl(nnc2_array_index, Opm::EclIO::INTE, inte_array, "inte");
+
+            if ((std::filesystem::exists(initFileName)) && (nnc1_array.size() > 0)) {
+                Opm::EclIO::EInit init(initFileName.generic_string());
+
+                auto init_dims = init.grid_dimension(m_grid_name);
+                int init_nactive = init.activeCells(m_grid_name);
+
+                if (init_dims != nijk) {
+                    std::string message = "Dimensions of Egrid differ from dimensions found in init file. ";
+                    std::string grid_str
+                        = std::to_string(nijk[0]) + "x" + std::to_string(nijk[1]) + "x" + std::to_string(nijk[2]);
+                    std::string init_str = std::to_string(init_dims[0]) + "x" + std::to_string(init_dims[1]) + "x"
+                        + std::to_string(init_dims[2]);
+                    message = message + "Egrid: " + grid_str + ". INIT file: " + init_str;
+                    OPM_THROW(std::invalid_argument, message);
+                }
+
+                if (init_nactive != nactive) {
+                    std::string message = "Number of active cells are different in Egrid and Init file.";
+                    message = message + " Egrid: " + std::to_string(nactive)
+                        + ". INIT file: " + std::to_string(init_nactive);
+                    OPM_THROW(std::invalid_argument, message);
+                }
+
+                auto trans_data = init.getInitData<float>("TRANNNC", m_grid_name);
+
+                if (trans_data.size() != nnc1_array.size()) {
+                    std::string message = "inconsistent size of array TRANNNC in init file. ";
+                    message = message + " Size of NNC1 and NNC2: " + std::to_string(nnc1_array.size());
+                    message = message + " Size of TRANNNC: " + std::to_string(trans_data.size());
+                    OPM_THROW(std::invalid_argument, message);
+                }
+
+                transnnc_array = trans_data;
+            }
+
+            m_nncs_loaded = true;
+        }
+    }
+
+    int EGrid::global_index(int i, int j, int k) const
+    {
+        if (i < 0 || i >= nijk[0] || j < 0 || j >= nijk[1] || k < 0 || k >= nijk[2]) {
+            OPM_THROW(std::invalid_argument, "i, j or/and k out of range");
+        }
+
+        return i + j * nijk[0] + k * nijk[0] * nijk[1];
+    }
+
+
+    int EGrid::active_index(int i, int j, int k) const
+    {
+        int n = i + j * nijk[0] + k * nijk[0] * nijk[1];
+
+        if (i < 0 || i >= nijk[0] || j < 0 || j >= nijk[1] || k < 0 || k >= nijk[2]) {
+            OPM_THROW(std::invalid_argument, "i, j or/and k out of range");
+        }
+
+        return act_index[n];
+    }
+
+
+    std::array<int, 3> EGrid::ijk_from_active_index(int actInd) const
+    {
+        if (actInd < 0 || actInd >= nactive) {
+            OPM_THROW(std::invalid_argument, "active index out of range");
+        }
+
+        int _glob = glob_index[actInd];
+
+        std::array<int, 3> result;
+        result[2] = _glob / (nijk[0] * nijk[1]);
+
+        int rest = _glob % (nijk[0] * nijk[1]);
+
+        result[1] = rest / nijk[0];
+        result[0] = rest % nijk[0];
+
+        return result;
+    }
+
+
+    std::array<int, 3> EGrid::ijk_from_global_index(int globInd) const
+    {
+        if (globInd < 0 || globInd >= nijk[0] * nijk[1] * nijk[2]) {
+            OPM_THROW(std::invalid_argument, "global index out of range");
+        }
+
+        std::array<int, 3> result;
+        result[2] = globInd / (nijk[0] * nijk[1]);
+
+        int rest = globInd % (nijk[0] * nijk[1]);
+
+        result[1] = rest / nijk[0];
+        result[0] = rest % nijk[0];
+
+        return result;
+    }
+
+    void EGrid::mapaxes_transform(double& x, double& y) const
+    {
+        double tmpx = x;
+        x = origin[0] + tmpx * unit_x[0] + y * unit_y[0];
+        y = origin[1] + tmpx * unit_x[1] + y * unit_y[1];
+    }
+
+    void EGrid::mapaxes_init()
+    {
+        origin = {m_mapaxes[2], m_mapaxes[3]};
+        unit_x = {m_mapaxes[4] - m_mapaxes[2], m_mapaxes[5] - m_mapaxes[3]};
+        unit_y = {m_mapaxes[0] - m_mapaxes[2], m_mapaxes[1] - m_mapaxes[3]};
+
+        auto norm_x = 1.0 / std::hypot(unit_x[0], unit_x[1]);
+        auto norm_y = 1.0 / std::hypot(unit_y[0], unit_y[1]);
+
+        unit_x[0] *= norm_x;
+        unit_x[1] *= norm_x;
+        unit_y[0] *= norm_y;
+        unit_y[1] *= norm_y;
+    }
+
+    void EGrid::getCellCorners(const std::array<int, 3>& ijk,
+                               std::array<double, 8>& X,
+                               std::array<double, 8>& Y,
+                               std::array<double, 8>& Z)
+    {
+        if (coord_array.empty())
+            load_grid_data();
+
+        std::vector<int> zind;
+        std::vector<int> pind;
+
+        int res_shift = res.at(ijk[2]) * (nijk[0] + 1) * (nijk[1] + 1) * 6;
+
+        // calculate indices for grid pillars in COORD arrray
+        pind.push_back(res_shift + ijk[1] * (nijk[0] + 1) * 6 + ijk[0] * 6);
+        pind.push_back(pind[0] + 6);
+        pind.push_back(pind[0] + (nijk[0] + 1) * 6);
+        pind.push_back(pind[2] + 6);
+
+        // get depths from zcorn array in ZCORN array
+        zind.push_back(ijk[2] * nijk[0] * nijk[1] * 8 + ijk[1] * nijk[0] * 4 + ijk[0] * 2);
+        zind.push_back(zind[0] + 1);
+        zind.push_back(zind[0] + nijk[0] * 2);
+        zind.push_back(zind[2] + 1);
+
+        for (int n = 0; n < 4; n++)
+            zind.push_back(zind[n] + nijk[0] * nijk[1] * 4);
+
+        for (int n = 0; n < 8; n++)
+            Z[n] = zcorn_array[zind[n]];
+
+        for (int n = 0; n < 4; n++) {
+            double xt;
+            double yt;
+            double xb;
+            double yb;
+
+            double zt = coord_array[pind[n] + 2];
+            double zb = coord_array[pind[n] + 5];
+
+            if (m_radial) {
+                xt = coord_array[pind[n]] * cos(coord_array[pind[n] + 1] / 180.0 * M_PI);
+                yt = coord_array[pind[n]] * sin(coord_array[pind[n] + 1] / 180.0 * M_PI);
+                xb = coord_array[pind[n] + 3] * cos(coord_array[pind[n] + 4] / 180.0 * M_PI);
+                yb = coord_array[pind[n] + 3] * sin(coord_array[pind[n] + 4] / 180.0 * M_PI);
+            } else {
+                xt = coord_array[pind[n]];
+                yt = coord_array[pind[n] + 1];
+                xb = coord_array[pind[n] + 3];
+                yb = coord_array[pind[n] + 4];
+            }
+
+            if (zt == zb) {
+                X[n] = xt;
+                X[n + 4] = xt;
+                Y[n] = yt;
+                Y[n + 4] = yt;
+            } else {
+                X[n] = xt + (xb - xt) / (zt - zb) * (zt - Z[n]);
+                X[n + 4] = xt + (xb - xt) / (zt - zb) * (zt - Z[n + 4]);
+                Y[n] = yt + (yb - yt) / (zt - zb) * (zt - Z[n]);
+                Y[n + 4] = yt + (yb - yt) / (zt - zb) * (zt - Z[n + 4]);
+            }
+        }
+    }
+
+
+    void
+    EGrid::getCellCorners(int globindex, std::array<double, 8>& X, std::array<double, 8>& Y, std::array<double, 8>& Z)
+    {
+        return getCellCorners(ijk_from_global_index(globindex), X, Y, Z);
+    }
+
+
+    std::vector<std::array<float, 3>> EGrid::getXYZ_layer(int layer, const std::array<int, 4>& box, bool bottom)
+    {
+        // layer is layer index, zero based. The box array is i and j range (i1,i2,j1,j2), also zero based
+
+        if ((layer < 0) || (layer > (nijk[2] - 1))) {
+            std::string message = "invalid layer index " + std::to_string(layer) + ". Valid range [0, ";
+            message = message + std::to_string(nijk[2] - 1) + "]";
+            throw std::invalid_argument(message);
+        }
+
+        if ((box[0] < 0) || (box[0] + 1 > nijk[0]) || (box[1] < 0) || (box[1] + 1 > nijk[0]) || (box[2] < 0)
+            || (box[2] + 1 > nijk[1]) || (box[3] < 0) || (box[3] + 1 > nijk[1]) || (box[0] > box[1])
+            || (box[2] > box[3])) {
+
+            throw std::invalid_argument("invalid box input, i1,i2,j1 or j2 out of valid range ");
+        }
+
+        int nodes_pr_surf = nijk[0] * nijk[1] * 4;
+        int zcorn_offset = nodes_pr_surf * layer * 2;
+
+        if (bottom)
+            zcorn_offset += nodes_pr_surf;
+
+        std::vector<float> layer_zcorn;
+        layer_zcorn.reserve(nodes_pr_surf);
+
+        std::vector<std::array<float, 3>> xyz_vector;
+
+        if (coord_array.size() == 0)
+            coord_array = getImpl(coord_array_index, REAL, real_array, "float");
+
+        if (zcorn_array.size() > 0) {
+            for (size_t n = 0; n < static_cast<size_t>(nodes_pr_surf); n++)
+                layer_zcorn.push_back(zcorn_array[zcorn_offset + n]);
+
+        } else {
+            layer_zcorn = get_zcorn_from_disk(layer, bottom);
+        }
+
+        std::array<double, 4> X;
+        std::array<double, 4> Y;
+        std::array<double, 4> Z;
+
+        std::array<int, 3> ijk;
+        ijk[2] = 0;
+
+        for (int j = box[2]; j < (box[3] + 1); j++) {
+            for (int i = box[0]; i < (box[1] + 1); i++) {
+
+                ijk[0] = i;
+                ijk[1] = j;
+
+                this->getCellCorners(ijk, layer_zcorn, X, Y, Z);
+
+                for (size_t n = 0; n < 4; n++) {
+                    std::array<float, 3> xyz;
+                    xyz[0] = X[n];
+                    xyz[1] = Y[n];
+                    xyz[2] = Z[n];
+
+                    xyz_vector.push_back(xyz);
+                }
+            }
+        }
+
+        return xyz_vector;
+    }
+
+
+    std::vector<std::array<float, 3>> EGrid::getXYZ_layer(int layer, bool bottom)
+    {
+        std::array<int, 4> box = {0, nijk[0] - 1, 0, nijk[1] - 1};
+        return this->getXYZ_layer(layer, box, bottom);
+    }
+
+
+    std::vector<float> EGrid::get_zcorn_from_disk(int layer, bool bottom)
+    {
+        if (formatted)
+            throw std::invalid_argument("partial loading of zcorn arrays not possible when using formatted input");
+
+        std::vector<float> zcorn_layer;
+        std::fstream fileH;
+
+        int nodes_pr_surf = nijk[0] * nijk[1] * 4;
+        int zcorn_offset = nodes_pr_surf * layer * 2;
+
+        if (bottom)
+            zcorn_offset += nodes_pr_surf;
+
+        fileH.open(inputFileName, std::ios::in | std::ios::binary);
+
+        if (!fileH)
+            throw std::runtime_error("Can not open EGrid file" + this->inputFilename);
+
+        std::string arrName(8, ' ');
+        eclArrType arrType;
+        int64_t num;
+        int sizeOfElement;
+
+        uint64_t zcorn_pos = 0;
+
+        while (!isEOF(&fileH)) {
+
+            readBinaryHeader(fileH, arrName, num, arrType, sizeOfElement);
+
+            if (arrName == "ZCORN   ") {
+                zcorn_pos = fileH.tellg();
+                break;
+            }
+
+            uint64_t sizeOfNextArray = sizeOnDiskBinary(num, arrType, sizeOfElement);
+            fileH.seekg(static_cast<std::streamoff>(sizeOfNextArray), std::ios_base::cur);
+        }
+
+        int elements_pr_block = Opm::EclIO::MaxBlockSizeReal / Opm::EclIO::sizeOfReal;
+        int num_blocks_start = zcorn_offset / elements_pr_block;
+
+        // adding size of zcorn real data before to ignored
+        uint64_t start_pos = zcorn_pos + Opm::EclIO::sizeOfReal * zcorn_offset;
+
+        // adding size of blocks (head and tail flags)
+        start_pos = start_pos + (1 + num_blocks_start * 2) * Opm::EclIO::sizeOfInte;
+
+        fileH.seekg(start_pos, std::ios_base::beg);
+
+        uint64_t zcorn_to = zcorn_offset + nodes_pr_surf;
+
+        int i1 = zcorn_offset / 1000 + 1;
+        uint64_t elemets = static_cast<uint64_t>(i1 * elements_pr_block - zcorn_offset);
+
+        uint64_t next_block = elemets < zcorn_to ? elemets : zcorn_to - zcorn_offset + 1;
+
+        uint64_t p1 = zcorn_offset;
+
+        while (p1 < zcorn_to) {
+
+            std::vector<float> buf(next_block);
+            fileH.read(reinterpret_cast<char*>(buf.data()), buf.size() * sizeof(float));
+
+            for (size_t n = 0; n < next_block; n++)
+                zcorn_layer.push_back(Opm::EclIO::flipEndianFloat(buf[n]));
+
+            p1 = p1 + next_block;
+
+            if (p1 < zcorn_to) {
+                int dtail;
+                fileH.read(reinterpret_cast<char*>(&dtail), sizeof(dtail));
+                fileH.read(reinterpret_cast<char*>(&dtail), sizeof(dtail));
+                dtail = Opm::EclIO::flipEndianInt(dtail);
+
+                next_block = static_cast<uint64_t>(dtail) / static_cast<uint64_t>(Opm::EclIO::sizeOfReal);
+
+                if ((p1 + next_block) > zcorn_to)
+                    next_block = zcorn_to - p1;
+            }
+        }
+
+        fileH.close();
+
+        return zcorn_layer;
+    }
+
+
+    void EGrid::getCellCorners(const std::array<int, 3>& ijk,
+                               const std::vector<float>& zcorn_layer,
+                               std::array<double, 4>& X,
+                               std::array<double, 4>& Y,
+                               std::array<double, 4>& Z)
+    {
+        std::vector<int> zind;
+        std::vector<int> pind;
+
+        // calculate indices for grid pillars in COORD arrray
+        pind.push_back(ijk[1] * (nijk[0] + 1) * 6 + ijk[0] * 6);
+        pind.push_back(pind[0] + 6);
+        pind.push_back(pind[0] + (nijk[0] + 1) * 6);
+        pind.push_back(pind[2] + 6);
+
+        // get depths from zcorn array in ZCORN array
+        zind.push_back(ijk[2] * nijk[0] * nijk[1] * 8 + ijk[1] * nijk[0] * 4 + ijk[0] * 2);
+        zind.push_back(zind[0] + 1);
+        zind.push_back(zind[0] + nijk[0] * 2);
+        zind.push_back(zind[2] + 1);
+
+        for (int n = 0; n < 4; n++)
+            Z[n] = zcorn_layer[zind[n]];
+
+        for (int n = 0; n < 4; n++) {
+            double xt;
+            double yt;
+            double xb;
+            double yb;
+
+            double zt = coord_array[pind[n] + 2];
+            double zb = coord_array[pind[n] + 5];
+
             xt = coord_array[pind[n]];
             yt = coord_array[pind[n] + 1];
             xb = coord_array[pind[n] + 3];
             yb = coord_array[pind[n] + 4];
-        }
 
-        if (zt == zb) {
-            X[n] = xt;
-            X[n+4] = xt;
-            Y[n] = yt;
-            Y[n+4] = yt;
-        } else {
-            X[n] = xt + (xb-xt) / (zt-zb) * (zt - Z[n]);
-            X[n+4] = xt + (xb-xt) / (zt-zb) * (zt-Z[n+4]);
-            Y[n] = yt+(yb-yt)/(zt-zb)*(zt-Z[n]);
-            Y[n+4] = yt+(yb-yt)/(zt-zb)*(zt-Z[n+4]);
-        }
-    }
-}
-
-
-void EGrid::getCellCorners(int globindex, std::array<double, 8>& X,
-                           std::array<double, 8>& Y, std::array<double, 8>& Z)
-{
-    return getCellCorners(ijk_from_global_index(globindex), X, Y, Z);
-}
-
-
-std::vector<std::array<float, 3>> EGrid::getXYZ_layer(int layer, const std::array<int, 4>& box, bool bottom)
-{
-   // layer is layer index, zero based. The box array is i and j range (i1,i2,j1,j2), also zero based
-
-    if ((layer < 0) || (layer > (nijk[2] -1))){
-        std::string message = "invalid layer index " + std::to_string(layer) + ". Valid range [0, ";
-        message = message + std::to_string(nijk[2] -1) + "]";
-        throw std::invalid_argument(message);
-    }
-
-    if ((box[0] < 0) || (box[0]+1 > nijk[0]) || (box[1] < 0) || (box[1]+1 > nijk[0]) ||
-         (box[2] < 0) || (box[2]+1 > nijk[1]) || (box[3] < 0) || (box[3]+1 > nijk[1]) ||
-           (box[0] > box[1]) || (box[2] > box[3])){
-
-        throw std::invalid_argument("invalid box input, i1,i2,j1 or j2 out of valid range ");
-    }
-
-    int nodes_pr_surf = nijk[0]*nijk[1]*4;
-    int zcorn_offset = nodes_pr_surf * layer * 2;
-
-    if (bottom)
-        zcorn_offset += nodes_pr_surf;
-
-    std::vector<float> layer_zcorn;
-    layer_zcorn.reserve(nodes_pr_surf);
-
-    std::vector<std::array<float, 3>> xyz_vector;
-
-    if (coord_array.size() == 0)
-        coord_array = getImpl(coord_array_index, REAL, real_array, "float");
-
-    if (zcorn_array.size() > 0){
-        for (size_t n = 0; n < static_cast<size_t>(nodes_pr_surf); n++)
-            layer_zcorn.push_back(zcorn_array[zcorn_offset + n]);
-
-    } else {
-        layer_zcorn = get_zcorn_from_disk(layer, bottom);
-    }
-
-    std::array<double,4> X;
-    std::array<double,4> Y;
-    std::array<double,4> Z;
-
-    std::array<int,3> ijk;
-    ijk[2]=0;
-
-    for (int j = box[2]; j < (box[3] + 1); j++) {
-        for (int i = box[0]; i < (box[1] + 1); i++) {
-
-            ijk[0]=i;
-            ijk[1]=j;
-
-            this->getCellCorners(ijk, layer_zcorn, X, Y, Z );
-
-            for (size_t n = 0; n < 4; n++){
-                std::array<float, 3> xyz;
-                xyz[0] = X[n];
-                xyz[1] = Y[n];
-                xyz[2] = Z[n];
-
-                xyz_vector.push_back(xyz);
+            if (zt == zb) {
+                X[n] = xt;
+                Y[n] = yt;
+            } else {
+                X[n] = xt + (xb - xt) / (zt - zb) * (zt - Z[n]);
+                Y[n] = yt + (yb - yt) / (zt - zb) * (zt - Z[n]);
             }
         }
     }
 
-    return xyz_vector;
-}
 
 
-std::vector<std::array<float, 3>> EGrid::getXYZ_layer(int layer, bool bottom)
-{
-    std::array<int, 4> box = {0, nijk[0] -1 , 0, nijk[1] -1 };
-    return this->getXYZ_layer(layer, box, bottom);
-}
-
-
-std::vector<float> EGrid::  get_zcorn_from_disk(int layer, bool bottom)
-{
-    if (formatted)
-        throw std::invalid_argument("partial loading of zcorn arrays not possible when using formatted input");
-
-    std::vector<float> zcorn_layer;
-    std::fstream fileH;
-
-    int nodes_pr_surf = nijk[0]*nijk[1]*4;
-    int zcorn_offset = nodes_pr_surf * layer * 2;
-
-    if (bottom)
-        zcorn_offset+=nodes_pr_surf;
-
-    fileH.open(inputFileName, std::ios::in |  std::ios::binary);
-
-    if (!fileH)
-        throw std::runtime_error("Can not open EGrid file" + this->inputFilename);
-
-    std::string arrName(8,' ');
-    eclArrType arrType;
-    int64_t num;
-    int sizeOfElement;
-
-    uint64_t zcorn_pos = 0;
-
-    while (!isEOF(&fileH)) {
-
-        readBinaryHeader(fileH,arrName,num, arrType, sizeOfElement);
-
-        if (arrName == "ZCORN   "){
-            zcorn_pos = fileH.tellg();
-            break;
-        }
-
-        uint64_t sizeOfNextArray = sizeOnDiskBinary(num, arrType, sizeOfElement);
-        fileH.seekg(static_cast<std::streamoff>(sizeOfNextArray), std::ios_base::cur);
-    }
-
-    int elements_pr_block = Opm::EclIO::MaxBlockSizeReal / Opm::EclIO::sizeOfReal;
-    int num_blocks_start = zcorn_offset / elements_pr_block;
-
-    // adding size of zcorn real data before to ignored
-    uint64_t start_pos = zcorn_pos + Opm::EclIO::sizeOfReal * zcorn_offset;
-
-    // adding size of blocks (head and tail flags)
-    start_pos = start_pos + (1 + num_blocks_start * 2) * Opm::EclIO::sizeOfInte;
-
-    fileH.seekg(start_pos, std::ios_base::beg);
-
-    uint64_t zcorn_to = zcorn_offset + nodes_pr_surf;
-
-    int i1 = zcorn_offset / 1000 + 1;
-    uint64_t elemets = static_cast<uint64_t>(i1 * elements_pr_block - zcorn_offset);
-
-    uint64_t next_block = elemets < zcorn_to ? elemets : zcorn_to - zcorn_offset + 1 ;
-
-    uint64_t p1 = zcorn_offset;
-
-    while (p1 < zcorn_to){
-
-        std::vector<float> buf(next_block);
-        fileH.read(reinterpret_cast<char*>(buf.data()), buf.size()*sizeof(float));
-
-        for (size_t n = 0; n < next_block; n++)
-            zcorn_layer.push_back(Opm::EclIO::flipEndianFloat(buf[n]));
-
-        p1 = p1 + next_block;
-
-        if (p1 < zcorn_to) {
-            int dtail;
-            fileH.read(reinterpret_cast<char*>(&dtail), sizeof(dtail));
-            fileH.read(reinterpret_cast<char*>(&dtail), sizeof(dtail));
-            dtail = Opm::EclIO::flipEndianInt(dtail);
-
-            next_block = static_cast<uint64_t>(dtail) / static_cast<uint64_t>(Opm::EclIO::sizeOfReal);
-
-            if ((p1 + next_block) > zcorn_to)
-                next_block = zcorn_to - p1;
-        }
-    }
-
-    fileH.close();
-
-    return zcorn_layer;
-}
-
-
-void EGrid::getCellCorners(const std::array<int, 3>& ijk, const std::vector<float>& zcorn_layer,
-                           std::array<double,4>& X, std::array<double,4>& Y, std::array<double,4>& Z)
-{
-    std::vector<int> zind;
-    std::vector<int> pind;
-
-   // calculate indices for grid pillars in COORD arrray
-    pind.push_back(ijk[1]*(nijk[0]+1)*6 + ijk[0]*6);
-    pind.push_back(pind[0] + 6);
-    pind.push_back(pind[0] + (nijk[0]+1)*6);
-    pind.push_back(pind[2] + 6);
-
-    // get depths from zcorn array in ZCORN array
-    zind.push_back(ijk[2]*nijk[0]*nijk[1]*8 + ijk[1]*nijk[0]*4 + ijk[0]*2);
-    zind.push_back(zind[0] + 1);
-    zind.push_back(zind[0] + nijk[0]*2);
-    zind.push_back(zind[2] + 1);
-
-    for (int n = 0; n< 4; n++)
-        Z[n] = zcorn_layer[zind[n]];
-
-    for (int  n = 0; n < 4; n++) {
-        double xt;
-        double yt;
-        double xb;
-        double yb;
-
-        double zt = coord_array[pind[n] + 2];
-        double zb = coord_array[pind[n] + 5];
-
-        xt = coord_array[pind[n]];
-        yt = coord_array[pind[n] + 1];
-        xb = coord_array[pind[n] + 3];
-        yb = coord_array[pind[n] + 4];
-
-        if (zt == zb) {
-            X[n] = xt;
-            Y[n] = yt;
-        } else {
-            X[n] = xt + (xb-xt) / (zt-zb) * (zt - Z[n]);
-            Y[n] = yt+(yb-yt)/(zt-zb)*(zt-Z[n]);
-        }
-
-    }
-}
-
-
-
-}} // namespace Opm::ecl
+} // namespace EclIO
+} // namespace Opm

--- a/opm/io/eclipse/EGrid.hpp
+++ b/opm/io/eclipse/EGrid.hpp
@@ -30,6 +30,23 @@ namespace Opm
 {
 namespace EclIO
 {
+    struct ENNCConnection {
+        int grid1_Id;
+        int grid1_CellIdx;
+        int grid2_Id;
+        int grid2_CellIdx;
+        float transValue;
+
+        ENNCConnection(int id1, int cellId1, int id2, int cellId2, float trans)
+        {
+            grid1_Id = id1;
+            grid2_Id = id2;
+            grid1_CellIdx = cellId1;
+            grid2_CellIdx = cellId2;
+            transValue = trans;
+        }
+    };
+
 
     class EGrid : public EclFile
     {
@@ -38,6 +55,7 @@ namespace EclIO
 
         int global_index(int i, int j, int k) const;
         int active_index(int i, int j, int k) const;
+        int active_frac_index(int i, int j, int k) const;
 
         const std::array<int, 3>& dimension() const
         {
@@ -45,22 +63,44 @@ namespace EclIO
         }
 
         std::array<int, 3> ijk_from_active_index(int actInd) const;
+        std::array<int, 3> ijk_from_active_frac_index(int actFracInd) const;
         std::array<int, 3> ijk_from_global_index(int globInd) const;
 
         void
         getCellCorners(int globindex, std::array<double, 8>& X, std::array<double, 8>& Y, std::array<double, 8>& Z);
+
         void getCellCorners(const std::array<int, 3>& ijk,
                             std::array<double, 8>& X,
                             std::array<double, 8>& Y,
                             std::array<double, 8>& Z);
 
+        void getCellCorners(const std::array<int, 3>& ijk,
+                            std::array<double, 8>& X,
+                            std::array<double, 8>& Y,
+                            std::array<double, 8>& Z,
+                            bool convert_to_radial_coords);
+
         std::vector<std::array<float, 3>> getXYZ_layer(int layer, bool bottom = false);
         std::vector<std::array<float, 3>> getXYZ_layer(int layer, const std::array<int, 4>& box, bool bottom = false);
 
+        // number of active cells that are either frac or matrix or both
+        int totalActiveCells() const
+        {
+            return (int)glob_index.size();
+        }
+
+        // number of active matrix cells
         int activeCells() const
         {
             return nactive;
         }
+
+        // number of active fracture cells
+        int activeFracCells() const
+        {
+            return nactive_frac;
+        }
+
         int totalNumberOfCells() const
         {
             return nijk[0] * nijk[1] * nijk[2];
@@ -78,6 +118,17 @@ namespace EclIO
             return m_radial;
         }
 
+        // porosity_mode < 0 means not specified, 0 = single, 1 = dual por, 2 = dual perm
+        int porosity_mode() const
+        {
+            return m_porosity_mode;
+        }
+
+        std::string grid_unit() const
+        {
+            return m_grid_unit;
+        }
+
         const std::vector<int>& hostCellsGlobalIndex() const
         {
             return host_cells;
@@ -93,6 +144,11 @@ namespace EclIO
             return lgr_names;
         }
 
+        const std::vector<std::string>& list_of_lgr_parents() const
+        {
+            return lgr_parents;
+        }
+
         const std::array<double, 6>& get_mapaxes() const
         {
             return m_mapaxes;
@@ -101,6 +157,20 @@ namespace EclIO
         {
             return m_mapunits;
         }
+
+        std::vector<ENNCConnection> nnc_connections(int this_grid_id);
+
+        void set_active_cells(const std::vector<int>& active_cell_info);
+
+        const std::vector<int>& active_indexes() const
+        {
+            return act_index;
+        };
+        const std::vector<int>& active_frac_indexes() const
+        {
+            return act_frac_index;
+        };
+
         const std::vector<float>& get_coord() const
         {
             return coord_array;
@@ -109,9 +179,6 @@ namespace EclIO
         {
             return zcorn_array;
         }
-
-
-
 
     private:
         std::filesystem::path inputFileName, initFileName;
@@ -129,9 +196,15 @@ namespace EclIO
         std::array<int, 3> host_nijk;
 
         int nactive;
+        int nactive_frac;
+
         mutable bool m_nncs_loaded;
 
+        int m_porosity_mode;
+        std::string m_grid_unit;
+
         std::vector<int> act_index;
+        std::vector<int> act_frac_index;
         std::vector<int> glob_index;
 
         std::vector<float> coord_array;
@@ -140,19 +213,25 @@ namespace EclIO
         std::vector<int> nnc1_array;
         std::vector<int> nnc2_array;
         std::vector<float> transnnc_array;
+        std::vector<int> nncg_array;
+        std::vector<int> nncl_array;
+        std::vector<float> transgl_array;
+
         std::vector<int> host_cells;
         std::map<int, int> res;
-
         std::vector<std::string> lgr_names;
-
+        std::vector<std::string> lgr_parents;
         int numres;
 
         int zcorn_array_index;
         int coord_array_index;
         int coordsys_array_index;
+
         int actnum_array_index;
         int nnc1_array_index;
         int nnc2_array_index;
+        int nncl_array_index;
+        int nncg_array_index;
 
         std::vector<float> get_zcorn_from_disk(int layer, bool bottom);
 
@@ -161,7 +240,6 @@ namespace EclIO
                             std::array<double, 4>& X,
                             std::array<double, 4>& Y,
                             std::array<double, 4>& Z);
-
         void mapaxes_init();
     };
 

--- a/opm/io/eclipse/EGrid.hpp
+++ b/opm/io/eclipse/EGrid.hpp
@@ -3,9 +3,8 @@
 
    This file is part of the Open Porous Media project (OPM).
 
-   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
    OPM is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -23,107 +22,150 @@
 
 #include <array>
 #include <filesystem>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
-namespace Opm { namespace EclIO {
-
-class EGrid : public EclFile
+namespace Opm
 {
-public:
-    explicit EGrid(const std::string& filename, const std::string& grid_name = "global");
+namespace EclIO
+{
 
-    int global_index(int i, int j, int k) const;
-    int active_index(int i, int j, int k) const;
+    class EGrid : public EclFile
+    {
+    public:
+        explicit EGrid(const std::string& filename, const std::string& grid_name = "global");
 
-    const std::array<int, 3>& dimension() const { return nijk; }
+        int global_index(int i, int j, int k) const;
+        int active_index(int i, int j, int k) const;
 
-    std::array<int, 3> ijk_from_active_index(int actInd) const;
-    std::array<int, 3> ijk_from_global_index(int globInd) const;
+        const std::array<int, 3>& dimension() const
+        {
+            return nijk;
+        }
 
-    void getCellCorners(int globindex, std::array<double, 8>& X, std::array<double, 8>& Y, std::array<double, 8>& Z);
-    void getCellCorners(const std::array<int, 3>& ijk, std::array<double, 8>& X, std::array<double, 8>& Y, std::array<double, 8>& Z);
+        std::array<int, 3> ijk_from_active_index(int actInd) const;
+        std::array<int, 3> ijk_from_global_index(int globInd) const;
 
-    std::vector<std::array<float, 3>> getXYZ_layer(int layer, bool bottom=false);
-    std::vector<std::array<float, 3>> getXYZ_layer(int layer, const std::array<int, 4>& box, bool bottom=false);
+        void
+        getCellCorners(int globindex, std::array<double, 8>& X, std::array<double, 8>& Y, std::array<double, 8>& Z);
+        void getCellCorners(const std::array<int, 3>& ijk,
+                            std::array<double, 8>& X,
+                            std::array<double, 8>& Y,
+                            std::array<double, 8>& Z);
 
-    int activeCells() const { return nactive; }
-    int totalNumberOfCells() const { return nijk[0] * nijk[1] * nijk[2]; }
+        std::vector<std::array<float, 3>> getXYZ_layer(int layer, bool bottom = false);
+        std::vector<std::array<float, 3>> getXYZ_layer(int layer, const std::array<int, 4>& box, bool bottom = false);
 
-    void load_grid_data();
-    void load_nnc_data();
-    bool with_mapaxes() const { return m_mapaxes_loaded; }
-    void mapaxes_transform(double& x, double& y) const;
-    bool is_radial() const { return m_radial; }
+        int activeCells() const
+        {
+            return nactive;
+        }
+        int totalNumberOfCells() const
+        {
+            return nijk[0] * nijk[1] * nijk[2];
+        }
 
-    const std::vector<int>& hostCellsGlobalIndex() const { return host_cells; }
-    std::vector<std::array<int, 3>> hostCellsIJK();
+        void load_grid_data();
+        void load_nnc_data();
+        bool with_mapaxes() const
+        {
+            return m_mapaxes_loaded;
+        }
+        void mapaxes_transform(double& x, double& y) const;
+        bool is_radial() const
+        {
+            return m_radial;
+        }
 
-    // zero based: i1,j1,k1, i2,j2,k2, transmisibility
-    using NNCentry = std::tuple<int, int, int, int, int, int, float>;
-    std::vector<NNCentry> get_nnc_ijk();
+        const std::vector<int>& hostCellsGlobalIndex() const
+        {
+            return host_cells;
+        }
+        std::vector<std::array<int, 3>> hostCellsIJK();
 
-    const std::vector<std::string>& list_of_lgrs() const { return lgr_names; }
+        // zero based: i1,j1,k1, i2,j2,k2, transmisibility
+        using NNCentry = std::tuple<int, int, int, int, int, int, float>;
+        std::vector<NNCentry> get_nnc_ijk();
 
-    const std::array<double, 6>& get_mapaxes() const { return m_mapaxes; }
-    const std::string& get_mapunits() const { return m_mapunits; }
-    const std::vector<float>& get_coord() const { return coord_array; }
-    const std::vector<float>& get_zcorn() const { return zcorn_array; }
+        const std::vector<std::string>& list_of_lgrs() const
+        {
+            return lgr_names;
+        }
+
+        const std::array<double, 6>& get_mapaxes() const
+        {
+            return m_mapaxes;
+        }
+        const std::string& get_mapunits() const
+        {
+            return m_mapunits;
+        }
+        const std::vector<float>& get_coord() const
+        {
+            return coord_array;
+        }
+        const std::vector<float>& get_zcorn() const
+        {
+            return zcorn_array;
+        }
 
 
 
 
-private:
-    std::filesystem::path inputFileName, initFileName;
-    std::string m_grid_name;
-    bool m_radial;
+    private:
+        std::filesystem::path inputFileName, initFileName;
+        std::string m_grid_name;
+        bool m_radial;
 
-    std::array<double, 6> m_mapaxes;
-    std::string m_mapunits;
-    bool m_mapaxes_loaded;
-    std::array<double, 4> origin;
-    std::array<double, 2> unit_x;
-    std::array<double, 2> unit_y;
+        std::array<double, 6> m_mapaxes;
+        std::string m_mapunits;
+        bool m_mapaxes_loaded;
+        std::array<double, 4> origin;
+        std::array<double, 2> unit_x;
+        std::array<double, 2> unit_y;
 
-    std::array<int, 3> nijk;
-    std::array<int, 3> host_nijk;
+        std::array<int, 3> nijk;
+        std::array<int, 3> host_nijk;
 
-    int nactive;
-    mutable bool m_nncs_loaded;
+        int nactive;
+        mutable bool m_nncs_loaded;
 
-    std::vector<int> act_index;
-    std::vector<int> glob_index;
+        std::vector<int> act_index;
+        std::vector<int> glob_index;
 
-    std::vector<float> coord_array;
-    std::vector<float> zcorn_array;
+        std::vector<float> coord_array;
+        std::vector<float> zcorn_array;
 
-    std::vector<int> nnc1_array;
-    std::vector<int> nnc2_array;
-    std::vector<float> transnnc_array;
-    std::vector<int> host_cells;
-    std::map<int,int> res;
-     
-    std::vector<std::string> lgr_names;
-    
-    int numres;
-    
-    int zcorn_array_index;
-    int coord_array_index;
-    int coordsys_array_index;
-    int actnum_array_index;
-    int nnc1_array_index;
-    int nnc2_array_index;
+        std::vector<int> nnc1_array;
+        std::vector<int> nnc2_array;
+        std::vector<float> transnnc_array;
+        std::vector<int> host_cells;
+        std::map<int, int> res;
 
-    std::vector<float> get_zcorn_from_disk(int layer, bool bottom);
+        std::vector<std::string> lgr_names;
 
-    void getCellCorners(const std::array<int, 3>& ijk, const std::vector<float>& zcorn_layer,
-                        std::array<double, 4>& X, std::array<double, 4>& Y, std::array<double, 4>& Z);
+        int numres;
 
-    void mapaxes_init();
-    
-};
+        int zcorn_array_index;
+        int coord_array_index;
+        int coordsys_array_index;
+        int actnum_array_index;
+        int nnc1_array_index;
+        int nnc2_array_index;
 
-}} // namespace Opm::EclIO
+        std::vector<float> get_zcorn_from_disk(int layer, bool bottom);
+
+        void getCellCorners(const std::array<int, 3>& ijk,
+                            const std::vector<float>& zcorn_layer,
+                            std::array<double, 4>& X,
+                            std::array<double, 4>& Y,
+                            std::array<double, 4>& Z);
+
+        void mapaxes_init();
+    };
+
+} // namespace EclIO
+} // namespace Opm
 
 #endif // OPM_IO_EGRID_HPP

--- a/opm/io/eclipse/EInit.cpp
+++ b/opm/io/eclipse/EInit.cpp
@@ -3,9 +3,8 @@
 
    This file is part of the Open Porous Media project (OPM).
 
-   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
    OPM is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -16,180 +15,181 @@
    along with OPM.  If not, see <http://www.gnu.org/licenses/>.
    */
 
-#include <opm/io/eclipse/EInit.hpp>
 #include <opm/common/ErrorMacros.hpp>
+#include <opm/io/eclipse/EInit.hpp>
 
 #include <algorithm>
 
-namespace Opm { namespace EclIO {
-
-
-EInit::EInit(const std::string &filename) : EclFile(filename)
+namespace Opm
 {
-    std::string lgrname;
+namespace EclIO
+{
 
-    lgrname = "global";
 
-    for (size_t n = 0; n < array_name.size(); n++) {
-        if (array_name[n] == "LGR"){
-            auto lgr = this->get<std::string>(n);
-            lgrname = lgr[0];
+    EInit::EInit(const std::string& filename)
+        : EclFile(filename)
+    {
+        std::string lgrname;
 
-            if (std::find(lgr_names.begin(), lgr_names.end(), lgrname) == lgr_names.end()){
-                lgr_names.push_back(lgrname);
-                lgr_array_index.push_back({});
-                lgr_nijk.push_back({});
-                lgr_nactive.push_back(0);
+        lgrname = "global";
+
+        for (size_t n = 0; n < array_name.size(); n++) {
+            if (array_name[n] == "LGR") {
+                auto lgr = this->get<std::string>(n);
+                lgrname = lgr[0];
+
+                if (std::find(lgr_names.begin(), lgr_names.end(), lgrname) == lgr_names.end()) {
+                    lgr_names.push_back(lgrname);
+                    lgr_array_index.push_back({});
+                    lgr_nijk.push_back({});
+                    lgr_nactive.push_back(0);
+                }
+            }
+
+            if (array_name[n] == "LGRSGONE")
+                lgrname = "global";
+
+            if ((lgrname == "global") && (array_name[n] != "LGRSGONE"))
+                global_array_index[array_name[n]] = n;
+
+            if ((lgrname != "global") && (array_name[n] != "LGRSGONE") && (array_name[n] != "LGR")) {
+                auto it = std::find(lgr_names.begin(), lgr_names.end(), lgrname);
+                size_t ind = std::distance(lgr_names.begin(), it);
+                lgr_array_index[ind][array_name[n]] = n;
+            }
+
+            if (array_name[n] == "INTEHEAD") {
+                auto inteh = getImpl(n, INTE, inte_array, "integer");
+
+                if (lgrname == "global") {
+                    global_nijk = {inteh[8], inteh[9], inteh[10]};
+                    global_nactive = inteh[11];
+                } else {
+                    auto it = std::find(lgr_names.begin(), lgr_names.end(), lgrname);
+                    size_t lgr_ind = std::distance(lgr_names.begin(), it);
+                    lgr_nijk[lgr_ind] = {inteh[8], inteh[9], inteh[10]};
+                    lgr_nactive[lgr_ind] = inteh[11];
+                }
             }
         }
+    }
 
-        if (array_name[n] == "LGRSGONE")
-            lgrname = "global";
 
-        if ((lgrname == "global") && (array_name[n] != "LGRSGONE"))
-            global_array_index[array_name[n]] = n;
+    int EInit::get_array_index(const std::string& name, const std::string& grid_name) const
+    {
+        if (grid_name == "global") {
+            if (global_array_index.count(name) == 0)
+                OPM_THROW(std::runtime_error, "Map key '" + name + "' not found in global_array_index");
 
-        if ((lgrname != "global") && (array_name[n] != "LGRSGONE") && (array_name[n] != "LGR"))
-        {
-           auto it = std::find(lgr_names.begin(), lgr_names.end(), lgrname);
-           size_t ind = std::distance(lgr_names.begin(), it);
-           lgr_array_index[ind][array_name[n]] = n;
-        }
+            return global_array_index.at(name);
 
-        if (array_name[n] == "INTEHEAD")
-        {
-            auto inteh = getImpl(n, INTE, inte_array, "integer");
+        } else {
 
-            if (lgrname == "global") {
-                global_nijk = {inteh[8], inteh[9], inteh[10]};
-                global_nactive = inteh[11];
-            } else {
-               auto it = std::find(lgr_names.begin(), lgr_names.end(), lgrname);
-               size_t lgr_ind = std::distance(lgr_names.begin(), it);
-               lgr_nijk[lgr_ind] = {inteh[8], inteh[9], inteh[10]};
-               lgr_nactive[lgr_ind] = inteh[11];
-            }
+            int lgr_index = get_lgr_index(grid_name);
+
+            if (lgr_array_index[lgr_index].count(name) == 0)
+                OPM_THROW(std::invalid_argument, "Map key '" + name + "' not found in lgr_array_index");
+
+            return lgr_array_index[lgr_index].at(name);
         }
     }
-}
 
-
-int EInit::get_array_index(const std::string& name, const std::string& grid_name) const
-{
-    if (grid_name == "global"){
-        if (global_array_index.count(name) == 0)
-            OPM_THROW(std::runtime_error, "Map key '" + name + "' not found in global_array_index");
-
-        return global_array_index.at(name);
-
-    } else {
-
-        int lgr_index = get_lgr_index(grid_name);
-
-        if (lgr_array_index[lgr_index].count(name) == 0)
-            OPM_THROW(std::invalid_argument, "Map key '" + name + "' not found in lgr_array_index");
-
-        return lgr_array_index[lgr_index].at(name);
-    }
-}
-
-int EInit::activeCells(const std::string& grid_name) const
-{
-    if (grid_name == "global")
-        return global_nactive;
-    else
-        return lgr_nactive[get_lgr_index(grid_name)];
-}
-
-const std::array<int, 3>& EInit::grid_dimension(const std::string& grid_name) const
-{
-    if (grid_name == "global")
-        return global_nijk;
-    else
-        return lgr_nijk[get_lgr_index(grid_name)];
-}
-
-bool EInit::hasLGR(const std::string& name) const{
-    if (std::find(lgr_names.begin(), lgr_names.end(), name) == lgr_names.end())
-        return false;
-    else
-        return true;
-}
-
-int EInit::get_lgr_index(const std::string& grid_name) const
-{
-    auto it = std::find(lgr_names.begin(), lgr_names.end(), grid_name);
-
-    if (it == lgr_names.end()) {
-        std::string message = "LGR '" + grid_name + "' not found in init file.";
-        OPM_THROW(std::invalid_argument, message);
-    }
-
-    return  std::distance(lgr_names.begin(), it);
-}
-
-std::vector<EclFile::EclEntry> EInit::list_arrays(const std::string& grid_name) const
-{
-    std::vector<EclEntry> array_list;
-
-    int lgr_index = this->get_lgr_index(grid_name);
-
-    for (auto const& x : lgr_array_index[lgr_index])
+    int EInit::activeCells(const std::string& grid_name) const
     {
-        int ind = x.second;
-        array_list.push_back(std::make_tuple(array_name[ind], array_type[ind], array_size[ind]));
+        if (grid_name == "global")
+            return global_nactive;
+        else
+            return lgr_nactive[get_lgr_index(grid_name)];
     }
 
-    return array_list;
-}
-
-std::vector<EclFile::EclEntry> EInit::list_arrays() const
-{
-    std::vector<EclEntry> array_list;
-
-    for (auto const& x : global_array_index)
+    const std::array<int, 3>& EInit::grid_dimension(const std::string& grid_name) const
     {
-        int ind = x.second;
-        array_list.push_back(std::make_tuple(array_name[ind], array_type[ind], array_size[ind]));
+        if (grid_name == "global")
+            return global_nijk;
+        else
+            return lgr_nijk[get_lgr_index(grid_name)];
     }
 
-    return array_list;
-}
+    bool EInit::hasLGR(const std::string& name) const
+    {
+        if (std::find(lgr_names.begin(), lgr_names.end(), name) == lgr_names.end())
+            return false;
+        else
+            return true;
+    }
 
-template <typename T>
-const std::vector<T>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name)
-{
-    int arr_ind = get_array_index(name, grid_name);
+    int EInit::get_lgr_index(const std::string& grid_name) const
+    {
+        auto it = std::find(lgr_names.begin(), lgr_names.end(), grid_name);
 
-    if constexpr (std::is_same_v<T, int>)
+        if (it == lgr_names.end()) {
+            std::string message = "LGR '" + grid_name + "' not found in init file.";
+            OPM_THROW(std::invalid_argument, message);
+        }
+
+        return std::distance(lgr_names.begin(), it);
+    }
+
+    std::vector<EclFile::EclEntry> EInit::list_arrays(const std::string& grid_name) const
+    {
+        std::vector<EclEntry> array_list;
+
+        int lgr_index = this->get_lgr_index(grid_name);
+
+        for (auto const& x : lgr_array_index[lgr_index]) {
+            int ind = x.second;
+            array_list.push_back(std::make_tuple(array_name[ind], array_type[ind], array_size[ind]));
+        }
+
+        return array_list;
+    }
+
+    std::vector<EclFile::EclEntry> EInit::list_arrays() const
+    {
+        std::vector<EclEntry> array_list;
+
+        for (auto const& x : global_array_index) {
+            int ind = x.second;
+            array_list.push_back(std::make_tuple(array_name[ind], array_type[ind], array_size[ind]));
+        }
+
+        return array_list;
+    }
+
+    template <typename T>
+    const std::vector<T>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name)
+    {
+        int arr_ind = get_array_index(name, grid_name);
+
+        if constexpr (std::is_same_v<T, int>)
             return getImpl(arr_ind, INTE, inte_array, "integer");
 
-    if constexpr (std::is_same_v<T, float>)
+        if constexpr (std::is_same_v<T, float>)
             return getImpl(arr_ind, REAL, real_array, "float");
 
-    if constexpr (std::is_same_v<T, double>)
+        if constexpr (std::is_same_v<T, double>)
             return getImpl(arr_ind, DOUB, doub_array, "double");
 
-    if constexpr (std::is_same_v<T, bool>)
+        if constexpr (std::is_same_v<T, bool>)
             return getImpl(arr_ind, LOGI, logi_array, "bool");
 
-    if constexpr (std::is_same_v<T, std::string>)
-    {
-        if (array_type[arr_ind] == Opm::EclIO::CHAR)
-            return getImpl(arr_ind, array_type[arr_ind], char_array, "char");
+        if constexpr (std::is_same_v<T, std::string>) {
+            if (array_type[arr_ind] == Opm::EclIO::CHAR)
+                return getImpl(arr_ind, array_type[arr_ind], char_array, "char");
 
-        if (array_type[arr_ind] == Opm::EclIO::C0NN)
-            return getImpl(arr_ind, array_type[arr_ind], char_array, "c0nn");
+            if (array_type[arr_ind] == Opm::EclIO::C0NN)
+                return getImpl(arr_ind, array_type[arr_ind], char_array, "c0nn");
 
-        OPM_THROW(std::runtime_error, "Array not of type CHAR or C0nn");
+            OPM_THROW(std::runtime_error, "Array not of type CHAR or C0nn");
+        }
+
+        OPM_THROW(std::runtime_error, "type not supported");
     }
 
-    OPM_THROW(std::runtime_error, "type not supported");
-}
+    template const std::vector<int>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name);
+    template const std::vector<float>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name);
+    template const std::vector<double>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name);
+    template const std::vector<bool>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name);
 
-template const std::vector<int>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name);
-template const std::vector<float>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name);
-template const std::vector<double>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name);
-template const std::vector<bool>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name);
-
-}} // namespace Opm::EclIO
+} // namespace EclIO
+} // namespace Opm

--- a/opm/io/eclipse/EInit.hpp
+++ b/opm/io/eclipse/EInit.hpp
@@ -53,6 +53,11 @@ namespace EclIO
             return this->ImplgetInitData<T>(name, grid_name);
         }
 
+        int number_of_nnc_in_header() const
+        {
+            return no_of_nnc;
+        }
+
     protected:
         template <typename T>
         const std::vector<T>& ImplgetInitData(const std::string& name, const std::string& grid_name = "global");
@@ -63,6 +68,9 @@ namespace EclIO
 
         int global_nactive;
         std::vector<int> lgr_nactive;
+        bool dual_porosity;
+
+        int no_of_nnc;
 
         std::vector<std::string> lgr_names;
 

--- a/opm/io/eclipse/EInit.hpp
+++ b/opm/io/eclipse/EInit.hpp
@@ -3,9 +3,8 @@
 
    This file is part of the Open Porous Media project (OPM).
 
-   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
    OPM is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -22,53 +21,59 @@
 #include <opm/io/eclipse/EclFile.hpp>
 
 #include <array>
-#include <vector>
 #include <map>
+#include <vector>
 
-namespace Opm { namespace EclIO {
-
-class EInit : public EclFile
+namespace Opm
 {
-public:
-    explicit EInit(const std::string& filename);
+namespace EclIO
+{
 
-    const std::vector<std::string>& list_of_lgrs() const { return lgr_names; }
-
-    std::vector<EclFile::EclEntry> list_arrays() const;
-    std::vector<EclFile::EclEntry> list_arrays(const std::string& grid_name) const;
-
-    const std::array<int, 3>& grid_dimension(const std::string& grid_name = "global") const;
-    int activeCells(const std::string& grid_name = "global") const;
-
-    bool hasLGR(const std::string& name) const;
-
-    template <typename T>
-    const std::vector<T>& getInitData(const std::string& name, const std::string& grid_name = "global")
+    class EInit : public EclFile
     {
-        return this->ImplgetInitData<T>(name, grid_name);
-    }
+    public:
+        explicit EInit(const std::string& filename);
 
-protected:
+        const std::vector<std::string>& list_of_lgrs() const
+        {
+            return lgr_names;
+        }
 
-    template <typename T>
-    const std::vector<T>& ImplgetInitData(const std::string& name, const std::string& grid_name = "global");
+        std::vector<EclFile::EclEntry> list_arrays() const;
+        std::vector<EclFile::EclEntry> list_arrays(const std::string& grid_name) const;
 
-private:
-    std::array<int, 3> global_nijk;
-    std::vector<std::array<int, 3>> lgr_nijk;
+        const std::array<int, 3>& grid_dimension(const std::string& grid_name = "global") const;
+        int activeCells(const std::string& grid_name = "global") const;
 
-    int global_nactive;
-    std::vector<int> lgr_nactive;
+        bool hasLGR(const std::string& name) const;
 
-    std::vector<std::string> lgr_names;
+        template <typename T>
+        const std::vector<T>& getInitData(const std::string& name, const std::string& grid_name = "global")
+        {
+            return this->ImplgetInitData<T>(name, grid_name);
+        }
 
-    std::map<std::string,int> global_array_index;
-    std::vector<std::map<std::string,int>> lgr_array_index;
+    protected:
+        template <typename T>
+        const std::vector<T>& ImplgetInitData(const std::string& name, const std::string& grid_name = "global");
 
-    int get_array_index(const std::string& name, const std::string& grid_name) const;
-    int get_lgr_index(const std::string& grid_name) const;
-};
+    private:
+        std::array<int, 3> global_nijk;
+        std::vector<std::array<int, 3>> lgr_nijk;
 
-}} // namespace Opm::EclIO
+        int global_nactive;
+        std::vector<int> lgr_nactive;
+
+        std::vector<std::string> lgr_names;
+
+        std::map<std::string, int> global_array_index;
+        std::vector<std::map<std::string, int>> lgr_array_index;
+
+        int get_array_index(const std::string& name, const std::string& grid_name) const;
+        int get_lgr_index(const std::string& grid_name) const;
+    };
+
+} // namespace EclIO
+} // namespace Opm
 
 #endif // OPM_IO_EINIT_HPP

--- a/opm/io/eclipse/ERst.cpp
+++ b/opm/io/eclipse/ERst.cpp
@@ -3,10 +3,8 @@
 
    This file is part of the Open Porous Media project (OPM).
 
-   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-#include <iostream>
+   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
    OPM is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -29,419 +27,432 @@
 #include <string>
 
 
-namespace {
-    int seqnumFromSeparateFilename(const std::string& filename)
+namespace
+{
+int
+seqnumFromSeparateFilename(const std::string& filename)
+{
+    const auto re = std::regex {R"~(\.[FX]([0-9]{4})$)~"};
+
+    auto match = std::smatch {};
+    if (std::regex_search(filename, match, re)) {
+        return std::stoi(match[1]);
+    }
+
+    throw std::invalid_argument {"Unable to Determine Report Step Sequence Number "
+                                 "From Restart Filename \""
+                                 + filename + '"'};
+}
+} // namespace
+
+
+namespace Opm
+{
+namespace EclIO
+{
+
+    ERst::ERst(const std::string& filename)
+        : EclFile(filename)
     {
-        const auto re = std::regex {
-            R"~(\.[FX]([0-9]{4})$)~"
-        };
-
-        auto match = std::smatch{};
-        if (std::regex_search(filename, match, re)) {
-            return std::stoi(match[1]);
-        }
-
-        throw std::invalid_argument {
-            "Unable to Determine Report Step Sequence Number "
-            "From Restart Filename \"" + filename + '"'
-        };
-    }
-}
-
-
-namespace Opm { namespace EclIO {
-
-ERst::ERst(const std::string& filename)
-    : EclFile(filename)
-{
-    if (this->hasKey("SEQNUM")) {
-        this->initUnified();
-    }
-    else {
-        this->initSeparate(seqnumFromSeparateFilename(filename));
-    }
-}
-
-
-bool ERst::hasReportStepNumber(int number) const
-{
-    auto search = arrIndexRange.find(number);
-    return search != arrIndexRange.end();
-}
-
-
-void ERst::loadReportStepNumber(int number)
-{
-    if (!hasReportStepNumber(number)) {
-        std::string message="Trying to load non existing report step number " + std::to_string(number);
-        OPM_THROW(std::invalid_argument, message);
-    }
-
-    std::vector<int> arrayIndexList;
-    arrayIndexList.reserve(arrIndexRange.at(number).second - arrIndexRange.at(number).first + 1);
-
-    for (int i = arrIndexRange.at(number).first; i < arrIndexRange.at(number).second; i++) {
-        arrayIndexList.push_back(i);
-    }
-
-    loadData(arrayIndexList);
-
-    reportLoaded[number] = true;
-}
-
-
-std::vector<EclFile::EclEntry> ERst::listOfRstArrays(int reportStepNumber)
-{
-    return this->listOfRstArrays(reportStepNumber, "global");
-}
-
-
-std::vector<EclFile::EclEntry> ERst::listOfRstArrays(int reportStepNumber, const std::string& lgr_name)
-{
-    std::vector<EclEntry> list;
-
-    if (!hasReportStepNumber(reportStepNumber)) {
-        std::string message = "Trying to get list of arrays from non existing report step number  " + std::to_string(reportStepNumber);
-        OPM_THROW(std::invalid_argument, message);
-    }
-
-    if ((lgr_name != "global") && (!this->hasLGR(lgr_name, reportStepNumber))) {
-        std::string message = "Trying to get list of arrays from non existing LGR " + lgr_name;
-        OPM_THROW(std::invalid_argument, message);
-    }
-
-    std::string lgr_name_upper = lgr_name;
-    std::transform(lgr_name_upper.begin(), lgr_name_upper.end(),lgr_name_upper.begin(), ::toupper);
-
-    int start_ind_lgr;
-    std::string last_array_name;
-
-    if ((lgr_name == "") or (lgr_name_upper == "GLOBAL")){
-        auto rng = this->arrIndexRange.at(reportStepNumber);
-        start_ind_lgr = std::get<0>(rng);
-
-        // if keyword LGR not found, loop will be stopped with keyword SEQNUM (next report step)
-        // or last array (end of file)
-        // Opm flow can have extra keywords after ENDSOL, which maks ENDSOL
-        // not usable for a global arrays end signal.
-
-        last_array_name = "LGR";
-    } else {
-        start_ind_lgr = get_start_index_lgrname(reportStepNumber, lgr_name);
-        last_array_name = "ENDLGR";
-    }
-
-    int n = start_ind_lgr;
-    list.emplace_back(array_name[n], array_type[n], array_size[n]);
-
-    do {
-        n++;
-
-        if ((array_name[n] != "SEQNUM") && (array_name[n] != "LGR"))
-            list.emplace_back(array_name[n], array_type[n], array_size[n]);
-
-    }   while ((array_name[n] != "SEQNUM") && (array_name[n] != last_array_name) && (n < static_cast<int>(array_name.size()) -1 ));
-
-    return list;
-}
-
-
-int ERst::occurrence_count(const std::string& name, int reportStepNumber) const
-{
-    if (!hasReportStepNumber(reportStepNumber)) {
-        std::string message = "Trying to count vectors of name " + name + " from non existing sequence " + std::to_string(reportStepNumber);
-        OPM_THROW(std::invalid_argument, message);
-    }
-
-    int count = 0;
-
-    auto range_it = arrIndexRange.find(reportStepNumber);
-
-    std::pair<int,int> indexRange = range_it->second;
-
-    for (int i=std::get<0>(indexRange); i<std::get<1>(indexRange);i++){
-        if (array_name[i] == name){
-            count++;
-        }
-    }
-
-    return count;
-}
-
-void ERst::initUnified()
-{
-    loadData("SEQNUM");
-
-    std::vector<int> firstIndex;
-
-    for (size_t i = 0;  i < array_name.size(); i++) {
-        if (array_name[i] == "SEQNUM") {
-            auto seqn = get<int>(i);
-            seqnum.push_back(seqn[0]);
-            firstIndex.push_back(i);
-            lgr_names.push_back({});
-        }
-
-        if (array_name[i] == "LGRNAMES") {
-            auto names = getImpl(i, CHAR, char_array, "string");
-            lgr_names[seqnum.size() -1 ] = names;
-        }
-    }
-
-    for (size_t i = 0; i < seqnum.size(); i++) {
-        std::pair<int,int> range;
-        range.first = firstIndex[i];
-
-        if (i != seqnum.size() - 1) {
-            range.second = firstIndex[i+1];
+        if (this->hasKey("SEQNUM")) {
+            this->initUnified();
         } else {
-            range.second = array_name.size();
-        }
-
-        arrIndexRange[seqnum[i]] = range;
-    }
-
-    nReports = seqnum.size();
-
-    for (int i = 0; i < nReports; i++) {
-        reportLoaded[seqnum[i]] = false;
-    }
-}
-
-bool ERst::hasLGR(const std::string& gridname, int reportStepNumber) const
-{
-    if (!hasReportStepNumber(reportStepNumber)) {
-        std::string message = "Checking for LGR name in non existing sequence " + std::to_string(reportStepNumber);
-        OPM_THROW(std::invalid_argument, message);
-    }
-
-   auto it_seqnum = std::find(seqnum.begin(), seqnum.end(), reportStepNumber);
-   int report_index = std::distance(seqnum.begin(), it_seqnum);
-   auto it_lgrname = std::find(lgr_names[report_index].begin(), lgr_names[report_index].end(), gridname);
-
-   return  (it_lgrname != lgr_names[report_index].end());
-}
-
-
-void ERst::initSeparate(const int number)
-{
-    auto& range = this->arrIndexRange[number];
-    range.first = 0;
-    range.second = static_cast<int>(this->array_name.size());
-
-    this->seqnum.assign(1, number);
-    this->nReports = 1;
-    this->reportLoaded[number] = false;
-    this->lgr_names.push_back({});
-
-    for (int i = range.first;  i < range.second; i++) {
-        if (array_name[i] == "LGRNAMES") {
-            auto names = getImpl(i, CHAR, char_array, "string");
-            lgr_names[0] = names;
-        }
-    }
-}
-
-int ERst::get_start_index_lgrname(int number, const std::string& lgr_name)
-{
-    if (!hasReportStepNumber(number)) {
-        std::string message = "Trying to get a restart vector from non report step " + std::to_string(number);
-        OPM_THROW(std::invalid_argument, message);
-    }
-
-    auto range_it = arrIndexRange.find(number);
-    std::pair<int,int> indexRange = range_it->second;
-    int start_ind_lgr = -1;
-
-    for (int n = indexRange.first; n < indexRange.second; n++) {
-        if (array_name[n] == "LGR") {
-            auto arr = getImpl(n, CHAR, char_array, "string");
-            if (arr[0] == lgr_name)
-                start_ind_lgr = n;
+            this->initSeparate(seqnumFromSeparateFilename(filename));
         }
     }
 
-    if (start_ind_lgr == -1){
-        std::string message = "LGR '" + lgr_name + "'not found in restart file";
-        OPM_THROW(std::runtime_error, message);
-    }
 
-    return start_ind_lgr;
-}
-
-std::tuple<int,int> ERst::getIndexRange(int reportStepNumber) const {
-
-    if (!hasReportStepNumber(reportStepNumber)) {
-        std::string message = "Trying to get index range for non existing sequence " + std::to_string(reportStepNumber);
-        OPM_THROW(std::invalid_argument, message);
-    }
-
-    auto range_it = arrIndexRange.find(reportStepNumber);
-
-    return range_it->second;
-}
-
-bool  ERst::hasArray(const std::string& name, int number) const
-{
-    if (!hasReportStepNumber(number))
-        return false;
-
-    auto range_it = arrIndexRange.find(number);
-
-    std::pair<int,int> indexRange = range_it->second;
-
-    auto it = std::find(array_name.begin() + indexRange.first,
-                        array_name.begin() + indexRange.second, name);
-
-    if (std::distance(array_name.begin(), it) == indexRange.second)
-        return false;
-
-    return true;
-}
-
-
-int ERst::getArrayIndex(const std::string& name, int number, int occurrenc)
-{
-    if (!hasReportStepNumber(number)) {
-        std::string message = "Trying to get vector " + name + " from non existing sequence " + std::to_string(number);
-        OPM_THROW(std::invalid_argument, message);
+    bool ERst::hasReportStepNumber(int number) const
+    {
+        auto search = arrIndexRange.find(number);
+        return search != arrIndexRange.end();
     }
 
 
-    auto range_it = arrIndexRange.find(number);
+    void ERst::loadReportStepNumber(int number)
+    {
+        if (!hasReportStepNumber(number)) {
+            std::string message = "Trying to load non existing report step number " + std::to_string(number);
+            OPM_THROW(std::invalid_argument, message);
+        }
 
-    std::pair<int,int> indexRange = range_it->second;
+        std::vector<int> arrayIndexList;
+        arrayIndexList.reserve(arrIndexRange.at(number).second - arrIndexRange.at(number).first + 1);
 
-    auto it = std::find(array_name.begin() + indexRange.first,
-                        array_name.begin() + indexRange.second, name);
+        for (int i = arrIndexRange.at(number).first; i < arrIndexRange.at(number).second; i++) {
+            arrayIndexList.push_back(i);
+        }
 
-    for (int t = 0; t < occurrenc; t++){
-        it = std::find(it + 1 , array_name.begin() + indexRange.second, name);
+        loadData(arrayIndexList);
+
+        reportLoaded[number] = true;
     }
 
-    if (std::distance(array_name.begin(),it) == indexRange.second) {
-        std::string message = "Array " + name + " not found in sequence " + std::to_string(number);
-        OPM_THROW(std::runtime_error, message);
+
+    std::vector<EclFile::EclEntry> ERst::listOfRstArrays(int reportStepNumber)
+    {
+        return this->listOfRstArrays(reportStepNumber, "global");
     }
 
-    return std::distance(array_name.begin(), it);
-}
 
-int ERst::getArrayIndex(const std::string& name, int number, const std::string& lgr_name)
-{
-    auto range_it = arrIndexRange.find(number);
-    std::pair<int,int> indexRange = range_it->second;
+    std::vector<EclFile::EclEntry> ERst::listOfRstArrays(int reportStepNumber, const std::string& lgr_name)
+    {
+        std::vector<EclEntry> list;
 
-    int start_ind_lgr = get_start_index_lgrname(number, lgr_name);
+        if (!hasReportStepNumber(reportStepNumber)) {
+            std::string message = "Trying to get list of arrays from non existing report step number  "
+                + std::to_string(reportStepNumber);
+            OPM_THROW(std::invalid_argument, message);
+        }
 
-    auto it = std::find(array_name.begin() + start_ind_lgr,
-                        array_name.begin() + indexRange.second, name);
+        if ((lgr_name != "global") && (!this->hasLGR(lgr_name, reportStepNumber))) {
+            std::string message = "Trying to get list of arrays from non existing LGR " + lgr_name;
+            OPM_THROW(std::invalid_argument, message);
+        }
 
-    if (std::distance(array_name.begin(),it) == indexRange.second) {
-        std::string message = "Array " + name + " not found for " + lgr_name;
-        OPM_THROW(std::runtime_error, message);
+        std::string lgr_name_upper = lgr_name;
+        std::transform(lgr_name_upper.begin(), lgr_name_upper.end(), lgr_name_upper.begin(), ::toupper);
+
+        int start_ind_lgr;
+        std::string last_array_name;
+
+        if ((lgr_name == "") or (lgr_name_upper == "GLOBAL")) {
+            auto rng = this->arrIndexRange.at(reportStepNumber);
+            start_ind_lgr = std::get<0>(rng);
+
+            // if keyword LGR not found, loop will be stopped with keyword SEQNUM (next report step)
+            // or last array (end of file)
+            // Opm flow can have extra keywords after ENDSOL, which maks ENDSOL
+            // not usable for a global arrays end signal.
+
+            last_array_name = "LGR";
+        } else {
+            start_ind_lgr = get_start_index_lgrname(reportStepNumber, lgr_name);
+            last_array_name = "ENDLGR";
+        }
+
+        int n = start_ind_lgr;
+        list.emplace_back(array_name[n], array_type[n], array_size[n]);
+
+        do {
+            n++;
+
+            if ((array_name[n] != "SEQNUM") && (array_name[n] != "LGR"))
+                list.emplace_back(array_name[n], array_type[n], array_size[n]);
+
+        } while ((array_name[n] != "SEQNUM") && (array_name[n] != last_array_name)
+                 && (n < static_cast<int>(array_name.size()) - 1));
+
+        return list;
     }
 
-    return std::distance(array_name.begin(), it);
-}
+
+    int ERst::occurrence_count(const std::string& name, int reportStepNumber) const
+    {
+        if (!hasReportStepNumber(reportStepNumber)) {
+            std::string message = "Trying to count vectors of name " + name + " from non existing sequence "
+                + std::to_string(reportStepNumber);
+            OPM_THROW(std::invalid_argument, message);
+        }
+
+        int count = 0;
+
+        auto range_it = arrIndexRange.find(reportStepNumber);
+
+        std::pair<int, int> indexRange = range_it->second;
+
+        for (int i = std::get<0>(indexRange); i < std::get<1>(indexRange); i++) {
+            if (array_name[i] == name) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    void ERst::initUnified()
+    {
+        loadData("SEQNUM");
+
+        std::vector<int> firstIndex;
+
+        for (size_t i = 0; i < array_name.size(); i++) {
+            if (array_name[i] == "SEQNUM") {
+                auto seqn = get<int>(i);
+                seqnum.push_back(seqn[0]);
+                firstIndex.push_back(i);
+                lgr_names.push_back({});
+            }
+
+            if (array_name[i] == "LGRNAMES") {
+                auto names = getImpl(i, CHAR, char_array, "string");
+                lgr_names[seqnum.size() - 1] = names;
+            }
+        }
+
+        for (size_t i = 0; i < seqnum.size(); i++) {
+            std::pair<int, int> range;
+            range.first = firstIndex[i];
+
+            if (i != seqnum.size() - 1) {
+                range.second = firstIndex[i + 1];
+            } else {
+                range.second = array_name.size();
+            }
+
+            arrIndexRange[seqnum[i]] = range;
+        }
+
+        nReports = seqnum.size();
+
+        for (int i = 0; i < nReports; i++) {
+            reportLoaded[seqnum[i]] = false;
+        }
+    }
+
+    bool ERst::hasLGR(const std::string& gridname, int reportStepNumber) const
+    {
+        if (!hasReportStepNumber(reportStepNumber)) {
+            std::string message = "Checking for LGR name in non existing sequence " + std::to_string(reportStepNumber);
+            OPM_THROW(std::invalid_argument, message);
+        }
+
+        auto it_seqnum = std::find(seqnum.begin(), seqnum.end(), reportStepNumber);
+        int report_index = std::distance(seqnum.begin(), it_seqnum);
+        auto it_lgrname = std::find(lgr_names[report_index].begin(), lgr_names[report_index].end(), gridname);
+
+        return (it_lgrname != lgr_names[report_index].end());
+    }
 
 
-std::streampos
-ERst::restartStepWritePosition(const int seqnumValue) const
-{
-    auto pos = this->arrIndexRange.lower_bound(seqnumValue);
+    void ERst::initSeparate(const int number)
+    {
+        auto& range = this->arrIndexRange[number];
+        range.first = 0;
+        range.second = static_cast<int>(this->array_name.size());
 
-    return (pos == this->arrIndexRange.end())
-        ? std::streampos(std::streamoff(-1))
-        : this->seekPosition(pos->second.first);
-}
+        this->seqnum.assign(1, number);
+        this->nReports = 1;
+        this->reportLoaded[number] = false;
+        this->lgr_names.push_back({});
 
-template<>
-const std::vector<int>& ERst::getRestartData<int>(const std::string& name, int reportStepNumber, int occurrence)
-{
-    int ind = getArrayIndex(name, reportStepNumber, occurrence);
-    return getImpl(ind, INTE, inte_array, "integer");
-}
+        for (int i = range.first; i < range.second; i++) {
+            if (array_name[i] == "LGRNAMES") {
+                auto names = getImpl(i, CHAR, char_array, "string");
+                lgr_names[0] = names;
+            }
+        }
+    }
 
-template<>
-const std::vector<float>& ERst::getRestartData<float>(const std::string& name, int reportStepNumber, int occurrence)
-{
-    int ind = getArrayIndex(name, reportStepNumber, occurrence);
-    return getImpl(ind, REAL, real_array, "float");
-}
+    int ERst::get_start_index_lgrname(int number, const std::string& lgr_name)
+    {
+        if (!hasReportStepNumber(number)) {
+            std::string message = "Trying to get a restart vector from non report step " + std::to_string(number);
+            OPM_THROW(std::invalid_argument, message);
+        }
 
-template<>
-const std::vector<double>& ERst::getRestartData<double>(const std::string& name, int reportStepNumber, int occurrence)
-{
-    int ind = getArrayIndex(name, reportStepNumber, occurrence);
-    return getImpl(ind, DOUB, doub_array, "double");
-}
+        auto range_it = arrIndexRange.find(number);
+        std::pair<int, int> indexRange = range_it->second;
+        int start_ind_lgr = -1;
 
-template<>
-const std::vector<bool>& ERst::getRestartData<bool>(const std::string& name, int reportStepNumber, int occurrence)
-{
-    int ind = getArrayIndex(name, reportStepNumber, occurrence);
-    return getImpl(ind, LOGI, logi_array, "bool");
-}
+        for (int n = indexRange.first; n < indexRange.second; n++) {
+            if (array_name[n] == "LGR") {
+                auto arr = getImpl(n, CHAR, char_array, "string");
+                if (arr[0] == lgr_name)
+                    start_ind_lgr = n;
+            }
+        }
 
-template<>
-const std::vector<std::string>& ERst::getRestartData<std::string>(const std::string& name, int reportStepNumber, int occurrence)
-{
-    int ind = getArrayIndex(name, reportStepNumber, occurrence);
-    return getImpl(ind, CHAR, char_array, "string");
-}
+        if (start_ind_lgr == -1) {
+            std::string message = "LGR '" + lgr_name + "'not found in restart file";
+            OPM_THROW(std::runtime_error, message);
+        }
 
-template<>
-const std::vector<float>& ERst::getRestartData<float>(const std::string& name, int reportStepNumber,const std::string& lgr_name)
-{
-    int ind = getArrayIndex(name, reportStepNumber, lgr_name);
-    return getImpl(ind, REAL, real_array, "float");
-}
+        return start_ind_lgr;
+    }
 
-template<>
-const std::vector<double>& ERst::getRestartData<double>(const std::string& name, int reportStepNumber,const std::string& lgr_name)
-{
-    int ind = getArrayIndex(name, reportStepNumber, lgr_name);
-    return getImpl(ind, DOUB, doub_array, "double");
-}
+    std::tuple<int, int> ERst::getIndexRange(int reportStepNumber) const
+    {
 
-template<>
-const std::vector<int>& ERst::getRestartData<int>(const std::string& name, int reportStepNumber,const std::string& lgr_name)
-{
-    int ind = getArrayIndex(name, reportStepNumber, lgr_name);
-    return getImpl(ind, INTE, inte_array, "int");
-}
+        if (!hasReportStepNumber(reportStepNumber)) {
+            std::string message
+                = "Trying to get index range for non existing sequence " + std::to_string(reportStepNumber);
+            OPM_THROW(std::invalid_argument, message);
+        }
 
-template<>
-const std::vector<bool>& ERst::getRestartData<bool>(const std::string& name, int reportStepNumber,const std::string& lgr_name)
-{
-    int ind = getArrayIndex(name, reportStepNumber, lgr_name);
-    return getImpl(ind, LOGI, logi_array, "bool");
-}
+        auto range_it = arrIndexRange.find(reportStepNumber);
 
-template<>
-const std::vector<std::string>& ERst::getRestartData<std::string>(const std::string& name, int reportStepNumber,const std::string& lgr_name)
-{
-    int ind = getArrayIndex(name, reportStepNumber, lgr_name);
-    return getImpl(ind, CHAR, char_array, "char");
-}
+        return range_it->second;
+    }
 
-template <typename T>
-const std::vector<T>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name)
-{
-    auto indRange = this->getIndexRange(reportStepNumber);
+    bool ERst::hasArray(const std::string& name, int number) const
+    {
+        if (!hasReportStepNumber(number))
+            return false;
 
-    if ((std::get<0>(indRange) + index) > std::get<1>(indRange))
-        OPM_THROW(std::invalid_argument, "getRestartData, index out of range");
+        auto range_it = arrIndexRange.find(number);
 
-    int start_ind = get_start_index_lgrname(reportStepNumber, lgr_name);
-    return  this->get<T>(index + start_ind);
-}
+        std::pair<int, int> indexRange = range_it->second;
 
-template const std::vector<int>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
-template const std::vector<std::string>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
-template const std::vector<float>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
-template const std::vector<double>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
-template const std::vector<bool>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
+        auto it = std::find(array_name.begin() + indexRange.first, array_name.begin() + indexRange.second, name);
 
-}} // namespace Opm::ecl
+        if (std::distance(array_name.begin(), it) == indexRange.second)
+            return false;
+
+        return true;
+    }
+
+
+    int ERst::getArrayIndex(const std::string& name, int number, int occurrenc)
+    {
+        if (!hasReportStepNumber(number)) {
+            std::string message
+                = "Trying to get vector " + name + " from non existing sequence " + std::to_string(number);
+            OPM_THROW(std::invalid_argument, message);
+        }
+
+
+        auto range_it = arrIndexRange.find(number);
+
+        std::pair<int, int> indexRange = range_it->second;
+
+        auto it = std::find(array_name.begin() + indexRange.first, array_name.begin() + indexRange.second, name);
+
+        for (int t = 0; t < occurrenc; t++) {
+            it = std::find(it + 1, array_name.begin() + indexRange.second, name);
+        }
+
+        if (std::distance(array_name.begin(), it) == indexRange.second) {
+            std::string message = "Array " + name + " not found in sequence " + std::to_string(number);
+            OPM_THROW(std::runtime_error, message);
+        }
+
+        return std::distance(array_name.begin(), it);
+    }
+
+    int ERst::getArrayIndex(const std::string& name, int number, const std::string& lgr_name)
+    {
+        auto range_it = arrIndexRange.find(number);
+        std::pair<int, int> indexRange = range_it->second;
+
+        int start_ind_lgr = get_start_index_lgrname(number, lgr_name);
+
+        auto it = std::find(array_name.begin() + start_ind_lgr, array_name.begin() + indexRange.second, name);
+
+        if (std::distance(array_name.begin(), it) == indexRange.second) {
+            std::string message = "Array " + name + " not found for " + lgr_name;
+            OPM_THROW(std::runtime_error, message);
+        }
+
+        return std::distance(array_name.begin(), it);
+    }
+
+
+    std::streampos ERst::restartStepWritePosition(const int seqnumValue) const
+    {
+        auto pos = this->arrIndexRange.lower_bound(seqnumValue);
+
+        return (pos == this->arrIndexRange.end()) ? std::streampos(std::streamoff(-1))
+                                                  : this->seekPosition(pos->second.first);
+    }
+
+    template <>
+    const std::vector<int>& ERst::getRestartData<int>(const std::string& name, int reportStepNumber, int occurrence)
+    {
+        int ind = getArrayIndex(name, reportStepNumber, occurrence);
+        return getImpl(ind, INTE, inte_array, "integer");
+    }
+
+    template <>
+    const std::vector<float>& ERst::getRestartData<float>(const std::string& name, int reportStepNumber, int occurrence)
+    {
+        int ind = getArrayIndex(name, reportStepNumber, occurrence);
+        return getImpl(ind, REAL, real_array, "float");
+    }
+
+    template <>
+    const std::vector<double>&
+    ERst::getRestartData<double>(const std::string& name, int reportStepNumber, int occurrence)
+    {
+        int ind = getArrayIndex(name, reportStepNumber, occurrence);
+        return getImpl(ind, DOUB, doub_array, "double");
+    }
+
+    template <>
+    const std::vector<bool>& ERst::getRestartData<bool>(const std::string& name, int reportStepNumber, int occurrence)
+    {
+        int ind = getArrayIndex(name, reportStepNumber, occurrence);
+        return getImpl(ind, LOGI, logi_array, "bool");
+    }
+
+    template <>
+    const std::vector<std::string>&
+    ERst::getRestartData<std::string>(const std::string& name, int reportStepNumber, int occurrence)
+    {
+        int ind = getArrayIndex(name, reportStepNumber, occurrence);
+        return getImpl(ind, CHAR, char_array, "string");
+    }
+
+    template <>
+    const std::vector<float>&
+    ERst::getRestartData<float>(const std::string& name, int reportStepNumber, const std::string& lgr_name)
+    {
+        int ind = getArrayIndex(name, reportStepNumber, lgr_name);
+        return getImpl(ind, REAL, real_array, "float");
+    }
+
+    template <>
+    const std::vector<double>&
+    ERst::getRestartData<double>(const std::string& name, int reportStepNumber, const std::string& lgr_name)
+    {
+        int ind = getArrayIndex(name, reportStepNumber, lgr_name);
+        return getImpl(ind, DOUB, doub_array, "double");
+    }
+
+    template <>
+    const std::vector<int>&
+    ERst::getRestartData<int>(const std::string& name, int reportStepNumber, const std::string& lgr_name)
+    {
+        int ind = getArrayIndex(name, reportStepNumber, lgr_name);
+        return getImpl(ind, INTE, inte_array, "int");
+    }
+
+    template <>
+    const std::vector<bool>&
+    ERst::getRestartData<bool>(const std::string& name, int reportStepNumber, const std::string& lgr_name)
+    {
+        int ind = getArrayIndex(name, reportStepNumber, lgr_name);
+        return getImpl(ind, LOGI, logi_array, "bool");
+    }
+
+    template <>
+    const std::vector<std::string>&
+    ERst::getRestartData<std::string>(const std::string& name, int reportStepNumber, const std::string& lgr_name)
+    {
+        int ind = getArrayIndex(name, reportStepNumber, lgr_name);
+        return getImpl(ind, CHAR, char_array, "char");
+    }
+
+    template <typename T>
+    const std::vector<T>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name)
+    {
+        auto indRange = this->getIndexRange(reportStepNumber);
+
+        if ((std::get<0>(indRange) + index) > std::get<1>(indRange))
+            OPM_THROW(std::invalid_argument, "getRestartData, index out of range");
+
+        int start_ind = get_start_index_lgrname(reportStepNumber, lgr_name);
+        return this->get<T>(index + start_ind);
+    }
+
+    template const std::vector<int>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
+    template const std::vector<std::string>&
+    ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
+    template const std::vector<float>&
+    ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
+    template const std::vector<double>&
+    ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
+    template const std::vector<bool>&
+    ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
+} // namespace EclIO
+} // namespace Opm

--- a/opm/io/eclipse/ERst.cpp
+++ b/opm/io/eclipse/ERst.cpp
@@ -114,7 +114,7 @@ namespace EclIO
         int start_ind_lgr;
         std::string last_array_name;
 
-        if ((lgr_name == "") or (lgr_name_upper == "GLOBAL")) {
+        if (lgr_name.empty() || lgr_name_upper == "GLOBAL") {
             auto rng = this->arrIndexRange.at(reportStepNumber);
             start_ind_lgr = std::get<0>(rng);
 
@@ -166,6 +166,30 @@ namespace EclIO
         }
 
         return count;
+    }
+
+    int ERst::dataSize(const std::string& name, int reportStepNumber) const
+    {
+        if (!hasReportStepNumber(reportStepNumber)) {
+            std::string message = "Trying to get size of vectors of name " + name + " from non existing sequence "
+                + std::to_string(reportStepNumber);
+            OPM_THROW(std::invalid_argument, message);
+        }
+
+        int dataSize = 0;
+
+        auto range_it = arrIndexRange.find(reportStepNumber);
+        if (range_it != arrIndexRange.end()) {
+            std::pair<int, int> indexRange = range_it->second;
+
+            for (int i = std::get<0>(indexRange); i < std::get<1>(indexRange); i++) {
+                if (array_name[i] == name) {
+                    dataSize += array_size[i];
+                }
+            }
+        }
+
+        return dataSize;
     }
 
     void ERst::initUnified()

--- a/opm/io/eclipse/ERst.cpp
+++ b/opm/io/eclipse/ERst.cpp
@@ -39,9 +39,7 @@ seqnumFromSeparateFilename(const std::string& filename)
         return std::stoi(match[1]);
     }
 
-    throw std::invalid_argument {"Unable to Determine Report Step Sequence Number "
-                                 "From Restart Filename \""
-                                 + filename + '"'};
+    return 0;
 }
 } // namespace
 

--- a/opm/io/eclipse/ERst.hpp
+++ b/opm/io/eclipse/ERst.hpp
@@ -3,9 +3,8 @@
 
    This file is part of the Open Porous Media project (OPM).
 
-   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
    OPM is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -28,77 +27,96 @@
 #include <vector>
 
 
-namespace Opm { namespace EclIO { namespace OutputStream {
-    class Restart;
-}}}
-
-namespace Opm { namespace EclIO {
-
-class ERst : public EclFile
+namespace Opm
 {
-public:
-    explicit ERst(const std::string& filename);
-
-    bool hasReportStepNumber(int number) const;
-    bool hasArray(const std::string& name, int number) const;
-    bool hasLGR(const std::string& gridname, int reportStepNumber) const;
-
-    void loadReportStepNumber(int number);
-
-    template <typename T>
-    const std::vector<T>& getRestartData(const std::string& name, int reportStepNumber)
+namespace EclIO
+{
+    namespace OutputStream
     {
-        return getRestartData<T>(name,reportStepNumber, 0);
+        class Restart;
     }
+} // namespace EclIO
+} // namespace Opm
 
-    template <typename T>
-    const std::vector<T>& getRestartData(const std::string& name, int reportStepNumber, int occurrence);
 
-    template <typename T>
-    const std::vector<T>& getRestartData(int index, int reportStepNumber)
+
+
+namespace Opm
+{
+namespace EclIO
+{
+
+    class ERst : public EclFile
     {
-        auto indRange = this->getIndexRange(reportStepNumber);
-        return  this->get<T>(index + std::get<0>(indRange));
-    }
+    public:
+        explicit ERst(const std::string& filename);
 
-    template <typename T>
-    const std::vector<T>& getRestartData(const std::string& name, int reportStepNumber, const std::string& lgr_name);
+        bool hasReportStepNumber(int number) const;
+        bool hasArray(const std::string& name, int number) const;
+        bool hasLGR(const std::string& gridname, int reportStepNumber) const;
 
-    template <typename T>
-    const std::vector<T>& getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
+        void loadReportStepNumber(int number);
 
-    int occurrence_count(const std::string& name, int reportStepNumber) const;
-    size_t numberOfReportSteps() const { return seqnum.size(); };
+        template <typename T>
+        const std::vector<T>& getRestartData(const std::string& name, int reportStepNumber)
+        {
+            return getRestartData<T>(name, reportStepNumber, 0);
+        }
 
-    const std::vector<int>& listOfReportStepNumbers() const { return seqnum; }
+        template <typename T>
+        const std::vector<T>& getRestartData(const std::string& name, int reportStepNumber, int occurrence);
 
-    std::vector<EclEntry> listOfRstArrays(int reportStepNumber);
-    std::vector<EclEntry> listOfRstArrays(int reportStepNumber, const std::string& lgr_name);
+        template <typename T>
+        const std::vector<T>& getRestartData(int index, int reportStepNumber)
+        {
+            auto indRange = this->getIndexRange(reportStepNumber);
+            return this->get<T>(index + std::get<0>(indRange));
+        }
 
-    friend class OutputStream::Restart;
+        template <typename T>
+        const std::vector<T>&
+        getRestartData(const std::string& name, int reportStepNumber, const std::string& lgr_name);
 
-private:
-    int nReports;
-    std::vector<int> seqnum;                           // report step numbers, from SEQNUM array in restart file
-    mutable std::unordered_map<int,bool> reportLoaded;
-    std::map<int, std::pair<int,int>> arrIndexRange;   // mapping report step number to array indeces (start and end)
-    std::vector<std::vector<std::string>> lgr_names;                           // report step numbers, from SEQNUM array in restart file
+        template <typename T>
+        const std::vector<T>& getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
 
-    void initUnified();
-    void initSeparate(const int number);
+        int occurrence_count(const std::string& name, int reportStepNumber) const;
+        size_t numberOfReportSteps() const
+        {
+            return seqnum.size();
+        };
 
-    int get_start_index_lgrname(int number, const std::string& lgr_name);
+        const std::vector<int>& listOfReportStepNumbers() const
+        {
+            return seqnum;
+        }
 
-    int getArrayIndex(const std::string& name, int seqnum, int occurrence);
-    int getArrayIndex(const std::string& name, int number, const std::string& lgr_name);
+        std::vector<EclEntry> listOfRstArrays(int reportStepNumber);
+        std::vector<EclEntry> listOfRstArrays(int reportStepNumber, const std::string& lgr_name);
 
-    std::tuple<int,int> getIndexRange(int reportStepNumber) const;
+        friend class OutputStream::Restart;
 
-    std::streampos
-    restartStepWritePosition(const int seqnumValue) const;
+    private:
+        int nReports;
+        std::vector<int> seqnum; // report step numbers, from SEQNUM array in restart file
+        mutable std::unordered_map<int, bool> reportLoaded;
+        std::map<int, std::pair<int, int>> arrIndexRange; // mapping report step number to array indeces (start and end)
+        std::vector<std::vector<std::string>> lgr_names; // report step numbers, from SEQNUM array in restart file
 
-};
+        void initUnified();
+        void initSeparate(const int number);
 
-}} // namespace Opm::EclIO
+        int get_start_index_lgrname(int number, const std::string& lgr_name);
+
+        int getArrayIndex(const std::string& name, int seqnum, int occurrence);
+        int getArrayIndex(const std::string& name, int number, const std::string& lgr_name);
+
+        std::tuple<int, int> getIndexRange(int reportStepNumber) const;
+
+        std::streampos restartStepWritePosition(const int seqnumValue) const;
+    };
+
+} // namespace EclIO
+} // namespace Opm
 
 #endif // OPM_IO_ERST_HPP

--- a/opm/io/eclipse/ERst.hpp
+++ b/opm/io/eclipse/ERst.hpp
@@ -38,9 +38,6 @@ namespace EclIO
 } // namespace EclIO
 } // namespace Opm
 
-
-
-
 namespace Opm
 {
 namespace EclIO
@@ -80,6 +77,7 @@ namespace EclIO
         template <typename T>
         const std::vector<T>& getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
 
+        int dataSize(const std::string& name, int reportStepNumber) const;
         int occurrence_count(const std::string& name, int reportStepNumber) const;
         size_t numberOfReportSteps() const
         {


### PR DESCRIPTION
This pull request includes several changes to improve support for LGR, NNC and dual porosity models.

A commit with only `clang-format` changes is included to clearly see the introduced changes.

### Enhancements to Grid Data Handling:

* Added new member variables `nncg_array_index` and `nncl_array_index` to the `EGrid`
* Introduced methods `load_nnc_data` and `nnc_connections` to load and manage NNC data, ensuring consistency between grid and init files.
* Added overload of `getCellCorners` to be able to read out coordinates without radial coordinate conversion.

### Improvements to Active Cell Management:

* Added the `set_active_cells` method to manage active and fracture active cells, and introduced `active_frac_index` and `ijk_from_active_frac_index` methods for handling fracture active cells. 