### PR TITLE
Document Action Object Collection

### DIFF
--- a/opm/input/eclipse/Schedule/Action/Actions.cpp
+++ b/opm/input/eclipse/Schedule/Action/Actions.cpp
@@ -16,134 +16,167 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include <opm/input/eclipse/Schedule/Action/Actions.hpp>
+
 #include <opm/input/eclipse/Schedule/Action/ActionX.hpp>
 
 #include <algorithm>
+#include <cstddef>
+#include <ctime>
+#include <iterator>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
-namespace Opm {
-namespace Action {
+#include <fmt/format.h>
 
+namespace {
 
-Actions::Actions(const std::vector<ActionX>& action, const std::vector<PyAction>& pyaction)
-    : actions(action),
-      pyactions(pyaction)
+    template <typename ActionCollection>
+    auto findActionByName(ActionCollection&& actions,
+                          const std::string& name)
+    {
+        return std::find_if(std::begin(actions), std::end(actions),
+                            [&name](const auto& action)
+                            { return action.name() == name; });
+    }
+
+} // Anonymous namespace
+
+namespace Opm::Action {
+
+Actions::Actions(const std::vector<ActionX>&  action,
+                 const std::vector<PyAction>& pyaction)
+    : actions_   { action }
+    , pyactions_ { pyaction }
 {}
-
 
 Actions Actions::serializationTestObject()
 {
     Actions result;
-    result.actions = {ActionX::serializationTestObject()};
-    result.pyactions = {PyAction::serializationTestObject()};
+    result.actions_ = {ActionX::serializationTestObject()};
+    result.pyactions_ = {PyAction::serializationTestObject()};
 
     return result;
 }
 
-
-std::size_t Actions::ecl_size() const {
-    return this->actions.size();
-}
-
-std::size_t Actions::py_size() const {
-    return this->pyactions.size();
-}
-
-bool Actions::empty() const {
-    return this->actions.empty() && this->pyactions.empty();
-}
-
-
-void Actions::add(const ActionX& action) {
-    auto iter = std::find_if( this->actions.begin(), this->actions.end(), [&action](const ActionX& arg) { return arg.name() == action.name(); });
-    if (iter == this->actions.end())
-        this->actions.push_back(action);
+void Actions::add(const ActionX& action)
+{
+    auto iter = findActionByName(this->actions_, action.name());
+    if (iter == this->actions_.end()) {
+        this->actions_.push_back(action);
+    }
     else {
-        auto id = iter->id() + 1;
+        const auto id = iter->id() + 1;
+
         *iter = action;
         iter->update_id(id);
     }
 }
 
-void Actions::add(const PyAction& pyaction) {
-    auto iter = std::find_if( this->pyactions.begin(), this->pyactions.end(), [&pyaction](const PyAction& arg) { return arg.name() == pyaction.name(); });
-    if (iter == this->pyactions.end())
-        this->pyactions.push_back(pyaction);
-    else
+void Actions::add(const PyAction& pyaction)
+{
+    auto iter = findActionByName(this->pyactions_, pyaction.name());
+    if (iter == this->pyactions_.end()) {
+        this->pyactions_.push_back(pyaction);
+    }
+    else {
         *iter = pyaction;
+    }
 }
 
+std::size_t Actions::ecl_size() const
+{
+    return this->actions_.size();
+}
 
-const ActionX& Actions::operator[](const std::string& name) const {
-    const auto iter = std::find_if( this->actions.begin(), this->actions.end(), [&name](const ActionX& action) { return action.name() == name; });
-    if (iter == this->actions.end())
-        throw std::range_error("No such action: " + name);
+std::size_t Actions::py_size() const
+{
+    return this->pyactions_.size();
+}
+
+int Actions::max_input_lines() const
+{
+    std::size_t max_il = 0;
+
+    for (const auto& act : this->actions_) {
+        if (act.keyword_strings().size() > max_il) {
+            max_il = act.keyword_strings().size();
+        }
+    }
+
+    return static_cast<int>(max_il);
+}
+
+bool Actions::empty() const
+{
+    return this->actions_.empty() && this->pyactions_.empty();
+}
+
+bool Actions::ready(const State& state, const std::time_t sim_time) const
+{
+    return std::any_of(this->actions_.begin(), this->actions_.end(),
+                       [&state, sim_time](const auto& action)
+                       { return action.ready(state, sim_time); });
+}
+
+const ActionX& Actions::operator[](const std::string& name) const
+{
+    auto iter = findActionByName(this->actions_, name);
+    if (iter == this->actions_.end()) {
+        throw std::range_error {
+            fmt::format("ACTIONX named '{}' is not "
+                        "known in current run.", name)
+        };
+    }
 
     return *iter;
 }
 
-bool Actions::has(const std::string& name) const {
-    const auto iter = std::find_if( this->actions.begin(), this->actions.end(), [&name](const ActionX& action) { return action.name() == name; });
-    return (iter != this->actions.end());
-}
-
-
-const ActionX& Actions::operator[](std::size_t index) const {
-    return this->actions[index];
-}
-
-int Actions::max_input_lines() const {
-    std::size_t max_il = 0;
-    for (const auto& act : this-> actions) {
-        if (act.keyword_strings().size() > max_il) max_il = act.keyword_strings().size() ;
-    }
-    return static_cast<int>(max_il);
-}
-
-
-bool Actions::ready(const State& state, std::time_t sim_time) const
+const ActionX& Actions::operator[](const std::size_t index) const
 {
-    return std::any_of(this->actions.begin(), this->actions.end(),
-                        [&state, sim_time](const auto& action)
-                        {
-                            return action.ready(state, sim_time);
-                        });
+    return this->actions_[index];
 }
 
-std::vector<const PyAction *> Actions::pending_python(const State& state) const {
-    std::vector<const PyAction *> pyaction_vector;
-    for (const auto& pyaction : this->pyactions) {
-        if (pyaction.ready(state))
-            pyaction_vector.push_back( &pyaction );
+std::vector<const ActionX*>
+Actions::pending(const State& state, const std::time_t sim_time) const
+{
+    auto action_vector = std::vector<const ActionX*> {};
+
+    for (const auto& action : this->actions_) {
+        if (action.ready(state, sim_time)) {
+            action_vector.push_back(&action);
+        }
     }
-    return pyaction_vector;
 
-}
-
-
-std::vector<const ActionX *> Actions::pending(const State& state, std::time_t sim_time) const {
-    std::vector<const ActionX *> action_vector;
-    for (const auto& action : this->actions) {
-        if (action.ready(state, sim_time))
-            action_vector.push_back( &action );
-    }
     return action_vector;
 }
 
-std::vector<ActionX>::const_iterator Actions::begin() const {
-    return this->actions.begin();
+std::vector<const PyAction*>
+Actions::pending_python(const State& state) const
+{
+    auto pyaction_vector = std::vector<const PyAction*> {};
+
+    for (const auto& pyaction : this->pyactions_) {
+        if (pyaction.ready(state)) {
+            pyaction_vector.push_back(&pyaction);
+        }
+    }
+
+    return pyaction_vector;
 }
 
-std::vector<ActionX>::const_iterator Actions::end() const {
-    return this->actions.end();
+bool Actions::has(const std::string& name) const
+{
+    return findActionByName(this->actions_, name)
+        != this->actions_.end();
 }
 
-
-bool Actions::operator==(const Actions& data) const {
-    return this->actions == data.actions &&
-           this->pyactions == data.pyactions;
+bool Actions::operator==(const Actions& data) const
+{
+    return (this->actions_ == data.actions_)
+        && (this->pyactions_ == data.pyactions_);
 }
 
-}
-}
+} // namespace Opm::Action

--- a/opm/input/eclipse/Schedule/Action/Actions.hpp
+++ b/opm/input/eclipse/Schedule/Action/Actions.hpp
@@ -17,63 +17,180 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef ActionCOnfig_HPP
 #define ActionCOnfig_HPP
-
-#include <string>
-#include <ctime>
-#include <vector>
 
 #include <opm/input/eclipse/Schedule/Action/ActionX.hpp>
 #include <opm/input/eclipse/Schedule/Action/PyAction.hpp>
 
-namespace Opm {
-namespace Action {
+#include <cstddef>
+#include <ctime>
+#include <string>
+#include <vector>
+
+namespace Opm::Action {
 
 class State;
 
-/*
-  The Actions class is a container of ACTIONX keywords. The main functionality
-  is to provide a list of ACTIONX keywords which are ready to be evaluated.
-*/
+} // namespace Opm::Action
 
-class Actions {
+namespace Opm::Action {
+
+/// Container of action keywords.
+///
+/// Mainly provides a list of action keywords, i.e., ACTIONX and/or
+/// PYACTION, whose conditions are ready for evaluation.
+class Actions
+{
 public:
+    /// Default constructor.
+    ///
+    /// Resulting object is primarily useful as a target of a
+    /// deserialisation operation, although may be subsequently populated
+    /// through the add() member functions.
     Actions() = default;
-    Actions(const std::vector<ActionX>& action, const std::vector<PyAction>& pyactions);
 
+    /// Constructor.
+    ///
+    /// Forms collection from sequences of individual action objects.
+    ///
+    /// \param[in] action Sequence of action objects formed from ACTIONX
+    /// keywords.
+    ///
+    /// \param[in] pyactions Sequence of action objects formed from PYACTION
+    /// keywords.
+    Actions(const std::vector<ActionX>&  action,
+            const std::vector<PyAction>& pyactions);
+
+    /// Create a serialisation test object.
     static Actions serializationTestObject();
 
-    std::size_t py_size() const;
-    std::size_t ecl_size() const;
-    int max_input_lines() const;
-    bool empty() const;
+    /// Include ActionX object in current collection
+    ///
+    /// Any existing ActionX object with the same name will be replaced.
+    ///
+    /// \param[in] action Action object to include in the current
+    /// collection.
     void add(const ActionX& action);
+
+    /// Include PyAction object in current collection
+    ///
+    /// Any existing PyAction object with the same name will be replaced.
+    ///
+    /// \param[in] action Action object to include in the current
+    /// collection.
     void add(const PyAction& pyaction);
+
+    /// Number of ActionX objects in this collection.
+    std::size_t ecl_size() const;
+
+    /// Number of PyAction objects in this collection.
+    std::size_t py_size() const;
+
+    /// Maximum number of records in any one ACTIONX block.
+    ///
+    /// Needed for restart file output purposes.
+    int max_input_lines() const;
+
+    /// Whether or not this collection is empty.
+    ///
+    /// True if this collection has neither ActionX nor PyAction objects.
+    bool empty() const;
+
+    /// Runnability predicate.
+    ///
+    /// \param[in] state Current run's action state, especially run counts
+    /// and trigger times.
+    ///
+    /// \param[in] sim_time Current simulation time.
+    ///
+    /// \return Whether or not any ActionX objects in the current collection
+    /// are ready to run at time \p sim_time.
     bool ready(const State& state, std::time_t sim_time) const;
+
+    /// Look up ActionX object by name.
+    ///
+    /// Throws an exception of type \code std::range_error \endcode if no
+    /// ActionX object with the particular name exists in the current
+    /// collection.
+    ///
+    /// \param[in] name ActionX object name.
+    ///
+    /// \return ActionX object whose
     const ActionX& operator[](const std::string& name) const;
+
+    /// Look up ActionX object by linear index
+    ///
+    /// \param[in] index Object index.  Must be in the range
+    /// 0..ecl_size()-1.
+    ///
+    /// \return Associated ActionX object.
     const ActionX& operator[](std::size_t index) const;
-    std::vector<const ActionX *> pending(const State& state, std::time_t sim_time) const;
-    std::vector<const PyAction *> pending_python(const State& state) const;
 
+    /// Retrieve ActionX objects that are ready to run.
+    ///
+    /// List comprised of those ActionX objects from the internal collection
+    /// whose run counts have not exceeded their associate maximum limit,
+    /// and for which the minimum wait time since last execution has passed.
+    ///
+    /// \param[in] state Current run's action state, especially run counts
+    /// and trigger times.
+    ///
+    /// \param[in] sim_time Current simulation time.
+    ///
+    /// \return Those ActionX objects that are ready to run at this time.
+    std::vector<const ActionX*>
+    pending(const State& state, std::time_t sim_time) const;
+
+    /// Retrieve PyAction objects that are ready to run.
+    ///
+    /// \param[in] state Current run's action state, especially run counts.
+    ///
+    /// \return Those PyAction objects that are ready to run.
+    std::vector<const PyAction*> pending_python(const State& state) const;
+
+    /// ActionX object existence predicate
+    ///
+    /// \param[in] name Action name.
+    ///
+    /// \return Whether or not \p name is among this collection's ActionX
+    /// objects.
     bool has(const std::string& name) const;
-    std::vector<ActionX>::const_iterator begin() const;
-    std::vector<ActionX>::const_iterator end() const;
 
+    /// Beginning of this collection's ActionX objects.
+    auto begin() const { return this->actions_.begin(); }
+
+    /// End of this collection's ActionX objects.
+    auto end() const { return this->actions_.end(); }
+
+    /// Equality predicate.
+    ///
+    /// \param[in] data Object against which \code *this \endcode will
+    /// be tested for equality.
+    ///
+    /// \return Whether or not \code *this \endcode is the same as \p data.
     bool operator==(const Actions& data) const;
 
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
-        serializer(actions);
-        serializer(pyactions);
+        serializer(this->actions_);
+        serializer(this->pyactions_);
     }
 
 private:
-    std::vector<ActionX> actions;
-    std::vector<PyAction> pyactions;
+    /// Collection's ActionX objects.
+    std::vector<ActionX> actions_{};
+
+    /// Collection's PyAction objects.
+    std::vector<PyAction> pyactions_{};
 };
-}
-}
-#endif
+
+} // namespace Opm::Action
+
+#endif // ActionCOnfig_HPP


### PR DESCRIPTION
In particular, provide Doxygen-style documentation for the members of class Action::Actions.

While here, also tag data members with a trailing underscore, split name-based action object lookup out to a helper function, and split some long lines.