### PR TITLE
Add comment about INCLUDE keyword for Pyaction and ACTIONX

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ActionX.cpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.cpp
@@ -102,6 +102,8 @@ bool ActionX::valid_keyword(const std::string& keyword)
 
         "ENDBOX", "EXIT",
 
+        //INCLUDE is allowed as well, but is handled differently by the Parser and thus does not need to be in this list
+
         "GCONINJE", "GCONPROD", "GCONSUMP",
         "GLIFTOPT",
         "GRUPNET", "GRUPTREE",

--- a/opm/input/eclipse/Schedule/Action/PyAction.cpp
+++ b/opm/input/eclipse/Schedule/Action/PyAction.cpp
@@ -43,6 +43,7 @@ bool PyAction::valid_keyword(const std::string& keyword) {
         "COMPSEGS",
         "FIELD",
         "ENDBOX", "EXIT",
+        //INCLUDE is allowed as well, but is handled differently by the Parser and thus does not need to be in this list
         "GCONINJE", "GCONPROD", "GCONSUMP","GRUPTREE",
         "METRIC", "MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-",
         "NEXT", "NEXTSTEP",


### PR DESCRIPTION
The PR https://github.com/OPM/opm-simulators/pull/5848 depends on https://github.com/OPM/opm-tests/pull/1278, so https://github.com/OPM/opm-tests/pull/1278 should be merged first. This PR is technically independent, but should still be merged before https://github.com/OPM/opm-simulators/pull/5848.

For the reference manual: With this, I've checked how the INCLUDE keyword can be used from a PyAction script. The path to the included files can be given relative to the location of the python script (as done in https://github.com/OPM/opm-tests/pull/1278) by retrieving the location of the python script as ` script_location = os.path.dirname(os.path.abspath(__file__))` and using that or as an absolute path.
A pure relative path does not work here, also using variables from the DATA file does not work, since the info is not available at the spot where the Python Script is run.