### PR TITLE
Include Ranges.h for fmt::join()

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQDefine.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQDefine.cpp
@@ -44,6 +44,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace {
 


### PR DESCRIPTION
Needed for libfmt v11 and forgotten in commit 0e63b8304.

Pointy Hat: [at]bska