### PR TITLE
Ensure setting GRUP control in WCONPROD works for wells in auto-choke groups

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -29,6 +29,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/F.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 
+#include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleStatic.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>
@@ -332,6 +333,25 @@ void handleWCONINJH(HandlerContext& handlerContext)
     }
 }
 
+bool belongsToAutoChokeGroup(const Well& well, const ScheduleState& state) {
+    const auto& network = state.network.get();
+    auto group_name = well.groupName();
+    while (group_name != "FIELD") {
+        if (network.has_node(group_name)) {
+            auto node_name = group_name;
+            if (network.node(node_name).as_choke())
+                return true;
+            while (network.uptree_branch(node_name)) {
+                node_name = network.uptree_branch(node_name)->uptree_node();
+                if (network.node(node_name).as_choke())
+                    return true;
+            }
+        }
+        group_name = state.groups.get(group_name).parent();
+    }
+    return false;
+}
+
 void handleWCONPROD(HandlerContext& handlerContext)
 {
     for (const auto& record : handlerContext.keyword) {
@@ -348,7 +368,7 @@ void handleWCONPROD(HandlerContext& handlerContext)
             const bool switching_from_injector = !well2.isProducer();
             auto properties = std::make_shared<Well::WellProductionProperties>(well2.getProductionProperties());
             properties->clearControls();
-            if (well2.isAvailableForGroupControl()) {
+            if (well2.isAvailableForGroupControl() || belongsToAutoChokeGroup(well2, handlerContext.state())) {
                 properties->addProductionControl(Well::ProducerCMode::GRUP);
             }
 

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -335,6 +335,8 @@ void handleWCONINJH(HandlerContext& handlerContext)
 
 bool belongsToAutoChokeGroup(const Well& well, const ScheduleState& state) {
     const auto& network = state.network.get();
+    if (!network.active())
+        return false;
     auto group_name = well.groupName();
     while (group_name != "FIELD") {
         if (network.has_node(group_name)) {


### PR DESCRIPTION
The attached variant of [NETWORK_MODEL5_STDW_AUTOCHK_V2.DATA](https://github.com/OPM/opm-tests/blob/master/network/NETWORK_MODEL5_STDW_AUTOCHK.DATA) illustrates the problem (crashes in master, should work with this PR): 

[NETWORK_MODEL5_STDW_AUTOCHK_V2.DATA.gz](https://github.com/user-attachments/files/18454068/NETWORK_MODEL5_STDW_AUTOCHK_V2.DATA.gz)
