### PR TITLE
Fix PyAction OpmLog

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -701,6 +701,7 @@ if(ENABLE_ECL_OUTPUT)
           tests/SPE1CASE2_RESTART_SKIPREST.DATA
           tests/SPE1CASE2.X0060
           tests/PYACTION.DATA
+          tests/logger.py
           tests/0A4_GRCTRL_LRAT_LRAT_GGR_BASE_MODEL2_MSW_ALL.DATA
           tests/MOD4_TEST_IGRP-DATA.DATA
           tests/2_WLIFT_MODEL5_NOINC.DATA

--- a/opm/common/OpmLog/OpmLog.cpp
+++ b/opm/common/OpmLog/OpmLog.cpp
@@ -53,6 +53,16 @@ namespace Opm {
         }
     }
 
+    bool OpmLog::setLogger(std::shared_ptr<Logger> logger) {
+        if (!m_logger) {
+            m_logger = std::move(logger);
+            return true;
+        } else if (m_logger.get() == logger.get()) { // We want to compare the addresses of the underlying Logger objects
+            return true;
+        } else {
+            return false; // Logger was set to something else
+        }
+    }
 
     std::shared_ptr<Logger> OpmLog::getLogger() {
         if (!m_logger)

--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -29,6 +29,9 @@
 namespace Opm {
 
     class LogBackend;
+#ifdef EMBEDDED_PYTHON
+    class PyRunModule;
+#endif
 
 /*
   The OpmLog class is a fully static class which manages a proper
@@ -107,6 +110,9 @@ public:
     static bool setLogger(std::shared_ptr<Logger> logger);
 
 private:
+#ifdef EMBEDDED_PYTHON
+    friend class PyRunModule;
+#endif
     static std::shared_ptr<Logger> getLogger();
     static std::shared_ptr<Logger> m_logger;
 };

--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -90,6 +90,22 @@ public:
 
     static bool stdoutIsTerminal();
 
+    /**
+     * @brief Sets the global logger instance for the `OpmLog` class.
+     *
+     * This static function allows setting a shared pointer to a `Logger` instance
+     * as the global logger. It ensures that the logger is set only if it has not
+     * been previously set or if the provided logger is the same as the existing one.
+     * This function prevents changing the logger once it has been set to a different instance.
+     * If the logger is already set to a different instance, the function will return `false`.
+     *
+     * @param logger A `std::shared_ptr` to a `Logger` instance that will be set as the global logger.
+     *
+     * @return `true` if the logger was successfully set or if the same logger was already set.
+     *         `false` if a different logger had already been set and the new logger could not be set.
+     */
+    static bool setLogger(std::shared_ptr<Logger> logger);
+
 private:
     static std::shared_ptr<Logger> getLogger();
     static std::shared_ptr<Logger> m_logger;

--- a/opm/input/eclipse/Python/PyRunModule.cpp
+++ b/opm/input/eclipse/Python/PyRunModule.cpp
@@ -53,6 +53,11 @@ PyRunModule::PyRunModule(std::shared_ptr<const Python> python, const std::string
     // opm_embedded needs to be loaded before user defined module.
     try {
         this->opm_embedded = py::module::import("opm_embedded");
+        //Set the inner Logger of OpmLog, if we don't set this manually, any log messages from the Python script will not reach OpmLog
+        py::object loggerSetForPython = this->opm_embedded.attr("OpmLog").attr("_setLogger")(py::cast(OpmLog::getLogger()));
+        if (!loggerSetForPython.cast<bool>()) {
+            OpmLog::warning("The opm_embedded.OpmLog could not be set up correctly. Running embedded Pyhton code will still work, without any logging functionality though.");
+        }
     } catch (const std::exception& e) {
         OpmLog::error(fmt::format("Exception thrown when loading Python module opm_embedded: {}. Possibly the PYTHONPATH of the system is not set correctly.", e.what()));
         throw e;

--- a/python/cxx/log.cpp
+++ b/python/cxx/log.cpp
@@ -1,6 +1,7 @@
 #include <string>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/Logger.hpp>
 
 #include "export.hpp"
 
@@ -38,10 +39,12 @@ void note(const std::string& msg) {
 
 void python::common::export_Log(py::module& module)
 {
-    py::class_<OpmLog, std::shared_ptr<OpmLog> >( module, "OpmLog", R"(
+    py::class_<Logger, std::shared_ptr<Logger>>(module, "Logger");
+    py::class_<OpmLog>( module, "OpmLog", R"(
             The Opm::OpmLog class - this is a fully static class which manages a proper
             Logger instance.
         )")
+        .def_static("_setLogger", &OpmLog::setLogger, "Internal function to set the logger.")
         .def_static("info", info, "Add an info message to the opm log.")
         .def_static("warning", warning, "Add a warning message to the opm log.")
         .def_static("error", error, "Add an error message to the opm log.")

--- a/tests/logger.py
+++ b/tests/logger.py
@@ -1,0 +1,10 @@
+# The python code in this file does the same as ACT-01 to ACT-05 of opm-tests/actionx/ACTIONX_WCONPROD.DATA
+import opm_embedded
+
+opm_embedded.OpmLog.info("Info from logger.py!")
+opm_embedded.OpmLog.warning("Warning from logger.py!")
+opm_embedded.OpmLog.error("Error from logger.py!")
+opm_embedded.OpmLog.problem("Problem from logger.py!")
+opm_embedded.OpmLog.bug("Bug from logger.py!")
+opm_embedded.OpmLog.debug("Debug from logger.py!")
+opm_embedded.OpmLog.note("Note from logger.py!")


### PR DESCRIPTION
This PR fixes logging messages with the OpmLog from embedded Python code.
This used to work and then stopped working at some point, I've now added a test for this (https://github.com/OPM/opm-common/pull/4440/commits/07fb92733edd72b0014d8d920d577da6b8a879c4) and made the test pass.

The issue was that the internal logger of the static class OpmLog was not set when OpmLog was called from embedded python code.
I have added a function [setLogger](https://github.com/OPM/opm-common/pull/4440/files#diff-a70a2bb12ffbd4bb87c6cf329a5ca80fe3e2e99f93132c0e467c78fa6d082c89R56) to the OpmLog such that the Logger can be set using [a python function on the python object OpmLog](https://github.com/OPM/opm-common/pull/4440/files#diff-34cbbda5f94972afb132c4c5a03f2b881c4da5b820b74eb2ee1569aab9180cf7R47).

I'm happy to discuss other approaches to this!