### PR TITLE
Remove GRUPNET from the supported keywords of ActionX since it is act…

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ActionX.cpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.cpp
@@ -107,7 +107,7 @@ bool ActionX::valid_keyword(const std::string& keyword)
         "GCONINJE", "GCONPROD", "GCONSUMP",
         "GEFAC",
         "GLIFTOPT",
-        "GRUPNET", "GRUPTREE",
+        "GRUPTREE",
 
         "MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-",
         "NEXT", "NEXTSTEP",


### PR DESCRIPTION
…ually not supported

See https://github.com/OPM/opm-tests/pull/1274