### PR TITLE
Fix Signature for PyAction::run() Without Embedded Python

### DIFF
--- a/opm/input/eclipse/Schedule/Action/PyAction.cpp
+++ b/opm/input/eclipse/Schedule/Action/PyAction.cpp
@@ -111,7 +111,8 @@ bool PyAction::operator==(const PyAction& other) const {
 #ifndef EMBEDDED_PYTHON
 
 bool PyAction::run(EclipseState&, Schedule&, std::size_t, SummaryState&,
-                   const std::function<void(const std::string&, const std::vector<std::string>&)>&) const
+                   const std::function<void(const std::string&, const std::vector<std::string>&)>&,
+                   const std::unordered_map<std::string, double>&) const
 {
     return false;
 }


### PR DESCRIPTION
Missed whilst reviewing #4434.