### PR TITLE
General cubic EOS formulation

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1047,6 +1047,9 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/eos/PengRobinsonParams.hpp
       opm/material/eos/PengRobinsonParamsMixture.hpp
       opm/material/eos/PengRobinsonMixture.hpp
+      opm/material/eos/CubicEOS.hpp
+      opm/material/eos/CubicEOSParams.hpp
+      opm/material/eos/PRParams.hpp
       opm/material/thermal/ConstantSolidHeatCapLawParams.hpp
       opm/material/thermal/ConstantSolidHeatCapLaw.hpp
       opm/material/thermal/EclHeatcrLaw.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1050,6 +1050,8 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/eos/CubicEOS.hpp
       opm/material/eos/CubicEOSParams.hpp
       opm/material/eos/PRParams.hpp
+      opm/material/eos/RKParams.hpp
+      opm/material/eos/SRKParams.hpp
       opm/material/thermal/ConstantSolidHeatCapLawParams.hpp
       opm/material/thermal/ConstantSolidHeatCapLaw.hpp
       opm/material/thermal/EclHeatcrLaw.hpp

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -317,6 +317,7 @@ CompositionalConfig CompositionalConfig::serializationTestObject() {
 
 CompositionalConfig::EOSType CompositionalConfig::eosTypeFromString(const std::string& str) {
     if (str == "PR") return EOSType::PR;
+    if (str == "PRCORR") return EOSType::PRCORR;
     if (str == "RK") return EOSType::RK;
     if (str == "SRK") return EOSType::SRK;
     if (str == "ZJ") return EOSType::ZJ;
@@ -326,6 +327,7 @@ CompositionalConfig::EOSType CompositionalConfig::eosTypeFromString(const std::s
 std::string CompositionalConfig::eosTypeToString(Opm::CompositionalConfig::EOSType eos) {
     switch (eos) {
         case EOSType::PR: return "PR";
+        case EOSType::PRCORR: return "PRCORR";
         case EOSType::RK: return "RK";
         case EOSType::SRK: return "SRK";
         case EOSType::ZJ: return "ZJ";

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
@@ -34,10 +34,11 @@ class Runspec;
 class CompositionalConfig {
 public:
     enum class EOSType {
-        PR,   // Peng-Robinson
-        RK,   // Redlich-Kwong
-        SRK,  // Soave-Redlich-Kwong
-        ZJ    // Zudkevitch-Joffe-Redlich-Kwong
+        PR,         // Peng-Robinson
+        PRCORR,     // Peng-Robinson modified
+        RK,         // Redlich-Kwong
+        SRK,        // Soave-Redlich-Kwong
+        ZJ          // Zudkevitch-Joffe-Redlich-Kwong
     };
 
     static EOSType eosTypeFromString(const std::string& str);

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -228,7 +228,7 @@ public:
     static bool flash_solve_scalar_(FluidState& fluid_state,
                                     const std::string& twoPhaseMethod,
                                     const Scalar flash_tolerance,
-				    const EOSType& eos_type,
+				                    const EOSType& eos_type,
                                     const int verbosity = 0)
     {
         // Do a stability test to check if cell is is_single_phase-phase (do for all cells the first time).
@@ -449,7 +449,7 @@ protected:
     template <class FlashFluidState, class ComponentVector>
     static void checkStability_(const FlashFluidState& fluid_state, bool& isTrivial, ComponentVector& K, ComponentVector& xy_loc,
                                 typename FlashFluidState::Scalar& S_loc, const ComponentVector& z, bool isGas, const EOSType& eos_type, 
-			 	int verbosity)
+			 	                int verbosity)
     {
         using FlashEval = typename FlashFluidState::Scalar;
         using CubicEOS = typename Opm::CubicEOS<Scalar, FluidSystem>;
@@ -625,7 +625,7 @@ protected:
                                    FlashFluidState& fluid_state,
                                    const ComponentVector& z,
                                    const Scalar tolerance,
-				   const EOSType& eos_type,
+				                   const EOSType& eos_type,
                                    int verbosity)
     {
         // Note: due to the need for inverse flash update for derivatives, the following two can be different
@@ -850,7 +850,7 @@ protected:
     template <typename FlashFluidStateScalar, typename FluidState>
     static void updateDerivativesTwoPhase_(const FlashFluidStateScalar& fluid_state_scalar,
                                            FluidState& fluid_state,
-					   const EOSType& eos_type)
+					                       const EOSType& eos_type)
     {
         using InputEval = typename FluidState::Scalar;
         using ComponentVector = Dune::FieldVector<InputEval, numComponents>;
@@ -1076,7 +1076,7 @@ protected:
                                                    const ComponentVector& z,
                                                    const bool newton_afterwards,
                                                    const Scalar flash_tolerance,
-						   const EOSType& eos_type,
+						                           const EOSType& eos_type,
                                                    const int verbosity)
     {
         // Determine max. iterations based on if it will be used as a standalone flash or as a pre-process to Newton (or other) method.

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -39,6 +39,8 @@
 #include <opm/material/Constants.hpp>
 #include <opm/material/eos/CubicEOS.hpp>
 
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
+
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
 #include <dune/common/classname.hh>
@@ -69,6 +71,8 @@ class PTFlash
     static constexpr int numMisciblePhases = FluidSystem::numMisciblePhases; //oil, gas
     static constexpr int numEq = numMisciblePhases + numMisciblePhases * numMiscibleComponents;
 
+    using EOSType = CompositionalConfig::EOSType;
+
 public:
     /*!
      * \brief Calculates the fluid state from the global mole fractions of the components and the phase pressures
@@ -78,6 +82,7 @@ public:
     static void solve(FluidState& fluid_state,
                       const std::string& twoPhaseMethod,
                       Scalar flash_tolerance,
+                      const EOSType& eos_type,
                       int verbosity = 0)
     {
         using ScalarFluidState = CompositionalFluidState<Scalar, FluidSystem>;
@@ -97,7 +102,7 @@ public:
 
         fluid_state_scalar.setTemperature(Opm::getValue(fluid_state.temperature(0)));
 
-        const auto is_single_phase = flash_solve_scalar_(fluid_state_scalar, twoPhaseMethod, flash_tolerance, verbosity);
+        const auto is_single_phase = flash_solve_scalar_(fluid_state_scalar, twoPhaseMethod, flash_tolerance, eos_type, verbosity);
 
         // the flash solution process were performed in scalar form, after the flash calculation finishes,
         // ensure that things in fluid_state_scalar is transformed to fluid_state
@@ -109,8 +114,8 @@ public:
         }
 
         // we update the derivatives in fluid_state
-        updateDerivatives_(fluid_state_scalar, fluid_state, is_single_phase);
-    } // end solve
+        updateDerivatives_(fluid_state_scalar, fluid_state, eos_type, is_single_phase);
+    } //end solve
 
     /*!
      * \brief Calculates the chemical equilibrium from the component
@@ -223,6 +228,7 @@ public:
     static bool flash_solve_scalar_(FluidState& fluid_state,
                                     const std::string& twoPhaseMethod,
                                     const Scalar flash_tolerance,
+				    const EOSType& eos_type,
                                     const int verbosity = 0)
     {
         // Do a stability test to check if cell is is_single_phase-phase (do for all cells the first time).
@@ -239,7 +245,7 @@ public:
             if (verbosity >= 1) {
                 std::cout << "Perform stability test (L <= 0 or L == 1)!" << std::endl;
             }
-            phaseStabilityTest_(is_stable, K_scalar, fluid_state, z_scalar, verbosity);
+            phaseStabilityTest_(is_stable, K_scalar, fluid_state, z_scalar, eos_type, verbosity);
         }
         if (verbosity >= 1) {
             std::cout << "Inputs after stability test are K = [" << K_scalar << "], L = [" << L_scalar << "], z = [" << z_scalar << "], P = " << fluid_state.pressure(0) << ", and T = " << fluid_state.temperature(0) << std::endl;
@@ -252,7 +258,7 @@ public:
         if ( !is_single_phase ) {
             // Rachford Rice equation to get initial L for composition solver
             L_scalar = solveRachfordRice_g_(K_scalar, z_scalar, verbosity);
-            flash_2ph(z_scalar, twoPhaseMethod, K_scalar, L_scalar, fluid_state, flash_tolerance, verbosity);
+            flash_2ph(z_scalar, twoPhaseMethod, K_scalar, L_scalar, fluid_state, flash_tolerance, eos_type, verbosity);
         } else {
             // Cell is one-phase. Use Li's phase labeling method to see if it's liquid or vapor
             L_scalar = li_single_phase_label_(fluid_state, z_scalar, verbosity);
@@ -364,7 +370,7 @@ public:
     }
 
     template <class FlashFluidState, class ComponentVector>
-    static void phaseStabilityTest_(bool& isStable, ComponentVector& K, FlashFluidState& fluid_state, const ComponentVector& z, int verbosity)
+    static void phaseStabilityTest_(bool& isStable, ComponentVector& K, FlashFluidState& fluid_state, const ComponentVector& z, const EOSType& eos_type, int verbosity)
     {
         // Declarations
         bool isTrivialL, isTrivialV;
@@ -377,14 +383,14 @@ public:
         if (verbosity == 3 || verbosity == 4) {
             std::cout << "Stability test for vapor phase:" << std::endl;
         }
-        checkStability_(fluid_state, isTrivialV, K0, y, S_v, z, /*isGas=*/true, verbosity);
+        checkStability_(fluid_state, isTrivialV, K0, y, S_v, z, /*isGas=*/true, eos_type, verbosity);
         bool V_unstable = (S_v < (1.0 + 1e-5)) || isTrivialV;
 
         // Check for liquids stable phase
         if (verbosity == 3 || verbosity == 4) {
             std::cout << "Stability test for liquid phase:" << std::endl;
         }
-        checkStability_(fluid_state, isTrivialL, K1, x, S_l, z, /*isGas=*/false, verbosity);
+        checkStability_(fluid_state, isTrivialL, K1, x, S_l, z, /*isGas=*/false, eos_type, verbosity);
         bool L_stable = (S_l < (1.0 + 1e-5)) || isTrivialL;
 
         // L-stable means success in making liquid, V-unstable means no success in making vapour
@@ -442,7 +448,8 @@ protected:
 
     template <class FlashFluidState, class ComponentVector>
     static void checkStability_(const FlashFluidState& fluid_state, bool& isTrivial, ComponentVector& K, ComponentVector& xy_loc,
-                                typename FlashFluidState::Scalar& S_loc, const ComponentVector& z, bool isGas, int verbosity)
+                                typename FlashFluidState::Scalar& S_loc, const ComponentVector& z, bool isGas, const EOSType& eos_type, 
+			 	int verbosity)
     {
         using FlashEval = typename FlashFluidState::Scalar;
         using CubicEOS = typename Opm::CubicEOS<Scalar, FluidSystem>;
@@ -488,10 +495,10 @@ protected:
                 fluid_state_global.setMoleFraction(phaseIdx2, compIdx, z[compIdx]);
             }
 
-            typename FluidSystem::template ParameterCache<FlashEval> paramCache_fake;
+            typename FluidSystem::template ParameterCache<FlashEval> paramCache_fake(eos_type);
             paramCache_fake.updatePhase(fluid_state_fake, phaseIdx);
 
-            typename FluidSystem::template ParameterCache<FlashEval> paramCache_global;
+            typename FluidSystem::template ParameterCache<FlashEval> paramCache_global(eos_type);
             paramCache_global.updatePhase(fluid_state_global, phaseIdx2);
 
             //fugacity for fake phases each component
@@ -578,6 +585,7 @@ protected:
                           typename FluidState::Scalar& L_scalar,
                           FluidState& fluid_state_scalar,
                           const Scalar flash_tolerance,
+                          const EOSType& eos_type,
                           int verbosity = 0) {
         if (verbosity >= 1) {
             std::cout << "Cell is two-phase! Solve Rachford-Rice with initial K = [" << K_scalar << "]" << std::endl;
@@ -590,17 +598,17 @@ protected:
             if (verbosity >= 1) {
                 std::cout << "Calculate composition using Newton." << std::endl;
             }
-            converged = newtonComposition_(K_scalar, L_scalar, fluid_state_scalar, z_scalar, flash_tolerance, verbosity);
+            converged = newtonComposition_(K_scalar, L_scalar, fluid_state_scalar, z_scalar, flash_tolerance, eos_type, verbosity);
         } else if (flash_2p_method == "ssi") {
             // Successive substitution
             if (verbosity >= 1) {
                 std::cout << "Calculate composition using Succcessive Substitution." << std::endl;
             }
-            converged = successiveSubstitutionComposition_(K_scalar, L_scalar, fluid_state_scalar, z_scalar, false, flash_tolerance, verbosity);
+            converged = successiveSubstitutionComposition_(K_scalar, L_scalar, fluid_state_scalar, z_scalar, false, flash_tolerance, eos_type, verbosity);
         } else if (flash_2p_method == "ssi+newton") {
-            converged = successiveSubstitutionComposition_(K_scalar, L_scalar, fluid_state_scalar, z_scalar, true, flash_tolerance, verbosity);
+            converged = successiveSubstitutionComposition_(K_scalar, L_scalar, fluid_state_scalar, z_scalar, true, flash_tolerance, eos_type, verbosity);
             if (!converged) {
-                converged = newtonComposition_(K_scalar, L_scalar, fluid_state_scalar, z_scalar, flash_tolerance, verbosity);
+                converged = newtonComposition_(K_scalar, L_scalar, fluid_state_scalar, z_scalar, flash_tolerance, eos_type, verbosity);
             }
         } else {
             throw std::logic_error("unknown two phase flash method " + flash_2p_method + " is specified");
@@ -617,6 +625,7 @@ protected:
                                    FlashFluidState& fluid_state,
                                    const ComponentVector& z,
                                    const Scalar tolerance,
+				   const EOSType& eos_type,
                                    int verbosity)
     {
         // Note: due to the need for inverse flash update for derivatives, the following two can be different
@@ -695,7 +704,7 @@ protected:
         flash_fluid_state.setTemperature(fluid_state.temperature(0));
 
         using ParamCache = typename FluidSystem::template ParameterCache<typename CompositionalFluidState<Eval, FluidSystem>::Scalar>;
-        ParamCache paramCache;
+        ParamCache paramCache(eos_type);
 
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             paramCache.updatePhase(flash_fluid_state, phaseIdx);
@@ -828,10 +837,11 @@ protected:
     template <typename FlashFluidStateScalar, typename FluidState>
     static void updateDerivatives_(const FlashFluidStateScalar& fluid_state_scalar,
                                    FluidState& fluid_state,
+                                   const EOSType& eos_type,
                                    bool is_single_phase)
     {
         if(!is_single_phase)
-            updateDerivativesTwoPhase_(fluid_state_scalar, fluid_state);
+            updateDerivativesTwoPhase_(fluid_state_scalar, fluid_state, eos_type);
         else
             updateDerivativesSinglePhase_(fluid_state_scalar, fluid_state);
 
@@ -839,7 +849,8 @@ protected:
 
     template <typename FlashFluidStateScalar, typename FluidState>
     static void updateDerivativesTwoPhase_(const FlashFluidStateScalar& fluid_state_scalar,
-                                           FluidState& fluid_state)
+                                           FluidState& fluid_state,
+					   const EOSType& eos_type)
     {
         using InputEval = typename FluidState::Scalar;
         using ComponentVector = Dune::FieldVector<InputEval, numComponents>;
@@ -886,7 +897,7 @@ protected:
         // compositions
         // TODO: we probably can simplify SecondaryFlashFluidState::Scalar
         using SecondaryParamCache = typename FluidSystem::template ParameterCache<typename SecondaryFlashFluidState::Scalar>;
-        SecondaryParamCache secondary_param_cache;
+        SecondaryParamCache secondary_param_cache(eos_type);
         for (unsigned phase_idx = 0; phase_idx < numPhases; ++phase_idx) {
             secondary_param_cache.updatePhase(secondary_fluid_state, phase_idx);
             for (unsigned comp_idx = 0; comp_idx < numComponents; ++comp_idx) {
@@ -936,7 +947,7 @@ protected:
 
         // TODO: is PrimaryFlashFluidState::Scalar> PrimaryEval here?
         using PrimaryParamCache = typename FluidSystem::template ParameterCache<typename PrimaryFlashFluidState::Scalar>;
-        PrimaryParamCache primary_param_cache;
+        PrimaryParamCache primary_param_cache(eos_type);
         for (unsigned phase_idx = 0; phase_idx < numPhases; ++phase_idx) {
             primary_param_cache.updatePhase(primary_fluid_state, phase_idx);
             for (unsigned comp_idx = 0; comp_idx < numComponents; ++comp_idx) {
@@ -1065,6 +1076,7 @@ protected:
                                                    const ComponentVector& z,
                                                    const bool newton_afterwards,
                                                    const Scalar flash_tolerance,
+						   const EOSType& eos_type,
                                                    const int verbosity)
     {
         // Determine max. iterations based on if it will be used as a standalone flash or as a pre-process to Newton (or other) method.
@@ -1092,7 +1104,7 @@ protected:
 
             // Calculate fugacity coefficient
             using ParamCache = typename FluidSystem::template ParameterCache<typename FlashFluidState::Scalar>;
-            ParamCache paramCache;
+            ParamCache paramCache(eos_type);
             for (int phaseIdx=0; phaseIdx<numPhases; ++phaseIdx){
                 paramCache.updatePhase(fluid_state, phaseIdx);
                 for (int compIdx=0; compIdx<numComponents; ++compIdx){

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -850,7 +850,7 @@ protected:
     template <typename FlashFluidStateScalar, typename FluidState>
     static void updateDerivativesTwoPhase_(const FlashFluidStateScalar& fluid_state_scalar,
                                            FluidState& fluid_state,
-					                       const EOSType& eos_type)
+                                           const EOSType& eos_type)
     {
         using InputEval = typename FluidState::Scalar;
         using ComponentVector = Dune::FieldVector<InputEval, numComponents>;

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -37,7 +37,7 @@
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/Valgrind.hpp>
 #include <opm/material/Constants.hpp>
-#include <opm/material/eos/PengRobinsonMixture.hpp>
+#include <opm/material/eos/CubicEOS.hpp>
 
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
@@ -445,7 +445,7 @@ protected:
                                 typename FlashFluidState::Scalar& S_loc, const ComponentVector& z, bool isGas, int verbosity)
     {
         using FlashEval = typename FlashFluidState::Scalar;
-        using PengRobinsonMixture = typename Opm::PengRobinsonMixture<Scalar, FluidSystem>;
+        using CubicEOS = typename Opm::CubicEOS<Scalar, FluidSystem>;
 
         // Declarations
         FlashFluidState fluid_state_fake = fluid_state;
@@ -496,8 +496,8 @@ protected:
 
             //fugacity for fake phases each component
             for (int compIdx=0; compIdx<numComponents; ++compIdx){
-                auto phiFake = PengRobinsonMixture::computeFugacityCoefficient(fluid_state_fake, paramCache_fake, phaseIdx, compIdx);
-                auto phiGlobal = PengRobinsonMixture::computeFugacityCoefficient(fluid_state_global, paramCache_global, phaseIdx2, compIdx);
+                auto phiFake = CubicEOS::computeFugacityCoefficient(fluid_state_fake, paramCache_fake, phaseIdx, compIdx);
+                auto phiGlobal = CubicEOS::computeFugacityCoefficient(fluid_state_global, paramCache_global, phaseIdx2, compIdx);
 
                 fluid_state_fake.setFugacityCoefficient(phaseIdx, compIdx, phiFake);
                 fluid_state_global.setFugacityCoefficient(phaseIdx2, compIdx, phiGlobal);

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -228,7 +228,7 @@ public:
     static bool flash_solve_scalar_(FluidState& fluid_state,
                                     const std::string& twoPhaseMethod,
                                     const Scalar flash_tolerance,
-				                    const EOSType& eos_type,
+                                    const EOSType& eos_type,
                                     const int verbosity = 0)
     {
         // Do a stability test to check if cell is is_single_phase-phase (do for all cells the first time).
@@ -449,7 +449,7 @@ protected:
     template <class FlashFluidState, class ComponentVector>
     static void checkStability_(const FlashFluidState& fluid_state, bool& isTrivial, ComponentVector& K, ComponentVector& xy_loc,
                                 typename FlashFluidState::Scalar& S_loc, const ComponentVector& z, bool isGas, const EOSType& eos_type, 
-			 	                int verbosity)
+                                int verbosity)
     {
         using FlashEval = typename FlashFluidState::Scalar;
         using CubicEOS = typename Opm::CubicEOS<Scalar, FluidSystem>;
@@ -625,7 +625,7 @@ protected:
                                    FlashFluidState& fluid_state,
                                    const ComponentVector& z,
                                    const Scalar tolerance,
-				                   const EOSType& eos_type,
+                                   const EOSType& eos_type,
                                    int verbosity)
     {
         // Note: due to the need for inverse flash update for derivatives, the following two can be different
@@ -1076,7 +1076,7 @@ protected:
                                                    const ComponentVector& z,
                                                    const bool newton_afterwards,
                                                    const Scalar flash_tolerance,
-						                           const EOSType& eos_type,
+                                                   const EOSType& eos_type,
                                                    const int verbosity)
     {
         // Determine max. iterations based on if it will be used as a standalone flash or as a pre-process to Newton (or other) method.

--- a/opm/material/eos/CubicEOS.hpp
+++ b/opm/material/eos/CubicEOS.hpp
@@ -1,0 +1,167 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#ifndef CUBIC_EOS_HPP
+#define CUBIC_EOS_HPP
+
+#include <opm/material/Constants.hpp>
+#include <opm/material/common/PolynomialUtils.hpp>
+
+namespace Opm
+{
+template<class Scalar, class FluidSystem>
+class CubicEOS
+{
+    enum { numComponents = FluidSystem::numComponents };
+
+    static constexpr Scalar R = Constants<Scalar>::R;
+
+public:
+    template <class FluidState, class Params, class LhsEval = typename FluidState::Scalar>
+    static LhsEval computeFugacityCoefficient(const FluidState& fs,
+                                              const Params& params,
+                                              unsigned phaseIdx,
+                                              unsigned compIdx)
+    {
+        // note that we normalize the component mole fractions, so
+        // that their sum is 100%. This increases numerical stability
+        // considerably if the fluid state is not physical.
+
+        // extract variables
+        LhsEval Vm = params.molarVolume(phaseIdx);
+        LhsEval T = fs.temperature(phaseIdx);
+        LhsEval p = fs.pressure(phaseIdx); // molar volume in [bar]
+        LhsEval A = params.A(phaseIdx);
+        LhsEval B = params.B(phaseIdx);
+        LhsEval Bi = params.Bi(phaseIdx, compIdx);
+        LhsEval m1 = params.m1(phaseIdx);
+        LhsEval m2 = params.m2(phaseIdx);
+
+        // Calculate Bi / B
+        LhsEval Bi_B = Bi / B;
+
+        // Calculate the compressibility factor
+        LhsEval RT = R * T;
+        LhsEval Z = p * Vm / RT; // compressibility factor
+
+        // calculate sum(A_ij * x_j)
+        LhsEval A_s = 0.0;
+        for (unsigned compJIdx = 0; compJIdx < numComponents; ++compJIdx) {
+            A_s += params.aCache(phaseIdx, compIdx, compJIdx) * fs.moleFraction(phaseIdx, compJIdx);
+        }
+
+        // calculate fugacity coefficient
+        LhsEval alpha;
+        LhsEval beta;
+        LhsEval gamma;
+        LhsEval ln_phi;
+        LhsEval fugCoeff;
+
+        alpha = -log(Z - B) + Bi_B * (Z - 1);
+        beta  = log((Z + m2 * B) / (Z + m1 * B)) * A / ((m1 - m2) * B);
+        gamma = (2 / A) * A_s - Bi_B;
+        ln_phi = alpha + (beta * gamma);
+
+        fugCoeff = exp(ln_phi);
+
+        ////////
+        // limit the fugacity coefficient to a reasonable range:
+        //
+        // on one side, we want the mole fraction to be at
+        // least 10^-3 if the fugacity is at the current pressure
+        //
+        fugCoeff = min(1e10, fugCoeff);
+        //
+        // on the other hand, if the mole fraction of the component is 100%, we want the
+        // fugacity to be at least 10^-3 Pa
+        //
+        fugCoeff = max(1e-10, fugCoeff);
+        ///////////
+
+        return fugCoeff;
+    }
+
+    template <class FluidState, class Params>
+    static typename FluidState::Scalar computeMolarVolume(const FluidState& fs,
+                                                          Params& params,
+                                                          unsigned phaseIdx,
+                                                          bool isGasPhase)
+    {
+        Valgrind::CheckDefined(fs.temperature(phaseIdx));
+        Valgrind::CheckDefined(fs.pressure(phaseIdx));
+
+        using Evaluation = typename FluidState::Scalar;
+        
+        // extract variables
+        const Evaluation& T = fs.temperature(phaseIdx);
+        const Evaluation& p = fs.pressure(phaseIdx);
+        const Evaluation& A = params.A(phaseIdx);
+        const Evaluation& B = params.B(phaseIdx);
+        const Evaluation& m1 = params.m1(phaseIdx);
+        const Evaluation& m2 = params.m2(phaseIdx);
+
+        // coefficients in cubic solver
+        const Evaluation a1 = 1.0;  // cubic term
+        const Evaluation a2 = (m1 + m2 - 1) * B - 1;  // quadratic term
+        const Evaluation a3 = A + m1 * m2 * B * B - (m1 + m2) * B * (B + 1);  // linear term
+        const Evaluation a4 = -A * B - m1 * m2 * B * B * (B + 1);  // constant term
+        Valgrind::CheckDefined(a1);
+        Valgrind::CheckDefined(a2);
+        Valgrind::CheckDefined(a3);
+        Valgrind::CheckDefined(a4);
+
+        // root of cubic equation
+        Evaluation Vm = 0;
+        Valgrind::SetUndefined(Vm);
+        Evaluation Z[3] = {0.0, 0.0, 0.0};
+        int numSol = cubicRoots(Z, a1, a2, a3, a4);
+        
+        // pick correct root
+        const Evaluation RT_p = R * T / p;
+        if (numSol == 3) {
+            // the EOS has three intersections with the pressure,
+            // i.e. the molar volume of gas is the largest one and the
+            // molar volume of liquid is the smallest one
+            if (isGasPhase)
+                Vm = max(1e-7, Z[2] * RT_p);
+            else
+                Vm = max(1e-7, Z[0] * RT_p);
+        }
+        else if (numSol == 1) {
+            // the EOS only has one intersection with the pressure,
+            // for the other phase, we take the extremum of the EOS
+            // with the largest distance from the intersection.
+            Vm = max(1e-7, Z[0] * RT_p);
+        }
+
+        Valgrind::CheckDefined(Vm);
+        assert(std::isfinite(scalarValue(Vm)));
+        assert(Vm > 0);
+        return Vm;
+
+    }
+
+};  // class CubicEOS
+
+}  // namespace Opm
+
+#endif

--- a/opm/material/eos/CubicEOSParams.hpp
+++ b/opm/material/eos/CubicEOSParams.hpp
@@ -24,7 +24,6 @@
 #define CUBIC_EOS_PARAMS_HPP
 
 #include <opm/material/Constants.hpp>
-// #include <opm/material/common/MathToolbox.hpp>
 
 namespace Opm
 {
@@ -35,8 +34,6 @@ class CubicEOSParams
     enum { numComponents = FluidSystem::numComponents };
     
     static constexpr Scalar R = Constants<Scalar>::R;
-
-    // using Toolbox = MathToolbox<Scalar>;
 
 public:
 
@@ -147,12 +144,12 @@ public:
         return B_;
     }
 
-    virtual Scalar calcOmegaA(Scalar temperature, unsigned compIdx)
+    virtual Scalar calcOmegaA([[maybe_unused]] Scalar temperature, [[maybe_unused]] unsigned compIdx)
     {
         throw std::logic_error("Not implemented");
     }
 
-    virtual Scalar calcOmegaB(Scalar temperature, unsigned compIdx)
+    virtual Scalar calcOmegaB([[maybe_unused]] Scalar temperature, [[maybe_unused]] unsigned compIdx)
     {
         throw std::logic_error("Not implemented");
     }

--- a/opm/material/eos/CubicEOSParams.hpp
+++ b/opm/material/eos/CubicEOSParams.hpp
@@ -1,0 +1,194 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#ifndef CUBIC_EOS_PARAMS_HPP
+#define CUBIC_EOS_PARAMS_HPP
+
+#include <opm/material/Constants.hpp>
+// #include <opm/material/common/MathToolbox.hpp>
+
+namespace Opm
+{
+
+template <class Scalar, class FluidSystem, unsigned phaseIdx>
+class CubicEOSParams
+{
+    enum { numComponents = FluidSystem::numComponents };
+    
+    static constexpr Scalar R = Constants<Scalar>::R;
+
+    // using Toolbox = MathToolbox<Scalar>;
+
+public:
+
+    void updatePure(Scalar temperature, Scalar pressure)
+    {
+        Valgrind::CheckDefined(temperature);
+        Valgrind::CheckDefined(pressure);
+
+        // calculate Ai and Bi
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
+            Scalar pr = pressure / FluidSystem::criticalPressure(compIdx);
+            Scalar Tr = temperature / FluidSystem::criticalTemperature(compIdx);
+            Scalar OmegaA = this->calcOmegaA(temperature, compIdx);
+            Scalar OmegaB = this->calcOmegaB(temperature, compIdx);
+
+            Scalar newA = OmegaA * pr / (Tr * Tr);
+            Scalar newB = OmegaB * pr / Tr;
+            assert(std::isfinite(scalarValue(newA)));
+            assert(std::isfinite(scalarValue(newB)));
+
+            setAi(newA, compIdx);
+            setBi(newB, compIdx);
+            Valgrind::CheckDefined(Ai(compIdx));
+            Valgrind::CheckDefined(Bi(compIdx));
+        }
+
+        // Update Aij
+        updateACache_();
+
+    }
+    
+    template <class FluidState>
+    void updateMix(const FluidState& fs)
+    {
+        using FlashEval = typename FluidState::Scalar;
+        
+        FlashEval newA = 0;
+        FlashEval newB = 0;
+        for (unsigned compIIdx = 0; compIIdx < numComponents; ++compIIdx) {
+            const FlashEval moleFracI = fs.moleFraction(phaseIdx, compIIdx);
+            FlashEval xi = max(0.0, min(1.0, moleFracI));
+            Valgrind::CheckDefined(xi);
+
+            for (unsigned compJIdx = 0; compJIdx < numComponents; ++compJIdx) {
+                const FlashEval moleFracJ = fs.moleFraction(phaseIdx, compJIdx );
+                FlashEval xj = max(0.0, min(1.0, moleFracJ));
+                Valgrind::CheckDefined(xj);
+
+                // Calculate A 
+                newA +=  xi * xj * aCache_[compIIdx][compJIdx];
+                assert(std::isfinite(scalarValue(newA)));
+            }
+
+            // Calculate B
+            newB += max(0.0, xi) * Bi(compIIdx);
+            assert(std::isfinite(scalarValue(newB)));
+        }
+
+        // assign A and B
+        setA(decay<Scalar>(newA));
+        setB(decay<Scalar>(newB));
+        Valgrind::CheckDefined(A());
+        Valgrind::CheckDefined(B());
+    }
+
+    Scalar aCache(unsigned compIIdx, unsigned compJIdx ) const
+    {
+        return aCache_[compIIdx][compJIdx];
+    }
+
+    void setAi(Scalar value, unsigned compIdx)
+    { 
+        Ai_[compIdx] = value; 
+    }
+
+    void setBi(Scalar value, unsigned compIdx)
+    { 
+        Bi_[compIdx] = value; 
+    }
+
+    Scalar Ai(unsigned compIdx) const
+    {
+        return Ai_[compIdx];
+    }
+
+    Scalar Bi(unsigned compIdx) const
+    {
+        return Bi_[compIdx];
+    }
+
+    void setA(Scalar value)
+    { 
+        A_ = value; 
+    }
+
+    void setB(Scalar value)
+    { 
+        B_ = value; 
+    }
+
+    Scalar A() const
+    {
+        return A_;
+    }
+
+    Scalar B() const
+    {
+        return B_;
+    }
+
+    virtual Scalar calcOmegaA(Scalar temperature, unsigned compIdx)
+    {
+        throw std::logic_error("Not implemented");
+    }
+
+    virtual Scalar calcOmegaB(Scalar temperature, unsigned compIdx)
+    {
+        throw std::logic_error("Not implemented");
+    }
+
+    Scalar m1() const
+    {
+        throw std::logic_error("Not implemented");
+    }   
+    
+    Scalar m2() const
+    {
+        throw std::logic_error("Not implemented");
+    }
+
+protected:
+    std::array<Scalar, numComponents> Ai_;
+    std::array<Scalar, numComponents> Bi_;
+    Scalar A_;
+    Scalar B_;
+    std::array<std::array<Scalar, numComponents>, numComponents> aCache_;
+
+private:
+    void updateACache_()
+    {
+        for (unsigned compIIdx = 0; compIIdx < numComponents; ++ compIIdx) {
+            for (unsigned compJIdx = 0; compJIdx < numComponents; ++ compJIdx) {
+                // interaction coefficient as given in SPE5
+                Scalar Psi = FluidSystem::interactionCoefficient(compIIdx, compJIdx);
+
+                aCache_[compIIdx][compJIdx] = sqrt(Ai(compIIdx) * Ai(compJIdx)) * (1 - Psi);
+            }
+        }
+    }
+
+};  // class CubicEOSParams
+
+}  // namespace Opm
+
+#endif

--- a/opm/material/eos/CubicEOSParams.hpp
+++ b/opm/material/eos/CubicEOSParams.hpp
@@ -48,7 +48,6 @@ class CubicEOSParams
 
 public:
 
-    template<typename EOSType>
     void setEOSType(EOSType& eos_type)
     {
         EosType_= eos_type;

--- a/opm/material/eos/PRParams.hpp
+++ b/opm/material/eos/PRParams.hpp
@@ -41,7 +41,7 @@ public:
         Scalar Tr = temperature / FluidSystem::criticalTemperature(compIdx);
         Scalar omega = FluidSystem::acentricFactor(compIdx);
         Scalar f_omega;
-        if (!modified || (modified && omega <= 0.49)) 
+        if (!modified || omega <= 0.49) 
             f_omega = 0.37464 + omega * (1.54226 + omega * (-0.26992));
         else
             f_omega = 0.379642 + omega * (1.48503 + omega * (-0.164423 + omega * 0.016666));

--- a/opm/material/eos/PRParams.hpp
+++ b/opm/material/eos/PRParams.hpp
@@ -26,26 +26,24 @@
 #ifndef PR_PARAMS_HPP
 #define PR_PARAMS_HPP
 
-#include <opm/material/eos/CubicEOSParams.hpp>
-
 #include <cmath>
 
 namespace Opm {
 
-template <class Scalar, class FluidSystem, unsigned phaseIdx>
-class PRParams : public CubicEOSParams<Scalar, FluidSystem, phaseIdx>
+template <class Scalar, class FluidSystem>
+class PRParams 
 {
     static constexpr Scalar R = Constants<Scalar>::R;
 
 public:
-    Scalar calcOmegaA(Scalar temperature, unsigned compIdx) override
+    static Scalar calcOmegaA(Scalar temperature, unsigned compIdx, bool modified)
     {
         Scalar Tr = temperature / FluidSystem::criticalTemperature(compIdx);
         Scalar omega = FluidSystem::acentricFactor(compIdx);
         Scalar f_omega;
-        if (omega < 0.49) 
+        if (!modified || (modified && omega <= 0.49)) 
             f_omega = 0.37464 + omega * (1.54226 + omega * (-0.26992));
-        else              
+        else
             f_omega = 0.379642 + omega * (1.48503 + omega * (-0.164423 + omega * 0.016666));
         Valgrind::CheckDefined(f_omega);
         
@@ -53,20 +51,21 @@ public:
         return 0.457235529 * tmp * tmp;
     }
 
-    Scalar calcOmegaB([[maybe_unused]] Scalar temperature, [[maybe_unused]] unsigned compIdx) override
+    static Scalar calcOmegaB() 
     {
         return Scalar(0.077796074);
     }
 
-    Scalar m1() const
+    static Scalar calcm1()
     {
         return Scalar(1 + std::sqrt(2));
     }
 
-    Scalar m2() const
+    static Scalar calcm2()
     {
         return Scalar(1 - std::sqrt(2));
     }
+
 };  // class PRParams
 
 }  // namespace Opm

--- a/opm/material/eos/PRParams.hpp
+++ b/opm/material/eos/PRParams.hpp
@@ -1,0 +1,76 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2022 NORCE.
+  Copyright 2022 SINTEF Digital, Mathematics and Cybernetics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#ifndef PR_PARAMS_HPP
+#define PR_PARAMS_HPP
+
+#include <opm/material/eos/CubicEOSParams.hpp>
+
+#include <cmath>
+
+namespace Opm {
+
+template <class Scalar, class FluidSystem, unsigned phaseIdx>
+class PRParams : public CubicEOSParams<Scalar, FluidSystem, phaseIdx>
+{
+    static constexpr Scalar R = Constants<Scalar>::R;
+
+    // using Toolbox = MathToolbox<Scalar>;
+
+public:
+    Scalar calcOmegaA(Scalar temperature, unsigned compIdx) override
+    {
+        Scalar Tr = temperature / FluidSystem::criticalTemperature(compIdx);
+        Scalar omega = FluidSystem::acentricFactor(compIdx);
+        Scalar f_omega;
+        if (omega < 0.49) 
+            f_omega = 0.37464  + omega*(1.54226 + omega*(-0.26992));
+        else              
+            f_omega = 0.379642 + omega*(1.48503 + omega*(-0.164423 + omega*0.016666));
+        Valgrind::CheckDefined(f_omega);
+        
+        Scalar tmp = 1 + f_omega*(1 - sqrt(Tr));
+        return 0.457235529 * tmp * tmp;
+    }
+
+    Scalar calcOmegaB([[maybe_unused]] Scalar temperature, [[maybe_unused]] unsigned compIdx) override
+    {
+        return Scalar(0.077796074);
+    }
+
+    Scalar m1() const
+    {
+        return Scalar(1 + std::sqrt(2));
+    }
+
+    Scalar m2() const
+    {
+        return Scalar(1 - std::sqrt(2));
+    }
+};  // class PRParams
+
+}  // namespace Opm
+
+#endif

--- a/opm/material/eos/RKParams.hpp
+++ b/opm/material/eos/RKParams.hpp
@@ -23,8 +23,8 @@
   module for the precise wording of the license and the list of
   copyright holders.
 */
-#ifndef PR_PARAMS_HPP
-#define PR_PARAMS_HPP
+#ifndef RK_PARAMS_HPP
+#define RK_PARAMS_HPP
 
 #include <opm/material/eos/CubicEOSParams.hpp>
 
@@ -33,7 +33,7 @@
 namespace Opm {
 
 template <class Scalar, class FluidSystem, unsigned phaseIdx>
-class PRParams : public CubicEOSParams<Scalar, FluidSystem, phaseIdx>
+class RKParams : public CubicEOSParams<Scalar, FluidSystem, phaseIdx>
 {
     static constexpr Scalar R = Constants<Scalar>::R;
 
@@ -41,31 +41,22 @@ public:
     Scalar calcOmegaA(Scalar temperature, unsigned compIdx) override
     {
         Scalar Tr = temperature / FluidSystem::criticalTemperature(compIdx);
-        Scalar omega = FluidSystem::acentricFactor(compIdx);
-        Scalar f_omega;
-        if (omega < 0.49) 
-            f_omega = 0.37464 + omega * (1.54226 + omega * (-0.26992));
-        else              
-            f_omega = 0.379642 + omega * (1.48503 + omega * (-0.164423 + omega * 0.016666));
-        Valgrind::CheckDefined(f_omega);
-        
-        Scalar tmp = 1 + f_omega*(1 - sqrt(Tr));
-        return 0.457235529 * tmp * tmp;
+        return 0.4274802 / sqrt(Tr);
     }
 
     Scalar calcOmegaB([[maybe_unused]] Scalar temperature, [[maybe_unused]] unsigned compIdx) override
     {
-        return Scalar(0.077796074);
+        return Scalar(0.08664035);
     }
 
     Scalar m1() const
     {
-        return Scalar(1 + std::sqrt(2));
+        return Scalar(0.0);
     }
 
     Scalar m2() const
     {
-        return Scalar(1 - std::sqrt(2));
+        return Scalar(1.0);
     }
 };  // class PRParams
 

--- a/opm/material/eos/RKParams.hpp
+++ b/opm/material/eos/RKParams.hpp
@@ -26,39 +26,37 @@
 #ifndef RK_PARAMS_HPP
 #define RK_PARAMS_HPP
 
-#include <opm/material/eos/CubicEOSParams.hpp>
-
-#include <cmath>
-
 namespace Opm {
 
-template <class Scalar, class FluidSystem, unsigned phaseIdx>
-class RKParams : public CubicEOSParams<Scalar, FluidSystem, phaseIdx>
+template <class Scalar, class FluidSystem>
+class RKParams
 {
     static constexpr Scalar R = Constants<Scalar>::R;
 
 public:
-    Scalar calcOmegaA(Scalar temperature, unsigned compIdx) override
+
+    static Scalar calcOmegaA(Scalar temperature, unsigned compIdx)
     {
         Scalar Tr = temperature / FluidSystem::criticalTemperature(compIdx);
         return 0.4274802 / sqrt(Tr);
     }
 
-    Scalar calcOmegaB([[maybe_unused]] Scalar temperature, [[maybe_unused]] unsigned compIdx) override
+    static Scalar calcOmegaB()
     {
         return Scalar(0.08664035);
     }
 
-    Scalar m1() const
+    static Scalar calcm1()
     {
         return Scalar(0.0);
     }
 
-    Scalar m2() const
+    static Scalar calcm2()
     {
         return Scalar(1.0);
     }
-};  // class PRParams
+
+};  // class RKParams
 
 }  // namespace Opm
 

--- a/opm/material/eos/SRKParams.hpp
+++ b/opm/material/eos/SRKParams.hpp
@@ -26,19 +26,16 @@
 #ifndef SRK_PARAMS_HPP
 #define SRK_PARAMS_HPP
 
-#include <opm/material/eos/CubicEOSParams.hpp>
-
-#include <cmath>
-
 namespace Opm {
 
-template <class Scalar, class FluidSystem, unsigned phaseIdx>
-class SRKParams : public CubicEOSParams<Scalar, FluidSystem, phaseIdx>
+template <class Scalar, class FluidSystem>
+class SRKParams
 {
     static constexpr Scalar R = Constants<Scalar>::R;
 
 public:
-    Scalar calcOmegaA(Scalar temperature, unsigned compIdx) override
+
+    static Scalar calcOmegaA(Scalar temperature, unsigned compIdx)
     {
         Scalar Tr = temperature / FluidSystem::criticalTemperature(compIdx);
         Scalar omega = FluidSystem::acentricFactor(compIdx);
@@ -49,21 +46,22 @@ public:
         return 0.4274802 * tmp * tmp;
     }
 
-    Scalar calcOmegaB([[maybe_unused]] Scalar temperature, [[maybe_unused]] unsigned compIdx) override
+    static Scalar calcOmegaB()
     {
         return Scalar(0.08664035);
     }
 
-    Scalar m1() const
+    static Scalar calcm1()
     {
         return Scalar(0.0);
     }
 
-    Scalar m2() const
+    static Scalar calcm2()
     {
         return Scalar(1.0);
     }
-};  // class PRParams
+
+};  // class SRKParams
 
 }  // namespace Opm
 

--- a/opm/material/eos/SRKParams.hpp
+++ b/opm/material/eos/SRKParams.hpp
@@ -23,8 +23,8 @@
   module for the precise wording of the license and the list of
   copyright holders.
 */
-#ifndef PR_PARAMS_HPP
-#define PR_PARAMS_HPP
+#ifndef SRK_PARAMS_HPP
+#define SRK_PARAMS_HPP
 
 #include <opm/material/eos/CubicEOSParams.hpp>
 
@@ -33,7 +33,7 @@
 namespace Opm {
 
 template <class Scalar, class FluidSystem, unsigned phaseIdx>
-class PRParams : public CubicEOSParams<Scalar, FluidSystem, phaseIdx>
+class SRKParams : public CubicEOSParams<Scalar, FluidSystem, phaseIdx>
 {
     static constexpr Scalar R = Constants<Scalar>::R;
 
@@ -42,30 +42,26 @@ public:
     {
         Scalar Tr = temperature / FluidSystem::criticalTemperature(compIdx);
         Scalar omega = FluidSystem::acentricFactor(compIdx);
-        Scalar f_omega;
-        if (omega < 0.49) 
-            f_omega = 0.37464 + omega * (1.54226 + omega * (-0.26992));
-        else              
-            f_omega = 0.379642 + omega * (1.48503 + omega * (-0.164423 + omega * 0.016666));
+        Scalar f_omega = 0.48 + omega * (1.574 + omega * (-0.176));
         Valgrind::CheckDefined(f_omega);
         
         Scalar tmp = 1 + f_omega*(1 - sqrt(Tr));
-        return 0.457235529 * tmp * tmp;
+        return 0.4274802 * tmp * tmp;
     }
 
     Scalar calcOmegaB([[maybe_unused]] Scalar temperature, [[maybe_unused]] unsigned compIdx) override
     {
-        return Scalar(0.077796074);
+        return Scalar(0.08664035);
     }
 
     Scalar m1() const
     {
-        return Scalar(1 + std::sqrt(2));
+        return Scalar(0.0);
     }
 
     Scalar m2() const
     {
-        return Scalar(1 - std::sqrt(2));
+        return Scalar(1.0);
     }
 };  // class PRParams
 

--- a/opm/material/fluidsystems/Co2BrineFluidSystem.hh
+++ b/opm/material/fluidsystems/Co2BrineFluidSystem.hh
@@ -66,7 +66,7 @@ namespace Opm {
         using ParameterCache = Opm::PTFlashParameterCache<ValueType, Co2BrineFluidSystem<Scalar>>;
         using ViscosityModel = typename Opm::ViscosityModels<Scalar, Co2BrineFluidSystem<Scalar>>;
 
-        using PengRobinsonMixture = typename Opm::PengRobinsonMixture<Scalar, Co2BrineFluidSystem<Scalar>>;
+        using CubicEOS = typename Opm::CubicEOS<Scalar, Co2BrineFluidSystem<Scalar>>;
 
 
         /*!
@@ -206,7 +206,7 @@ namespace Opm {
             assert(phaseIdx < numPhases);
             assert(compIdx < numComponents);
 
-            LhsEval phi = PengRobinsonMixture::computeFugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx);
+            LhsEval phi = CubicEOS::computeFugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx);
 
             return phi;
         }

--- a/opm/material/fluidsystems/GenericOilGasFluidSystem.hpp
+++ b/opm/material/fluidsystems/GenericOilGasFluidSystem.hpp
@@ -33,7 +33,7 @@
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #endif
 
-#include <opm/material/eos/PengRobinsonMixture.hpp>
+#include <opm/material/eos/CubicEOS.hpp>
 #include <opm/material/fluidsystems/BaseFluidSystem.hpp>
 #include <opm/material/fluidsystems/PTFlashParameterCache.hpp> // TODO: this is something else need to check
 #include <opm/material/viscositymodels/LBC.hpp>
@@ -78,7 +78,7 @@ namespace Opm {
         template <class ValueType>
         using ParameterCache = Opm::PTFlashParameterCache<ValueType, GenericOilGasFluidSystem<Scalar, NumComp>>;
         using ViscosityModel = Opm::ViscosityModels<Scalar, GenericOilGasFluidSystem<Scalar, NumComp>>;
-        using PengRobinsonMixture = Opm::PengRobinsonMixture<Scalar, GenericOilGasFluidSystem<Scalar, NumComp>>;
+        using CubicEOS = Opm::CubicEOS<Scalar, GenericOilGasFluidSystem<Scalar, NumComp>>;
 
         struct ComponentParam {
             std::string name;
@@ -292,7 +292,7 @@ namespace Opm {
             assert(phaseIdx < numPhases);
             assert(compIdx < numComponents);
 
-            return decay<LhsEval>(PengRobinsonMixture::computeFugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx));
+            return decay<LhsEval>(CubicEOS::computeFugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx));
         }
 
         // TODO: the following interfaces are needed by function checkFluidSystem()

--- a/opm/material/fluidsystems/PTFlashParameterCache.hpp
+++ b/opm/material/fluidsystems/PTFlashParameterCache.hpp
@@ -71,21 +71,8 @@ public:
 
     //! The cached parameters for the gas phase
     using GasPhaseParams = Opm::CubicEOSParams<Scalar, FluidSystem, gasPhaseIdx>;
-    
-    PTFlashParameterCache()
-    {            
-            VmUpToDate_[oilPhaseIdx] = false;
-            Valgrind::SetUndefined(Vm_[oilPhaseIdx]);
-            VmUpToDate_[gasPhaseIdx] = false;
-            Valgrind::SetUndefined(Vm_[gasPhaseIdx]);
 
-            auto pr = EOSType::PR;
-            oilPhaseParams_.setEOSType(pr);
-            gasPhaseParams_.setEOSType(pr);
-    }
-
-    template<typename EOSType>
-    PTFlashParameterCache(EOSType& eos_type)
+    PTFlashParameterCache(EOSType eos_type)
     {
         VmUpToDate_[oilPhaseIdx] = false;
         Valgrind::SetUndefined(Vm_[oilPhaseIdx]);

--- a/opm/material/fluidsystems/ThreeComponentFluidSystem.hh
+++ b/opm/material/fluidsystems/ThreeComponentFluidSystem.hh
@@ -26,7 +26,7 @@
 #ifndef OPM_THREECOMPONENTFLUIDSYSTEM_HH
 #define OPM_THREECOMPONENTFLUIDSYSTEM_HH
 
-#include <opm/material/eos/PengRobinsonMixture.hpp>
+#include <opm/material/eos/CubicEOS.hpp>
 #include <opm/material/fluidsystems/BaseFluidSystem.hpp>
 #include <opm/material/components/SimpleCO2.hpp>
 #include <opm/material/components/C10.hpp>
@@ -72,7 +72,7 @@ namespace Opm {
         template <class ValueType>
         using ParameterCache = PTFlashParameterCache<ValueType, ThreeComponentFluidSystem<Scalar>>;
         using ViscosityModel = ViscosityModels<Scalar, ThreeComponentFluidSystem<Scalar>>;
-        using PengRobinsonMixture = ::Opm::PengRobinsonMixture<Scalar, ThreeComponentFluidSystem<Scalar>>;
+        using CubicEOS = ::Opm::CubicEOS<Scalar, ThreeComponentFluidSystem<Scalar>>;
 
         /*!
          * \brief The acentric factor of a component [].
@@ -205,7 +205,7 @@ namespace Opm {
             assert(phaseIdx < numPhases);
             assert(compIdx < numComponents);
 
-            return decay<LhsEval>(PengRobinsonMixture::computeFugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx));
+            return decay<LhsEval>(CubicEOS::computeFugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx));
         }
 
         //! \copydoc BaseFluidSystem::isCompressible

--- a/tests/material/test_co2brine_ptflash.cpp
+++ b/tests/material/test_co2brine_ptflash.cpp
@@ -86,16 +86,6 @@ for (const auto& sample : test_methods) {
     fluid_state.setPressure(FluidSystem::oilPhaseIdx, p_init);
     fluid_state.setPressure(FluidSystem::gasPhaseIdx, p_init);
 
-    fluid_state.setMoleFraction(FluidSystem::oilPhaseIdx, FluidSystem::Comp0Idx, comp[0]);
-    fluid_state.setMoleFraction(FluidSystem::oilPhaseIdx, FluidSystem::Comp1Idx, comp[1]);
-
-    fluid_state.setMoleFraction(FluidSystem::gasPhaseIdx, FluidSystem::Comp0Idx, comp[0]);
-    fluid_state.setMoleFraction(FluidSystem::gasPhaseIdx, FluidSystem::Comp1Idx, comp[1]);
-
-    // It is used here only for calculate the z
-    fluid_state.setSaturation(FluidSystem::oilPhaseIdx, sat[0]);
-    fluid_state.setSaturation(FluidSystem::gasPhaseIdx, sat[1]);
-
     fluid_state.setTemperature(temp);
 
     for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {

--- a/tests/material/test_co2brine_ptflash.cpp
+++ b/tests/material/test_co2brine_ptflash.cpp
@@ -47,10 +47,13 @@
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
 
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
+
 #include <stdexcept>
 
 // It is a two component system
 using Scalar = double;
+using EOSType = Opm::CompositionalConfig::EOSType;
 using FluidSystem = Opm::Co2BrineFluidSystem<Scalar>;
 using ThreeComponentSystem = Opm::ThreeComponentFluidSystem<Scalar>;
 
@@ -83,6 +86,16 @@ for (const auto& sample : test_methods) {
     fluid_state.setPressure(FluidSystem::oilPhaseIdx, p_init);
     fluid_state.setPressure(FluidSystem::gasPhaseIdx, p_init);
 
+    fluid_state.setMoleFraction(FluidSystem::oilPhaseIdx, FluidSystem::Comp0Idx, comp[0]);
+    fluid_state.setMoleFraction(FluidSystem::oilPhaseIdx, FluidSystem::Comp1Idx, comp[1]);
+
+    fluid_state.setMoleFraction(FluidSystem::gasPhaseIdx, FluidSystem::Comp0Idx, comp[0]);
+    fluid_state.setMoleFraction(FluidSystem::gasPhaseIdx, FluidSystem::Comp1Idx, comp[1]);
+
+    // It is used here only for calculate the z
+    fluid_state.setSaturation(FluidSystem::oilPhaseIdx, sat[0]);
+    fluid_state.setSaturation(FluidSystem::gasPhaseIdx, sat[1]);
+
     fluid_state.setTemperature(temp);
 
     for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
@@ -102,7 +115,8 @@ for (const auto& sample : test_methods) {
     fluid_state.setLvalue(Ltmp);
 
     using Flash = Opm::PTFlash<double, FluidSystem>;
-    Flash::solve(fluid_state, sample, flash_tolerance, flash_verbosity);
+    auto eos_type = EOSType::PRCORR;
+    Flash::solve(fluid_state, sample, flash_tolerance, eos_type, flash_verbosity);
 
     ComponentVector x, y;
     const Evaluation L = fluid_state.L();
@@ -188,7 +202,8 @@ for (const auto& sample : test_methods) {
     fluid_state.setLvalue(Ltmp);
 
     using Flash = Opm::PTFlash<double, FluidSystem>;
-    Flash::solve(fluid_state, sample, flash_tolerance, flash_verbosity);
+    auto eos_type = EOSType::PRCORR;
+    Flash::solve(fluid_state, sample, flash_tolerance, eos_type, flash_verbosity);
 
     ComponentVector x, y;
     const Evaluation L = fluid_state.L();

--- a/tests/material/test_threecomponents_ptflash.cpp
+++ b/tests/material/test_threecomponents_ptflash.cpp
@@ -45,8 +45,11 @@
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
 
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
+
 // It is a three component system
 using Scalar = double;
+using EOSType = Opm::CompositionalConfig::EOSType;
 using FluidSystem = Opm::ThreeComponentFluidSystem<Scalar>;
 
 constexpr auto numComponents = FluidSystem::numComponents;
@@ -99,7 +102,8 @@ for (const auto& sample : test_methods) {
     fluid_state.setLvalue(Ltmp);
 
     using Flash = Opm::PTFlash<double, FluidSystem>;
-    Flash::solve(fluid_state,  sample, flash_tolerance, flash_verbosity);
+    auto eos_type = EOSType::PR;
+    Flash::solve(fluid_state, sample, flash_tolerance, eos_type, flash_verbosity);
 
     ComponentVector x, y;
     const Evaluation L = fluid_state.L();


### PR DESCRIPTION
Implemented a general cubic EOS code to calculate EOS parameters with cubic formulations other than just Peng-Robinson. Added the Redlich-Kwong and Soave-Redlich-Kwong EOS formulations. The chosen EOS type must be set when initializing a PTFlashParameterCache instance.