### PR TITLE
 Add GEFAC to allowed keywords in ACTIONX block and in PYACTION

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ActionX.cpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.cpp
@@ -105,6 +105,7 @@ bool ActionX::valid_keyword(const std::string& keyword)
         //INCLUDE is allowed as well, but is handled differently by the Parser and thus does not need to be in this list
 
         "GCONINJE", "GCONPROD", "GCONSUMP",
+        "GEFAC",
         "GLIFTOPT",
         "GRUPNET", "GRUPTREE",
 

--- a/opm/input/eclipse/Schedule/Action/PyAction.cpp
+++ b/opm/input/eclipse/Schedule/Action/PyAction.cpp
@@ -44,7 +44,7 @@ bool PyAction::valid_keyword(const std::string& keyword) {
         "FIELD",
         "ENDBOX", "EXIT",
         //INCLUDE is allowed as well, but is handled differently by the Parser and thus does not need to be in this list
-        "GCONINJE", "GCONPROD", "GCONSUMP","GRUPTREE",
+        "GCONINJE", "GCONPROD", "GCONSUMP", "GEFAC", "GRUPTREE",
         "METRIC", "MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-",
         "NEXT", "NEXTSTEP",
         "WCONINJE", "WCONPROD", "WECON", "WEFAC", "WELOPEN", "WELTARG", "WGRUPCON",


### PR DESCRIPTION
The PR https://github.com/OPM/opm-simulators/pull/5846 depends on this PR and on https://github.com/OPM/opm-tests/pull/1277, this PR and https://github.com/OPM/opm-tests/pull/1277 should be merged first.

For the reference manual:
With this PR, the keyword GEFAC is made available for inserting it into the simulation from an ACTIONX block and from PYACTION code.