### PR TITLE
Add nonstatic blackoilfluidsystem

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -57,6 +57,7 @@ list (APPEND MAIN_SOURCE_FILES
       opm/material/densead/Evaluation.cpp
       opm/material/fluidmatrixinteractions/EclEpsScalingPoints.cpp
       opm/material/fluidsystems/BlackOilFluidSystem.cpp
+      opm/material/fluidsystems/BlackOilFluidSystemNonStatic.cpp
       opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.cpp
       opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.cpp
       opm/material/fluidsystems/blackoilpvt/Co2GasPvt.cpp
@@ -926,6 +927,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/fluidsystems/GasPhase.hpp
       opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
       opm/material/fluidsystems/BlackOilFluidSystem.hpp
+      opm/material/fluidsystems/BlackOilFluidSystemNonStatic.hpp
       opm/material/fluidsystems/LiquidPhase.hpp
       opm/material/fluidsystems/PTFlashParameterCache.hpp
       opm/material/fluidsystems/Spe5ParameterCache.hpp

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -45,6 +45,8 @@
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+template <typename>
+struct always_false1 : std::false_type {};
 
 namespace {
 
@@ -428,11 +430,10 @@ namespace Opm {
             return const_cast<ptr_member<T>&>(std::as_const(*this).template get<T>());
         }
 
+        
         template <typename T>
         const ptr_member<T>& get() const
         {
-            struct always_false1 : std::false_type {};
-
             if constexpr ( std::is_same_v<T, PAvg> )
                              return this->pavg;
             else if constexpr ( std::is_same_v<T, WellTestConfig> )
@@ -478,14 +479,13 @@ namespace Opm {
             else if constexpr ( std::is_same_v<T, WCYCLE> )
                                   return this->wcycle;
             else
-                static_assert(always_false1::value, "Template type <T> not supported in get()");
+                static_assert(always_false1<T>::value, "Template type <T> not supported in get()");
         }
 
 
         template <typename K, typename T>
         map_member<K,T>& get_map()
         {
-            struct always_false2 : std::false_type {};
             if constexpr ( std::is_same_v<T, VFPProdTable> )
                              return this->vfpprod;
             else if constexpr ( std::is_same_v<T, VFPInjTable> )
@@ -495,7 +495,7 @@ namespace Opm {
             else if constexpr ( std::is_same_v<T, Well> )
                                   return this->wells;
             else
-                static_assert(always_false2::value, "Template type <K,T> not supported in get_map()");
+                static_assert(always_false1<T>::value, "Template type <K,T> not supported in get_map()");
         }
 
         map_member<int, VFPProdTable> vfpprod;

--- a/opm/material/binarycoefficients/Brine_CO2.hpp
+++ b/opm/material/binarycoefficients/Brine_CO2.hpp
@@ -823,7 +823,11 @@ private:
             convTerm = 1.0;
         }
         else {
+#if !OPM_IS_INSIDE_DEVICE_FUNCTION
             throw std::runtime_error("Activity model for salt-out effect has not been implemented!");
+#else
+            assert(false && "Activity model for salt-out effect has not been implemented!");
+#endif
         }
 
         // Eq. (18)

--- a/opm/material/fluidsystems/BlackOilFluidSystemNonStatic.cpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystemNonStatic.cpp
@@ -1,0 +1,471 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+#include <opm/material/fluidsystems/BlackOilFluidSystemNonStatic.hpp>
+
+#include <opm/common/ErrorMacros.hpp>
+
+#if HAVE_ECL_INPUT
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/FlatTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+#endif
+
+#include <string_view>
+
+#include <fmt/format.h>
+
+namespace Opm {
+
+#if HAVE_ECL_INPUT
+template <class Scalar, class IndexTraits>
+void BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
+initFromState(const EclipseState& eclState, const Schedule& schedule)
+{
+    if (eclState.getSimulationConfig().useEnthalpy()) {
+        enthalpy_eq_energy_ = false;
+    } else {
+        enthalpy_eq_energy_ = true;
+    }
+    std::size_t num_regions = eclState.runspec().tabdims().getNumPVTTables();
+    initBegin(num_regions);
+
+    numActivePhases_ = 0;
+    std::fill_n(&phaseIsActive_[0], numPhases, false);
+
+    if (eclState.runspec().phases().active(Phase::OIL)) {
+        phaseIsActive_[oilPhaseIdx] = true;
+        ++numActivePhases_;
+    }
+
+    if (eclState.runspec().phases().active(Phase::GAS)) {
+        phaseIsActive_[gasPhaseIdx] = true;
+        ++numActivePhases_;
+    }
+
+    if (eclState.runspec().phases().active(Phase::WATER)) {
+        phaseIsActive_[waterPhaseIdx] = true;
+        ++numActivePhases_;
+    }
+
+    // this fluidsystem only supports one, two or three phases
+    if (numActivePhases_ < 1 || numActivePhases_ > 3) {
+        OPM_THROW(std::runtime_error,
+                  fmt::format("Fluidsystem supports 1-3 phases, but {} is active\n",
+                              numActivePhases_));
+    }
+
+    // set the surface conditions using the STCOND keyword
+    surfaceTemperature = eclState.getTableManager().stCond().temperature;
+    surfacePressure = eclState.getTableManager().stCond().pressure;
+
+    // The reservoir temperature does not really belong into the table manager. TODO:
+    // change this in opm-parser
+    setReservoirTemperature(eclState.getTableManager().rtemp());
+
+    setEnableDissolvedGas(eclState.getSimulationConfig().hasDISGAS());
+    setEnableVaporizedOil(eclState.getSimulationConfig().hasVAPOIL());
+    setEnableVaporizedWater(eclState.getSimulationConfig().hasVAPWAT());
+
+    if (eclState.getSimulationConfig().hasDISGASW()) {
+        if (eclState.runspec().co2Storage() || eclState.runspec().h2Storage())
+            setEnableDissolvedGasInWater(eclState.getSimulationConfig().hasDISGASW());
+        else if (eclState.runspec().co2Sol() || eclState.runspec().h2Sol()) {
+            // For CO2SOL and H2SOL the dissolved gas in water is added in the solvent model
+            // The HC gas is not allowed to dissolved into water.
+            // For most HC gasses this is a resonable assumption.
+            OpmLog::info("CO2SOL/H2SOL is activated together with DISGASW. \n"
+                         "Only CO2/H2 is allowed to dissolve into water");
+        } else
+            OPM_THROW(std::runtime_error,
+                      "DISGASW only supported in combination with CO2STORE/H2STORE or CO2SOL/H2SOL");
+    }
+
+    if (phaseIsActive(gasPhaseIdx)) {
+        gasPvt_ = std::make_shared<GasPvt>();
+        gasPvt_->initFromState(eclState, schedule);
+    }
+
+    if (phaseIsActive(oilPhaseIdx)) {
+        oilPvt_ = std::make_shared<OilPvt>();
+        oilPvt_->initFromState(eclState, schedule);
+    }
+
+    if (phaseIsActive(waterPhaseIdx)) {
+        waterPvt_ = std::make_shared<WaterPvt>();
+        waterPvt_->initFromState(eclState, schedule);
+    }
+
+    // set the reference densities of all PVT regions
+    for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
+        setReferenceDensities(oilPvt_ ? oilPvt_->oilReferenceDensity(regionIdx) : 700.0,
+                              waterPvt_ ? waterPvt_->waterReferenceDensity(regionIdx) : 1000.0,
+                              gasPvt_ ? gasPvt_->gasReferenceDensity(regionIdx) : 2.0,
+                              regionIdx);
+    }
+
+    // set default molarMass and mappings
+    initEnd();
+
+    // use molarMass of CO2 and Brine as default
+    // when we are using the the CO2STORE option
+    if (eclState.runspec().co2Storage()) {
+        const Scalar salinity = eclState.getCo2StoreConfig().salinity();  // mass fraction
+        for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
+            if (phaseIsActive(oilPhaseIdx)) // The oil component is used for the brine if OIL is active
+                molarMass_[regionIdx][oilCompIdx] = BrineCo2Pvt<Scalar>::Brine::molarMass(salinity);
+            if (phaseIsActive(waterPhaseIdx))
+                molarMass_[regionIdx][waterCompIdx] = BrineCo2Pvt<Scalar>::Brine::molarMass(salinity);
+            if (!phaseIsActive(gasPhaseIdx)) {
+                OPM_THROW(std::runtime_error,
+                          "CO2STORE requires gas phase\n");
+            }
+            molarMass_[regionIdx][gasCompIdx] = BrineCo2Pvt<Scalar>::CO2::molarMass();
+        }
+    }
+
+    // Use molar mass of H2 and Brine as default in H2STORE keyword
+    if (eclState.runspec().h2Storage()) {
+        // Salinity in mass fraction
+        const Scalar molality = eclState.getTableManager().salinity(); // mol/kg
+        const Scalar MmNaCl = 58.44e-3; // molar mass of NaCl [kg/mol]
+        const Scalar salinity = 1 / ( 1 + 1 / (molality*MmNaCl));
+        for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
+            if (phaseIsActive(oilPhaseIdx)) // The oil component is used for the brine if OIL is active
+                molarMass_[regionIdx][oilCompIdx] = BrineH2Pvt<Scalar>::Brine::molarMass(salinity);
+            if (phaseIsActive(waterPhaseIdx))
+                molarMass_[regionIdx][waterCompIdx] = BrineH2Pvt<Scalar>::Brine::molarMass(salinity);
+            if (!phaseIsActive(gasPhaseIdx)) {
+                OPM_THROW(std::runtime_error,
+                          "H2STORE requires gas phase\n");
+            }
+            molarMass_[regionIdx][gasCompIdx] = BrineH2Pvt<Scalar>::H2::molarMass();
+        }
+    }
+
+    // For co2storage and h2storage we dont have a concept of tables and should not spend time on
+    // checking if we are at the saturated front
+    setUseSaturatedTables(!(eclState.runspec().h2Storage() || eclState.runspec().co2Storage()));
+
+    setEnableDiffusion(eclState.getSimulationConfig().isDiffusive());
+    if (enableDiffusion()) {
+        const auto& diffCoeffTables = eclState.getTableManager().getDiffusionCoefficientTable();
+        if (!diffCoeffTables.empty()) {
+            // if diffusion coefficient table is empty we relay on the PVT model to
+            // to give us the coefficients.
+            diffusionCoefficients_.resize(num_regions,{0,0,0,0,0,0,0,0,0});
+            if (diffCoeffTables.size() != num_regions) {
+                OPM_THROW(std::runtime_error,
+                          fmt::format("Table sizes mismatch. DiffCoeffs: {}, NumRegions: {}\n",
+                                      diffCoeffTables.size(), num_regions));
+            }
+            for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
+                const auto& diffCoeffTable = diffCoeffTables[regionIdx];
+                molarMass_[regionIdx][oilCompIdx] = diffCoeffTable.oil_mw;
+                molarMass_[regionIdx][gasCompIdx] = diffCoeffTable.gas_mw;
+                setDiffusionCoefficient(diffCoeffTable.gas_in_gas, gasCompIdx, gasPhaseIdx, regionIdx);
+                setDiffusionCoefficient(diffCoeffTable.oil_in_gas, oilCompIdx, gasPhaseIdx, regionIdx);
+                setDiffusionCoefficient(diffCoeffTable.gas_in_oil, gasCompIdx, oilPhaseIdx, regionIdx);
+                setDiffusionCoefficient(diffCoeffTable.oil_in_oil, oilCompIdx, oilPhaseIdx, regionIdx);
+                if (diffCoeffTable.gas_in_oil_cross_phase > 0 || diffCoeffTable.oil_in_oil_cross_phase > 0) {
+                    OPM_THROW(std::runtime_error,
+                              "Cross phase diffusion is set in the deck, "
+                              "but not implemented in Flow. "
+                              "Please default DIFFC item 7 and item 8 "
+                              "or set it to zero.");
+                }
+            }
+        } else if ( (eclState.runspec().co2Storage() || eclState.runspec().h2Storage())
+                && eclState.runspec().phases().active(Phase::GAS)
+                && eclState.runspec().phases().active(Phase::WATER))
+        {
+            diffusionCoefficients_.resize(num_regions, {0,0,0,0,0,0,0,0,0});
+            // diffusion coefficients can be set using DIFFCGAS and DIFFCWAT
+            // for CO2STORE and H2STORE cases with gas + water
+            const auto& diffCoeffWatTables = eclState.getTableManager().getDiffusionCoefficientWaterTable();
+            if (!diffCoeffWatTables.empty()) {
+                for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
+                    const auto& diffCoeffWatTable = diffCoeffWatTables[regionIdx];
+                    setDiffusionCoefficient(diffCoeffWatTable.co2_in_water, gasCompIdx, waterPhaseIdx, regionIdx);
+                    setDiffusionCoefficient(diffCoeffWatTable.h2o_in_water, waterCompIdx, waterPhaseIdx, regionIdx);
+                }
+            }
+            const auto& diffCoeffGasTables = eclState.getTableManager().getDiffusionCoefficientGasTable();
+            if (!diffCoeffGasTables.empty()) {
+                for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
+                    const auto& diffCoeffGasTable = diffCoeffGasTables[regionIdx];
+                    setDiffusionCoefficient(diffCoeffGasTable.co2_in_gas, gasCompIdx, gasPhaseIdx, regionIdx);
+                    setDiffusionCoefficient(diffCoeffGasTable.h2o_in_gas, waterCompIdx, gasPhaseIdx, regionIdx);
+                }
+            }
+        }
+    }
+}
+#endif
+
+template <class Scalar, class IndexTraits>
+void BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
+initBegin(std::size_t numPvtRegions)
+{
+    isInitialized_ = false;
+    useSaturatedTables_ = true;
+
+    enableDissolvedGas_ = true;
+    enableDissolvedGasInWater_ = false;
+    enableVaporizedOil_ = false;
+    enableVaporizedWater_ = false;
+    enableDiffusion_ = false;
+
+    oilPvt_ = nullptr;
+    gasPvt_ = nullptr;
+    waterPvt_ = nullptr;
+
+    surfaceTemperature = 273.15 + 15.56; // [K]
+    surfacePressure = 1.01325e5; // [Pa]
+    setReservoirTemperature(surfaceTemperature);
+
+    numActivePhases_ = numPhases;
+    std::fill_n(&phaseIsActive_[0], numPhases, true);
+
+    resizeArrays_(numPvtRegions);
+}
+
+template <class Scalar, class IndexTraits>
+void BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
+setReferenceDensities(Scalar rhoOil,
+                      Scalar rhoWater,
+                      Scalar rhoGas,
+                      unsigned regionIdx)
+{
+    referenceDensity_[regionIdx][oilPhaseIdx] = rhoOil;
+    referenceDensity_[regionIdx][waterPhaseIdx] = rhoWater;
+    referenceDensity_[regionIdx][gasPhaseIdx] = rhoGas;
+}
+
+template <class Scalar, class IndexTraits>
+void BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::initEnd()
+{
+    // calculate the final 2D functions which are used for interpolation.
+    const std::size_t num_regions = molarMass_.size();
+    for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
+        // calculate molar masses
+
+        // water is simple: 18 g/mol
+        molarMass_[regionIdx][waterCompIdx] = 18e-3;
+
+        if (phaseIsActive(gasPhaseIdx)) {
+            // for gas, we take the density at standard conditions and assume it to be ideal
+            Scalar p = surfacePressure;
+            Scalar T = surfaceTemperature;
+            Scalar rho_g = referenceDensity_[/*regionIdx=*/0][gasPhaseIdx];
+            molarMass_[regionIdx][gasCompIdx] = Constants<Scalar>::R*T*rho_g / p;
+        }
+        else
+            // hydrogen gas. we just set this do avoid NaNs later
+            molarMass_[regionIdx][gasCompIdx] = 2e-3;
+
+        // finally, for oil phase, we take the molar mass from the spe9 paper
+        molarMass_[regionIdx][oilCompIdx] = 175e-3; // kg/mol
+    }
+
+
+    int activePhaseIdx = 0;
+    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        if(phaseIsActive(phaseIdx)){
+            canonicalToActivePhaseIdx_[phaseIdx] = activePhaseIdx;
+            activeToCanonicalPhaseIdx_[activePhaseIdx] = phaseIdx;
+            activePhaseIdx++;
+        }
+    }
+    isInitialized_ = true;
+}
+
+template <class Scalar, class IndexTraits>
+std::string_view BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
+phaseName(unsigned phaseIdx)
+{
+    switch (phaseIdx) {
+    case waterPhaseIdx:
+        return "water";
+    case oilPhaseIdx:
+        return "oil";
+    case gasPhaseIdx:
+        return "gas";
+
+    default:
+        throw std::logic_error(fmt::format("Phase index {} is unknown", phaseIdx));
+    }
+}
+
+template <class Scalar, class IndexTraits>
+unsigned BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
+solventComponentIndex(unsigned phaseIdx)
+{
+    switch (phaseIdx) {
+    case waterPhaseIdx:
+        return waterCompIdx;
+    case oilPhaseIdx:
+        return oilCompIdx;
+    case gasPhaseIdx:
+        return gasCompIdx;
+
+    default:
+        throw std::logic_error(fmt::format("Phase index {} is unknown", phaseIdx));
+    }
+}
+
+template <class Scalar, class IndexTraits>
+unsigned BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
+soluteComponentIndex(unsigned phaseIdx)
+{
+    switch (phaseIdx) {
+    case waterPhaseIdx:
+        if (enableDissolvedGasInWater())
+            return gasCompIdx;
+        throw std::logic_error("The water phase does not have any solutes in the black oil model!");
+    case oilPhaseIdx:
+        return gasCompIdx;
+    case gasPhaseIdx:
+        if (enableVaporizedWater()) {
+            return waterCompIdx;
+        }
+        return oilCompIdx;
+
+    default:
+        throw std::logic_error(fmt::format("Phase index {} is unknown", phaseIdx));
+    }
+}
+
+template <class Scalar, class IndexTraits>
+std::string_view BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
+componentName(unsigned compIdx)
+{
+    switch (compIdx) {
+    case waterCompIdx:
+        return "Water";
+    case oilCompIdx:
+        return "Oil";
+    case gasCompIdx:
+        return "Gas";
+
+    default:
+        throw std::logic_error(fmt::format("Component index {} is unknown", compIdx));
+    }
+}
+
+template <class Scalar, class IndexTraits>
+short BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
+activeToCanonicalPhaseIdx(unsigned activePhaseIdx)
+{
+    assert(activePhaseIdx<numActivePhases());
+    return activeToCanonicalPhaseIdx_[activePhaseIdx];
+}
+
+template <class Scalar, class IndexTraits>
+short BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
+canonicalToActivePhaseIdx(unsigned phaseIdx)
+{
+    assert(phaseIdx<numPhases);
+    assert(phaseIsActive(phaseIdx));
+    return canonicalToActivePhaseIdx_[phaseIdx];
+}
+
+template <class Scalar, class IndexTraits>
+void BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
+resizeArrays_(std::size_t numRegions)
+{
+    molarMass_.resize(numRegions);
+    referenceDensity_.resize(numRegions);
+}
+
+// template<> unsigned char BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::numActivePhases_ = 0;
+// template<> std::array<bool, BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::numPhases>
+// BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::phaseIsActive_ = {false, false, false};
+
+// template<> unsigned char BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::numActivePhases_ = 0;
+// template<> std::array<bool, BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::numPhases>
+// BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::phaseIsActive_ = {false, false, false};
+
+// template<> std::array<short, BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::numPhases> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::activeToCanonicalPhaseIdx_ = {0, 1, 2};
+
+// template<> std::array<short, BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::numPhases> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::activeToCanonicalPhaseIdx_ = {0, 1, 2};
+
+// template<> std::array<short, BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::numPhases> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::canonicalToActivePhaseIdx_ = {0, 1, 2};
+
+// template<> std::array<short, BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::numPhases> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::canonicalToActivePhaseIdx_ = {0, 1, 2};
+
+// template<> double BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::surfaceTemperature = 0.0;
+// template<> float BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::surfaceTemperature = 0.0;
+
+// template<> double BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::surfacePressure = 0.0;
+// template<> float BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::surfacePressure = 0.0;
+
+// template<> double BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::reservoirTemperature_ = 0.0;
+// template<> float BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::reservoirTemperature_ = 0.0;
+
+// template<> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::enableDissolvedGas_ = true;
+// template<> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::enableDissolvedGas_ = true;
+
+// template <> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::enableDissolvedGasInWater_ = false;
+// template <> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::enableDissolvedGasInWater_ = false;
+
+// template <> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::enableVaporizedOil_ = false;
+// template <> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::enableVaporizedOil_ = false;
+
+// template <> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::enableVaporizedWater_ = false;
+// template <> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::enableVaporizedWater_ = false;
+
+// template <> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::enableDiffusion_ = false;
+// template <> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::enableDiffusion_ = false;
+
+// template <> std::shared_ptr<OilPvtMultiplexer<double>> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::oilPvt_ = nullptr;
+// template <> std::shared_ptr<OilPvtMultiplexer<float>> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::oilPvt_ = nullptr;
+
+// template <> std::shared_ptr<GasPvtMultiplexer<double>> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::gasPvt_ = nullptr;
+// template <> std::shared_ptr<GasPvtMultiplexer<float>> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::gasPvt_ = nullptr;
+
+// template <> std::shared_ptr<WaterPvtMultiplexer<double>> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::waterPvt_ = nullptr;
+// template <> std::shared_ptr<WaterPvtMultiplexer<float>> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::waterPvt_ = nullptr;
+
+// template <> std::vector<std::array<double, 3>> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::referenceDensity_ = {};
+// template <> std::vector<std::array<float, 3>> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::referenceDensity_ = {};
+
+// template <> std::vector<std::array<double, 3>> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::molarMass_ = {};
+// template <> std::vector<std::array<float, 3>> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::molarMass_ = {};
+
+// template <> std::vector<std::array<double, 9>> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::diffusionCoefficients_ = {};
+// template <> std::vector<std::array<float, 9>> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::diffusionCoefficients_ = {};
+
+// template <> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::isInitialized_ = false;
+// template <> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::isInitialized_ = false;
+
+// template <> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::useSaturatedTables_ = false;
+// template <> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::useSaturatedTables_ = false;
+
+// IMPORTANT: The following two lines must come after the template specializations above
+//    or else the static variable above will appear as undefined in the generated object file.
+template class BlackOilFluidSystemNonStatic<double,BlackOilDefaultIndexTraits>;
+template class BlackOilFluidSystemNonStatic<float,BlackOilDefaultIndexTraits>;
+
+} // namespace Opm

--- a/opm/material/fluidsystems/BlackOilFluidSystemNonStatic.cpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystemNonStatic.cpp
@@ -36,12 +36,13 @@
 
 #include <fmt/format.h>
 
-namespace Opm {
+namespace Opm
+{
 
 #if HAVE_ECL_INPUT
 template <class Scalar, class IndexTraits>
-void BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
-initFromState(const EclipseState& eclState, const Schedule& schedule)
+void
+BlackOilFluidSystemNonStatic<Scalar, IndexTraits>::initFromState(const EclipseState& eclState, const Schedule& schedule)
 {
     if (eclState.getSimulationConfig().useEnthalpy()) {
         enthalpy_eq_energy_ = false;
@@ -72,8 +73,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
     // this fluidsystem only supports one, two or three phases
     if (numActivePhases_ < 1 || numActivePhases_ > 3) {
         OPM_THROW(std::runtime_error,
-                  fmt::format("Fluidsystem supports 1-3 phases, but {} is active\n",
-                              numActivePhases_));
+                  fmt::format("Fluidsystem supports 1-3 phases, but {} is active\n", numActivePhases_));
     }
 
     // set the surface conditions using the STCOND keyword
@@ -131,15 +131,14 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
     // use molarMass of CO2 and Brine as default
     // when we are using the the CO2STORE option
     if (eclState.runspec().co2Storage()) {
-        const Scalar salinity = eclState.getCo2StoreConfig().salinity();  // mass fraction
+        const Scalar salinity = eclState.getCo2StoreConfig().salinity(); // mass fraction
         for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
             if (phaseIsActive(oilPhaseIdx)) // The oil component is used for the brine if OIL is active
                 molarMass_[regionIdx][oilCompIdx] = BrineCo2Pvt<Scalar>::Brine::molarMass(salinity);
             if (phaseIsActive(waterPhaseIdx))
                 molarMass_[regionIdx][waterCompIdx] = BrineCo2Pvt<Scalar>::Brine::molarMass(salinity);
             if (!phaseIsActive(gasPhaseIdx)) {
-                OPM_THROW(std::runtime_error,
-                          "CO2STORE requires gas phase\n");
+                OPM_THROW(std::runtime_error, "CO2STORE requires gas phase\n");
             }
             molarMass_[regionIdx][gasCompIdx] = BrineCo2Pvt<Scalar>::CO2::molarMass();
         }
@@ -150,15 +149,14 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
         // Salinity in mass fraction
         const Scalar molality = eclState.getTableManager().salinity(); // mol/kg
         const Scalar MmNaCl = 58.44e-3; // molar mass of NaCl [kg/mol]
-        const Scalar salinity = 1 / ( 1 + 1 / (molality*MmNaCl));
+        const Scalar salinity = 1 / (1 + 1 / (molality * MmNaCl));
         for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
             if (phaseIsActive(oilPhaseIdx)) // The oil component is used for the brine if OIL is active
                 molarMass_[regionIdx][oilCompIdx] = BrineH2Pvt<Scalar>::Brine::molarMass(salinity);
             if (phaseIsActive(waterPhaseIdx))
                 molarMass_[regionIdx][waterCompIdx] = BrineH2Pvt<Scalar>::Brine::molarMass(salinity);
             if (!phaseIsActive(gasPhaseIdx)) {
-                OPM_THROW(std::runtime_error,
-                          "H2STORE requires gas phase\n");
+                OPM_THROW(std::runtime_error, "H2STORE requires gas phase\n");
             }
             molarMass_[regionIdx][gasCompIdx] = BrineH2Pvt<Scalar>::H2::molarMass();
         }
@@ -174,11 +172,12 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
         if (!diffCoeffTables.empty()) {
             // if diffusion coefficient table is empty we relay on the PVT model to
             // to give us the coefficients.
-            diffusionCoefficients_.resize(num_regions,{0,0,0,0,0,0,0,0,0});
+            diffusionCoefficients_.resize(num_regions, {0, 0, 0, 0, 0, 0, 0, 0, 0});
             if (diffCoeffTables.size() != num_regions) {
                 OPM_THROW(std::runtime_error,
                           fmt::format("Table sizes mismatch. DiffCoeffs: {}, NumRegions: {}\n",
-                                      diffCoeffTables.size(), num_regions));
+                                      diffCoeffTables.size(),
+                                      num_regions));
             }
             for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
                 const auto& diffCoeffTable = diffCoeffTables[regionIdx];
@@ -196,11 +195,10 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
                               "or set it to zero.");
                 }
             }
-        } else if ( (eclState.runspec().co2Storage() || eclState.runspec().h2Storage())
-                && eclState.runspec().phases().active(Phase::GAS)
-                && eclState.runspec().phases().active(Phase::WATER))
-        {
-            diffusionCoefficients_.resize(num_regions, {0,0,0,0,0,0,0,0,0});
+        } else if ((eclState.runspec().co2Storage() || eclState.runspec().h2Storage())
+                   && eclState.runspec().phases().active(Phase::GAS)
+                   && eclState.runspec().phases().active(Phase::WATER)) {
+            diffusionCoefficients_.resize(num_regions, {0, 0, 0, 0, 0, 0, 0, 0, 0});
             // diffusion coefficients can be set using DIFFCGAS and DIFFCWAT
             // for CO2STORE and H2STORE cases with gas + water
             const auto& diffCoeffWatTables = eclState.getTableManager().getDiffusionCoefficientWaterTable();
@@ -225,8 +223,8 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
 #endif
 
 template <class Scalar, class IndexTraits>
-void BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
-initBegin(std::size_t numPvtRegions)
+void
+BlackOilFluidSystemNonStatic<Scalar, IndexTraits>::initBegin(std::size_t numPvtRegions)
 {
     isInitialized_ = false;
     useSaturatedTables_ = true;
@@ -252,11 +250,11 @@ initBegin(std::size_t numPvtRegions)
 }
 
 template <class Scalar, class IndexTraits>
-void BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
-setReferenceDensities(Scalar rhoOil,
-                      Scalar rhoWater,
-                      Scalar rhoGas,
-                      unsigned regionIdx)
+void
+BlackOilFluidSystemNonStatic<Scalar, IndexTraits>::setReferenceDensities(Scalar rhoOil,
+                                                                         Scalar rhoWater,
+                                                                         Scalar rhoGas,
+                                                                         unsigned regionIdx)
 {
     referenceDensity_[regionIdx][oilPhaseIdx] = rhoOil;
     referenceDensity_[regionIdx][waterPhaseIdx] = rhoWater;
@@ -264,7 +262,8 @@ setReferenceDensities(Scalar rhoOil,
 }
 
 template <class Scalar, class IndexTraits>
-void BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::initEnd()
+void
+BlackOilFluidSystemNonStatic<Scalar, IndexTraits>::initEnd()
 {
     // calculate the final 2D functions which are used for interpolation.
     const std::size_t num_regions = molarMass_.size();
@@ -279,9 +278,8 @@ void BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::initEnd()
             Scalar p = surfacePressure;
             Scalar T = surfaceTemperature;
             Scalar rho_g = referenceDensity_[/*regionIdx=*/0][gasPhaseIdx];
-            molarMass_[regionIdx][gasCompIdx] = Constants<Scalar>::R*T*rho_g / p;
-        }
-        else
+            molarMass_[regionIdx][gasCompIdx] = Constants<Scalar>::R * T * rho_g / p;
+        } else
             // hydrogen gas. we just set this do avoid NaNs later
             molarMass_[regionIdx][gasCompIdx] = 2e-3;
 
@@ -292,7 +290,7 @@ void BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::initEnd()
 
     int activePhaseIdx = 0;
     for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-        if(phaseIsActive(phaseIdx)){
+        if (phaseIsActive(phaseIdx)) {
             canonicalToActivePhaseIdx_[phaseIdx] = activePhaseIdx;
             activeToCanonicalPhaseIdx_[activePhaseIdx] = phaseIdx;
             activePhaseIdx++;
@@ -302,8 +300,8 @@ void BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::initEnd()
 }
 
 template <class Scalar, class IndexTraits>
-std::string_view BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
-phaseName(unsigned phaseIdx)
+std::string_view
+BlackOilFluidSystemNonStatic<Scalar, IndexTraits>::phaseName(unsigned phaseIdx)
 {
     switch (phaseIdx) {
     case waterPhaseIdx:
@@ -319,8 +317,8 @@ phaseName(unsigned phaseIdx)
 }
 
 template <class Scalar, class IndexTraits>
-unsigned BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
-solventComponentIndex(unsigned phaseIdx)
+unsigned
+BlackOilFluidSystemNonStatic<Scalar, IndexTraits>::solventComponentIndex(unsigned phaseIdx)
 {
     switch (phaseIdx) {
     case waterPhaseIdx:
@@ -336,8 +334,8 @@ solventComponentIndex(unsigned phaseIdx)
 }
 
 template <class Scalar, class IndexTraits>
-unsigned BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
-soluteComponentIndex(unsigned phaseIdx)
+unsigned
+BlackOilFluidSystemNonStatic<Scalar, IndexTraits>::soluteComponentIndex(unsigned phaseIdx)
 {
     switch (phaseIdx) {
     case waterPhaseIdx:
@@ -358,8 +356,8 @@ soluteComponentIndex(unsigned phaseIdx)
 }
 
 template <class Scalar, class IndexTraits>
-std::string_view BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
-componentName(unsigned compIdx)
+std::string_view
+BlackOilFluidSystemNonStatic<Scalar, IndexTraits>::componentName(unsigned compIdx)
 {
     switch (compIdx) {
     case waterCompIdx:
@@ -375,97 +373,33 @@ componentName(unsigned compIdx)
 }
 
 template <class Scalar, class IndexTraits>
-short BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
-activeToCanonicalPhaseIdx(unsigned activePhaseIdx)
+short
+BlackOilFluidSystemNonStatic<Scalar, IndexTraits>::activeToCanonicalPhaseIdx(unsigned activePhaseIdx)
 {
-    assert(activePhaseIdx<numActivePhases());
+    assert(activePhaseIdx < numActivePhases());
     return activeToCanonicalPhaseIdx_[activePhaseIdx];
 }
 
 template <class Scalar, class IndexTraits>
-short BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
-canonicalToActivePhaseIdx(unsigned phaseIdx)
+short
+BlackOilFluidSystemNonStatic<Scalar, IndexTraits>::canonicalToActivePhaseIdx(unsigned phaseIdx)
 {
-    assert(phaseIdx<numPhases);
+    assert(phaseIdx < numPhases);
     assert(phaseIsActive(phaseIdx));
     return canonicalToActivePhaseIdx_[phaseIdx];
 }
 
 template <class Scalar, class IndexTraits>
-void BlackOilFluidSystemNonStatic<Scalar,IndexTraits>::
-resizeArrays_(std::size_t numRegions)
+void
+BlackOilFluidSystemNonStatic<Scalar, IndexTraits>::resizeArrays_(std::size_t numRegions)
 {
     molarMass_.resize(numRegions);
     referenceDensity_.resize(numRegions);
 }
 
-// template<> unsigned char BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::numActivePhases_ = 0;
-// template<> std::array<bool, BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::numPhases>
-// BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::phaseIsActive_ = {false, false, false};
-
-// template<> unsigned char BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::numActivePhases_ = 0;
-// template<> std::array<bool, BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::numPhases>
-// BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::phaseIsActive_ = {false, false, false};
-
-// template<> std::array<short, BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::numPhases> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::activeToCanonicalPhaseIdx_ = {0, 1, 2};
-
-// template<> std::array<short, BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::numPhases> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::activeToCanonicalPhaseIdx_ = {0, 1, 2};
-
-// template<> std::array<short, BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::numPhases> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::canonicalToActivePhaseIdx_ = {0, 1, 2};
-
-// template<> std::array<short, BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::numPhases> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::canonicalToActivePhaseIdx_ = {0, 1, 2};
-
-// template<> double BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::surfaceTemperature = 0.0;
-// template<> float BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::surfaceTemperature = 0.0;
-
-// template<> double BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::surfacePressure = 0.0;
-// template<> float BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::surfacePressure = 0.0;
-
-// template<> double BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::reservoirTemperature_ = 0.0;
-// template<> float BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::reservoirTemperature_ = 0.0;
-
-// template<> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::enableDissolvedGas_ = true;
-// template<> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::enableDissolvedGas_ = true;
-
-// template <> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::enableDissolvedGasInWater_ = false;
-// template <> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::enableDissolvedGasInWater_ = false;
-
-// template <> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::enableVaporizedOil_ = false;
-// template <> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::enableVaporizedOil_ = false;
-
-// template <> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::enableVaporizedWater_ = false;
-// template <> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::enableVaporizedWater_ = false;
-
-// template <> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::enableDiffusion_ = false;
-// template <> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::enableDiffusion_ = false;
-
-// template <> std::shared_ptr<OilPvtMultiplexer<double>> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::oilPvt_ = nullptr;
-// template <> std::shared_ptr<OilPvtMultiplexer<float>> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::oilPvt_ = nullptr;
-
-// template <> std::shared_ptr<GasPvtMultiplexer<double>> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::gasPvt_ = nullptr;
-// template <> std::shared_ptr<GasPvtMultiplexer<float>> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::gasPvt_ = nullptr;
-
-// template <> std::shared_ptr<WaterPvtMultiplexer<double>> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::waterPvt_ = nullptr;
-// template <> std::shared_ptr<WaterPvtMultiplexer<float>> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::waterPvt_ = nullptr;
-
-// template <> std::vector<std::array<double, 3>> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::referenceDensity_ = {};
-// template <> std::vector<std::array<float, 3>> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::referenceDensity_ = {};
-
-// template <> std::vector<std::array<double, 3>> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::molarMass_ = {};
-// template <> std::vector<std::array<float, 3>> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::molarMass_ = {};
-
-// template <> std::vector<std::array<double, 9>> BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::diffusionCoefficients_ = {};
-// template <> std::vector<std::array<float, 9>> BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::diffusionCoefficients_ = {};
-
-// template <> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::isInitialized_ = false;
-// template <> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::isInitialized_ = false;
-
-// template <> bool BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>::useSaturatedTables_ = false;
-// template <> bool BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>::useSaturatedTables_ = false;
-
 // IMPORTANT: The following two lines must come after the template specializations above
 //    or else the static variable above will appear as undefined in the generated object file.
-template class BlackOilFluidSystemNonStatic<double,BlackOilDefaultIndexTraits>;
-template class BlackOilFluidSystemNonStatic<float,BlackOilDefaultIndexTraits>;
+template class BlackOilFluidSystemNonStatic<double, BlackOilDefaultIndexTraits>;
+template class BlackOilFluidSystemNonStatic<float, BlackOilDefaultIndexTraits>;
 
 } // namespace Opm

--- a/opm/material/fluidsystems/BlackOilFluidSystemNonStatic.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystemNonStatic.hpp
@@ -28,19 +28,19 @@
 #define OPM_BLACK_OIL_FLUID_SYSTEM_NON_STATIC_HPP
 
 #include "BlackOilDefaultIndexTraits.hpp"
-#include "blackoilpvt/OilPvtMultiplexer.hpp"
 #include "blackoilpvt/GasPvtMultiplexer.hpp"
+#include "blackoilpvt/OilPvtMultiplexer.hpp"
 #include "blackoilpvt/WaterPvtMultiplexer.hpp"
 
 #include <opm/common/TimingMacros.hpp>
 
+#include <opm/material/Constants.hpp>
 #include <opm/material/fluidsystems/BaseFluidSystem.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
-#include <opm/material/Constants.hpp>
 
+#include <opm/material/common/HasMemberGeneratorMacros.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/Valgrind.hpp>
-#include <opm/material/common/HasMemberGeneratorMacros.hpp>
 #include <opm/material/fluidsystems/NullParameterCache.hpp>
 
 #include <array>
@@ -51,108 +51,115 @@
 #include <string_view>
 #include <vector>
 
-namespace Opm {
+namespace Opm
+{
 
 #if HAVE_ECL_INPUT
 class EclipseState;
 class Schedule;
 #endif
 
-namespace BlackOilTwo {
-OPM_GENERATE_HAS_MEMBER(Rs, ) // Creates 'HasMember_Rs<T>'.
-OPM_GENERATE_HAS_MEMBER(Rv, ) // Creates 'HasMember_Rv<T>'.
-OPM_GENERATE_HAS_MEMBER(Rvw, ) // Creates 'HasMember_Rvw<T>'.
-OPM_GENERATE_HAS_MEMBER(Rsw, ) // Creates 'HasMember_Rsw<T>'.
-OPM_GENERATE_HAS_MEMBER(saltConcentration, )
-OPM_GENERATE_HAS_MEMBER(saltSaturation, )
-
-template <class FluidSystem, class FluidState, class LhsEval>
-LhsEval getRs_(typename std::enable_if<!HasMember_Rs<FluidState>::value, const FluidState&>::type fluidState,
-               unsigned regionIdx)
+namespace BlackOilTwo
 {
-    const auto& XoG =
-        decay<LhsEval>(fluidState.massFraction(FluidSystem::oilPhaseIdx, FluidSystem::gasCompIdx));
-    return FluidSystem::convertXoGToRs(XoG, regionIdx);
-}
+    OPM_GENERATE_HAS_MEMBER(Rs, ) // Creates 'HasMember_Rs<T>'.
+    OPM_GENERATE_HAS_MEMBER(Rv, ) // Creates 'HasMember_Rv<T>'.
+    OPM_GENERATE_HAS_MEMBER(Rvw, ) // Creates 'HasMember_Rvw<T>'.
+    OPM_GENERATE_HAS_MEMBER(Rsw, ) // Creates 'HasMember_Rsw<T>'.
+    OPM_GENERATE_HAS_MEMBER(saltConcentration, )
+    OPM_GENERATE_HAS_MEMBER(saltSaturation, )
 
-template <class FluidSystem, class FluidState, class LhsEval>
-auto getRs_(typename std::enable_if<HasMember_Rs<FluidState>::value, const FluidState&>::type fluidState,
-            unsigned)
-    -> decltype(decay<LhsEval>(fluidState.Rs()))
-{ return decay<LhsEval>(fluidState.Rs()); }
+    template <class FluidSystem, class FluidState, class LhsEval>
+    LhsEval getRs_(typename std::enable_if<!HasMember_Rs<FluidState>::value, const FluidState&>::type fluidState,
+                   unsigned regionIdx)
+    {
+        const auto& XoG = decay<LhsEval>(fluidState.massFraction(FluidSystem::oilPhaseIdx, FluidSystem::gasCompIdx));
+        return FluidSystem::convertXoGToRs(XoG, regionIdx);
+    }
 
-template <class FluidSystem, class FluidState, class LhsEval>
-LhsEval getRv_(typename std::enable_if<!HasMember_Rv<FluidState>::value, const FluidState&>::type fluidState,
-               unsigned regionIdx)
-{
-    const auto& XgO =
-        decay<LhsEval>(fluidState.massFraction(FluidSystem::gasPhaseIdx, FluidSystem::oilCompIdx));
-    return FluidSystem::convertXgOToRv(XgO, regionIdx);
-}
+    template <class FluidSystem, class FluidState, class LhsEval>
+    auto getRs_(typename std::enable_if<HasMember_Rs<FluidState>::value, const FluidState&>::type fluidState, unsigned)
+        -> decltype(decay<LhsEval>(fluidState.Rs()))
+    {
+        return decay<LhsEval>(fluidState.Rs());
+    }
 
-template <class FluidSystem, class FluidState, class LhsEval>
-auto getRv_(typename std::enable_if<HasMember_Rv<FluidState>::value, const FluidState&>::type fluidState,
-            unsigned)
-    -> decltype(decay<LhsEval>(fluidState.Rv()))
-{ return decay<LhsEval>(fluidState.Rv()); }
+    template <class FluidSystem, class FluidState, class LhsEval>
+    LhsEval getRv_(typename std::enable_if<!HasMember_Rv<FluidState>::value, const FluidState&>::type fluidState,
+                   unsigned regionIdx)
+    {
+        const auto& XgO = decay<LhsEval>(fluidState.massFraction(FluidSystem::gasPhaseIdx, FluidSystem::oilCompIdx));
+        return FluidSystem::convertXgOToRv(XgO, regionIdx);
+    }
 
-template <class FluidSystem, class FluidState, class LhsEval>
-LhsEval getRvw_(typename std::enable_if<!HasMember_Rvw<FluidState>::value, const FluidState&>::type fluidState,
-               unsigned regionIdx)
-{
-    const auto& XgW =
-        decay<LhsEval>(fluidState.massFraction(FluidSystem::gasPhaseIdx, FluidSystem::waterCompIdx));
-    return FluidSystem::convertXgWToRvw(XgW, regionIdx);
-}
+    template <class FluidSystem, class FluidState, class LhsEval>
+    auto getRv_(typename std::enable_if<HasMember_Rv<FluidState>::value, const FluidState&>::type fluidState, unsigned)
+        -> decltype(decay<LhsEval>(fluidState.Rv()))
+    {
+        return decay<LhsEval>(fluidState.Rv());
+    }
 
-template <class FluidSystem, class FluidState, class LhsEval>
-auto getRvw_(typename std::enable_if<HasMember_Rvw<FluidState>::value, const FluidState&>::type fluidState,
-            unsigned)
-    -> decltype(decay<LhsEval>(fluidState.Rvw()))
-{ return decay<LhsEval>(fluidState.Rvw()); }
+    template <class FluidSystem, class FluidState, class LhsEval>
+    LhsEval getRvw_(typename std::enable_if<!HasMember_Rvw<FluidState>::value, const FluidState&>::type fluidState,
+                    unsigned regionIdx)
+    {
+        const auto& XgW = decay<LhsEval>(fluidState.massFraction(FluidSystem::gasPhaseIdx, FluidSystem::waterCompIdx));
+        return FluidSystem::convertXgWToRvw(XgW, regionIdx);
+    }
 
-template <class FluidSystem, class FluidState, class LhsEval>
-LhsEval getRsw_(typename std::enable_if<!HasMember_Rsw<FluidState>::value, const FluidState&>::type fluidState,
-               unsigned regionIdx)
-{
-    const auto& XwG =
-        decay<LhsEval>(fluidState.massFraction(FluidSystem::waterPhaseIdx, FluidSystem::gasCompIdx));
-    return FluidSystem::convertXwGToRsw(XwG, regionIdx);
-}
+    template <class FluidSystem, class FluidState, class LhsEval>
+    auto getRvw_(typename std::enable_if<HasMember_Rvw<FluidState>::value, const FluidState&>::type fluidState,
+                 unsigned) -> decltype(decay<LhsEval>(fluidState.Rvw()))
+    {
+        return decay<LhsEval>(fluidState.Rvw());
+    }
 
-template <class FluidSystem, class FluidState, class LhsEval>
-auto getRsw_(typename std::enable_if<HasMember_Rsw<FluidState>::value, const FluidState&>::type fluidState,
-            unsigned)
-    -> decltype(decay<LhsEval>(fluidState.Rsw()))
-{ return decay<LhsEval>(fluidState.Rsw()); }
+    template <class FluidSystem, class FluidState, class LhsEval>
+    LhsEval getRsw_(typename std::enable_if<!HasMember_Rsw<FluidState>::value, const FluidState&>::type fluidState,
+                    unsigned regionIdx)
+    {
+        const auto& XwG = decay<LhsEval>(fluidState.massFraction(FluidSystem::waterPhaseIdx, FluidSystem::gasCompIdx));
+        return FluidSystem::convertXwGToRsw(XwG, regionIdx);
+    }
 
-template <class FluidSystem, class FluidState, class LhsEval>
-LhsEval getSaltConcentration_(typename std::enable_if<!HasMember_saltConcentration<FluidState>::value,
-                              const FluidState&>::type,
-                              unsigned)
-{return 0.0;}
+    template <class FluidSystem, class FluidState, class LhsEval>
+    auto getRsw_(typename std::enable_if<HasMember_Rsw<FluidState>::value, const FluidState&>::type fluidState,
+                 unsigned) -> decltype(decay<LhsEval>(fluidState.Rsw()))
+    {
+        return decay<LhsEval>(fluidState.Rsw());
+    }
 
-template <class FluidSystem, class FluidState, class LhsEval>
-auto getSaltConcentration_(typename std::enable_if<HasMember_saltConcentration<FluidState>::value, const FluidState&>::type fluidState,
-            unsigned)
-    -> decltype(decay<LhsEval>(fluidState.saltConcentration()))
-{ return decay<LhsEval>(fluidState.saltConcentration()); }
+    template <class FluidSystem, class FluidState, class LhsEval>
+    LhsEval getSaltConcentration_(
+        typename std::enable_if<!HasMember_saltConcentration<FluidState>::value, const FluidState&>::type, unsigned)
+    {
+        return 0.0;
+    }
 
-template <class FluidSystem, class FluidState, class LhsEval>
-LhsEval getSaltSaturation_(typename std::enable_if<!HasMember_saltSaturation<FluidState>::value,
-                              const FluidState&>::type,
-                              unsigned)
-{return 0.0;}
+    template <class FluidSystem, class FluidState, class LhsEval>
+    auto getSaltConcentration_(
+        typename std::enable_if<HasMember_saltConcentration<FluidState>::value, const FluidState&>::type fluidState,
+        unsigned) -> decltype(decay<LhsEval>(fluidState.saltConcentration()))
+    {
+        return decay<LhsEval>(fluidState.saltConcentration());
+    }
 
-template <class FluidSystem, class FluidState, class LhsEval>
-auto getSaltSaturation_(typename std::enable_if<HasMember_saltSaturation<FluidState>::value, const FluidState&>::type fluidState,
-            unsigned)
-    -> decltype(decay<LhsEval>(fluidState.saltSaturation()))
-{ return decay<LhsEval>(fluidState.saltSaturation()); }
+    template <class FluidSystem, class FluidState, class LhsEval>
+    LhsEval
+    getSaltSaturation_(typename std::enable_if<!HasMember_saltSaturation<FluidState>::value, const FluidState&>::type,
+                       unsigned)
+    {
+        return 0.0;
+    }
 
-}
+    template <class FluidSystem, class FluidState, class LhsEval>
+    auto getSaltSaturation_(
+        typename std::enable_if<HasMember_saltSaturation<FluidState>::value, const FluidState&>::type fluidState,
+        unsigned) -> decltype(decay<LhsEval>(fluidState.saltSaturation()))
+    {
+        return decay<LhsEval>(fluidState.saltSaturation());
+    }
 
-// TODO: format
+} // namespace BlackOilTwo
 
 template <class Scalar, class IndexTraits>
 class BlackOilFluidSystem;
@@ -164,7 +171,7 @@ class BlackOilFluidSystem;
  * \tparam Scalar The type used for scalar floating point values
  */
 template <class Scalar, class IndexTraits_ = BlackOilDefaultIndexTraits>
-class BlackOilFluidSystemNonStatic : public BaseFluidSystem<Scalar, BlackOilFluidSystemNonStatic<Scalar, IndexTraits_> >
+class BlackOilFluidSystemNonStatic : public BaseFluidSystem<Scalar, BlackOilFluidSystemNonStatic<Scalar, IndexTraits_>>
 {
     using ThisType = BlackOilFluidSystemNonStatic;
     using StaticType = BlackOilFluidSystem<Scalar, IndexTraits_>;
@@ -179,7 +186,7 @@ private:
     BlackOilFluidSystemNonStatic(Scalar _surfacePressure_,
                                  Scalar _surfaceTemperature_,
                                  unsigned _numActivePhases_,
-                                    std::array<bool, 3> _phaseIsActive_,
+                                 std::array<bool, 3> _phaseIsActive_,
                                  Scalar _reservoirTemperature_,
                                  std::shared_ptr<GasPvt> _gasPvt_,
                                  std::shared_ptr<OilPvt> _oilPvt_,
@@ -197,38 +204,37 @@ private:
                                  bool _isInitialized_,
                                  bool _useSaturatedTables_,
                                  bool _enthalpy_eq_energy_)
-        : surfacePressure(_surfacePressure_),
-          surfaceTemperature(_surfaceTemperature_),
-        numActivePhases_(_numActivePhases_),
-        phaseIsActive_(_phaseIsActive_),
-          reservoirTemperature_(_reservoirTemperature_),
-          gasPvt_(_gasPvt_),
-          oilPvt_(_oilPvt_),
-          waterPvt_(_waterPvt_),
-          enableDissolvedGas_(_enableDissolvedGas_),
-          enableDissolvedGasInWater_(_enableDissolvedGasInWater_),
-          enableVaporizedOil_(_enableVaporizedOil_),
-          enableVaporizedWater_(_enableVaporizedWater_),
-          enableDiffusion_(_enableDiffusion_),
-          referenceDensity_(_referenceDensity_),
-          molarMass_(_molarMass_),
-          diffusionCoefficients_(_diffusionCoefficients_),
-          activeToCanonicalPhaseIdx_(_activeToCanonicalPhaseIdx_),
-          canonicalToActivePhaseIdx_(_canonicalToActivePhaseIdx_),
-          isInitialized_(_isInitialized_),
-          useSaturatedTables_(_useSaturatedTables_),
-          enthalpy_eq_energy_(_enthalpy_eq_energy_)
+        : surfacePressure(_surfacePressure_)
+        , surfaceTemperature(_surfaceTemperature_)
+        , numActivePhases_(_numActivePhases_)
+        , phaseIsActive_(_phaseIsActive_)
+        , reservoirTemperature_(_reservoirTemperature_)
+        , gasPvt_(_gasPvt_)
+        , oilPvt_(_oilPvt_)
+        , waterPvt_(_waterPvt_)
+        , enableDissolvedGas_(_enableDissolvedGas_)
+        , enableDissolvedGasInWater_(_enableDissolvedGasInWater_)
+        , enableVaporizedOil_(_enableVaporizedOil_)
+        , enableVaporizedWater_(_enableVaporizedWater_)
+        , enableDiffusion_(_enableDiffusion_)
+        , referenceDensity_(_referenceDensity_)
+        , molarMass_(_molarMass_)
+        , diffusionCoefficients_(_diffusionCoefficients_)
+        , activeToCanonicalPhaseIdx_(_activeToCanonicalPhaseIdx_)
+        , canonicalToActivePhaseIdx_(_canonicalToActivePhaseIdx_)
+        , isInitialized_(_isInitialized_)
+        , useSaturatedTables_(_useSaturatedTables_)
+        , enthalpy_eq_energy_(_enthalpy_eq_energy_)
     {
     }
 
 public:
-
     static const ThisType& getInstance()
     {
         static ThisType instance(StaticType::surfacePressure,
                                  StaticType::surfaceTemperature,
                                  StaticType::numActivePhases(),
-                                    StaticType::phaseIsActiveArray(),
+                                 StaticType::phaseIsActiveArray(),
                                  StaticType::reservoirTemperature(),
                                  StaticType::gasPvtSharedPtr(),
                                  StaticType::oilPvtSharedPtr(),
@@ -249,65 +255,8 @@ public:
         return instance;
     }
 
-    template<class EvaluationT>
+    template <class EvaluationT>
     using ParameterCache = typename StaticType::template ParameterCache<EvaluationT>;
-    //! \copydoc BaseFluidSystem::ParameterCache
-    // template <class EvaluationT>
-    // struct ParameterCache : public NullParameterCache<EvaluationT>
-    // {
-    //     using Evaluation = EvaluationT;
-
-    // public:
-    //     explicit ParameterCache(Scalar maxOilSat = 1.0, unsigned regionIdx = 0)
-    //         : maxOilSat_(maxOilSat)
-    //         , regionIdx_(regionIdx)
-    //     {
-    //     }
-
-    //     /*!
-    //      * \brief Copy the data which is not dependent on the type of the Scalars from
-    //      *        another parameter cache.
-    //      *
-    //      * For the black-oil parameter cache this means that the region index must be
-    //      * copied.
-    //      */
-    //     template <class OtherCache>
-    //     void assignPersistentData(const OtherCache& other)
-    //     {
-    //         regionIdx_ = other.regionIndex();
-    //         maxOilSat_ = other.maxOilSat();
-    //     }
-
-    //     /*!
-    //      * \brief Return the index of the region which should be used to determine the
-    //      *        thermodynamic properties
-    //      *
-    //      * This is only required because "oil" and "gas" are pseudo-components, i.e. for
-    //      * more comprehensive equations of state there would only be one "region".
-    //      */
-    //     unsigned regionIndex() const
-    //     { return regionIdx_; }
-
-    //     /*!
-    //      * \brief Set the index of the region which should be used to determine the
-    //      *        thermodynamic properties
-    //      *
-    //      * This is only required because "oil" and "gas" are pseudo-components, i.e. for
-    //      * more comprehensive equations of state there would only be one "region".
-    //      */
-    //     void setRegionIndex(unsigned val)
-    //     { regionIdx_ = val; }
-
-    //     const Evaluation& maxOilSat() const
-    //     { return maxOilSat_; }
-
-    //     void setMaxOilSat(const Evaluation& val)
-    //     { maxOilSat_ = val; }
-
-    // private:
-    //     Evaluation maxOilSat_;
-    //     unsigned regionIdx_;
-    // };
 
     /****************************************
      * Initialization
@@ -336,7 +285,9 @@ public:
      * By default, dissolved gas is considered.
      */
     void setEnableDissolvedGas(bool yesno)
-    { enableDissolvedGas_ = yesno; }
+    {
+        enableDissolvedGas_ = yesno;
+    }
 
     /*!
      * \brief Specify whether the fluid system should consider that the oil component can
@@ -345,32 +296,40 @@ public:
      * By default, vaporized oil is not considered.
      */
     void setEnableVaporizedOil(bool yesno)
-    { enableVaporizedOil_ = yesno; }
+    {
+        enableVaporizedOil_ = yesno;
+    }
 
-     /*!
+    /*!
      * \brief Specify whether the fluid system should consider that the water component can
      *        dissolve in the gas phase
      *
      * By default, vaporized water is not considered.
      */
     void setEnableVaporizedWater(bool yesno)
-    { enableVaporizedWater_ = yesno; }
+    {
+        enableVaporizedWater_ = yesno;
+    }
 
-     /*!
+    /*!
      * \brief Specify whether the fluid system should consider that the gas component can
      *        dissolve in the water phase
      *
      * By default, dissovled gas in water is not considered.
      */
     void setEnableDissolvedGasInWater(bool yesno)
-    { enableDissolvedGasInWater_ = yesno; }
+    {
+        enableDissolvedGasInWater_ = yesno;
+    }
     /*!
      * \brief Specify whether the fluid system should consider diffusion
      *
      * By default, diffusion is not considered.
      */
     void setEnableDiffusion(bool yesno)
-    { enableDiffusion_ = yesno; }
+    {
+        enableDiffusion_ = yesno;
+    }
 
     /*!
      * \brief Specify whether the saturated tables should be used
@@ -378,25 +337,33 @@ public:
      * By default, saturated tables are used
      */
     void setUseSaturatedTables(bool yesno)
-    { useSaturatedTables_ = yesno; }
+    {
+        useSaturatedTables_ = yesno;
+    }
 
     /*!
      * \brief Set the pressure-volume-saturation (PVT) relations for the gas phase.
      */
     void setGasPvt(std::shared_ptr<GasPvt> pvtObj)
-    { gasPvt_ = pvtObj; }
+    {
+        gasPvt_ = pvtObj;
+    }
 
     /*!
      * \brief Set the pressure-volume-saturation (PVT) relations for the oil phase.
      */
     void setOilPvt(std::shared_ptr<OilPvt> pvtObj)
-    { oilPvt_ = pvtObj; }
+    {
+        oilPvt_ = pvtObj;
+    }
 
     /*!
      * \brief Set the pressure-volume-saturation (PVT) relations for the water phase.
      */
     void setWaterPvt(std::shared_ptr<WaterPvt> pvtObj)
-    { waterPvt_ = pvtObj; }
+    {
+        waterPvt_ = pvtObj;
+    }
 
     void setVapPars(const Scalar par1, const Scalar par2)
     {
@@ -418,10 +385,7 @@ public:
      * \param rhoWater The reference density of the water phase.
      * \param rhoGas The reference density of the gas phase.
      */
-    void setReferenceDensities(Scalar rhoOil,
-                                      Scalar rhoWater,
-                                      Scalar rhoGas,
-                                      unsigned regionIdx);
+    void setReferenceDensities(Scalar rhoOil, Scalar rhoWater, Scalar rhoGas, unsigned regionIdx);
 
     /*!
      * \brief Finish initializing the black oil fluid system.
@@ -429,7 +393,9 @@ public:
     void initEnd();
 
     bool isInitialized()
-    { return isInitialized_; }
+    {
+        return isInitialized_;
+    }
 
     /****************************************
      * Generic phase properties
@@ -477,12 +443,14 @@ public:
 
 protected:
     unsigned char numActivePhases_;
-    std::array<bool,numPhases> phaseIsActive_;
+    std::array<bool, numPhases> phaseIsActive_;
 
 public:
     //! \brief Returns the number of active fluid phases (i.e., usually three)
     unsigned numActivePhases() const
-    { return numActivePhases_; }
+    {
+        return numActivePhases_;
+    }
 
     //! \brief Returns whether a fluid phase is active
     bool phaseIsActive(unsigned phaseIdx) const
@@ -502,7 +470,9 @@ public:
 
     //! \copydoc BaseFluidSystem::molarMass
     Scalar molarMass(unsigned compIdx, unsigned regionIdx = 0) const
-    { return molarMass_[regionIdx][compIdx]; }
+    {
+        return molarMass_[regionIdx][compIdx];
+    }
 
     //! \copydoc BaseFluidSystem::isIdealMixture
     bool isIdealMixture(unsigned /*phaseIdx*/) const
@@ -514,11 +484,15 @@ public:
 
     //! \copydoc BaseFluidSystem::isCompressible
     bool isCompressible(unsigned /*phaseIdx*/) const
-    { return true; /* all phases are compressible */ }
+    {
+        return true; /* all phases are compressible */
+    }
 
     //! \copydoc BaseFluidSystem::isIdealGas
     bool isIdealGas(unsigned /*phaseIdx*/) const
-    { return false; }
+    {
+        return false;
+    }
 
 
     /****************************************
@@ -530,7 +504,9 @@ public:
      * By default, this is 1.
      */
     std::size_t numRegions() const
-    { return molarMass_.size(); }
+    {
+        return molarMass_.size();
+    }
 
     /*!
      * \brief Returns whether the fluid system should consider that the gas component can
@@ -539,7 +515,9 @@ public:
      * By default, dissolved gas is considered.
      */
     bool enableDissolvedGas() const
-    { return enableDissolvedGas_; }
+    {
+        return enableDissolvedGas_;
+    }
 
 
     /*!
@@ -549,7 +527,9 @@ public:
      * By default, dissolved gas is considered.
      */
     bool enableDissolvedGasInWater() const
-    { return enableDissolvedGasInWater_; }
+    {
+        return enableDissolvedGasInWater_;
+    }
 
     /*!
      * \brief Returns whether the fluid system should consider that the oil component can
@@ -558,7 +538,9 @@ public:
      * By default, vaporized oil is not considered.
      */
     bool enableVaporizedOil() const
-    { return enableVaporizedOil_; }
+    {
+        return enableVaporizedOil_;
+    }
 
     /*!
      * \brief Returns whether the fluid system should consider that the water component can
@@ -567,15 +549,19 @@ public:
      * By default, vaporized water is not considered.
      */
     bool enableVaporizedWater() const
-    { return enableVaporizedWater_; }
+    {
+        return enableVaporizedWater_;
+    }
 
     /*!
      * \brief Returns whether the fluid system should consider diffusion
      *
      * By default, diffusion is not considered.
      */
-    bool enableDiffusion() const 
-    { return enableDiffusion_; }
+    bool enableDiffusion() const
+    {
+        return enableDiffusion_;
+    }
 
     /*!
      * \brief Returns whether the saturated tables should be used
@@ -583,7 +569,9 @@ public:
      * By default, saturated tables are used. If false the unsaturated tables are extrapolated
      */
     bool useSaturatedTables() const
-    { return useSaturatedTables_; }
+    {
+        return useSaturatedTables_;
+    }
 
     /*!
      * \brief Returns the density of a fluid phase at surface pressure [kg/m^3]
@@ -591,50 +579,54 @@ public:
      * \copydoc Doxygen::phaseIdxParam
      */
     Scalar referenceDensity(unsigned phaseIdx, unsigned regionIdx) const
-    { return referenceDensity_[regionIdx][phaseIdx]; }
+    {
+        return referenceDensity_[regionIdx][phaseIdx];
+    }
 
     /****************************************
      * thermodynamic quantities (generic version)
      ****************************************/
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    LhsEval density(const FluidState& fluidState,
-                           const ParameterCache<ParamCacheEval>& paramCache,
-                           unsigned phaseIdx) const
-    { return density<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex()); }
+    LhsEval
+    density(const FluidState& fluidState, const ParameterCache<ParamCacheEval>& paramCache, unsigned phaseIdx) const
+    {
+        return density<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex());
+    }
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     LhsEval fugacityCoefficient(const FluidState& fluidState,
-                                       const ParameterCache<ParamCacheEval>& paramCache,
-                                       unsigned phaseIdx,
-                                       unsigned compIdx) const
+                                const ParameterCache<ParamCacheEval>& paramCache,
+                                unsigned phaseIdx,
+                                unsigned compIdx) const
     {
-        return fugacityCoefficient<FluidState, LhsEval>(fluidState,
-                                                        phaseIdx,
-                                                        compIdx,
-                                                        paramCache.regionIndex());
+        return fugacityCoefficient<FluidState, LhsEval>(fluidState, phaseIdx, compIdx, paramCache.regionIndex());
     }
 
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    LhsEval viscosity(const FluidState& fluidState,
-                             const ParameterCache<ParamCacheEval>& paramCache,
-                             unsigned phaseIdx) const
-    { return viscosity<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex()); }
+    LhsEval
+    viscosity(const FluidState& fluidState, const ParameterCache<ParamCacheEval>& paramCache, unsigned phaseIdx) const
+    {
+        return viscosity<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex());
+    }
 
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
-    LhsEval enthalpy(const FluidState& fluidState,
-                            const ParameterCache<ParamCacheEval>& paramCache,
-                            unsigned phaseIdx) const
-    { return enthalpy<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex()); }
+    LhsEval
+    enthalpy(const FluidState& fluidState, const ParameterCache<ParamCacheEval>& paramCache, unsigned phaseIdx) const
+    {
+        return enthalpy<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex());
+    }
 
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     LhsEval internalEnergy(const FluidState& fluidState,
-                                  const ParameterCache<ParamCacheEval>& paramCache,
-                                  unsigned phaseIdx) const
-    { return internalEnergy<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex()); }
+                           const ParameterCache<ParamCacheEval>& paramCache,
+                           unsigned phaseIdx) const
+    {
+        return internalEnergy<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex());
+    }
 
     /****************************************
      * thermodynamic quantities (black-oil specific version: Note that the PVT region
@@ -642,16 +634,15 @@ public:
      ****************************************/
     //! \copydoc BaseFluidSystem::density
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval density(const FluidState& fluidState,
-                           unsigned phaseIdx,
-                           unsigned regionIdx) const
+    LhsEval density(const FluidState& fluidState, unsigned phaseIdx, unsigned regionIdx) const
     {
         assert(phaseIdx <= numPhases);
         assert(regionIdx <= numRegions());
 
         const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& saltConcentration = BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+        const LhsEval& saltConcentration
+            = BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
 
         switch (phaseIdx) {
         case oilPhaseIdx: {
@@ -660,29 +651,28 @@ public:
                 const LhsEval& Rs = BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 const LhsEval& bo = oilPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rs);
 
-                return
-                    bo*referenceDensity(oilPhaseIdx, regionIdx)
-                    + Rs*bo*referenceDensity(gasPhaseIdx, regionIdx);
+                return bo * referenceDensity(oilPhaseIdx, regionIdx)
+                    + Rs * bo * referenceDensity(gasPhaseIdx, regionIdx);
             }
 
             // immiscible oil
             const LhsEval Rs(0.0);
             const auto& bo = oilPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rs);
 
-            return referenceDensity(phaseIdx, regionIdx)*bo;
+            return referenceDensity(phaseIdx, regionIdx) * bo;
         }
 
         case gasPhaseIdx: {
-             if (enableVaporizedOil() && enableVaporizedWater()) {
+            if (enableVaporizedOil() && enableVaporizedWater()) {
                 // gas containing vaporized oil and vaporized water
                 const LhsEval& Rv = BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
-                const LhsEval& Rvw = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const LhsEval& Rvw
+                    = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
 
-                return
-                    bg*referenceDensity(gasPhaseIdx, regionIdx)
-                    + Rv*bg*referenceDensity(oilPhaseIdx, regionIdx)
-                    + Rvw*bg*referenceDensity(waterPhaseIdx, regionIdx);
+                return bg * referenceDensity(gasPhaseIdx, regionIdx)
+                    + Rv * bg * referenceDensity(oilPhaseIdx, regionIdx)
+                    + Rvw * bg * referenceDensity(waterPhaseIdx, regionIdx);
             }
             if (enableVaporizedOil()) {
                 // miscible gas
@@ -690,44 +680,42 @@ public:
                 const LhsEval& Rv = BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
 
-                return
-                    bg*referenceDensity(gasPhaseIdx, regionIdx)
-                    + Rv*bg*referenceDensity(oilPhaseIdx, regionIdx);
+                return bg * referenceDensity(gasPhaseIdx, regionIdx)
+                    + Rv * bg * referenceDensity(oilPhaseIdx, regionIdx);
             }
             if (enableVaporizedWater()) {
                 // gas containing vaporized water
                 const LhsEval Rv(0.0);
-                const LhsEval& Rvw = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const LhsEval& Rvw
+                    = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
 
-                return
-                    bg*referenceDensity(gasPhaseIdx, regionIdx)
-                    + Rvw*bg*referenceDensity(waterPhaseIdx, regionIdx);
+                return bg * referenceDensity(gasPhaseIdx, regionIdx)
+                    + Rvw * bg * referenceDensity(waterPhaseIdx, regionIdx);
             }
 
             // immiscible gas
             const LhsEval Rv(0.0);
             const LhsEval Rvw(0.0);
             const auto& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
-            return bg*referenceDensity(phaseIdx, regionIdx);
+            return bg * referenceDensity(phaseIdx, regionIdx);
         }
 
         case waterPhaseIdx:
             if (enableDissolvedGasInWater()) {
-                 // gas miscible in water
-                const LhsEval& Rsw =BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                // gas miscible in water
+                const LhsEval& Rsw
+                    = BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 const LhsEval& bw = waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rsw, saltConcentration);
-                return
-                    bw*referenceDensity(waterPhaseIdx, regionIdx)
-                    + Rsw*bw*referenceDensity(gasPhaseIdx, regionIdx);
+                return bw * referenceDensity(waterPhaseIdx, regionIdx)
+                    + Rsw * bw * referenceDensity(gasPhaseIdx, regionIdx);
             }
             const LhsEval Rsw(0.0);
-            return
-                referenceDensity(waterPhaseIdx, regionIdx)
+            return referenceDensity(waterPhaseIdx, regionIdx)
                 * waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rsw, saltConcentration);
         }
 
-        throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
     }
 
     /*!
@@ -740,9 +728,7 @@ public:
      * the water density takes into account the amount of dissolved gas
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval saturatedDensity(const FluidState& fluidState,
-                                    unsigned phaseIdx,
-                                    unsigned regionIdx) const
+    LhsEval saturatedDensity(const FluidState& fluidState, unsigned phaseIdx, unsigned regionIdx) const
     {
         assert(phaseIdx <= numPhases);
         assert(regionIdx <= numRegions());
@@ -757,28 +743,27 @@ public:
                 const LhsEval& Rs = saturatedDissolutionFactor<FluidState, LhsEval>(fluidState, oilPhaseIdx, regionIdx);
                 const LhsEval& bo = oilPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rs);
 
-                return
-                    bo*referenceDensity(oilPhaseIdx, regionIdx)
-                    + Rs*bo*referenceDensity(gasPhaseIdx, regionIdx);
+                return bo * referenceDensity(oilPhaseIdx, regionIdx)
+                    + Rs * bo * referenceDensity(gasPhaseIdx, regionIdx);
             }
 
             // immiscible oil
             const LhsEval Rs(0.0);
             const LhsEval& bo = oilPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rs);
-            return referenceDensity(phaseIdx, regionIdx)*bo;
+            return referenceDensity(phaseIdx, regionIdx) * bo;
         }
 
         case gasPhaseIdx: {
             if (enableVaporizedOil() && enableVaporizedWater()) {
                 // gas containing vaporized oil and vaporized water
                 const LhsEval& Rv = saturatedDissolutionFactor<FluidState, LhsEval>(fluidState, gasPhaseIdx, regionIdx);
-                const LhsEval& Rvw = saturatedVaporizationFactor<FluidState, LhsEval>(fluidState, gasPhaseIdx, regionIdx);
+                const LhsEval& Rvw
+                    = saturatedVaporizationFactor<FluidState, LhsEval>(fluidState, gasPhaseIdx, regionIdx);
                 const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
 
-                return
-                    bg*referenceDensity(gasPhaseIdx, regionIdx)
-                    + Rv*bg*referenceDensity(oilPhaseIdx, regionIdx)
-                    + Rvw*bg*referenceDensity(waterPhaseIdx, regionIdx) ;
+                return bg * referenceDensity(gasPhaseIdx, regionIdx)
+                    + Rv * bg * referenceDensity(oilPhaseIdx, regionIdx)
+                    + Rvw * bg * referenceDensity(waterPhaseIdx, regionIdx);
             }
 
             if (enableVaporizedOil()) {
@@ -787,20 +772,19 @@ public:
                 const LhsEval& Rv = saturatedDissolutionFactor<FluidState, LhsEval>(fluidState, gasPhaseIdx, regionIdx);
                 const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
 
-                return
-                    bg*referenceDensity(gasPhaseIdx, regionIdx)
-                    + Rv*bg*referenceDensity(oilPhaseIdx, regionIdx);
+                return bg * referenceDensity(gasPhaseIdx, regionIdx)
+                    + Rv * bg * referenceDensity(oilPhaseIdx, regionIdx);
             }
 
             if (enableVaporizedWater()) {
                 // gas containing vaporized water
                 const LhsEval Rv(0.0);
-                const LhsEval& Rvw = saturatedVaporizationFactor<FluidState, LhsEval>(fluidState, gasPhaseIdx, regionIdx);
+                const LhsEval& Rvw
+                    = saturatedVaporizationFactor<FluidState, LhsEval>(fluidState, gasPhaseIdx, regionIdx);
                 const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
 
-                return
-                    bg*referenceDensity(gasPhaseIdx, regionIdx)
-                    + Rvw*bg*referenceDensity(waterPhaseIdx, regionIdx);
+                return bg * referenceDensity(gasPhaseIdx, regionIdx)
+                    + Rvw * bg * referenceDensity(waterPhaseIdx, regionIdx);
             }
 
             // immiscible gas
@@ -808,28 +792,25 @@ public:
             const LhsEval Rvw(0.0);
             const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
 
-            return referenceDensity(phaseIdx, regionIdx)*bg;
-
+            return referenceDensity(phaseIdx, regionIdx) * bg;
         }
 
-        case waterPhaseIdx:
-        {
+        case waterPhaseIdx: {
             if (enableDissolvedGasInWater()) {
-                 // miscible in water
+                // miscible in water
                 const auto& saltConcentration = decay<LhsEval>(fluidState.saltConcentration());
-                const LhsEval& Rsw = saturatedDissolutionFactor<FluidState, LhsEval>(fluidState, waterPhaseIdx, regionIdx);
+                const LhsEval& Rsw
+                    = saturatedDissolutionFactor<FluidState, LhsEval>(fluidState, waterPhaseIdx, regionIdx);
                 const LhsEval& bw = waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rsw, saltConcentration);
-                return
-                    bw*referenceDensity(waterPhaseIdx, regionIdx)
-                    + Rsw*bw*referenceDensity(gasPhaseIdx, regionIdx);
+                return bw * referenceDensity(waterPhaseIdx, regionIdx)
+                    + Rsw * bw * referenceDensity(gasPhaseIdx, regionIdx);
             }
-            return
-                referenceDensity(waterPhaseIdx, regionIdx)
-                *inverseFormationVolumeFactor<FluidState, LhsEval>(fluidState, waterPhaseIdx, regionIdx);
+            return referenceDensity(waterPhaseIdx, regionIdx)
+                * inverseFormationVolumeFactor<FluidState, LhsEval>(fluidState, waterPhaseIdx, regionIdx);
         }
         }
 
-        throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
     }
 
     /*!
@@ -841,9 +822,7 @@ public:
      * the given temperature and pressure.
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval inverseFormationVolumeFactor(const FluidState& fluidState,
-                                                unsigned phaseIdx,
-                                                unsigned regionIdx) const
+    LhsEval inverseFormationVolumeFactor(const FluidState& fluidState, unsigned phaseIdx, unsigned regionIdx) const
     {
         OPM_TIMEBLOCK_LOCAL(inverseFormationVolumeFactor);
         assert(phaseIdx <= numPhases);
@@ -857,8 +836,8 @@ public:
             if (enableDissolvedGas()) {
                 const auto& Rs = BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 if (useSaturatedTables() && fluidState.saturation(gasPhaseIdx) > 0.0
-                    && Rs >= (1.0 - 1e-10)*oilPvt_->saturatedGasDissolutionFactor(regionIdx, scalarValue(T), scalarValue(p)))
-                {
+                    && Rs >= (1.0 - 1e-10)
+                            * oilPvt_->saturatedGasDissolutionFactor(regionIdx, scalarValue(T), scalarValue(p))) {
                     return oilPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
                 } else {
                     return oilPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rs);
@@ -870,24 +849,25 @@ public:
         }
         case gasPhaseIdx: {
             if (enableVaporizedOil() && enableVaporizedWater()) {
-                 const auto& Rvw = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
-                 const auto& Rv = BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
-                 if (useSaturatedTables() && fluidState.saturation(waterPhaseIdx) > 0.0
-                    && Rvw >= (1.0 - 1e-10)*gasPvt_->saturatedWaterVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p))
+                const auto& Rvw = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const auto& Rv = BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                if (useSaturatedTables() && fluidState.saturation(waterPhaseIdx) > 0.0
+                    && Rvw >= (1.0 - 1e-10)
+                            * gasPvt_->saturatedWaterVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p))
                     && fluidState.saturation(oilPhaseIdx) > 0.0
-                    && Rv >= (1.0 - 1e-10)*gasPvt_->saturatedOilVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p)))
-                 {
+                    && Rv >= (1.0 - 1e-10)
+                            * gasPvt_->saturatedOilVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p))) {
                     return gasPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
-                 } else {
+                } else {
                     return gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
-                 }
+                }
             }
 
             if (enableVaporizedOil()) {
                 const auto& Rv = BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 if (useSaturatedTables() && fluidState.saturation(oilPhaseIdx) > 0.0
-                    && Rv >= (1.0 - 1e-10)*gasPvt_->saturatedOilVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p)))
-                {
+                    && Rv >= (1.0 - 1e-10)
+                            * gasPvt_->saturatedOilVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p))) {
                     return gasPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
                 } else {
                     const LhsEval Rvw(0.0);
@@ -898,8 +878,8 @@ public:
             if (enableVaporizedWater()) {
                 const auto& Rvw = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 if (useSaturatedTables() && fluidState.saturation(waterPhaseIdx) > 0.0
-                    && Rvw >= (1.0 - 1e-10)*gasPvt_->saturatedWaterVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p)))
-                {
+                    && Rvw >= (1.0 - 1e-10)
+                            * gasPvt_->saturatedWaterVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p))) {
                     return gasPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
                 } else {
                     const LhsEval Rv(0.0);
@@ -911,14 +891,15 @@ public:
             const LhsEval Rvw(0.0);
             return gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
         }
-        case waterPhaseIdx:
-        {
-            const auto& saltConcentration = BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+        case waterPhaseIdx: {
+            const auto& saltConcentration
+                = BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
             if (enableDissolvedGasInWater()) {
                 const auto& Rsw = BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 if (useSaturatedTables() && fluidState.saturation(gasPhaseIdx) > 0.0
-                    && Rsw >= (1.0 - 1e-10)*waterPvt_->saturatedGasDissolutionFactor(regionIdx, scalarValue(T), scalarValue(p), scalarValue(saltConcentration)))
-                {
+                    && Rsw >= (1.0 - 1e-10)
+                            * waterPvt_->saturatedGasDissolutionFactor(
+                                regionIdx, scalarValue(T), scalarValue(p), scalarValue(saltConcentration))) {
                     return waterPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p, saltConcentration);
                 } else {
                     return waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rsw, saltConcentration);
@@ -927,7 +908,8 @@ public:
             const LhsEval Rsw(0.0);
             return waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rsw, saltConcentration);
         }
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        default:
+            throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
 
@@ -941,9 +923,8 @@ public:
      * the water density takes into account the amount of dissolved gas
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval saturatedInverseFormationVolumeFactor(const FluidState& fluidState,
-                                                         unsigned phaseIdx,
-                                                         unsigned regionIdx) const
+    LhsEval
+    saturatedInverseFormationVolumeFactor(const FluidState& fluidState, unsigned phaseIdx, unsigned regionIdx) const
     {
         OPM_TIMEBLOCK_LOCAL(saturatedInverseFormationVolumeFactor);
         assert(phaseIdx <= numPhases);
@@ -951,22 +932,25 @@ public:
 
         const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const auto& saltConcentration = BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+        const auto& saltConcentration
+            = BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
 
         switch (phaseIdx) {
-        case oilPhaseIdx: return oilPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
-        case gasPhaseIdx: return gasPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
-        case waterPhaseIdx: return waterPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p, saltConcentration);
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        case oilPhaseIdx:
+            return oilPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
+        case gasPhaseIdx:
+            return gasPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
+        case waterPhaseIdx:
+            return waterPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p, saltConcentration);
+        default:
+            throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
 
     //! \copydoc BaseFluidSystem::fugacityCoefficient
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval fugacityCoefficient(const FluidState& fluidState,
-                                       unsigned phaseIdx,
-                                       unsigned compIdx,
-                                       unsigned regionIdx) const
+    LhsEval
+    fugacityCoefficient(const FluidState& fluidState, unsigned phaseIdx, unsigned compIdx, unsigned regionIdx) const
     {
         assert(phaseIdx <= numPhases);
         assert(compIdx <= numComponents);
@@ -978,14 +962,14 @@ public:
         // for the fugacity coefficient of the oil component in the oil phase, we use
         // some pseudo-realistic value for the vapor pressure to ease physical
         // interpretation of the results
-        const LhsEval phi_oO = 20e3/p;
+        const LhsEval phi_oO = 20e3 / p;
 
         // for the gas component in the gas phase, assume it to be an ideal gas
         constexpr const Scalar phi_gG = 1.0;
 
         // for the fugacity coefficient of the water component in the water phase, we use
         // the same approach as for the oil component in the oil phase
-        const LhsEval phi_wW = 30e3/p;
+        const LhsEval phi_wW = 30e3 / p;
 
         switch (phaseIdx) {
         case gasPhaseIdx: // fugacity coefficients for all components in the gas phase
@@ -1001,7 +985,7 @@ public:
                 if (!enableVaporizedOil())
                     // if there's no vaporized oil, the gas phase is assumed to be
                     // immiscible with the oil component
-                    return phi_gG*1e6;
+                    return phi_gG * 1e6;
 
                 const auto& R_vSat = gasPvt_->saturatedOilVaporizationFactor(regionIdx, T, p);
                 const auto& X_gOSat = convertRvToXgO(R_vSat, regionIdx);
@@ -1015,15 +999,15 @@ public:
                 const auto& p_o = decay<LhsEval>(fluidState.pressure(oilPhaseIdx));
                 const auto& p_g = decay<LhsEval>(fluidState.pressure(gasPhaseIdx));
 
-                return phi_oO*p_o*x_oOSat / (p_g*x_gOSat);
+                return phi_oO * p_o * x_oOSat / (p_g * x_gOSat);
             }
 
             case waterCompIdx:
                 // the water component is assumed to be never miscible with the gas phase
-                return phi_gG*1e6;
+                return phi_gG * 1e6;
 
             default:
-                throw std::logic_error("Invalid component index "+std::to_string(compIdx));
+                throw std::logic_error("Invalid component index " + std::to_string(compIdx));
             }
 
         case oilPhaseIdx: // fugacity coefficients for all components in the oil phase
@@ -1037,7 +1021,7 @@ public:
                 if (!enableDissolvedGas())
                     // if there's no dissolved gas, the oil phase is assumed to be
                     // immiscible with the gas component
-                    return phi_oO*1e6;
+                    return phi_oO * 1e6;
 
                 const auto& R_vSat = gasPvt_->saturatedOilVaporizationFactor(regionIdx, T, p);
                 const auto& X_gOSat = convertRvToXgO(R_vSat, regionIdx);
@@ -1051,14 +1035,14 @@ public:
                 const auto& p_o = decay<LhsEval>(fluidState.pressure(oilPhaseIdx));
                 const auto& p_g = decay<LhsEval>(fluidState.pressure(gasPhaseIdx));
 
-                return phi_gG*p_g*x_gGSat / (p_o*x_oGSat);
+                return phi_gG * p_g * x_gGSat / (p_o * x_oGSat);
             }
 
             case waterCompIdx:
-                return phi_oO*1e6;
+                return phi_oO * 1e6;
 
             default:
-                throw std::logic_error("Invalid component index "+std::to_string(compIdx));
+                throw std::logic_error("Invalid component index " + std::to_string(compIdx));
             }
 
         case waterPhaseIdx: // fugacity coefficients for all components in the water phase
@@ -1069,15 +1053,18 @@ public:
             // component. (i.e., the affinity of the gas and oil components to the water
             // phase is lower by a few orders of magnitude)
             switch (compIdx) {
-            case waterCompIdx: return phi_wW;
-            case oilCompIdx: return 1.1e6*phi_wW;
-            case gasCompIdx: return 1e6*phi_wW;
+            case waterCompIdx:
+                return phi_wW;
+            case oilCompIdx:
+                return 1.1e6 * phi_wW;
+            case gasCompIdx:
+                return 1e6 * phi_wW;
             default:
-                throw std::logic_error("Invalid component index "+std::to_string(compIdx));
+                throw std::logic_error("Invalid component index " + std::to_string(compIdx));
             }
 
         default:
-            throw std::logic_error("Invalid phase index "+std::to_string(phaseIdx));
+            throw std::logic_error("Invalid phase index " + std::to_string(phaseIdx));
         }
 
         throw std::logic_error("Unhandled phase or component index");
@@ -1085,9 +1072,7 @@ public:
 
     //! \copydoc BaseFluidSystem::viscosity
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval viscosity(const FluidState& fluidState,
-                             unsigned phaseIdx,
-                             unsigned regionIdx) const
+    LhsEval viscosity(const FluidState& fluidState, unsigned phaseIdx, unsigned regionIdx) const
     {
         OPM_TIMEBLOCK_LOCAL(viscosity);
         assert(phaseIdx <= numPhases);
@@ -1101,8 +1086,8 @@ public:
             if (enableDissolvedGas()) {
                 const auto& Rs = BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 if (useSaturatedTables() && fluidState.saturation(gasPhaseIdx) > 0.0
-                    && Rs >= (1.0 - 1e-10)*oilPvt_->saturatedGasDissolutionFactor(regionIdx, scalarValue(T), scalarValue(p)))
-                {
+                    && Rs >= (1.0 - 1e-10)
+                            * oilPvt_->saturatedGasDissolutionFactor(regionIdx, scalarValue(T), scalarValue(p))) {
                     return oilPvt_->saturatedViscosity(regionIdx, T, p);
                 } else {
                     return oilPvt_->viscosity(regionIdx, T, p, Rs);
@@ -1114,24 +1099,25 @@ public:
         }
 
         case gasPhaseIdx: {
-             if (enableVaporizedOil() && enableVaporizedWater()) {
-                 const auto& Rvw = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
-                 const auto& Rv = BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
-                 if (useSaturatedTables() && fluidState.saturation(waterPhaseIdx) > 0.0
-                    && Rvw >= (1.0 - 1e-10)*gasPvt_->saturatedWaterVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p))
+            if (enableVaporizedOil() && enableVaporizedWater()) {
+                const auto& Rvw = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const auto& Rv = BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                if (useSaturatedTables() && fluidState.saturation(waterPhaseIdx) > 0.0
+                    && Rvw >= (1.0 - 1e-10)
+                            * gasPvt_->saturatedWaterVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p))
                     && fluidState.saturation(oilPhaseIdx) > 0.0
-                    && Rv >= (1.0 - 1e-10)*gasPvt_->saturatedOilVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p)))
-                 {
-                     return gasPvt_->saturatedViscosity(regionIdx, T, p);
-                 } else {
-                     return gasPvt_->viscosity(regionIdx, T, p, Rv, Rvw);
-                 }
+                    && Rv >= (1.0 - 1e-10)
+                            * gasPvt_->saturatedOilVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p))) {
+                    return gasPvt_->saturatedViscosity(regionIdx, T, p);
+                } else {
+                    return gasPvt_->viscosity(regionIdx, T, p, Rv, Rvw);
+                }
             }
             if (enableVaporizedOil()) {
                 const auto& Rv = BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 if (useSaturatedTables() && fluidState.saturation(oilPhaseIdx) > 0.0
-                    && Rv >= (1.0 - 1e-10)*gasPvt_->saturatedOilVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p)))
-                {
+                    && Rv >= (1.0 - 1e-10)
+                            * gasPvt_->saturatedOilVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p))) {
                     return gasPvt_->saturatedViscosity(regionIdx, T, p);
                 } else {
                     const LhsEval Rvw(0.0);
@@ -1141,8 +1127,8 @@ public:
             if (enableVaporizedWater()) {
                 const auto& Rvw = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 if (useSaturatedTables() && fluidState.saturation(waterPhaseIdx) > 0.0
-                    && Rvw >= (1.0 - 1e-10)*gasPvt_->saturatedWaterVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p)))
-                {
+                    && Rvw >= (1.0 - 1e-10)
+                            * gasPvt_->saturatedWaterVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p))) {
                     return gasPvt_->saturatedViscosity(regionIdx, T, p);
                 } else {
                     const LhsEval Rv(0.0);
@@ -1155,14 +1141,15 @@ public:
             return gasPvt_->viscosity(regionIdx, T, p, Rv, Rvw);
         }
 
-        case waterPhaseIdx:
-        {
-            const LhsEval& saltConcentration = BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+        case waterPhaseIdx: {
+            const LhsEval& saltConcentration
+                = BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
             if (enableDissolvedGasInWater()) {
                 const auto& Rsw = BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 if (useSaturatedTables() && fluidState.saturation(gasPhaseIdx) > 0.0
-                    && Rsw >= (1.0 - 1e-10)*waterPvt_->saturatedGasDissolutionFactor(regionIdx, scalarValue(T), scalarValue(p), scalarValue(saltConcentration)))
-                {
+                    && Rsw >= (1.0 - 1e-10)
+                            * waterPvt_->saturatedGasDissolutionFactor(
+                                regionIdx, scalarValue(T), scalarValue(p), scalarValue(saltConcentration))) {
                     return waterPvt_->saturatedViscosity(regionIdx, T, p, saltConcentration);
                 } else {
                     return waterPvt_->viscosity(regionIdx, T, p, Rsw, saltConcentration);
@@ -1173,13 +1160,11 @@ public:
         }
         }
 
-        throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
     }
 
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval internalEnergy(const FluidState& fluidState,
-                                  const unsigned phaseIdx,
-                                  const unsigned regionIdx) const
+    LhsEval internalEnergy(const FluidState& fluidState, const unsigned phaseIdx, const unsigned regionIdx) const
     {
         const auto p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         const auto T = decay<LhsEval>(fluidState.temperature(phaseIdx));
@@ -1187,160 +1172,176 @@ public:
         switch (phaseIdx) {
         case oilPhaseIdx:
             if (!oilPvt_->mixingEnergy()) {
-                return oilPvt_->internalEnergy
-                    (regionIdx, T, p,
-                     BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                return oilPvt_->internalEnergy(
+                    regionIdx,
+                    T,
+                    p,
+                    BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
             }
             break;
 
         case waterPhaseIdx:
             if (!waterPvt_->mixingEnergy()) {
-                return waterPvt_->internalEnergy
-                    (regionIdx, T, p,
-                     BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
-                     BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                return waterPvt_->internalEnergy(
+                    regionIdx,
+                    T,
+                    p,
+                    BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                    BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
             }
             break;
 
         case gasPhaseIdx:
             if (!gasPvt_->mixingEnergy()) {
-                return gasPvt_->internalEnergy
-                    (regionIdx, T, p,
-                     BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
-                     BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                return gasPvt_->internalEnergy(
+                    regionIdx,
+                    T,
+                    p,
+                    BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                    BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
             }
             break;
 
         default:
-            throw std::logic_error {
-                "Phase index " + std::to_string(phaseIdx) + " does not support internal energy"
-            };
+            throw std::logic_error {"Phase index " + std::to_string(phaseIdx) + " does not support internal energy"};
         }
 
-        return internalMixingTotalEnergy<FluidState,LhsEval>(fluidState, phaseIdx, regionIdx)
-            /  density<FluidState,LhsEval>(fluidState, phaseIdx, regionIdx);
+        return internalMixingTotalEnergy<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx)
+            / density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
     }
 
 
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval internalMixingTotalEnergy(const FluidState& fluidState,
-                                             unsigned phaseIdx,
-                                             unsigned regionIdx) const
+    LhsEval internalMixingTotalEnergy(const FluidState& fluidState, unsigned phaseIdx, unsigned regionIdx) const
     {
         assert(phaseIdx <= numPhases);
         assert(regionIdx <= numRegions());
         const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
-        const LhsEval& saltConcentration = BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+        const LhsEval& saltConcentration
+            = BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
         // to avoid putting all thermal into the interface of the multiplexer
         switch (phaseIdx) {
         case oilPhaseIdx: {
-            auto oilEnergy = oilPvt_->internalEnergy(regionIdx, T, p,
-                                                     BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+            auto oilEnergy = oilPvt_->internalEnergy(
+                regionIdx, T, p, BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
             assert(oilPvt_->mixingEnergy());
-            //mixing energy adsed
+            // mixing energy adsed
             if (enableDissolvedGas()) {
                 // miscible oil
                 const LhsEval& Rs = BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 const LhsEval& bo = oilPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rs);
-                const auto& gasEnergy =
-                    gasPvt_->internalEnergy(regionIdx, T, p,
-                                            BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
-                                            BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
-                const auto hVapG = gasPvt_->hVap(regionIdx);// pressure correction ? assume equal to energy change
-                return
-                    oilEnergy*bo*referenceDensity(oilPhaseIdx, regionIdx)
-                    + (gasEnergy-hVapG)*Rs*bo*referenceDensity(gasPhaseIdx, regionIdx);
+                const auto& gasEnergy = gasPvt_->internalEnergy(
+                    regionIdx,
+                    T,
+                    p,
+                    BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                    BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                const auto hVapG = gasPvt_->hVap(regionIdx); // pressure correction ? assume equal to energy change
+                return oilEnergy * bo * referenceDensity(oilPhaseIdx, regionIdx)
+                    + (gasEnergy - hVapG) * Rs * bo * referenceDensity(gasPhaseIdx, regionIdx);
             }
 
             // immiscible oil
             const LhsEval Rs(0.0);
             const auto& bo = oilPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rs);
 
-            return oilEnergy*referenceDensity(phaseIdx, regionIdx)*bo;
+            return oilEnergy * referenceDensity(phaseIdx, regionIdx) * bo;
         }
 
         case gasPhaseIdx: {
-            const auto& gasEnergy =
-                gasPvt_->internalEnergy(regionIdx, T, p,
-                                        BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
-                                        BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+            const auto& gasEnergy = gasPvt_->internalEnergy(
+                regionIdx,
+                T,
+                p,
+                BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
             assert(gasPvt_->mixingEnergy());
             if (enableVaporizedOil() && enableVaporizedWater()) {
-                const auto& oilEnergy =
-                    oilPvt_->internalEnergy(regionIdx, T, p,
-                                            BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
-                const auto waterEnergy =
-                    waterPvt_->internalEnergy(regionIdx, T, p,
-                                              BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
-                                              BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                const auto& oilEnergy = oilPvt_->internalEnergy(
+                    regionIdx,
+                    T,
+                    p,
+                    BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                const auto waterEnergy = waterPvt_->internalEnergy(
+                    regionIdx,
+                    T,
+                    p,
+                    BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                    BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
                 // gas containing vaporized oil and vaporized water
                 const LhsEval& Rv = BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
-                const LhsEval& Rvw = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const LhsEval& Rvw
+                    = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
                 const auto hVapO = oilPvt_->hVap(regionIdx);
                 const auto hVapW = waterPvt_->hVap(regionIdx);
-                return
-                    gasEnergy*bg*referenceDensity(gasPhaseIdx, regionIdx)
-                    + (oilEnergy+hVapO)*Rv*bg*referenceDensity(oilPhaseIdx, regionIdx)
-                    + (waterEnergy+hVapW)*Rvw*bg*referenceDensity(waterPhaseIdx, regionIdx);
+                return gasEnergy * bg * referenceDensity(gasPhaseIdx, regionIdx)
+                    + (oilEnergy + hVapO) * Rv * bg * referenceDensity(oilPhaseIdx, regionIdx)
+                    + (waterEnergy + hVapW) * Rvw * bg * referenceDensity(waterPhaseIdx, regionIdx);
             }
             if (enableVaporizedOil()) {
-                const auto& oilEnergy =
-                    oilPvt_->internalEnergy(regionIdx, T, p,
-                                            BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                const auto& oilEnergy = oilPvt_->internalEnergy(
+                    regionIdx,
+                    T,
+                    p,
+                    BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
                 // miscible gas
                 const LhsEval Rvw(0.0);
                 const LhsEval& Rv = BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
                 const auto hVapO = oilPvt_->hVap(regionIdx);
-                return
-                    gasEnergy*bg*referenceDensity(gasPhaseIdx, regionIdx)
-                    + (oilEnergy+hVapO)*Rv*bg*referenceDensity(oilPhaseIdx, regionIdx);
+                return gasEnergy * bg * referenceDensity(gasPhaseIdx, regionIdx)
+                    + (oilEnergy + hVapO) * Rv * bg * referenceDensity(oilPhaseIdx, regionIdx);
             }
             if (enableVaporizedWater()) {
                 // gas containing vaporized water
                 const LhsEval Rv(0.0);
-                const LhsEval& Rvw = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const LhsEval& Rvw
+                    = BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
-                const auto waterEnergy =
-                    waterPvt_->internalEnergy(regionIdx, T, p,
-                                              BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
-                                              BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                const auto waterEnergy = waterPvt_->internalEnergy(
+                    regionIdx,
+                    T,
+                    p,
+                    BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                    BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
                 const auto hVapW = waterPvt_->hVap(regionIdx);
-                return
-                    gasEnergy*bg*referenceDensity(gasPhaseIdx, regionIdx)
-                    + (waterEnergy+hVapW)*Rvw*bg*referenceDensity(waterPhaseIdx, regionIdx);
+                return gasEnergy * bg * referenceDensity(gasPhaseIdx, regionIdx)
+                    + (waterEnergy + hVapW) * Rvw * bg * referenceDensity(waterPhaseIdx, regionIdx);
             }
 
             // immiscible gas
             const LhsEval Rv(0.0);
             const LhsEval Rvw(0.0);
             const auto& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
-            return gasEnergy*bg*referenceDensity(phaseIdx, regionIdx);
+            return gasEnergy * bg * referenceDensity(phaseIdx, regionIdx);
         }
 
         case waterPhaseIdx:
-            const auto waterEnergy =
-                waterPvt_->internalEnergy(regionIdx, T, p,
-                                          BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
-                                          BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+            const auto waterEnergy = waterPvt_->internalEnergy(
+                regionIdx,
+                T,
+                p,
+                BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
             assert(waterPvt_->mixingEnergy());
             if (enableDissolvedGasInWater()) {
-                const auto& gasEnergy =
-                    gasPvt_->internalEnergy(regionIdx, T, p,
-                                            BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
-                                            BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                const auto& gasEnergy = gasPvt_->internalEnergy(
+                    regionIdx,
+                    T,
+                    p,
+                    BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                    BlackOilTwo::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
                 // gas miscible in water
-                const LhsEval& Rsw = saturatedDissolutionFactor<FluidState, LhsEval>(fluidState, waterPhaseIdx, regionIdx);
+                const LhsEval& Rsw
+                    = saturatedDissolutionFactor<FluidState, LhsEval>(fluidState, waterPhaseIdx, regionIdx);
                 const LhsEval& bw = waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rsw, saltConcentration);
-                return
-                    waterEnergy*bw*referenceDensity(waterPhaseIdx, regionIdx)
-                    + gasEnergy*Rsw*bw*referenceDensity(gasPhaseIdx, regionIdx);
+                return waterEnergy * bw * referenceDensity(waterPhaseIdx, regionIdx)
+                    + gasEnergy * Rsw * bw * referenceDensity(gasPhaseIdx, regionIdx);
             }
             const LhsEval Rsw(0.0);
-            return
-                waterEnergy*referenceDensity(waterPhaseIdx, regionIdx)
+            return waterEnergy * referenceDensity(waterPhaseIdx, regionIdx)
                 * waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rsw, saltConcentration);
         }
         throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
@@ -1350,16 +1351,14 @@ public:
 
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval enthalpy(const FluidState& fluidState,
-                            unsigned phaseIdx,
-                            unsigned regionIdx) const
+    LhsEval enthalpy(const FluidState& fluidState, unsigned phaseIdx, unsigned regionIdx) const
     {
         // should preferably not be used values should be taken from intensive quantities fluid state.
         const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         auto energy = internalEnergy<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
-        if(!enthalpy_eq_energy_){
+        if (!enthalpy_eq_energy_) {
             // used for simplified models
-            energy += p/density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
+            energy += p / density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
         }
         return energy;
     }
@@ -1371,9 +1370,7 @@ public:
      * it is always 0.
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval saturatedVaporizationFactor(const FluidState& fluidState,
-                                              unsigned phaseIdx,
-                                              unsigned regionIdx) const
+    LhsEval saturatedVaporizationFactor(const FluidState& fluidState, unsigned phaseIdx, unsigned regionIdx) const
     {
         assert(phaseIdx <= numPhases);
         assert(regionIdx <= numRegions());
@@ -1383,10 +1380,14 @@ public:
         const auto& saltConcentration = decay<LhsEval>(fluidState.saltConcentration());
 
         switch (phaseIdx) {
-        case oilPhaseIdx: return 0.0;
-        case gasPhaseIdx: return gasPvt_->saturatedWaterVaporizationFactor(regionIdx, T, p, saltConcentration);
-        case waterPhaseIdx: return 0.0;
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        case oilPhaseIdx:
+            return 0.0;
+        case gasPhaseIdx:
+            return gasPvt_->saturatedWaterVaporizationFactor(regionIdx, T, p, saltConcentration);
+        case waterPhaseIdx:
+            return 0.0;
+        default:
+            throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
 
@@ -1398,9 +1399,9 @@ public:
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     LhsEval saturatedDissolutionFactor(const FluidState& fluidState,
-                                              unsigned phaseIdx,
-                                              unsigned regionIdx,
-                                              const LhsEval& maxOilSaturation) const
+                                       unsigned phaseIdx,
+                                       unsigned regionIdx,
+                                       const LhsEval& maxOilSaturation) const
     {
         OPM_TIMEBLOCK_LOCAL(saturatedDissolutionFactor);
         assert(phaseIdx <= numPhases);
@@ -1411,11 +1412,18 @@ public:
         const auto& So = (phaseIdx == waterPhaseIdx) ? 0 : decay<LhsEval>(fluidState.saturation(oilPhaseIdx));
 
         switch (phaseIdx) {
-        case oilPhaseIdx: return oilPvt_->saturatedGasDissolutionFactor(regionIdx, T, p, So, maxOilSaturation);
-        case gasPhaseIdx: return gasPvt_->saturatedOilVaporizationFactor(regionIdx, T, p, So, maxOilSaturation);
-        case waterPhaseIdx: return waterPvt_->saturatedGasDissolutionFactor(regionIdx, T, p,
-        BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        case oilPhaseIdx:
+            return oilPvt_->saturatedGasDissolutionFactor(regionIdx, T, p, So, maxOilSaturation);
+        case gasPhaseIdx:
+            return gasPvt_->saturatedOilVaporizationFactor(regionIdx, T, p, So, maxOilSaturation);
+        case waterPhaseIdx:
+            return waterPvt_->saturatedGasDissolutionFactor(
+                regionIdx,
+                T,
+                p,
+                BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+        default:
+            throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
 
@@ -1428,9 +1436,7 @@ public:
      * phase's saturation is small-
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval saturatedDissolutionFactor(const FluidState& fluidState,
-                                              unsigned phaseIdx,
-                                              unsigned regionIdx) const
+    LhsEval saturatedDissolutionFactor(const FluidState& fluidState, unsigned phaseIdx, unsigned regionIdx) const
     {
         OPM_TIMEBLOCK_LOCAL(saturatedDissolutionFactor);
         assert(phaseIdx <= numPhases);
@@ -1440,11 +1446,18 @@ public:
         const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
 
         switch (phaseIdx) {
-        case oilPhaseIdx: return oilPvt_->saturatedGasDissolutionFactor(regionIdx, T, p);
-        case gasPhaseIdx: return gasPvt_->saturatedOilVaporizationFactor(regionIdx, T, p);
-        case waterPhaseIdx: return waterPvt_->saturatedGasDissolutionFactor(regionIdx, T, p,
-        BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        case oilPhaseIdx:
+            return oilPvt_->saturatedGasDissolutionFactor(regionIdx, T, p);
+        case gasPhaseIdx:
+            return gasPvt_->saturatedOilVaporizationFactor(regionIdx, T, p);
+        case waterPhaseIdx:
+            return waterPvt_->saturatedGasDissolutionFactor(
+                regionIdx,
+                T,
+                p,
+                BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+        default:
+            throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
 
@@ -1452,8 +1465,7 @@ public:
      * \brief Returns the bubble point pressure $P_b$ using the current Rs
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval bubblePointPressure(const FluidState& fluidState,
-                                       unsigned regionIdx) const
+    LhsEval bubblePointPressure(const FluidState& fluidState, unsigned regionIdx) const
     {
         return saturationPressure(fluidState, oilPhaseIdx, regionIdx);
     }
@@ -1463,8 +1475,7 @@ public:
      * \brief Returns the dew point pressure $P_d$ using the current Rv
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval dewPointPressure(const FluidState& fluidState,
-                                       unsigned regionIdx) const
+    LhsEval dewPointPressure(const FluidState& fluidState, unsigned regionIdx) const
     {
         return saturationPressure(fluidState, gasPhaseIdx, regionIdx);
     }
@@ -1480,9 +1491,7 @@ public:
      * here just returns 0, though.
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
-    LhsEval saturationPressure(const FluidState& fluidState,
-                                      unsigned phaseIdx,
-                                      unsigned regionIdx) const
+    LhsEval saturationPressure(const FluidState& fluidState, unsigned phaseIdx, unsigned regionIdx) const
     {
         assert(phaseIdx <= numPhases);
         assert(regionIdx <= numRegions());
@@ -1490,12 +1499,20 @@ public:
         const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
 
         switch (phaseIdx) {
-        case oilPhaseIdx: return oilPvt_->saturationPressure(regionIdx, T, BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
-        case gasPhaseIdx: return gasPvt_->saturationPressure(regionIdx, T, BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
-        case waterPhaseIdx: return waterPvt_->saturationPressure(regionIdx, T,
-        BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
-        BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        case oilPhaseIdx:
+            return oilPvt_->saturationPressure(
+                regionIdx, T, BlackOilTwo::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+        case gasPhaseIdx:
+            return gasPvt_->saturationPressure(
+                regionIdx, T, BlackOilTwo::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+        case waterPhaseIdx:
+            return waterPvt_->saturationPressure(
+                regionIdx,
+                T,
+                BlackOilTwo::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                BlackOilTwo::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+        default:
+            throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
 
@@ -1512,7 +1529,7 @@ public:
         Scalar rho_oRef = referenceDensity_[regionIdx][oilPhaseIdx];
         Scalar rho_gRef = referenceDensity_[regionIdx][gasPhaseIdx];
 
-        return XoG/(1.0 - XoG)*(rho_oRef/rho_gRef);
+        return XoG / (1.0 - XoG) * (rho_oRef / rho_gRef);
     }
 
     /*!
@@ -1525,7 +1542,7 @@ public:
         Scalar rho_wRef = referenceDensity_[regionIdx][waterPhaseIdx];
         Scalar rho_gRef = referenceDensity_[regionIdx][gasPhaseIdx];
 
-        return XwG/(1.0 - XwG)*(rho_wRef/rho_gRef);
+        return XwG / (1.0 - XwG) * (rho_wRef / rho_gRef);
     }
 
     /*!
@@ -1538,7 +1555,7 @@ public:
         Scalar rho_oRef = referenceDensity_[regionIdx][oilPhaseIdx];
         Scalar rho_gRef = referenceDensity_[regionIdx][gasPhaseIdx];
 
-        return XgO/(1.0 - XgO)*(rho_gRef/rho_oRef);
+        return XgO / (1.0 - XgO) * (rho_gRef / rho_oRef);
     }
 
     /*!
@@ -1551,7 +1568,7 @@ public:
         Scalar rho_wRef = referenceDensity_[regionIdx][waterPhaseIdx];
         Scalar rho_gRef = referenceDensity_[regionIdx][gasPhaseIdx];
 
-        return XgW/(1.0 - XgW)*(rho_gRef/rho_wRef);
+        return XgW / (1.0 - XgW) * (rho_gRef / rho_wRef);
     }
 
 
@@ -1565,8 +1582,8 @@ public:
         Scalar rho_oRef = referenceDensity_[regionIdx][oilPhaseIdx];
         Scalar rho_gRef = referenceDensity_[regionIdx][gasPhaseIdx];
 
-        const LhsEval& rho_oG = Rs*rho_gRef;
-        return rho_oG/(rho_oRef + rho_oG);
+        const LhsEval& rho_oG = Rs * rho_gRef;
+        return rho_oG / (rho_oRef + rho_oG);
     }
 
     /*!
@@ -1579,8 +1596,8 @@ public:
         Scalar rho_wRef = referenceDensity_[regionIdx][waterPhaseIdx];
         Scalar rho_gRef = referenceDensity_[regionIdx][gasPhaseIdx];
 
-        const LhsEval& rho_wG = Rsw*rho_gRef;
-        return rho_wG/(rho_wRef + rho_wG);
+        const LhsEval& rho_wG = Rsw * rho_gRef;
+        return rho_wG / (rho_wRef + rho_wG);
     }
 
     /*!
@@ -1593,8 +1610,8 @@ public:
         Scalar rho_oRef = referenceDensity_[regionIdx][oilPhaseIdx];
         Scalar rho_gRef = referenceDensity_[regionIdx][gasPhaseIdx];
 
-        const LhsEval& rho_gO = Rv*rho_oRef;
-        return rho_gO/(rho_gRef + rho_gO);
+        const LhsEval& rho_gO = Rv * rho_oRef;
+        return rho_gO / (rho_gRef + rho_gO);
     }
 
     /*!
@@ -1607,8 +1624,8 @@ public:
         Scalar rho_wRef = referenceDensity_[regionIdx][waterPhaseIdx];
         Scalar rho_gRef = referenceDensity_[regionIdx][gasPhaseIdx];
 
-        const LhsEval& rho_gW = Rvw*rho_wRef;
-        return rho_gW/(rho_gRef + rho_gW);
+        const LhsEval& rho_gW = Rvw * rho_wRef;
+        return rho_gW / (rho_gRef + rho_gW);
     }
 
     /*!
@@ -1620,7 +1637,7 @@ public:
         Scalar MW = molarMass_[regionIdx][waterCompIdx];
         Scalar MG = molarMass_[regionIdx][gasCompIdx];
 
-        return XgW*MG / (MW*(1 - XgW) + XgW*MG);
+        return XgW * MG / (MW * (1 - XgW) + XgW * MG);
     }
 
     /*!
@@ -1632,7 +1649,7 @@ public:
         Scalar MW = molarMass_[regionIdx][waterCompIdx];
         Scalar MG = molarMass_[regionIdx][gasCompIdx];
 
-        return XwG*MW / (MG*(1 - XwG) + XwG*MW);
+        return XwG * MW / (MG * (1 - XwG) + XwG * MW);
     }
 
     /*!
@@ -1644,7 +1661,7 @@ public:
         Scalar MO = molarMass_[regionIdx][oilCompIdx];
         Scalar MG = molarMass_[regionIdx][gasCompIdx];
 
-        return XoG*MO / (MG*(1 - XoG) + XoG*MO);
+        return XoG * MO / (MG * (1 - XoG) + XoG * MO);
     }
 
     /*!
@@ -1656,7 +1673,7 @@ public:
         Scalar MO = molarMass_[regionIdx][oilCompIdx];
         Scalar MG = molarMass_[regionIdx][gasCompIdx];
 
-        return xoG*MG / (xoG*(MG - MO) + MO);
+        return xoG * MG / (xoG * (MG - MO) + MO);
     }
 
     /*!
@@ -1668,7 +1685,7 @@ public:
         Scalar MO = molarMass_[regionIdx][oilCompIdx];
         Scalar MG = molarMass_[regionIdx][gasCompIdx];
 
-        return XgO*MG / (MO*(1 - XgO) + XgO*MG);
+        return XgO * MG / (MO * (1 - XgO) + XgO * MG);
     }
 
     /*!
@@ -1680,7 +1697,7 @@ public:
         Scalar MO = molarMass_[regionIdx][oilCompIdx];
         Scalar MG = molarMass_[regionIdx][gasCompIdx];
 
-        return xgO*MO / (xgO*(MO - MG) + MG);
+        return xgO * MO / (xgO * (MO - MG) + MG);
     }
 
     /*!
@@ -1691,7 +1708,9 @@ public:
      *       specific methods of the fluid systems from above should be used instead.
      */
     const GasPvt& gasPvt() const
-    { return *gasPvt_; }
+    {
+        return *gasPvt_;
+    }
 
     /*!
      * \brief Return a reference to the low-level object which calculates the oil phase
@@ -1701,7 +1720,9 @@ public:
      *       specific methods of the fluid systems from above should be used instead.
      */
     const OilPvt& oilPvt() const
-    { return *oilPvt_; }
+    {
+        return *oilPvt_;
+    }
 
     /*!
      * \brief Return a reference to the low-level object which calculates the water phase
@@ -1711,7 +1732,9 @@ public:
      *       specific methods of the fluid systems from above should be used instead.
      */
     const WaterPvt& waterPvt() const
-    { return *waterPvt_; }
+    {
+        return *waterPvt_;
+    }
 
     /*!
      * \brief Set the temperature of the reservoir.
@@ -1719,7 +1742,9 @@ public:
      * This method is black-oil specific and only makes sense for isothermal simulations.
      */
     Scalar reservoirTemperature(unsigned = 0) const
-    { return reservoirTemperature_; }
+    {
+        return reservoirTemperature_;
+    }
 
     /*!
      * \brief Return the temperature of the reservoir.
@@ -1727,7 +1752,9 @@ public:
      * This method is black-oil specific and only makes sense for isothermal simulations.
      */
     void setReservoirTemperature(Scalar value)
-    { reservoirTemperature_ = value; }
+    {
+        reservoirTemperature_ = value;
+    }
 
     short activeToCanonicalPhaseIdx(unsigned activePhaseIdx);
 
@@ -1735,27 +1762,31 @@ public:
 
     //! \copydoc BaseFluidSystem::diffusionCoefficient
     Scalar diffusionCoefficient(unsigned compIdx, unsigned phaseIdx, unsigned regionIdx = 0) const
-    { return diffusionCoefficients_[regionIdx][numPhases*compIdx + phaseIdx]; }
+    {
+        return diffusionCoefficients_[regionIdx][numPhases * compIdx + phaseIdx];
+    }
 
     //! \copydoc BaseFluidSystem::setDiffusionCoefficient
     void setDiffusionCoefficient(Scalar coefficient, unsigned compIdx, unsigned phaseIdx, unsigned regionIdx = 0)
-    { diffusionCoefficients_[regionIdx][numPhases*compIdx + phaseIdx] = coefficient ; }
+    {
+        diffusionCoefficients_[regionIdx][numPhases * compIdx + phaseIdx] = coefficient;
+    }
 
     /*!
      * \copydoc BaseFluidSystem::diffusionCoefficient
      */
     template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
     LhsEval diffusionCoefficient(const FluidState& fluidState,
-                                        const ParameterCache<ParamCacheEval>& paramCache,
-                                        unsigned phaseIdx,
-                                        unsigned compIdx) const
+                                 const ParameterCache<ParamCacheEval>& paramCache,
+                                 unsigned phaseIdx,
+                                 unsigned compIdx) const
     {
         // diffusion is disabled by the user
-        if(!enableDiffusion())
+        if (!enableDiffusion())
             return 0.0;
 
         // diffusion coefficients are set, and we use them
-        if(!diffusionCoefficients_.empty()) {
+        if (!diffusionCoefficients_.empty()) {
             return diffusionCoefficient(compIdx, phaseIdx, paramCache.regionIndex());
         }
 
@@ -1763,17 +1794,23 @@ public:
         const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
 
         switch (phaseIdx) {
-        case oilPhaseIdx: return oilPvt().diffusionCoefficient(T, p, compIdx);
-        case gasPhaseIdx: return gasPvt().diffusionCoefficient(T, p, compIdx);
-        case waterPhaseIdx: return waterPvt().diffusionCoefficient(T, p, compIdx);
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        case oilPhaseIdx:
+            return oilPvt().diffusionCoefficient(T, p, compIdx);
+        case gasPhaseIdx:
+            return gasPvt().diffusionCoefficient(T, p, compIdx);
+        case waterPhaseIdx:
+            return waterPvt().diffusionCoefficient(T, p, compIdx);
+        default:
+            throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
-    void setEnergyEqualEnthalpy(bool enthalpy_eq_energy) {
+    void setEnergyEqualEnthalpy(bool enthalpy_eq_energy)
+    {
         enthalpy_eq_energy_ = enthalpy_eq_energy;
     }
 
-    bool enthalpyEqualEnergy() const{
+    bool enthalpyEqualEnergy() const
+    {
         return enthalpy_eq_energy_;
     }
 
@@ -1797,9 +1834,9 @@ private:
     // HACK for GCC 4.4: the array size has to be specified using the literal value '3'
     // here, because GCC 4.4 seems to be unable to determine the number of phases from
     // the BlackOil fluid system in the attribute declaration below...
-    std::vector<std::array<Scalar, /*numPhases=*/3> > referenceDensity_;
-    std::vector<std::array<Scalar, /*numComponents=*/3> > molarMass_;
-    std::vector<std::array<Scalar, /*numComponents=*/3 * /*numPhases=*/3> > diffusionCoefficients_;
+    std::vector<std::array<Scalar, /*numPhases=*/3>> referenceDensity_;
+    std::vector<std::array<Scalar, /*numComponents=*/3>> molarMass_;
+    std::vector<std::array<Scalar, /*numComponents=*/3 * /*numPhases=*/3>> diffusionCoefficients_;
 
     std::array<short, numPhases> activeToCanonicalPhaseIdx_;
     std::array<short, numPhases> canonicalToActivePhaseIdx_;
@@ -1809,37 +1846,8 @@ private:
     bool enthalpy_eq_energy_ = false;
 };
 
-template <typename T> using BOFSNS = BlackOilFluidSystemNonStatic<T, BlackOilDefaultIndexTraits>;
-
-/*
-#define DECLARE_INSTANCE(T) \
-template<> unsigned char BOFSNS<T>::numActivePhases_; \
-template<> std::array<bool, BOFSNS<T>::numPhases> BOFSNS<T>::phaseIsActive_; \
-template<> std::array<short, BOFSNS<T>::numPhases> BOFSNS<T>::activeToCanonicalPhaseIdx_; \
-template<> std::array<short, BOFSNS<T>::numPhases> BOFSNS<T>::canonicalToActivePhaseIdx_; \
-template<> T BOFSNS<T>::surfaceTemperature; \
-template<> T BOFSNS<T>::surfacePressure; \
-template<> T BOFSNS<T>::reservoirTemperature_; \
-template<> bool BOFSNS<T>::enableDissolvedGas_; \
-template<> bool BOFSNS<T>::enableDissolvedGasInWater_; \
-template<> bool BOFSNS<T>::enableVaporizedOil_; \
-template<> bool BOFSNS<T>::enableVaporizedWater_; \
-template<> bool BOFSNS<T>::enableDiffusion_; \
-template<> std::shared_ptr<OilPvtMultiplexer<T>> BOFSNS<T>::oilPvt_; \
-template<> std::shared_ptr<GasPvtMultiplexer<T>> BOFSNS<T>::gasPvt_; \
-template<> std::shared_ptr<WaterPvtMultiplexer<T>> BOFSNS<T>::waterPvt_; \
-template<> std::vector<std::array<T, 3>> BOFSNS<T>::referenceDensity_; \
-template<> std::vector<std::array<T, 3>> BOFSNS<T>::molarMass_; \
-template<> std::vector<std::array<T, 9>> BOFSNS<T>::diffusionCoefficients_; \
-template<> bool BOFSNS<T>::isInitialized_; \
-template<> bool BOFSNS<T>::useSaturatedTables_;
-
-DECLARE_INSTANCE(float)
-DECLARE_INSTANCE(double)
-
-#undef DECLARE_INSTANCE
-
-*/
+template <typename T>
+using BOFSNS = BlackOilFluidSystemNonStatic<T, BlackOilDefaultIndexTraits>;
 
 } // namespace Opm
 

--- a/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
+++ b/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
@@ -57,14 +57,17 @@ template <class Scalar, class WettingPhase, class NonwettingPhase>
 class TwoPhaseImmiscibleFluidSystem
     : public BaseFluidSystem<Scalar, TwoPhaseImmiscibleFluidSystem<Scalar, WettingPhase, NonwettingPhase> >
 {
-    // do not try to instanciate this class, it has only static members!
-    TwoPhaseImmiscibleFluidSystem()
-    {}
+
 
     typedef TwoPhaseImmiscibleFluidSystem<Scalar, WettingPhase, NonwettingPhase> ThisType;
     typedef BaseFluidSystem<Scalar, ThisType> Base;
 
 public:
+
+    // only static members, usually unneeded to use this ctor
+    TwoPhaseImmiscibleFluidSystem()
+    {}
+
     template <class Evaluation>
     struct ParameterCache : public NullParameterCache<Evaluation>
     {};


### PR DESCRIPTION
Add support for a dynamically allocated `BlackOilFluidSystem` (BOFS) object. The purpose of this is to avoid dependence on statically allocated data when later BOFS on the GPU.

This does include a bad-looking duplication of the class for now