### PR TITLE
Added "dummy" water phase to compositional fluid system

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -976,7 +976,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/fluidsystems/H2OAirFluidSystem.hpp
       opm/material/fluidsystems/H2ON2FluidSystem.hpp
       opm/material/fluidsystems/ThreeComponentFluidSystem.hh
-      opm/material/fluidsystems/GenericOilGasFluidSystem.hpp
+      opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
       opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
       opm/material/fluidmatrixinteractions/SatCurveMultiplexerParams.hpp
       opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -71,6 +71,7 @@ class PTFlash
     static constexpr int numMiscibleComponents = FluidSystem::numMiscibleComponents;
     static constexpr int numMisciblePhases = FluidSystem::numMisciblePhases; //oil, gas
     static constexpr int numEq = numMisciblePhases + numMisciblePhases * numMiscibleComponents;
+    static constexpr bool waterEnabled = FluidSystem::waterEnabled;
 
     using EOSType = CompositionalConfig::EOSType;
 
@@ -868,7 +869,7 @@ protected:
 
         // getting the secondary Jocobian matrix
         constexpr size_t num_equations = numMisciblePhases * numMiscibleComponents + 1;
-        constexpr size_t secondary_num_pv = numComponents + 2; // pressure, z for all the components
+        constexpr size_t secondary_num_pv = numComponents + (waterEnabled ? 2 : 1); // pressure, z for all the components
         using SecondaryEval = Opm::DenseAd::Evaluation<double, secondary_num_pv>; // three z and one pressure
         using SecondaryComponentVector = Dune::FieldVector<SecondaryEval, numComponents>;
         using SecondaryFlashFluidState = Opm::CompositionalFluidState<SecondaryEval, FluidSystem>;

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -67,6 +67,7 @@ class PTFlash
     static constexpr int numComponents = FluidSystem::numComponents;
     enum { oilPhaseIdx = FluidSystem::oilPhaseIdx};
     enum { gasPhaseIdx = FluidSystem::gasPhaseIdx};
+    enum { waterPhaseIdx = FluidSystem::waterPhaseIdx};
     static constexpr int numMiscibleComponents = FluidSystem::numMiscibleComponents;
     static constexpr int numMisciblePhases = FluidSystem::numMisciblePhases; //oil, gas
     static constexpr int numEq = numMisciblePhases + numMisciblePhases * numMiscibleComponents;
@@ -707,6 +708,9 @@ protected:
         ParamCache paramCache(eos_type);
 
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            if (phaseIdx == static_cast<unsigned int>(waterPhaseIdx)) {
+                continue;
+            }
             paramCache.updatePhase(flash_fluid_state, phaseIdx);
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 // TODO: will phi here carry the correct derivatives?
@@ -746,6 +750,9 @@ protected:
             flash_fluid_state.setLvalue(l);
 
             for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+                if (phaseIdx == static_cast<unsigned int>(waterPhaseIdx)) {
+                    continue;
+                }
                 paramCache.updatePhase(flash_fluid_state, phaseIdx);
                 for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                     Eval phi = FluidSystem::fugacityCoefficient(flash_fluid_state, paramCache, phaseIdx, compIdx);
@@ -861,7 +868,7 @@ protected:
 
         // getting the secondary Jocobian matrix
         constexpr size_t num_equations = numMisciblePhases * numMiscibleComponents + 1;
-        constexpr size_t secondary_num_pv = numComponents + 1; // pressure, z for all the components
+        constexpr size_t secondary_num_pv = numComponents + 2; // pressure, z for all the components
         using SecondaryEval = Opm::DenseAd::Evaluation<double, secondary_num_pv>; // three z and one pressure
         using SecondaryComponentVector = Dune::FieldVector<SecondaryEval, numComponents>;
         using SecondaryFlashFluidState = Opm::CompositionalFluidState<SecondaryEval, FluidSystem>;
@@ -899,6 +906,9 @@ protected:
         using SecondaryParamCache = typename FluidSystem::template ParameterCache<typename SecondaryFlashFluidState::Scalar>;
         SecondaryParamCache secondary_param_cache(eos_type);
         for (unsigned phase_idx = 0; phase_idx < numPhases; ++phase_idx) {
+            if (phase_idx == static_cast<unsigned int>(waterPhaseIdx)) {
+                continue;
+            }
             secondary_param_cache.updatePhase(secondary_fluid_state, phase_idx);
             for (unsigned comp_idx = 0; comp_idx < numComponents; ++comp_idx) {
                 SecondaryEval phi = FluidSystem::fugacityCoefficient(secondary_fluid_state, secondary_param_cache, phase_idx, comp_idx);
@@ -949,6 +959,9 @@ protected:
         using PrimaryParamCache = typename FluidSystem::template ParameterCache<typename PrimaryFlashFluidState::Scalar>;
         PrimaryParamCache primary_param_cache(eos_type);
         for (unsigned phase_idx = 0; phase_idx < numPhases; ++phase_idx) {
+            if (phase_idx == static_cast<unsigned int>(waterPhaseIdx)) {
+                continue;
+            }
             primary_param_cache.updatePhase(primary_fluid_state, phase_idx);
             for (unsigned comp_idx = 0; comp_idx < numComponents; ++comp_idx) {
                 PrimaryEval phi = FluidSystem::fugacityCoefficient(primary_fluid_state, primary_param_cache, phase_idx, comp_idx);
@@ -1106,6 +1119,9 @@ protected:
             using ParamCache = typename FluidSystem::template ParameterCache<typename FlashFluidState::Scalar>;
             ParamCache paramCache(eos_type);
             for (int phaseIdx=0; phaseIdx<numPhases; ++phaseIdx){
+                if (phaseIdx == waterPhaseIdx) {
+                    continue;
+                }
                 paramCache.updatePhase(fluid_state, phaseIdx);
                 for (int compIdx=0; compIdx<numComponents; ++compIdx){
                     auto phi = FluidSystem::fugacityCoefficient(fluid_state, paramCache, phaseIdx, compIdx);

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -71,7 +71,6 @@ class PTFlash
     static constexpr int numMiscibleComponents = FluidSystem::numMiscibleComponents;
     static constexpr int numMisciblePhases = FluidSystem::numMisciblePhases; //oil, gas
     static constexpr int numEq = numMisciblePhases + numMisciblePhases * numMiscibleComponents;
-    static constexpr bool waterEnabled = FluidSystem::waterEnabled;
 
     using EOSType = CompositionalConfig::EOSType;
 
@@ -863,7 +862,7 @@ protected:
 
         // getting the secondary Jocobian matrix
         constexpr size_t num_equations = numMisciblePhases * numMiscibleComponents + 1;
-        constexpr size_t secondary_num_pv = numComponents + (waterEnabled ? 2 : 1); // pressure, z for all the components
+        constexpr size_t secondary_num_pv = numComponents + 1; // pressure, z for all the components
         using SecondaryEval = Opm::DenseAd::Evaluation<double, secondary_num_pv>; // three z and one pressure
         using SecondaryComponentVector = Dune::FieldVector<SecondaryEval, numComponents>;
         using SecondaryFlashFluidState = Opm::CompositionalFluidState<SecondaryEval, FluidSystem>;

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -708,10 +708,7 @@ protected:
         using ParamCache = typename FluidSystem::template ParameterCache<typename CompositionalFluidState<Eval, FluidSystem>::Scalar>;
         ParamCache paramCache(eos_type);
 
-        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            if (phaseIdx == static_cast<unsigned int>(waterPhaseIdx)) {
-                continue;
-            }
+        for (unsigned phaseIdx = 0; phaseIdx < numMisciblePhases; ++phaseIdx) {
             paramCache.updatePhase(flash_fluid_state, phaseIdx);
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 // TODO: will phi here carry the correct derivatives?
@@ -750,10 +747,7 @@ protected:
             }
             flash_fluid_state.setLvalue(l);
 
-            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-                if (phaseIdx == static_cast<unsigned int>(waterPhaseIdx)) {
-                    continue;
-                }
+            for (unsigned phaseIdx = 0; phaseIdx < numMisciblePhases; ++phaseIdx) {
                 paramCache.updatePhase(flash_fluid_state, phaseIdx);
                 for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                     Eval phi = FluidSystem::fugacityCoefficient(flash_fluid_state, paramCache, phaseIdx, compIdx);
@@ -906,10 +900,7 @@ protected:
         // TODO: we probably can simplify SecondaryFlashFluidState::Scalar
         using SecondaryParamCache = typename FluidSystem::template ParameterCache<typename SecondaryFlashFluidState::Scalar>;
         SecondaryParamCache secondary_param_cache(eos_type);
-        for (unsigned phase_idx = 0; phase_idx < numPhases; ++phase_idx) {
-            if (phase_idx == static_cast<unsigned int>(waterPhaseIdx)) {
-                continue;
-            }
+        for (unsigned phase_idx = 0; phase_idx < numMisciblePhases; ++phase_idx) {
             secondary_param_cache.updatePhase(secondary_fluid_state, phase_idx);
             for (unsigned comp_idx = 0; comp_idx < numComponents; ++comp_idx) {
                 SecondaryEval phi = FluidSystem::fugacityCoefficient(secondary_fluid_state, secondary_param_cache, phase_idx, comp_idx);
@@ -959,10 +950,7 @@ protected:
         // TODO: is PrimaryFlashFluidState::Scalar> PrimaryEval here?
         using PrimaryParamCache = typename FluidSystem::template ParameterCache<typename PrimaryFlashFluidState::Scalar>;
         PrimaryParamCache primary_param_cache(eos_type);
-        for (unsigned phase_idx = 0; phase_idx < numPhases; ++phase_idx) {
-            if (phase_idx == static_cast<unsigned int>(waterPhaseIdx)) {
-                continue;
-            }
+        for (unsigned phase_idx = 0; phase_idx < numMisciblePhases; ++phase_idx) {
             primary_param_cache.updatePhase(primary_fluid_state, phase_idx);
             for (unsigned comp_idx = 0; comp_idx < numComponents; ++comp_idx) {
                 PrimaryEval phi = FluidSystem::fugacityCoefficient(primary_fluid_state, primary_param_cache, phase_idx, comp_idx);
@@ -1119,10 +1107,7 @@ protected:
             // Calculate fugacity coefficient
             using ParamCache = typename FluidSystem::template ParameterCache<typename FlashFluidState::Scalar>;
             ParamCache paramCache(eos_type);
-            for (int phaseIdx=0; phaseIdx<numPhases; ++phaseIdx){
-                if (phaseIdx == waterPhaseIdx) {
-                    continue;
-                }
+            for (int phaseIdx=0; phaseIdx<numMisciblePhases; ++phaseIdx){
                 paramCache.updatePhase(fluid_state, phaseIdx);
                 for (int compIdx=0; compIdx<numComponents; ++compIdx){
                     auto phi = FluidSystem::fugacityCoefficient(fluid_state, paramCache, phaseIdx, compIdx);

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -526,5 +526,7 @@ readGlobalThreePhaseOptions_(const Runspec& runspec)
 
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,0,1,2>>;
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,0,1,2>>;
+template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,2,0,1>>;
+template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,2,0,1>>;
 
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
@@ -306,6 +306,8 @@ readScaledEpsPointsImbibition_(unsigned elemIdx, EclTwoPhaseSystemType type,
 // Make some actual code, by realizing the previously defined templated class
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,0,1,2>>::InitParams::HystParams;
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,0,1,2>>::InitParams::HystParams;
+template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,2,0,1>>::InitParams::HystParams;
+template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,2,0,1>>::InitParams::HystParams;
 
 
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
@@ -339,5 +339,7 @@ satOrImbRegion_(std::vector<int>& array, std::vector<int>& default_vec, unsigned
 // Make some actual code, by realizing the previously defined templated class
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,0,1,2>>::InitParams;
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,0,1,2>>::InitParams;
+template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,2,0,1>>::InitParams;
+template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,2,0,1>>::InitParams;
 
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
@@ -455,6 +455,8 @@ readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionId
 // Make some actual code, by realizing the previously defined templated class
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,0,1,2>>::InitParams::ReadEffectiveParams;
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,0,1,2>>::InitParams::ReadEffectiveParams;
+template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,2,0,1>>::InitParams::ReadEffectiveParams;
+template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,2,0,1>>::InitParams::ReadEffectiveParams;
 
 
 } // namespace Opm

--- a/opm/material/fluidsystems/Co2BrineFluidSystem.hh
+++ b/opm/material/fluidsystems/Co2BrineFluidSystem.hh
@@ -55,6 +55,7 @@ namespace Opm {
         static constexpr int numMiscibleComponents = 2;
         static constexpr int oilPhaseIdx = 0;
         static constexpr int gasPhaseIdx = 1;
+        static constexpr int waterPhaseIdx = -1;
 
         static constexpr int Comp0Idx = 0;
         static constexpr int Comp1Idx = 1;

--- a/opm/material/fluidsystems/Co2BrineFluidSystem.hh
+++ b/opm/material/fluidsystems/Co2BrineFluidSystem.hh
@@ -53,6 +53,7 @@ namespace Opm {
         static constexpr int numComponents = 2;
         static constexpr int numMisciblePhases=2;
         static constexpr int numMiscibleComponents = 2;
+        static constexpr bool waterEnabled = false;
         static constexpr int oilPhaseIdx = 0;
         static constexpr int gasPhaseIdx = 1;
         static constexpr int waterPhaseIdx = -1;

--- a/opm/material/fluidsystems/GenericOilGasFluidSystem.hpp
+++ b/opm/material/fluidsystems/GenericOilGasFluidSystem.hpp
@@ -34,6 +34,7 @@
 #endif
 
 #include <opm/material/eos/CubicEOS.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp>
 #include <opm/material/fluidsystems/BaseFluidSystem.hpp>
 #include <opm/material/fluidsystems/PTFlashParameterCache.hpp> // TODO: this is something else need to check
 #include <opm/material/viscositymodels/LBC.hpp>
@@ -59,16 +60,16 @@ namespace Opm {
     class GenericOilGasFluidSystem : public BaseFluidSystem<Scalar, GenericOilGasFluidSystem<Scalar, NumComp> > {
     public:
         // TODO: I do not think these should be constant in fluidsystem, will try to make it non-constant later
-        static constexpr int numPhases = 2;
+        static constexpr int numPhases = 3;
         static constexpr int numComponents = NumComp;
         static constexpr int numMisciblePhases = 2;
         // \Note: not totally sure when we should distinguish numMiscibleComponents and numComponents.
         // Possibly when with a dummy phase like water?
         static constexpr int numMiscibleComponents = NumComp;
         // TODO: phase location should be more general
-        static constexpr int waterPhaseIdx = -1;
-        static constexpr int oilPhaseIdx = 0;
-        static constexpr int gasPhaseIdx = 1;
+        static constexpr int waterPhaseIdx = 0;
+        static constexpr int oilPhaseIdx = 1;
+        static constexpr int gasPhaseIdx = 2;
 
         static constexpr int waterCompIdx = -1;
         static constexpr int oilCompIdx = 0;
@@ -79,6 +80,7 @@ namespace Opm {
         using ParameterCache = Opm::PTFlashParameterCache<ValueType, GenericOilGasFluidSystem<Scalar, NumComp>>;
         using ViscosityModel = Opm::ViscosityModels<Scalar, GenericOilGasFluidSystem<Scalar, NumComp>>;
         using CubicEOS = Opm::CubicEOS<Scalar, GenericOilGasFluidSystem<Scalar, NumComp>>;
+       	using WaterPvt = WaterPvtMultiplexer<Scalar>;
 
         struct ComponentParam {
             std::string name;
@@ -101,7 +103,7 @@ namespace Opm {
 
         static bool phaseIsActive(unsigned phaseIdx)
         {
-            return phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx;
+            return phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx || phaseIdx == waterPhaseIdx;
         }
 
         template<typename Param>
@@ -123,7 +125,7 @@ namespace Opm {
         /*!
          * \brief Initialize the fluid system using an ECL deck object
          */
-        static void initFromState(const EclipseState& eclState, const Schedule& /* schedule */)
+        static void initFromState(const EclipseState& eclState, const Schedule& schedule)
         {
             // TODO: we are not considering the EOS region for now
             const auto& comp_config = eclState.compositionalConfig();
@@ -148,11 +150,16 @@ namespace Opm {
             }
             FluidSystem::printComponentParams();
             interaction_coefficients_ = comp_config.binaryInteractionCoefficient(0);
+
+            // Init. water pvt from deck
+            waterPvt_->initFromState(eclState, schedule);
+
         }
 #endif // HAVE_ECL_INPUT
 
         static void init()
         {
+            waterPvt_ = std::make_unique<WaterPvt>();
             component_param_.reserve(numComponents);
         }
 
@@ -235,7 +242,8 @@ namespace Opm {
         //! \copydoc BaseFluidSystem::phaseName
         static std::string_view phaseName(unsigned phaseIdx)
         {
-                static const std::string_view name[] = {"o",  // oleic phase
+                static const std::string_view name[] = {"w",  // aqueous phase
+                                                        "o",  // oleic phase
                                                         "g"};  // gas phase
 
                 assert(phaseIdx < numPhases);
@@ -265,6 +273,13 @@ namespace Opm {
             if (phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx) {
                 return decay<LhsEval>(fluidState.averageMolarMass(phaseIdx) / paramCache.molarVolume(phaseIdx));
             }
+            else {
+                const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+                const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+                const Scalar& rho_w_ref = waterPvt_->waterReferenceDensity(0);
+                const LhsEval& bw = waterPvt_->inverseFormationVolumeFactor(0, T, p, LhsEval(0.0), LhsEval(0.0));
+                return rho_w_ref * bw;
+            }
 
             return {};
         }
@@ -277,8 +292,16 @@ namespace Opm {
         {
             assert(isConsistent());
             assert(phaseIdx < numPhases);
-            // Use LBC method to calculate viscosity
-            return decay<LhsEval>(ViscosityModel::LBC(fluidState, paramCache, phaseIdx));
+
+            if (phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx) {
+                // Use LBC method to calculate viscosity
+                return decay<LhsEval>(ViscosityModel::LBC(fluidState, paramCache, phaseIdx));
+            }
+            else {
+                const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+                const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+                return waterPvt_->viscosity(0, T, p, LhsEval(0.0), LhsEval(0.0));
+            }
         }
 
         //! \copydoc BaseFluidSystem::fugacityCoefficient
@@ -288,6 +311,9 @@ namespace Opm {
                                            unsigned phaseIdx,
                                            unsigned compIdx)
         {
+            if (phaseIdx == waterPhaseIdx)
+                return LhsEval(0.0);
+
             assert(isConsistent());
             assert(phaseIdx < numPhases);
             assert(compIdx < numComponents);
@@ -317,7 +343,7 @@ namespace Opm {
         {
             assert(phaseIdx < numPhases);
 
-            return (phaseIdx == 0);
+            return (phaseIdx == oilPhaseIdx);
         }
 
         //! \copydoc BaseFluidSystem::isIdealGas
@@ -325,7 +351,7 @@ namespace Opm {
         {
             assert(phaseIdx < numPhases);
 
-            return (phaseIdx == 1);
+            return (phaseIdx == gasPhaseIdx);
         }
         // the following funcitons are needed to compile the GenericOutputBlackoilModule
         // not implemented for this FluidSystem yet
@@ -404,6 +430,7 @@ namespace Opm {
 
         static std::vector<ComponentParam> component_param_;
         static std::vector<Scalar> interaction_coefficients_;
+        static std::unique_ptr<WaterPvt> waterPvt_;
 
     public:
         static std::string printComponentParams() {
@@ -428,5 +455,10 @@ namespace Opm {
     template <class Scalar, int NumComp>
     std::vector<Scalar>
     GenericOilGasFluidSystem<Scalar, NumComp>::interaction_coefficients_;
+    
+    template <class Scalar, int NumComp>
+    std::unique_ptr<WaterPvtMultiplexer<Scalar> > 
+    GenericOilGasFluidSystem<Scalar, NumComp>::waterPvt_;
+
 }
 #endif // OPM_GENERICOILGASFLUIDSYSTEM_HPP

--- a/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
+++ b/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
@@ -23,8 +23,8 @@
   copyright holders.
 */
 
-#ifndef OPM_GENERICOILGASFLUIDSYSTEM_HPP
-#define OPM_GENERICOILGASFLUIDSYSTEM_HPP
+#ifndef OPM_GENERIC_OIL_GAS_WATER_FLUIDSYSTEM_HPP
+#define OPM_GENERIC_OIL_GAS_WATER_FLUIDSYSTEM_HPP
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 
@@ -57,7 +57,7 @@ namespace Opm {
  * \tparam NumComp The number of the components in the fluid system.
  */
     template<class Scalar, int NumComp>
-    class GenericOilGasFluidSystem : public BaseFluidSystem<Scalar, GenericOilGasFluidSystem<Scalar, NumComp> > {
+    class GenericOilGasWaterFluidSystem : public BaseFluidSystem<Scalar, GenericOilGasWaterFluidSystem<Scalar, NumComp> > {
     public:
         // TODO: I do not think these should be constant in fluidsystem, will try to make it non-constant later
         static constexpr int numPhases = 3;
@@ -77,10 +77,10 @@ namespace Opm {
         static constexpr int compositionSwitchIdx = -1; // equil initializer
 
         template <class ValueType>
-        using ParameterCache = Opm::PTFlashParameterCache<ValueType, GenericOilGasFluidSystem<Scalar, NumComp>>;
-        using ViscosityModel = Opm::ViscosityModels<Scalar, GenericOilGasFluidSystem<Scalar, NumComp>>;
-        using CubicEOS = Opm::CubicEOS<Scalar, GenericOilGasFluidSystem<Scalar, NumComp>>;
-       	using WaterPvt = WaterPvtMultiplexer<Scalar>;
+        using ParameterCache = Opm::PTFlashParameterCache<ValueType, GenericOilGasWaterFluidSystem<Scalar, NumComp>>;
+        using ViscosityModel = Opm::ViscosityModels<Scalar, GenericOilGasWaterFluidSystem<Scalar, NumComp>>;
+        using CubicEOS = Opm::CubicEOS<Scalar, GenericOilGasWaterFluidSystem<Scalar, NumComp>>;
+        using WaterPvt = WaterPvtMultiplexer<Scalar>;
 
         struct ComponentParam {
             std::string name;
@@ -130,7 +130,7 @@ namespace Opm {
             // TODO: we are not considering the EOS region for now
             const auto& comp_config = eclState.compositionalConfig();
             // how should we utilize the numComps from the CompositionalConfig?
-            using FluidSystem = GenericOilGasFluidSystem<Scalar, NumComp>;
+            using FluidSystem = GenericOilGasWaterFluidSystem<Scalar, NumComp>;
             const std::size_t num_comps = comp_config.numComps();
             // const std::size_t num_eos_region = comp_config.
             assert(num_comps == NumComp);
@@ -358,48 +358,48 @@ namespace Opm {
         template <class LhsEval>
         static LhsEval convertXwGToxwG(const LhsEval&, unsigned)
         {
-            assert(false && "convertXwGToxwG not implemented for GenericOilGasFluidSystem!");
+            assert(false && "convertXwGToxwG not implemented for GenericOilGasWaterFluidSystem!");
             return 0.;
         }
         template <class LhsEval>
         static LhsEval convertXoGToxoG(const LhsEval&, unsigned)
         {
-            assert(false && "convertXoGToxoG not implemented for GenericOilGasFluidSystem!");
+            assert(false && "convertXoGToxoG not implemented for GenericOilGasWaterFluidSystem!");
             return 0.;
         }
 
         template <class LhsEval>
         static LhsEval convertxoGToXoG(const LhsEval&, unsigned)
         {
-            assert(false && "convertxoGToXoG not implemented for GenericOilGasFluidSystem!");
+            assert(false && "convertxoGToXoG not implemented for GenericOilGasWaterFluidSystem!");
             return 0.;
         }
 
         template <class LhsEval>
         static LhsEval convertXgOToxgO(const LhsEval&, unsigned)
         {
-            assert(false && "convertXgOToxgO not implemented for GenericOilGasFluidSystem!");
+            assert(false && "convertXgOToxgO not implemented for GenericOilGasWaterFluidSystem!");
             return 0.;
         }
 
         template <class LhsEval>
         static LhsEval convertRswToXwG(const LhsEval&, unsigned)
         {
-            assert(false && "convertRswToXwG not implemented for GenericOilGasFluidSystem!");
+            assert(false && "convertRswToXwG not implemented for GenericOilGasWaterFluidSystem!");
             return 0.;
         }
 
         template <class LhsEval>
         static LhsEval convertRvwToXgW(const LhsEval&, unsigned)
         {
-            assert(false && "convertRvwToXgW not implemented for GenericOilGasFluidSystem!");
+            assert(false && "convertRvwToXgW not implemented for GenericOilGasWaterFluidSystem!");
             return 0.;
         }
 
         template <class LhsEval>
         static LhsEval convertXgWToxgW(const LhsEval&, unsigned)
         {
-            assert(false && "convertXgWToxgW not implemented for GenericOilGasFluidSystem!");
+            assert(false && "convertXgWToxgW not implemented for GenericOilGasWaterFluidSystem!");
             return 0.;
         }
 
@@ -449,16 +449,16 @@ namespace Opm {
     };
 
     template <class Scalar, int NumComp>
-    std::vector<typename GenericOilGasFluidSystem<Scalar, NumComp>::ComponentParam>
-    GenericOilGasFluidSystem<Scalar, NumComp>::component_param_;
+    std::vector<typename GenericOilGasWaterFluidSystem<Scalar, NumComp>::ComponentParam>
+    GenericOilGasWaterFluidSystem<Scalar, NumComp>::component_param_;
 
     template <class Scalar, int NumComp>
     std::vector<Scalar>
-    GenericOilGasFluidSystem<Scalar, NumComp>::interaction_coefficients_;
+    GenericOilGasWaterFluidSystem<Scalar, NumComp>::interaction_coefficients_;
     
     template <class Scalar, int NumComp>
     std::unique_ptr<WaterPvtMultiplexer<Scalar> > 
-    GenericOilGasFluidSystem<Scalar, NumComp>::waterPvt_;
+    GenericOilGasWaterFluidSystem<Scalar, NumComp>::waterPvt_;
 
 }
-#endif // OPM_GENERICOILGASFLUIDSYSTEM_HPP
+#endif // OPM_GENERIC_OIL_GAS_WATER_FLUIDSYSTEM_HPP

--- a/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
+++ b/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
@@ -178,7 +178,7 @@ namespace Opm {
         * \brief Set the pressure-volume-saturation (PVT) relations for the water phase.
         */
         static void setWaterPvt(std::shared_ptr<WaterPvt> pvtObj)
-        { waterPvt_ = pvtObj; }
+        { waterPvt_ = std::move(pvtObj); }
 
         /*!
          * \brief The acentric factor of a component [].

--- a/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
+++ b/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
@@ -159,9 +159,15 @@ namespace Opm {
 
         static void init()
         {
-            waterPvt_ = std::make_unique<WaterPvt>();
+            waterPvt_ = std::make_shared<WaterPvt>();
             component_param_.reserve(numComponents);
         }
+
+        /*!
+        * \brief Set the pressure-volume-saturation (PVT) relations for the water phase.
+        */
+        static void setWaterPvt(std::shared_ptr<WaterPvt> pvtObj)
+        { waterPvt_ = pvtObj; }
 
         /*!
          * \brief The acentric factor of a component [].
@@ -430,7 +436,7 @@ namespace Opm {
 
         static std::vector<ComponentParam> component_param_;
         static std::vector<Scalar> interaction_coefficients_;
-        static std::unique_ptr<WaterPvt> waterPvt_;
+        static std::shared_ptr<WaterPvt> waterPvt_;
 
     public:
         static std::string printComponentParams() {
@@ -457,7 +463,7 @@ namespace Opm {
     GenericOilGasWaterFluidSystem<Scalar, NumComp>::interaction_coefficients_;
     
     template <class Scalar, int NumComp>
-    std::unique_ptr<WaterPvtMultiplexer<Scalar> > 
+    std::shared_ptr<WaterPvtMultiplexer<Scalar> > 
     GenericOilGasWaterFluidSystem<Scalar, NumComp>::waterPvt_;
 
 }

--- a/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
+++ b/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
@@ -259,9 +259,9 @@ namespace Opm {
         //! \copydoc BaseFluidSystem::phaseName
         static std::string_view phaseName(unsigned phaseIdx)
         {
-                static const std::string_view name[] = {"w",  // aqueous phase
-                                                        "o",  // oleic phase
-                                                        "g"};  // gas phase
+                static const std::string_view name[] = {"o",  // oleic phase
+                                                        "g",  // gas phase
+                                                        "w"}  // aqueous phase
 
                 assert(phaseIdx < numPhases);
                 return name[phaseIdx];

--- a/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
+++ b/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
@@ -261,7 +261,7 @@ namespace Opm {
         {
                 static const std::string_view name[] = {"o",  // oleic phase
                                                         "g",  // gas phase
-                                                        "w"}  // aqueous phase
+                                                        "w"};  // aqueous phase
 
                 assert(phaseIdx < numPhases);
                 return name[phaseIdx];

--- a/opm/material/fluidsystems/PTFlashParameterCache.hpp
+++ b/opm/material/fluidsystems/PTFlashParameterCache.hpp
@@ -56,6 +56,7 @@ class PTFlashParameterCache
     enum { numPhases = FluidSystem::numPhases };
     enum { oilPhaseIdx = FluidSystem::oilPhaseIdx };
     enum { gasPhaseIdx = FluidSystem::gasPhaseIdx };
+    enum { waterPhaseIdx = FluidSystem::waterPhaseIdx };
 
     static_assert(static_cast<int>(oilPhaseIdx) >= 0, "Oil phase index must be non-negative");
     static_assert(static_cast<int>(oilPhaseIdx) < static_cast<int>(numPhases),
@@ -89,6 +90,11 @@ public:
                      unsigned phaseIdx,
                      int exceptQuantities = ParentType::None)
     {
+        if (FluidSystem::phaseIsActive(waterPhaseIdx) && 
+            phaseIdx == static_cast<unsigned int>(waterPhaseIdx)) {
+            return;
+        }
+
         assert ((phaseIdx == static_cast<unsigned int>(oilPhaseIdx)) ||
                 (phaseIdx == static_cast<unsigned int>(gasPhaseIdx)));
 

--- a/opm/material/fluidsystems/PTFlashParameterCache.hpp
+++ b/opm/material/fluidsystems/PTFlashParameterCache.hpp
@@ -58,6 +58,8 @@ class PTFlashParameterCache
     enum { gasPhaseIdx = FluidSystem::gasPhaseIdx };
     enum { waterPhaseIdx = FluidSystem::waterPhaseIdx };
 
+    static constexpr bool waterEnabled = FluidSystem::waterEnabled;
+
     static_assert(static_cast<int>(oilPhaseIdx) >= 0, "Oil phase index must be non-negative");
     static_assert(static_cast<int>(oilPhaseIdx) < static_cast<int>(numPhases),
                   "Oil phase index must be strictly less than FluidSystem's number of phases");
@@ -90,8 +92,7 @@ public:
                      unsigned phaseIdx,
                      int exceptQuantities = ParentType::None)
     {
-        if (FluidSystem::phaseIsActive(waterPhaseIdx) && 
-            phaseIdx == static_cast<unsigned int>(waterPhaseIdx)) {
+        if (waterEnabled && phaseIdx == static_cast<unsigned int>(waterPhaseIdx)) {
             return;
         }
 

--- a/opm/material/fluidsystems/ThreeComponentFluidSystem.hh
+++ b/opm/material/fluidsystems/ThreeComponentFluidSystem.hh
@@ -56,6 +56,7 @@ namespace Opm {
         static constexpr int numComponents = 3;
         static constexpr int numMisciblePhases=2;
         static constexpr int numMiscibleComponents = 3;
+        static constexpr bool waterEnabled = false;
         // TODO: phase location should be more general
         static constexpr int oilPhaseIdx = 0;
         static constexpr int gasPhaseIdx = 1;

--- a/opm/material/fluidsystems/ThreeComponentFluidSystem.hh
+++ b/opm/material/fluidsystems/ThreeComponentFluidSystem.hh
@@ -59,6 +59,7 @@ namespace Opm {
         // TODO: phase location should be more general
         static constexpr int oilPhaseIdx = 0;
         static constexpr int gasPhaseIdx = 1;
+        static constexpr int waterPhaseIdx = -1;
 
         static constexpr int Comp0Idx = 0;
         static constexpr int Comp1Idx = 1;
@@ -73,6 +74,11 @@ namespace Opm {
         using ParameterCache = PTFlashParameterCache<ValueType, ThreeComponentFluidSystem<Scalar>>;
         using ViscosityModel = ViscosityModels<Scalar, ThreeComponentFluidSystem<Scalar>>;
         using CubicEOS = ::Opm::CubicEOS<Scalar, ThreeComponentFluidSystem<Scalar>>;
+
+        static bool phaseIsActive(unsigned phaseIdx)
+        {
+            return phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx;
+        }
 
         /*!
          * \brief The acentric factor of a component [].

--- a/tests/material/test_fluidsystems.cpp
+++ b/tests/material/test_fluidsystems.cpp
@@ -48,7 +48,7 @@
 #include <opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/fluidsystems/BrineCO2FluidSystem.hpp>
-#include <opm/material/fluidsystems/GenericOilGasFluidSystem.hpp>
+#include <opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp>
 #include <opm/material/fluidsystems/H2ON2FluidSystem.hpp>
 #include <opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp>
 #include <opm/material/fluidsystems/H2OAirFluidSystem.hpp>
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeComponentFluidSystem, Scalar, ScalarTypes)
 BOOST_AUTO_TEST_CASE_TEMPLATE(GenericFluidSystem, Scalar, ScalarTypes)
 {
     using Evaluation = Opm::DenseAd::Evaluation<Scalar, 4>;
-    using FluidSystem = Opm::GenericOilGasFluidSystem<Scalar, 4>;
+    using FluidSystem = Opm::GenericOilGasWaterFluidSystem<Scalar, 4>;
 
     using CompParm = typename FluidSystem::ComponentParam;
     using CO2 = Opm::SimpleCO2<Scalar>;
@@ -409,6 +409,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(GenericFluidSystem, Scalar, ScalarTypes)
                                        C10::criticalPressure(), C10::criticalVolume(), C10::acentricFactor()});
     FluidSystem::addComponent(CompParm{N2::name(), N2::molarMass(), N2::criticalTemperature(),
                                        N2::criticalPressure(), N2::criticalVolume(), N2::acentricFactor()});
+
+    // initialize water pvt
+    FluidSystem::init();
 
     checkFluidSystem<Scalar, FluidSystem, Scalar, Scalar>();
     checkFluidSystem<Scalar, FluidSystem, Evaluation, Scalar>();

--- a/tests/material/test_fluidsystems.cpp
+++ b/tests/material/test_fluidsystems.cpp
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeComponentFluidSystem, Scalar, ScalarTypes)
 BOOST_AUTO_TEST_CASE_TEMPLATE(GenericFluidSystem, Scalar, ScalarTypes)
 {
     using Evaluation = Opm::DenseAd::Evaluation<Scalar, 4>;
-    using FluidSystem = Opm::GenericOilGasWaterFluidSystem<Scalar, 4>;
+    using FluidSystem = Opm::GenericOilGasWaterFluidSystem<Scalar, 4, true>;
 
     using CompParm = typename FluidSystem::ComponentParam;
     using CO2 = Opm::SimpleCO2<Scalar>;

--- a/tests/material/test_fluidsystems.cpp
+++ b/tests/material/test_fluidsystems.cpp
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(GenericFluidSystem, Scalar, ScalarTypes)
     // initialize water pvt
     using WaterPvt = typename FluidSystem::WaterPvt;
     std::shared_ptr<WaterPvt> waterPvt;
-    FluidSystem::setWaterPvt(std::move(waterPvt));
+    FluidSystem::setWaterPvt(waterPvt);
 
     checkFluidSystem<Scalar, FluidSystem, Scalar, Scalar>();
     checkFluidSystem<Scalar, FluidSystem, Evaluation, Scalar>();

--- a/tests/material/test_fluidsystems.cpp
+++ b/tests/material/test_fluidsystems.cpp
@@ -411,7 +411,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(GenericFluidSystem, Scalar, ScalarTypes)
                                        N2::criticalPressure(), N2::criticalVolume(), N2::acentricFactor()});
 
     // initialize water pvt
-    FluidSystem::init();
+    using WaterPvt = typename FluidSystem::WaterPvt;
+    std::shared_ptr<WaterPvt> waterPvt;
+    FluidSystem::setWaterPvt(std::move(waterPvt));
 
     checkFluidSystem<Scalar, FluidSystem, Scalar, Scalar>();
     checkFluidSystem<Scalar, FluidSystem, Evaluation, Scalar>();


### PR DESCRIPTION
The compositional fluid system is expanded to three phases where the water phase is a "dummy"/immiscible phase. Water phase properties are given through PVT functions the same way as in the black oil fluid system.