### PR TITLE
Push Group Name Pattern Matching Into GroupOrder Class

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1372,18 +1372,19 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         };
     }
 
-    std::vector<std::string> Schedule::wellNames(const std::string& pattern) const {
+    std::vector<std::string> Schedule::wellNames(const std::string& pattern) const
+    {
         return this->wellNames(pattern, this->size() - 1);
     }
 
-    std::vector<std::string> Schedule::wellNames(std::size_t timeStep) const {
-        const auto& well_order = this->snapshots[timeStep].well_order();
-        return well_order.names();
+    std::vector<std::string> Schedule::wellNames(std::size_t timeStep) const
+    {
+        return this->snapshots[timeStep].well_order().names();
     }
 
-    std::vector<std::string> Schedule::wellNames() const {
-        const auto& well_order = this->snapshots.back().well_order();
-        return well_order.names();
+    std::vector<std::string> Schedule::wellNames() const
+    {
+        return this->snapshots.back().well_order().names();
     }
 
     std::vector<std::string> Schedule::groupNames(const std::string& pattern, std::size_t timeStep) const {
@@ -1412,28 +1413,36 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         return {};
     }
 
-    std::vector<std::string> Schedule::groupNames(std::size_t timeStep) const {
-        const auto& group_order = this->snapshots[timeStep].group_order();
-        return group_order.names();
+    const std::vector<std::string>& Schedule::groupNames(std::size_t timeStep) const
+    {
+        return this->snapshots[timeStep].group_order().names();
     }
 
-    std::vector<std::string> Schedule::groupNames(const std::string& pattern) const {
+    std::vector<std::string> Schedule::groupNames(const std::string& pattern) const
+    {
         return this->groupNames(pattern, this->snapshots.size() - 1);
     }
 
-    std::vector<std::string> Schedule::groupNames() const {
-        const auto& group_order = this->snapshots.back().group_order();
-        return group_order.names();
+    const std::vector<std::string>& Schedule::groupNames() const
+    {
+        return this->snapshots.back().group_order().names();
     }
 
-    std::vector<const Group*> Schedule::restart_groups(std::size_t timeStep) const {
-        const auto& restart_groups = this->snapshots[timeStep].group_order().restart_groups();
-        std::vector<const Group*> rst_groups(restart_groups.size() , nullptr );
-        for (std::size_t restart_index = 0; restart_index < restart_groups.size(); restart_index++) {
+    std::vector<const Group*> Schedule::restart_groups(std::size_t timeStep) const
+    {
+        const auto restart_groups = this->snapshots[timeStep].group_order().restart_groups();
+
+        std::vector<const Group*> rst_groups(restart_groups.size(), nullptr);
+        for (std::size_t restart_index = 0;
+             restart_index < restart_groups.size(); ++restart_index)
+        {
             const auto& group_name = restart_groups[restart_index];
-            if (group_name.has_value())
+
+            if (group_name.has_value()) {
                 rst_groups[restart_index] = &this->getGroup(group_name.value(), timeStep);
+            }
         }
+
         return rst_groups;
     }
 

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1387,30 +1387,10 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         return this->snapshots.back().well_order().names();
     }
 
-    std::vector<std::string> Schedule::groupNames(const std::string& pattern, std::size_t timeStep) const {
-        if (pattern.size() == 0)
-            return {};
-
-        const auto& group_order = this->snapshots[timeStep].group_order();
-
-        // Normal pattern matching
-        auto star_pos = pattern.find('*');
-        if (star_pos != std::string::npos) {
-            std::vector<std::string> names;
-            std::copy_if(group_order.begin(), group_order.end(),
-                         std::back_inserter(names),
-                         [&pattern](const auto& gname)
-                         {
-                             return shmatch(pattern, gname);
-                         });
-            return names;
-        }
-
-        // Normal group name without any special characters
-        if (group_order.has(pattern))
-            return { pattern };
-
-        return {};
+    std::vector<std::string> Schedule::groupNames(const std::string& pattern,
+                                                  const std::size_t timeStep) const
+    {
+        return this->snapshots[timeStep].group_order().names(pattern);
     }
 
     const std::vector<std::string>& Schedule::groupNames(std::size_t timeStep) const

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -227,18 +227,17 @@ namespace Opm {
 
         bool hasGroup(const std::string& groupName, std::size_t timeStep) const;
         std::vector<std::string> groupNames(const std::string& pattern, std::size_t timeStep) const;
-        std::vector<std::string> groupNames(std::size_t timeStep) const;
+        const std::vector<std::string>& groupNames(std::size_t timeStep) const;
         std::vector<std::string> groupNames(const std::string& pattern) const;
-        std::vector<std::string> groupNames() const;
-        /*
-          The restart_groups function returns a vector of groups pointers which
-          is organized as follows:
+        const std::vector<std::string>& groupNames() const;
 
-            1. The number of elements is WELLDIMS::MAXGROUPS + 1
-            2. The elements are sorted according to group.insert_index().
-            3. If there are less than WELLDIMS::MAXGROUPS nullptr is used.
-            4. The very last element corresponds to the FIELD group.
-        */
+        // The restart_groups function returns a vector of groups pointers which
+        // is organized as follows:
+        //
+        //   1. The number of elements is WELLDIMS::MAXGROUPS + 1
+        //   2. The elements are sorted according to group.insert_index().
+        //   3. If there are less than WELLDIMS::MAXGROUPS nullptr is used.
+        //   4. The very last element corresponds to the FIELD group.
         std::vector<const Group*> restart_groups(std::size_t timeStep) const;
 
         std::vector<std::string> changed_wells(std::size_t reportStep) const;
@@ -249,10 +248,15 @@ namespace Opm {
         std::unordered_set<int> getAquiferFluxSchedule() const;
         std::vector<Well> getWells(std::size_t timeStep) const;
         std::vector<Well> getWellsatEnd() const;
-        std::vector<Well> getActiveWellsAtEnd() const; // Get wells that have been active any time during simulation
-        std::vector<std::string> getInactiveWellNamesAtEnd() const; // Get well names of wells that have never been active
 
-        const std::unordered_map<std::string, std::set<int>>& getPossibleFutureConnections() const;
+        // Get wells that have been active any time during simulation
+        std::vector<Well> getActiveWellsAtEnd() const;
+
+        // Get well names of wells that have never been active
+        std::vector<std::string> getInactiveWellNamesAtEnd() const;
+
+        const std::unordered_map<std::string, std::set<int>>&
+        getPossibleFutureConnections() const;
 
         void shut_well(const std::string& well_name, std::size_t report_step);
         void shut_well(const std::string& well_name);

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -225,19 +225,63 @@ namespace Opm {
         std::vector<std::string> wellNames(std::size_t timeStep) const;
         std::vector<std::string> wellNames() const;
 
+        /// Query for group existence at particular time
+        ///
+        /// \param[in] groupName Fully specified group name.
+        ///
+        /// \param[in] timeStep Zero-based report step index.
+        ///
+        /// \return Whether or not group \p groupName exists at time \p
+        /// timeStep.
         bool hasGroup(const std::string& groupName, std::size_t timeStep) const;
-        std::vector<std::string> groupNames(const std::string& pattern, std::size_t timeStep) const;
+
+        /// Retrieve names of all groups at particular time whose names
+        /// match a pattern.
+        ///
+        /// \param[in] pattern Group name pattern.  Expected to be a group
+        /// name root such as 'PR*' or a fully specified group name such as
+        /// 'PROD'.
+        ///
+        /// \param[in] timeStep Zero-based report step index.
+        ///
+        /// \return Names of all groups at \p timeStep whose names match the
+        /// \p pattern.
+        std::vector<std::string>
+        groupNames(const std::string& pattern, std::size_t timeStep) const;
+
+        /// Retrieve names of all groups at a particular time.
+        ///
+        /// \param[in] timeStep Zero-based report step index.
+        ///
+        /// \return Names of all groups in simulation which are active at
+        /// time \p timeStep.
         const std::vector<std::string>& groupNames(std::size_t timeStep) const;
+
+        /// Retrieve names of all groups matching a pattern
+        ///
+        /// \param[in] pattern Group name pattern.  Expected to be a group
+        /// name root such as 'PR*' or a fully specified group name such as
+        /// 'PROD'.
+        ///
+        /// \return Names of all groups in simulation run matching the \p
+        /// pattern.
         std::vector<std::string> groupNames(const std::string& pattern) const;
+
+        /// Retrieve names of all groups in model
+        ///
+        /// Includes FIELD group.
         const std::vector<std::string>& groupNames() const;
 
-        // The restart_groups function returns a vector of groups pointers which
-        // is organized as follows:
-        //
-        //   1. The number of elements is WELLDIMS::MAXGROUPS + 1
-        //   2. The elements are sorted according to group.insert_index().
-        //   3. If there are less than WELLDIMS::MAXGROUPS nullptr is used.
-        //   4. The very last element corresponds to the FIELD group.
+        /// Retrieve collection of group objects suiteable for restart file output
+        ///
+        /// The collection is sized and ordered as follows
+        ///
+        ///  -# The number of elements is WELLDIMS::MAXGROUPS + 1
+        ///  -# The elements are sorted according to group.insert_index().
+        ///  -# Nullptr represents an unused slot.
+        ///  -# The very last element corresponds to the FIELD group.
+        ///
+        /// \param[in] timeStep Zero-based report step index.
         std::vector<const Group*> restart_groups(std::size_t timeStep) const;
 
         std::vector<std::string> changed_wells(std::size_t reportStep) const;

--- a/opm/input/eclipse/Schedule/Well/NameOrder.cpp
+++ b/opm/input/eclipse/Schedule/Well/NameOrder.cpp
@@ -99,7 +99,7 @@ const std::string& NameOrder::operator[](std::size_t index) const
 // --------------------------------------------------------------------------------
 
 GroupOrder::GroupOrder(const std::size_t max_groups)
-    : m_max_groups { max_groups }
+    : max_groups_ { max_groups }
 {
     this->add("FIELD");
 }
@@ -116,28 +116,22 @@ GroupOrder GroupOrder::serializationTestObject()
 
 void GroupOrder::add(const std::string& gname)
 {
-    auto iter = std::find(this->m_name_list.begin(),
-                          this->m_name_list.end(), gname);
-    if (iter == this->m_name_list.end()) {
-        this->m_name_list.push_back(gname);
+    auto iter = std::find(this->name_list_.begin(),
+                          this->name_list_.end(), gname);
+    if (iter == this->name_list_.end()) {
+        this->name_list_.push_back(gname);
     }
 }
 
 bool GroupOrder::has(const std::string& gname) const
 {
-    auto iter = std::find(this->m_name_list.begin(),
-                          this->m_name_list.end(), gname);
-    return iter != this->m_name_list.end();
-}
-
-const std::vector<std::string>& GroupOrder::names() const
-{
-    return this->m_name_list;
+    return std::find(this->name_list_.begin(), this->name_list_.end(), gname)
+        != this->name_list_.end();
 }
 
 std::vector<std::optional<std::string>> GroupOrder::restart_groups() const
 {
-    std::vector<std::optional<std::string>> groups(this->m_max_groups + 1);
+    auto groups = std::vector<std::optional<std::string>>(this->max_groups_ + 1);
 
     const auto& input_groups = this->names();
 
@@ -149,8 +143,8 @@ std::vector<std::optional<std::string>> GroupOrder::restart_groups() const
 
 bool GroupOrder::operator==(const GroupOrder& other) const
 {
-    return (this->m_max_groups == other.m_max_groups)
-        && (this->m_name_list == other.m_name_list);
+    return (this->max_groups_ == other.max_groups_)
+        && (this->name_list_ == other.name_list_);
 }
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/Well/NameOrder.cpp
+++ b/opm/input/eclipse/Schedule/Well/NameOrder.cpp
@@ -19,6 +19,8 @@
 
 #include <opm/input/eclipse/Schedule/Well/NameOrder.hpp>
 
+#include <opm/common/utility/shmatch.hpp>
+
 #include <algorithm>
 #include <cstddef>
 #include <initializer_list>
@@ -127,6 +129,34 @@ bool GroupOrder::has(const std::string& gname) const
 {
     return std::find(this->name_list_.begin(), this->name_list_.end(), gname)
         != this->name_list_.end();
+}
+
+std::vector<std::string> GroupOrder::names(const std::string& pattern) const
+{
+    auto gnames = std::vector<std::string>{};
+
+    if (pattern.empty()) {
+        return gnames;
+    }
+
+    // Normal pattern matching
+    if (const auto star_pos = pattern.find('*');
+        star_pos != std::string::npos)
+    {
+        gnames.reserve(this->name_list_.size());
+
+        std::copy_if(this->name_list_.begin(),
+                     this->name_list_.end(),
+                     std::back_inserter(gnames),
+                     [&pattern](const auto& gname)
+                     { return shmatch(pattern, gname); });
+    }
+    else if (this->has(pattern)) {
+        // Normal group name without any special characters.
+        gnames.push_back(pattern);
+    }
+
+    return gnames;
 }
 
 std::vector<std::optional<std::string>> GroupOrder::restart_groups() const

--- a/opm/input/eclipse/Schedule/Well/NameOrder.hpp
+++ b/opm/input/eclipse/Schedule/Well/NameOrder.hpp
@@ -96,6 +96,15 @@ public:
         return this->name_list_;
     }
 
+    /// Retrieve list of group names matching a pattern
+    ///
+    /// Regular wild-card matching only.
+    ///
+    /// \param[in] pattern Group name or group name template.
+    ///
+    /// \return List of unique group names matching \p pattern.
+    std::vector<std::string> names(const std::string& pattern) const;
+
     /// Group name existence predicate.
     ///
     /// \param[in] gname Group name


### PR DESCRIPTION
This PR introduces a new member function
```C++
std::vector<std::string> GroupOrder::names(const std::string& pattern)
```
which returns a sequence of group names that match a certain pattern.  This is in preparation of adding such group name pattern matching in UDQ contexts, especially for assignments.  We then reimplement `Schedule::groupNames(const std::string& pattern)` in terms of this new member function.

While here, also add Doxygen-style documentation to the `NameOrder` and `GroupOrder` classes, and simplify some of the related functions in the `Schedule` class.