### PR TITLE
simplying the function interface of PTFlash::solve()

### DIFF
--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -76,7 +76,6 @@ public:
      */
     template <class FluidState>
     static void solve(FluidState& fluid_state,
-                      const Dune::FieldVector<typename FluidState::Scalar, numComponents>& z,
                       const std::string& twoPhaseMethod,
                       Scalar /*tolerance = -1.*/,
                       int verbosity = 0)
@@ -97,7 +96,12 @@ public:
         // Print header
         if (verbosity >= 1) {
             std::cout << "********" << std::endl;
-            std::cout << "Inputs are K = [" << K << "], L = [" << L << "], z = [" << z << "], P = " << fluid_state.pressure(0) << ", and T = " << fluid_state.temperature(0) << std::endl;
+            std::cout << "Inputs are K = [" << K << "], L = [" << L << "] " << fluid_state.pressure(0) << ", and T = " << fluid_state.temperature(0) << std::endl;
+        }
+
+        Dune::FieldVector<typename FluidState::Scalar, numComponents> z;
+        for (unsigned i = 0; i < numComponents; ++i) {
+            z[i] = fluid_state.moleFraction(i);
         }
 
         using ScalarVector = Dune::FieldVector<Scalar, numComponents>;
@@ -105,15 +109,13 @@ public:
         ScalarVector z_scalar;
         ScalarVector K_scalar;
         for (unsigned i = 0; i < numComponents; ++i) {
-            z_scalar[i] = Opm::getValue(z[i]);
+            z_scalar[i] = Opm::getValue(z[i]); // z[i]);
             K_scalar[i] = Opm::getValue(K[i]);
         }
         using ScalarFluidState = CompositionalFluidState<Scalar, FluidSystem>;
         ScalarFluidState fluid_state_scalar;
 
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
-            fluid_state_scalar.setMoleFraction(oilPhaseIdx, compIdx, Opm::getValue(fluid_state.moleFraction(oilPhaseIdx, compIdx)));
-            fluid_state_scalar.setMoleFraction(gasPhaseIdx, compIdx, Opm::getValue(fluid_state.moleFraction(gasPhaseIdx, compIdx)));
             fluid_state_scalar.setKvalue(compIdx, Opm::getValue(fluid_state.K(compIdx)));
         }
 
@@ -173,7 +175,7 @@ public:
         fluid_state.setLvalue(L_scalar);
         // we update the derivatives in fluid_state
         updateDerivatives_(fluid_state_scalar, z, fluid_state, is_single_phase);
-    }//end solve
+    } // end solve
 
     /*!
      * \brief Calculates the chemical equilibrium from the component

--- a/tests/material/test_co2brine_ptflash.cpp
+++ b/tests/material/test_co2brine_ptflash.cpp
@@ -89,7 +89,7 @@ for (const auto& sample : test_methods) {
         fluid_state.setMoleFraction(compIdx, comp[compIdx]);
     }
 
-    const double flash_tolerance = 1.e-12; // just to test the setup in co2-compositional
+    const double flash_tolerance = 1.e-8; // just to test the setup in co2-compositional
     const int flash_verbosity = 0;
 
     // TODO: should we set these?

--- a/tests/material/test_threecomponents_ptflash.cpp
+++ b/tests/material/test_threecomponents_ptflash.cpp
@@ -55,6 +55,7 @@ using ComponentVector = Dune::FieldVector<Evaluation, numComponents>;
 using FluidState = Opm::CompositionalFluidState<Evaluation, FluidSystem>;
 
 std::vector<std::string> test_methods {"newton", "ssi", "ssi+newton"};
+// std::vector<std::string> test_methods {"ssi"};
 
 #if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 > 66
 BOOST_DATA_TEST_CASE(PtFlash, test_methods)
@@ -72,59 +73,18 @@ for (const auto& sample : test_methods) {
     comp[1] = Evaluation::createVariable(0.3, 2);
     comp[2] = 1. - comp[0] - comp[1];
 
-    // TODO: not sure whether the saturation matter here.
-    ComponentVector sat;
-    // We assume that currently everything is in the oil phase
-    sat[0] = 1.0; sat[1] = 1.0-sat[0];
-    Scalar temp = 300.0;
+    const Scalar temp = 300.0;
 
     // FluidState will be the input for the flash calculation
     FluidState fluid_state;
     fluid_state.setPressure(FluidSystem::oilPhaseIdx, p_init);
     fluid_state.setPressure(FluidSystem::gasPhaseIdx, p_init);
 
-    fluid_state.setMoleFraction(FluidSystem::oilPhaseIdx, FluidSystem::Comp0Idx, comp[0]);
-    fluid_state.setMoleFraction(FluidSystem::oilPhaseIdx, FluidSystem::Comp1Idx, comp[1]);
-    fluid_state.setMoleFraction(FluidSystem::oilPhaseIdx, FluidSystem::Comp2Idx, comp[2]);
-
-    fluid_state.setMoleFraction(FluidSystem::gasPhaseIdx, FluidSystem::Comp0Idx, comp[0]);
-    fluid_state.setMoleFraction(FluidSystem::gasPhaseIdx, FluidSystem::Comp1Idx, comp[1]);
-    fluid_state.setMoleFraction(FluidSystem::gasPhaseIdx, FluidSystem::Comp2Idx, comp[2]);
-
-    // It is used here only for calculate the z
-    fluid_state.setSaturation(FluidSystem::oilPhaseIdx, sat[0]);
-    fluid_state.setSaturation(FluidSystem::gasPhaseIdx, sat[1]);
+    fluid_state.setMoleFraction(FluidSystem::Comp0Idx, comp[0]);
+    fluid_state.setMoleFraction(FluidSystem::Comp1Idx, comp[1]);
+    fluid_state.setMoleFraction(FluidSystem::Comp2Idx, comp[2]);
 
     fluid_state.setTemperature(temp);
-
-    // ParameterCache paramCache;
-    {
-        typename FluidSystem::template ParameterCache<Evaluation> paramCache;
-        paramCache.updatePhase(fluid_state, FluidSystem::oilPhaseIdx);
-        paramCache.updatePhase(fluid_state, FluidSystem::gasPhaseIdx);
-        fluid_state.setDensity(FluidSystem::oilPhaseIdx, FluidSystem::density(fluid_state, paramCache, FluidSystem::oilPhaseIdx));
-        fluid_state.setDensity(FluidSystem::gasPhaseIdx, FluidSystem::density(fluid_state, paramCache, FluidSystem::gasPhaseIdx));
-    }
-
-    ComponentVector z(0.); // TODO; z needs to be normalized.
-    {
-        Scalar sumMoles = 0.0;
-        for (unsigned phaseIdx = 0; phaseIdx < FluidSystem::numPhases; ++phaseIdx) {
-            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
-                Scalar tmp = Opm::getValue(fluid_state.molarity(phaseIdx, compIdx) * fluid_state.saturation(phaseIdx));
-                z[compIdx] += Opm::max(tmp, 1e-8);
-                sumMoles += tmp;
-            }
-        }
-        z /= sumMoles;
-        // p And z is the primary variables
-        Evaluation z_last = 1.;
-        for (unsigned compIdx = 0; compIdx < numComponents - 1; ++compIdx) {
-            z[compIdx] = Evaluation::createVariable(Opm::getValue(z[compIdx]), int(compIdx) + 1);
-            z_last -= z[compIdx];
-        }
-        z[numComponents - 1] = z_last;
-    }
 
     const double flash_tolerance = 1.e-12; // just to test the setup in co2-compositional
     const int flash_verbosity = 0;
@@ -139,7 +99,7 @@ for (const auto& sample : test_methods) {
     fluid_state.setLvalue(Ltmp);
 
     using Flash = Opm::PTFlash<double, FluidSystem>;
-    Flash::solve(fluid_state, z, sample, flash_tolerance, flash_verbosity);
+    Flash::solve(fluid_state,  sample, flash_tolerance, flash_verbosity);
 
     ComponentVector x, y;
     const Evaluation L = fluid_state.L();

--- a/tests/material/test_threecomponents_ptflash.cpp
+++ b/tests/material/test_threecomponents_ptflash.cpp
@@ -86,7 +86,7 @@ for (const auto& sample : test_methods) {
 
     fluid_state.setTemperature(temp);
 
-    const double flash_tolerance = 1.e-12; // just to test the setup in co2-compositional
+    const double flash_tolerance = 1.e-8; // just to test the setup in co2-compositional
     const int flash_verbosity = 0;
 
     // TODO: should we set these?


### PR DESCRIPTION
so that we can based on the mole fractions and pressure and temperature to perform the PTFlash::solve(). 

The current way needs too much information that might not be helpful/needed, which makes the usage hard, mostly to create the input for the function, for example, initializing input to perform PTFlash::solve() in the wellbore, which requires to initialize/create the input on site. 