### PR TITLE
refactor move_to_gpu

### DIFF
--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -326,7 +326,7 @@ private:
 namespace Opm::gpuistl{
     template<class Scalar, class GPUContainer>
     UniformTabulated2DFunction<Scalar, GPUContainer>
-    move_to_gpu(const UniformTabulated2DFunction<Scalar>& tab){
+    copy_to_gpu(const UniformTabulated2DFunction<Scalar>& tab){
         return UniformTabulated2DFunction<Scalar, GPUContainer>(tab.xMin(), tab.xMax(), tab.numX(), tab.yMin(), tab.yMax(), tab.numY(), GPUContainer(tab.samples()));
     }
 

--- a/opm/material/components/CO2Tables.hpp
+++ b/opm/material/components/CO2Tables.hpp
@@ -94,10 +94,10 @@ namespace Opm::gpuistl {
 
     template <class Scalar, class OldContainerType, class NewContainerType>
     CO2Tables<Scalar, NewContainerType>
-    move_to_gpu(const CO2Tables<Scalar, OldContainerType>& oldCO2Tables) {
+    copy_to_gpu(const CO2Tables<Scalar, OldContainerType>& oldCO2Tables) {
         return CO2Tables<Scalar, NewContainerType>(
-            move_to_gpu<Scalar, NewContainerType>(oldCO2Tables.getTabulatedEnthalpy()),
-            move_to_gpu<Scalar, NewContainerType>(oldCO2Tables.getTabulatedDensity())
+            copy_to_gpu<Scalar, NewContainerType>(oldCO2Tables.getTabulatedEnthalpy()),
+            copy_to_gpu<Scalar, NewContainerType>(oldCO2Tables.getTabulatedDensity())
         );
     }
 }

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -77,7 +77,7 @@ public:
             finalize();
         }
         else{
-            // safe if we have a GPU type instantiated by move_to_gpu or make_view
+            // safe if we have a GPU type instantiated by copy_to_gpu or make_view
             EnsureFinalized::finalize();
         }
     }
@@ -268,7 +268,7 @@ namespace Opm::gpuistl{
 /// @param params the parameters object living on the CPU
 /// @return the GPU PiecewiseLinearTwoPhaseMaterialParams object
 template <class GPUContainerType, class TraitsT>
-PiecewiseLinearTwoPhaseMaterialParams<TraitsT, GPUContainerType> move_to_gpu(const PiecewiseLinearTwoPhaseMaterialParams<TraitsT>& params) {
+PiecewiseLinearTwoPhaseMaterialParams<TraitsT, GPUContainerType> copy_to_gpu(const PiecewiseLinearTwoPhaseMaterialParams<TraitsT>& params) {
 
     // only create the GPU object if the CPU object is finalized
     params.checkFinalized();

--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -798,7 +798,7 @@ namespace Opm::gpuistl
 
     template<class Scalar, class Params, class GPUContainer>
     BrineCo2Pvt<Scalar, Params, GPUContainer>
-    move_to_gpu(const BrineCo2Pvt<Scalar>& cpuBrineCo2)
+    copy_to_gpu(const BrineCo2Pvt<Scalar>& cpuBrineCo2)
     {
         return BrineCo2Pvt<Scalar, Params, GPUContainer>(
             GPUContainer(cpuBrineCo2.getBrineReferenceDensity()),
@@ -807,7 +807,7 @@ namespace Opm::gpuistl
             cpuBrineCo2.getActivityModel(),
             cpuBrineCo2.getThermalMixingModelSalt(),
             cpuBrineCo2.getThermalMixingModelLiquid(),
-            move_to_gpu<Scalar, std::vector<Scalar>, GPUContainer>(cpuBrineCo2.getParams())
+            copy_to_gpu<Scalar, std::vector<Scalar>, GPUContainer>(cpuBrineCo2.getParams())
         );
     }
 

--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -451,10 +451,10 @@ private:
 namespace Opm::gpuistl{
     template<class Scalar, class Params, class GPUContainer>
     Co2GasPvt<Scalar, Params, GPUContainer>
-    move_to_gpu(const Co2GasPvt<Scalar>& cpuCo2)
+    copy_to_gpu(const Co2GasPvt<Scalar>& cpuCo2)
     {
         return Co2GasPvt<Scalar, Params, GPUContainer>(
-            move_to_gpu<Scalar, std::vector<Scalar>, GPUContainer>(cpuCo2.getParams()),
+            copy_to_gpu<Scalar, std::vector<Scalar>, GPUContainer>(cpuCo2.getParams()),
             GPUContainer(cpuCo2.getBrineReferenceDensity()),
             GPUContainer(cpuCo2.getGasReferenceDensity()),
             GPUContainer(cpuCo2.getSalinity()),


### PR DESCRIPTION
To avoid confusion with move semantics in C++ `move_to_gpu` is renamed to `copy_to_gpu` as the movement of data to the GPU does not invalidate the existing CPU copy.