### PR TITLE
Don't Lose Events Introduced Immediately After Restart

### DIFF
--- a/opm/input/eclipse/Schedule/Events.cpp
+++ b/opm/input/eclipse/Schedule/Events.cpp
@@ -52,6 +52,11 @@ namespace Opm {
         this->m_events = 0;
     }
 
+    void Events::merge(const Events& events)
+    {
+        this->m_events |= events.m_events;
+    }
+
     bool Events::hasEvent(const std::uint64_t eventMask) const
     {
         return (this->m_events & eventMask) != 0;
@@ -118,6 +123,15 @@ namespace Opm {
 
         for (auto& eventPair : this->m_wellgroup_events) {
             eventPair.second.reset();
+        }
+    }
+
+    void WellGroupEvents::merge(const WellGroupEvents& events)
+    {
+        for (const auto& [wgName, wgEvents] : events.m_wellgroup_events) {
+            // We use operator[]() here to transparently handle 'wgName' not
+            // already being present in 'this->m_wellgroup_events'.
+            this->m_wellgroup_events[wgName].merge(wgEvents);
         }
     }
 

--- a/opm/input/eclipse/Schedule/Events.hpp
+++ b/opm/input/eclipse/Schedule/Events.hpp
@@ -142,6 +142,12 @@ namespace Opm
         /// Remove all events from collection.
         void reset();
 
+        /// Merge current event collection with other.
+        ///
+        /// Resulting collection (\c *this) has the union of the events in
+        /// both collections.
+        void merge(const Events& events);
+
         /// Event existence predicate.
         ///
         /// \param[in] eventMask Bit mask of events for which to check
@@ -218,6 +224,12 @@ namespace Opm
         /// Typically used only when preparing the events system for a new
         /// report step as part of Schedule object initialisation.
         void reset();
+
+        /// Merge current event collection with other.
+        ///
+        /// Resulting collection (\c *this) has the union of the events for
+        /// all wells and groups in both collections.
+        void merge(const WellGroupEvents& events);
 
         /// Check if any events have ever been registered for a named well
         /// or group.

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -177,8 +177,8 @@ namespace Opm {
             // Events added during restart reading well be added to previous step, but need to be active at the
             // restart step to ensure well potentials and guide rates are available at the first step.
             const auto prev_step = std::max(static_cast<int>(restart_step-1), 0);
-            this->snapshots[restart_step].update_wellgroup_events(this->snapshots[prev_step].wellgroup_events());
-            this->snapshots[restart_step].update_events(this->snapshots[prev_step].events());
+            this->snapshots[restart_step].wellgroup_events().merge(this->snapshots[prev_step].wellgroup_events());
+            this->snapshots[restart_step].events().merge(this->snapshots[prev_step].events());
         } else {
             this->iterateScheduleSection(0, this->m_sched_deck.size(),
                                          parseContext, errors, grid, nullptr, "", keepKeywords);

--- a/tests/parser/EventTests.cpp
+++ b/tests/parser/EventTests.cpp
@@ -62,3 +62,129 @@ BOOST_AUTO_TEST_CASE(CreateEmpty)
     BOOST_CHECK_THROW(wg_events.at("NO_SUCH_WELL"), std::invalid_argument);
 }
 
+BOOST_AUTO_TEST_CASE(MergeEvents)
+{
+    using SchEvt = Opm::ScheduleEvents::Events;
+
+    auto ev1 = Opm::Events{};
+    ev1.addEvent(SchEvt::NEW_WELL);
+    ev1.addEvent(SchEvt::GROUP_CHANGE);
+    ev1.addEvent(SchEvt::COMPLETION_CHANGE);
+
+    {
+        auto ev2 = Opm::Events{};
+        ev2.addEvent(SchEvt::NEW_GROUP);
+        ev2.addEvent(SchEvt::GROUP_PRODUCTION_UPDATE);
+
+        ev1.merge(ev2);
+    }
+
+    // -----------------------------------------------------------------------
+
+    BOOST_CHECK_MESSAGE(ev1.hasEvent(SchEvt::NEW_WELL),
+                        R"(Merged collection must have NEW_WELL)");
+    BOOST_CHECK_MESSAGE(ev1.hasEvent(SchEvt::GROUP_CHANGE),
+                        R"(Merged collection must have GROUP_CHANGE)");
+    BOOST_CHECK_MESSAGE(ev1.hasEvent(SchEvt::COMPLETION_CHANGE),
+                        R"(Merged collection must have COMPLETION_CHANGE)");
+
+    // -----------------------------------------------------------------------
+
+    BOOST_CHECK_MESSAGE(ev1.hasEvent(SchEvt::NEW_GROUP),
+                        R"(Merged collection must have NEW_GROUP)");
+    BOOST_CHECK_MESSAGE(ev1.hasEvent(SchEvt::GROUP_PRODUCTION_UPDATE),
+                        R"(Merged collection must have GROUP_PRODUCTION_UPDATE)");
+
+    // -----------------------------------------------------------------------
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::WELL_WELSPECS_UPDATE),
+                        R"(Merged collection must NOT have WELL_WELSPECS_UPDATE)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::PRODUCTION_UPDATE),
+                        R"(Merged collection must NOT have PRODUCTION_UPDATE)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::INJECTION_UPDATE),
+                        R"(Merged collection must NOT have INJECTION_UPDATE)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::WELL_STATUS_CHANGE),
+                        R"(Merged collection must NOT have WELL_STATUS_CHANGE)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::GEO_MODIFIER),
+                        R"(Merged collection must NOT have GEO_MODIFIER)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::TUNING_CHANGE),
+                        R"(Merged collection must NOT have TUNING_CHANGE)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::VFPINJ_UPDATE),
+                        R"(Merged collection must NOT have VFPINJ_UPDATE)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::VFPPROD_UPDATE),
+                        R"(Merged collection must NOT have VFPROD_UPDATE)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::GROUP_INJECTION_UPDATE),
+                        R"(Merged collection must NOT have GROUP_INJECTION_UPDATE)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::WELL_PRODUCTIVITY_INDEX),
+                        R"(Merged collection must NOT have WELL_PRODUCTIVITY_INDEX)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::WELLGROUP_EFFICIENCY_UPDATE),
+                        R"(Merged collection must NOT have WELLGROUP_EFFICIENCY_UPDATE)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::INJECTION_TYPE_CHANGED),
+                        R"(Merged collection must NOT have INJECTION_TYPE_CHANGED)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::WELL_SWITCHED_INJECTOR_PRODUCER),
+                        R"(Merged collection must NOT have WELL_SWITCHED_INJECTOR_PRODUCER)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::ACTIONX_WELL_EVENT),
+                        R"(Merged collection must NOT have ACTIONX_WELL_EVENT)");
+
+    BOOST_CHECK_MESSAGE(! ev1.hasEvent(SchEvt::REQUEST_OPEN_WELL),
+                        R"(Merged collection must NOT have REQUEST_OPEN_WELL)");
+}
+
+BOOST_AUTO_TEST_CASE(MergeEventCollections)
+{
+    using SchEvt = Opm::ScheduleEvents::Events;
+
+    auto c1 = Opm::WellGroupEvents{};
+    c1.addWell("P1");
+    c1.addEvent("P1", SchEvt::GROUP_CHANGE);
+    c1.addEvent("P1", SchEvt::COMPLETION_CHANGE);
+    c1.addGroup("G1");
+
+    {
+        auto c2 = Opm::WellGroupEvents{};
+        c2.addGroup("G1");
+        c2.addEvent("G1", SchEvt::GROUP_PRODUCTION_UPDATE);
+
+        c2.addGroup("G2");
+
+        c1.merge(c2);
+    }
+
+    BOOST_CHECK_MESSAGE(c1.has("P1"), R"(Well "P1" must exist in merged collection)");
+    BOOST_CHECK_MESSAGE(c1.has("G1"), R"(Group "G1" must exist in merged collection)");
+    BOOST_CHECK_MESSAGE(c1.has("G2"), R"(Group "G2" must exist in merged collection)");
+
+    // -----------------------------------------------------------------------
+
+    BOOST_CHECK_MESSAGE(c1.hasEvent("P1", SchEvt::NEW_WELL),
+                        R"(Merged collection must have NEW_WELL for "P1")");
+    BOOST_CHECK_MESSAGE(c1.hasEvent("P1", SchEvt::GROUP_CHANGE),
+                        R"(Merged collection must have GROUP_CHANGE for "P1")");
+    BOOST_CHECK_MESSAGE(c1.hasEvent("P1", SchEvt::COMPLETION_CHANGE),
+                        R"(Merged collection must have COMPLETION_CHANGE for "P1")");
+
+    // -----------------------------------------------------------------------
+
+    BOOST_CHECK_MESSAGE(c1.hasEvent("G1", SchEvt::NEW_GROUP),
+                        R"(Merged collection must have NEW_GROUP for "G1")");
+    BOOST_CHECK_MESSAGE(c1.hasEvent("G1", SchEvt::GROUP_PRODUCTION_UPDATE),
+                        R"(Merged collection must have GROUP_PRODUCTION_UPDATE for "G1")");
+
+    // -----------------------------------------------------------------------
+
+    BOOST_CHECK_MESSAGE(c1.hasEvent("G2", SchEvt::NEW_GROUP),
+                        R"(Merged collection must have NEW_GROUP for "G2")");
+}


### PR DESCRIPTION
Commit 092f0a2e (PR #4108) introduced logic to ensure that events added at the restart time&ndash;e.g., group level controls&ndash;would be available during the first time step after restart.  This empirically improved non-linear convergence for certain field cases.

This change did however have the unintended side effect of clearing any other events that might happen on the first report step after the restart time.  If, in particular, that included introducing a new well (WELSPECS keyword), then the events system would lose the new well and any subsequent changes to the well (e.g., WCONPROD or WELOPEN) would then throw an exception for the unknown well in
```
WellGroupEvents::addEvent(well, evt)
```
This PR switches the unconditional 'update_wellgroup_events()' call of commit 092f0a2e into using a new member function
```
WellGroupEvents::merge(events)
```
instead.  This maintains the intended effect of commit 092f0a2e, while also preserving any other events that might happen immediately after the restart time.