### PR TITLE
Simplify Action Condition Parsing API

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ActionAST.cpp
+++ b/opm/input/eclipse/Schedule/Action/ActionAST.cpp
@@ -21,9 +21,8 @@
 
 #include <opm/input/eclipse/Schedule/Action/ASTNode.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionContext.hpp>
+#include <opm/input/eclipse/Schedule/Action/ActionParser.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionValue.hpp>
-
-#include "ActionParser.hpp"
 
 #include <memory>
 #include <string>
@@ -33,7 +32,7 @@
 Opm::Action::AST::AST() = default;
 
 Opm::Action::AST::AST(const std::vector<std::string>& tokens)
-    : condition { std::make_unique<ASTNode>(::Opm::Action::Parser::parse(tokens)) }
+    : condition { Parser::parseCondition(tokens) }
 {}
 
 Opm::Action::AST::~AST() = default;

--- a/opm/input/eclipse/Schedule/Action/ActionParser.cpp
+++ b/opm/input/eclipse/Schedule/Action/ActionParser.cpp
@@ -17,13 +17,15 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "ActionParser.hpp"
+#include <opm/input/eclipse/Schedule/Action/ActionParser.hpp>
 
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 #include <algorithm>
-#include <cstdlib>
-#include <cstring>
+#include <cassert>
+#include <cstdlib>              // std::strtod()
+#include <cstring>              // std::strlen()
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -31,20 +33,518 @@
 
 #include <fmt/format.h>
 
-namespace Opm::Action {
+namespace {
 
-Parser::Parser(const std::vector<std::string>& tokens_arg)
-    : tokens(tokens_arg)
-{}
+/// Classify ACTIONX condition sub expression according to summary vector
+/// category.
+///
+/// Mostly needed to aid condition evaluation later.
+///
+/// \param[in] arg Condition sub expression.  Expected to be the name of a
+/// summary vector.
+///
+/// \return Summary function category of \p arg.
+Opm::Action::FuncType functionType(const std::string& arg)
+{
+    using FuncType = Opm::Action::FuncType;
 
-TokenType Parser::get_type(const std::string& arg)
+    if ((arg == "YEAR") || (arg == "DAY")) {
+        return FuncType::time;
+    }
+
+    if (arg == "MNTH") { return FuncType::time_month; }
+
+    using Cat = Opm::SummaryConfigNode::Category;
+
+    switch (Opm::parseKeywordCategory(arg)) {
+    case Cat::Aquifer:    return FuncType::aquifer;
+    case Cat::Well:       return FuncType::well;
+    case Cat::Group:      return FuncType::group;
+    case Cat::Connection: return FuncType::well_connection;
+    case Cat::Region:     return FuncType::region;
+    case Cat::Block:      return FuncType::block;
+    case Cat::Segment:    return FuncType::well_segment;
+    default:              return FuncType::none;
+    }
+}
+
+/// Convert string to lower case characters.
+///
+/// \param[in] arg Input string.  Assumed to contain characters in the basic
+/// execution character set only.
+///
+/// \return Lower case copy of input string \p arg.
+std::string makeLowercase(const std::string& arg)
 {
     std::string lower_arg = arg;
-    std::for_each(lower_arg.begin(),
-                  lower_arg.end(),
+
+    std::for_each(lower_arg.begin(), lower_arg.end(),
                   [](char& c) {
                       c = std::tolower(static_cast<unsigned char>(c));
                   });
+
+    return lower_arg;
+}
+
+/// Convert sequence of action condition textual tokens into an expression
+/// tree suitable for evaluation.
+///
+/// Client code is expected to construct an object and then call the
+/// buildParseTree() member function, typically within one or two
+/// statements.
+class ActionParser
+{
+public:
+    /// Constructor.
+    ///
+    /// Initiates parsing process by grabbing a reference to a sequence of
+    /// condition tokens.
+    ///
+    /// \param[in] tokens Sequence of concatenated condition string tokens
+    /// of a single ACTIONX condition block from which to form an expression
+    /// evaluation tree.  Newline characters and other whitespace assumed to
+    /// be removed.
+    explicit ActionParser(const std::vector<std::string>& tokens)
+        : tokens_ { tokens }
+    {}
+
+    /// Form expression evaluation tree from internal token sequence.
+    std::unique_ptr<Opm::Action::ASTNode> buildParseTree();
+
+private:
+    /// Expression parse tree node
+    ///
+    /// Associates a parse tree string token to a token type
+    struct Node
+    {
+        /// Default constructor.
+        Node() = default;
+
+        /// Constructor.
+        ///
+        /// \param[in] type_arg Condition token type, e.g., expression or
+        /// logical operator.
+        ///
+        /// \param[in] value_arg Condition token string value.
+        explicit Node(const Opm::Action::TokenType type_arg,
+                      const std::string& value_arg = "")
+            : type (type_arg)
+            , value(value_arg)
+        {}
+
+        /// Condition token type.
+        Opm::Action::TokenType type { Opm::Action::TokenType::error };
+
+        /// Condition token string value.
+        std::string value{};
+    };
+
+    /// Index type for a sequence of tokens.
+    using TokenSize = std::vector<std::string>::size_type;
+
+    /// Type for representing the current token position.
+    ///
+    /// Signed type to allow '-1' to represent an invalid position.
+    using CurrentPos = std::make_signed_t<TokenSize>;
+
+    /// Sequence of concatenated condition string tokens of a single ACTIONX
+    /// condition block.
+    ///
+    /// Newline characters and other whitespace assume to be removed.
+    /// Constructor argument.
+    const std::vector<std::string>& tokens_;
+
+    /// Current token position (index into tokens_).
+    ///
+    /// Default value -1 represents an invalid position.
+    CurrentPos current_pos_ = -1;
+
+    /// Retrieve the current string token.
+    ///
+    /// Will throw an exception of type std::logic_error if the
+    /// parseIsComplete().
+    ///
+    /// \return tokens_[current_pos_].
+    [[nodiscard]] const std::string& currentToken() const;
+
+    /// Retrieve the current token type.
+    ///
+    /// \return Token type of currentToken().  Special 'end' token if the
+    /// parseIsComplete().
+    [[nodiscard]] Opm::Action::TokenType currentType() const;
+
+    /// Construct a parse tree node from current token.
+    [[nodiscard]] Node current() const;
+
+    /// Process completion predicate.
+    ///
+    /// \return Whether or not we have consumed all input tokens, i.e.,
+    /// whether or not the current_pos_ is within the valid range of tokens_
+    [[nodiscard]] bool parseIsComplete() const;
+
+    /// Finish current token and advance to next token position.
+    void advanceTokenPosition();
+
+    /// Finish current token and advance to next.
+    ///
+    /// Convenience function which calls advanceTokenPosition() and returns
+    /// current() at that position.
+    ///
+    /// \return Next token.
+    [[nodiscard]] Node next();
+
+    /// Parse an arithmetic comparison.
+    ///
+    /// Current token sequence is expected to be of the form
+    ///
+    ///    Some Expression <OP> Some Other Expression
+    ///
+    /// in which <OP> is an arithmetic comparison operator such as '<' or
+    /// '.EQ.'.
+    ///
+    /// This function consumes tokens from tokens_ and advances the current
+    /// token position until either the comparison expression is complete,
+    /// we encounter a failure condition, or exhaust the token sequence.
+    ///
+    /// \return Parse tree for an arithmetic comparison.  Will return an
+    /// invalid parse tree (TokenType::error) if any of the following
+    /// conditions hold
+    ///
+    ///  * The left or right expressions could not be successfully parsed.
+    ///  * The operator <OP> was not recognised as an arithmetic operator.
+    [[nodiscard]] Opm::Action::ASTNode parse_cmp();
+
+    /// Parse an arithmetic comparison operator.
+    ///
+    /// This function consumes a single token from tokens_ and advances the
+    /// current token position if successful.  Otherwise, the current token
+    /// position is unchanged.
+    ///
+    /// \return AST node for an arithmetic comparison operator.  Invalid AST
+    /// node (TokenType::error) if currentToken() is not recognised as an
+    /// arithmetic operator.
+    [[nodiscard]] Opm::Action::ASTNode parse_op();
+
+    /// Parse an arithmetic expression to the left of a comparison operator
+    ///
+    /// This function consumes tokens from tokens_ and advances the current
+    /// token position as long as the tokens are expressions or numbers.
+    ///
+    /// \return AST node for an arithmetic expression.  Invalid AST node
+    /// (TokenType::error) if the current token on entry is not an
+    /// expression type token.
+    [[nodiscard]] Opm::Action::ASTNode parse_left();
+
+    /// Parse an arithmetic expression to the right of a comparison operator
+    ///
+    /// This function consumes tokens from tokens_ and advances the current
+    /// token position as long as the tokens are expressions or numbers.
+    ///
+    /// \return AST node for an arithmetic expression.  Invalid AST node
+    /// (TokenType::error) if the current token on entry is not an
+    /// expression type token.
+    [[nodiscard]] Opm::Action::ASTNode parse_right();
+
+    /// Parse a sequence of conjunction ('AND') clauses at the same level
+    ///
+    /// Current token sequence is expected to be of the form
+    ///
+    ///    Logical_1 (AND Logical_2 AND ... AND Logical_n)_opt
+    ///
+    /// in which 'Logical_i' are logical expression clauses such as
+    /// arithmetic comparisons (parse_cmp()) or some other kind of grouped
+    /// logical expressions.  All clauses, including the 'AND' operators,
+    /// other than 'Logical_1' are optional.
+    ///
+    /// This function consumes tokens and advances the current token
+    /// position as long as we're able to parse out sub clauses 'Logical_i'.
+    ///
+    /// \return Parse tree for a conjunction.  Invalid AST node if one of
+    /// the sub clauses generates a parse error.
+    [[nodiscard]] Opm::Action::ASTNode parse_and();
+
+    /// Parse a sequence of disjunction ('OR') clauses at the same level.
+    /// Current token sequence is expected to be of the form
+    ///
+    ///    Logical_1 (OR Logical_2 OR ... OR Logical_n)_opt
+    ///
+    /// in which 'Logical_i' are logical expression clauses.  All clauses,
+    /// including the 'OR' operators, other than 'Logical_1' are optional.
+    ///
+    /// This function consumes tokens and advances the current token
+    /// position as long as we're able to parse out sub clauses 'Logical_i'.
+    ///
+    /// \return Parse tree for a disjunction.  Invalid AST node if one of
+    /// the sub clauses generates a parse error.
+    [[nodiscard]] Opm::Action::ASTNode parse_or();
+};
+
+std::unique_ptr<Opm::Action::ASTNode> ActionParser::buildParseTree()
+{
+    if (const auto start_node = this->next();
+        start_node.type == Opm::Action::TokenType::end)
+    {
+        return std::make_unique<Opm::Action::ASTNode>(start_node.type);
+    }
+
+    auto tree = this->parse_or();
+
+    if (tree.type == Opm::Action::TokenType::error) {
+        throw std::invalid_argument {
+            "Failed to parse ACTIONX condition."
+        };
+    }
+
+    if (this->currentType() != Opm::Action::TokenType::end) {
+        throw std::invalid_argument {
+            fmt::format("Extra unhandled data starting with "
+                        "token[{}] = {} in ACTIONX condition",
+                        this->current_pos_, this->currentToken())
+        };
+    }
+
+    return std::make_unique<Opm::Action::ASTNode>(std::move(tree));
+}
+
+const std::string& ActionParser::currentToken() const
+{
+    if (this->parseIsComplete()) {
+        throw std::logic_error {
+            "Parse process proceeds beyond token sequence end"
+        };
+    }
+
+    return this->tokens_[this->current_pos_];
+}
+
+Opm::Action::TokenType ActionParser::currentType() const
+{
+    return this->parseIsComplete()
+        ? Opm::Action::TokenType::end
+        : Opm::Action::Parser::tokenType(this->currentToken());
+}
+
+ActionParser::Node ActionParser::current() const
+{
+    if (this->parseIsComplete()) {
+        return Node { Opm::Action::TokenType::end };
+    }
+
+    const auto& arg = this->currentToken();
+    return Node { Opm::Action::Parser::tokenType(arg), arg };
+}
+
+bool ActionParser::parseIsComplete() const
+{
+    assert (this->current_pos_ >= 0);
+
+    return static_cast<TokenSize>(this->current_pos_)
+        >= this->tokens_.size();
+}
+
+void ActionParser::advanceTokenPosition()
+{
+    ++this->current_pos_;
+}
+
+ActionParser::Node ActionParser::next()
+{
+    this->advanceTokenPosition();
+    return this->current();
+}
+
+Opm::Action::ASTNode ActionParser::parse_left()
+{
+    auto curr = this->current();
+    if (curr.type != Opm::Action::TokenType::ecl_expr) {
+        throw std::invalid_argument {
+            fmt::format("Expected expression as left hand side "
+                        "of comparison, but got {} instead.",
+                        curr.value)
+        };
+    }
+
+    // Note: Func must be an independent object here--i.e., not a
+    // reference--since we update 'curr' in the loop below.
+    const auto func = curr.value;
+    const auto func_type = functionType(curr.value);
+
+    auto arg_list = std::vector<std::string>{};
+
+    curr = this->next();
+    while ((curr.type == Opm::Action::TokenType::ecl_expr) ||
+           (curr.type == Opm::Action::TokenType::number))
+    {
+        arg_list.push_back(curr.value);
+        curr = this->next();
+    }
+
+    return Opm::Action::ASTNode {
+        Opm::Action::TokenType::ecl_expr, func_type, func, arg_list
+    };
+}
+
+Opm::Action::ASTNode ActionParser::parse_op()
+{
+    const auto curr = this->current();
+
+    if ((curr.type == Opm::Action::TokenType::op_gt) ||
+        (curr.type == Opm::Action::TokenType::op_ge) ||
+        (curr.type == Opm::Action::TokenType::op_lt) ||
+        (curr.type == Opm::Action::TokenType::op_le) ||
+        (curr.type == Opm::Action::TokenType::op_eq) ||
+        (curr.type == Opm::Action::TokenType::op_ne))
+    {
+        this->advanceTokenPosition();
+
+        return Opm::Action::ASTNode { curr.type };
+    }
+
+    return Opm::Action::ASTNode { Opm::Action::TokenType::error };
+}
+
+Opm::Action::ASTNode ActionParser::parse_right()
+{
+    auto curr = this->current();
+    if (curr.type == Opm::Action::TokenType::number) {
+        this->advanceTokenPosition();
+
+        return Opm::Action::ASTNode {
+            std::strtod(curr.value.c_str(), nullptr)
+        };
+    }
+
+    curr = this->current();
+    if (curr.type != Opm::Action::TokenType::ecl_expr) {
+        return Opm::Action::ASTNode { Opm::Action::TokenType::error };
+    }
+
+    // Note: Func must be an independent object here--i.e., not a
+    // reference--since we update 'curr' in the loop below.
+    const auto func = curr.value;
+    const auto func_type = Opm::Action::FuncType::none;
+
+    auto arg_list = std::vector<std::string>{};
+
+    curr = this->next();
+    while ((curr.type == Opm::Action::TokenType::ecl_expr) ||
+           (curr.type == Opm::Action::TokenType::number))
+    {
+        arg_list.push_back(curr.value);
+        curr = this->next();
+    }
+
+    return Opm::Action::ASTNode {
+        Opm::Action::TokenType::ecl_expr, func_type, func, arg_list
+    };
+}
+
+Opm::Action::ASTNode ActionParser::parse_cmp()
+{
+    if (this->currentType() == Opm::Action::TokenType::open_paren) {
+        this->advanceTokenPosition(); // Consume "("
+
+        const auto inner_expr = this->parse_or();
+
+        if (this->currentType() != Opm::Action::TokenType::close_paren) {
+            return Opm::Action::ASTNode { Opm::Action::TokenType::error };
+        }
+
+        this->advanceTokenPosition(); // Consume ")"
+
+        return inner_expr;
+    }
+
+    auto left_node = this->parse_left();
+    if (left_node.type == Opm::Action::TokenType::error) {
+        return Opm::Action::ASTNode { Opm::Action::TokenType::error };
+    }
+
+    auto op_node = this->parse_op();
+    if (op_node.type == Opm::Action::TokenType::error) {
+        return Opm::Action::ASTNode { Opm::Action::TokenType::error };
+    }
+
+    auto right_node = this->parse_right();
+    if (right_node.type == Opm::Action::TokenType::error) {
+        return Opm::Action::ASTNode { Opm::Action::TokenType::error };
+    }
+
+    op_node.add_child(std::move(left_node));
+    op_node.add_child(std::move(right_node));
+
+    return op_node;
+}
+
+Opm::Action::ASTNode ActionParser::parse_and()
+{
+    auto left = this->parse_cmp();
+    if (left.type == Opm::Action::TokenType::error) {
+        return Opm::Action::ASTNode { Opm::Action::TokenType::error };
+    }
+
+    if (this->currentType() != Opm::Action::TokenType::op_and) {
+        return left;
+    }
+
+    auto and_node = Opm::Action::ASTNode { Opm::Action::TokenType::op_and };
+    and_node.add_child(std::move(left));
+
+    while (this->currentType() == Opm::Action::TokenType::op_and) {
+        this->advanceTokenPosition();
+
+        auto next_cmp = this->parse_cmp();
+        if (next_cmp.type == Opm::Action::TokenType::error) {
+            return Opm::Action::ASTNode { Opm::Action::TokenType::error };
+        }
+
+        and_node.add_child(std::move(next_cmp));
+    }
+
+    return and_node;
+}
+
+Opm::Action::ASTNode ActionParser::parse_or()
+{
+    auto left = this->parse_and();
+    if (left.type == Opm::Action::TokenType::error) {
+        return Opm::Action::ASTNode { Opm::Action::TokenType::error };
+    }
+
+    if (this->currentType() != Opm::Action::TokenType::op_or) {
+        return left;
+    }
+
+    auto or_node = Opm::Action::ASTNode { Opm::Action::TokenType::op_or };
+    or_node.add_child(std::move(left));
+
+    while (this->currentType() == Opm::Action::TokenType::op_or) {
+        this->advanceTokenPosition();
+
+        auto next_cmp = this->parse_or();
+        if (next_cmp.type == Opm::Action::TokenType::error) {
+            return Opm::Action::ASTNode { Opm::Action::TokenType::error };
+        }
+
+        or_node.add_child(std::move(next_cmp));
+    }
+
+    return or_node;
+}
+
+} // Anonymous namespace
+
+namespace Opm::Action::Parser {
+
+std::unique_ptr<ASTNode>
+parseCondition(const std::vector<std::string>& tokens)
+{
+    return ActionParser{tokens}.buildParseTree();
+}
+
+TokenType tokenType(const std::string& arg)
+{
+    const auto lower_arg = makeLowercase(arg);
 
     if (lower_arg == "and") {
         return TokenType::op_and;
@@ -86,6 +586,11 @@ TokenType Parser::get_type(const std::string& arg)
         return TokenType::op_ne;
     }
 
+    // Check if 'arg' is a number.
+    //
+    // Might want to switch to std::from_chars() here, or possibly a
+    // different function, one that recognises numbers like 0.123D+4,
+    // instead.
     {
         char* end_ptr = nullptr;
         std::strtod(lower_arg.c_str(), &end_ptr);
@@ -98,243 +603,4 @@ TokenType Parser::get_type(const std::string& arg)
     return TokenType::ecl_expr;
 }
 
-FuncType Parser::get_func(const std::string& arg)
-{
-    if (arg == "YEAR") return FuncType::time;
-    if (arg == "MNTH") return FuncType::time_month;
-    if (arg == "DAY")  return FuncType::time;
-
-    using Cat = SummaryConfigNode::Category;
-    SummaryConfigNode::Category cat = parseKeywordCategory(arg);
-    switch (cat) {
-        case Cat::Aquifer:    return FuncType::aquifer;
-        case Cat::Well:       return FuncType::well;
-        case Cat::Group:      return FuncType::group;
-        case Cat::Connection: return FuncType::well_connection;
-        case Cat::Region:     return FuncType::region;
-        case Cat::Block:      return FuncType::block;
-        case Cat::Segment:    return FuncType::well_segment;
-        default:              return FuncType::none;
-    }
-}
-
-ParseNode Parser::next()
-{
-    this->current_pos++;
-    if (static_cast<size_t>(this->current_pos) == this->tokens.size()) {
-        return ParseNode(TokenType::end);
-    }
-
-    std::string arg = this->tokens[this->current_pos];
-    return ParseNode(get_type(arg), arg);
-}
-
-ParseNode Parser::current() const
-{
-    if (static_cast<size_t>(this->current_pos) == this->tokens.size()) {
-        return ParseNode(TokenType::end);
-    }
-
-    std::string arg = this->tokens[this->current_pos];
-    return ParseNode(get_type(arg), arg);
-}
-
-ASTNode Parser::parse_left()
-{
-    auto curr = this->current();
-    if (curr.type != TokenType::ecl_expr) {
-        throw std::invalid_argument {
-            fmt::format("Expected expression as left hand side "
-                        "of comparison, but got {} instead.",
-                        curr.value)
-        };
-    }
-
-    std::string func = curr.value;
-    FuncType func_type = get_func(curr.value);
-    std::vector<std::string> arg_list;
-    curr = this->next();
-    while ((curr.type == TokenType::ecl_expr) ||
-           (curr.type == TokenType::number))
-    {
-        arg_list.push_back(curr.value);
-        curr = this->next();
-    }
-
-    return ASTNode { TokenType::ecl_expr, func_type, func, arg_list };
-}
-
-ASTNode Parser::parse_op()
-{
-    const auto curr = this->current();
-
-    if ((curr.type == TokenType::op_gt) ||
-        (curr.type == TokenType::op_ge) ||
-        (curr.type == TokenType::op_lt) ||
-        (curr.type == TokenType::op_le) ||
-        (curr.type == TokenType::op_eq) ||
-        (curr.type == TokenType::op_ne))
-    {
-        this->next();
-
-        return ASTNode { curr.type };
-    }
-
-    return ASTNode { TokenType::error };
-}
-
-ASTNode Parser::parse_right()
-{
-    auto curr = this->current();
-    if (curr.type == TokenType::number) {
-        this->next();
-        return ASTNode { strtod(curr.value.c_str(), nullptr) };
-    }
-
-    curr = this->current();
-    if (curr.type != TokenType::ecl_expr) {
-        return ASTNode { TokenType::error };
-    }
-
-    std::string func = curr.value;
-    FuncType func_type = FuncType::none;
-    std::vector<std::string> arg_list;
-    curr = this->next();
-    while ((curr.type == TokenType::ecl_expr) ||
-           (curr.type == TokenType::number))
-    {
-        arg_list.push_back(curr.value);
-        curr = this->next();
-    }
-
-    return ASTNode { TokenType::ecl_expr, func_type, func, arg_list };
-}
-
-ASTNode Parser::parse_cmp()
-{
-    auto curr = this->current();
-
-    if (curr.type == TokenType::open_paren) {
-        this->next();
-        auto inner_expr = this->parse_or();
-
-        curr = this->current();
-        if (curr.type != TokenType::close_paren) {
-            return ASTNode { TokenType::error };
-        }
-
-        this->next();
-
-        return ASTNode { inner_expr };
-    }
-    else {
-        auto left_node = this->parse_left();
-        if (left_node.type == TokenType::error) {
-            return ASTNode { TokenType::error };
-        }
-
-        auto op_node = this->parse_op();
-        if (op_node.type == TokenType::error) {
-            return ASTNode { TokenType::error };
-        }
-
-        auto right_node = this->parse_right();
-        if (right_node.type == TokenType::error) {
-            return ASTNode { TokenType::error };
-        }
-
-        op_node.add_child(std::move(left_node));
-        op_node.add_child(std::move(right_node));
-
-        return op_node;
-    }
-}
-
-ASTNode Parser::parse_and()
-{
-    auto left = this->parse_cmp();
-    if (left.type == TokenType::error) {
-        return ASTNode { TokenType::error };
-    }
-
-    auto curr = this->current();
-    if (curr.type == TokenType::op_and) {
-        ASTNode and_node(TokenType::op_and);
-        and_node.add_child(std::move(left));
-
-        while (this->current().type == TokenType::op_and) {
-            this->next();
-            auto next_cmp = this->parse_cmp();
-            if (next_cmp.type == TokenType::error) {
-                return ASTNode { TokenType::error };
-            }
-
-            and_node.add_child(std::move(next_cmp));
-        }
-
-        return and_node;
-    }
-
-    return left;
-}
-
-ASTNode Parser::parse_or()
-{
-    auto left = this->parse_and();
-    if (left.type == TokenType::error) {
-        return ASTNode { TokenType::error };
-    }
-
-    auto curr = this->current();
-    if (curr.type == TokenType::op_or) {
-        ASTNode or_node(TokenType::op_or);
-        or_node.add_child(std::move(left));
-
-        while (this->current().type == TokenType::op_or) {
-            this->next();
-            auto next_cmp = this->parse_or();
-            if (next_cmp.type == TokenType::error) {
-                return ASTNode { TokenType::error };
-            }
-
-            or_node.add_child(std::move(next_cmp));
-        }
-
-        return or_node;
-    }
-
-    return left;
-}
-
-ASTNode Parser::parse(const std::vector<std::string>& tokens)
-{
-    Parser parser(tokens);
-
-    auto start_node = parser.next();
-    if (start_node.type == TokenType::end) {
-        return ASTNode { start_node.type };
-    }
-
-    auto tree = parser.parse_or();
-
-    if (tree.type == TokenType::error) {
-        throw std::invalid_argument {
-            "Failed to parse ACTIONX condition."
-        };
-    }
-
-    auto curr = parser.current();
-    if (curr.type != TokenType::end) {
-        const auto index = parser.current_pos;
-
-        throw std::invalid_argument {
-            fmt::format("Extra unhandled data starting with "
-                        "token[{}] = {} in ACTIONX condition",
-                        index, curr.value)
-        };
-    }
-
-    return tree;
-}
-
-} // namespace Opm::Action
+} // namespace Opm::Action::Parser

--- a/opm/input/eclipse/Schedule/Action/ActionParser.hpp
+++ b/opm/input/eclipse/Schedule/Action/ActionParser.hpp
@@ -24,51 +24,27 @@
 #include <opm/input/eclipse/Schedule/Action/ActionValue.hpp>
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
-namespace Opm::Action {
+namespace Opm::Action::Parser {
+    /// Form expression evaluation tree from sequence of condition tokens.
+    ///
+    /// \param[in] tokens Sequence of concatenated condition string tokens
+    /// of a single ACTIONX condition block from which to form an expression
+    /// evaluation tree.  Newline characters and other whitespace assumed to
+    /// be removed.
+    [[nodiscard]] std::unique_ptr<ASTNode>
+    parseCondition(const std::vector<std::string>& tokens);
 
-struct ParseNode
-{
-    ParseNode(TokenType type_arg, const std::string& value_arg)
-        : type (type_arg)
-        , value(value_arg)
-    {}
-
-    // Implicit converting constructor.
-    explicit ParseNode(TokenType type_arg)
-        : ParseNode(type_arg, "")
-    {}
-
-    TokenType type;
-    std::string value;
-};
-
-class Parser
-{
-public:
-    static Action::ASTNode parse(const std::vector<std::string>& tokens);
-    static TokenType get_type(const std::string& arg);
-    static FuncType get_func(const std::string& arg);
-
-private:
-    explicit Parser(const std::vector<std::string>& tokens);
-
-    ParseNode current() const;
-    ParseNode next();
-    size_t pos() const;
-    Action::ASTNode parse_cmp();
-    Action::ASTNode parse_op();
-    Action::ASTNode parse_left();
-    Action::ASTNode parse_right();
-    Action::ASTNode parse_and();
-    Action::ASTNode parse_or();
-
-    const std::vector<std::string>& tokens;
-    std::int64_t current_pos = -1;
-};
-
-} // namespace Opm::Action
+    /// Classify an Action condition string token.
+    ///
+    /// \param[in] arg Action condition string token.
+    ///
+    /// \return Kind of token contained in \p arg, e.g., an expression, an
+    /// operator or a parenthesis.
+    [[nodiscard]] TokenType tokenType(const std::string& arg);
+} // namespace Opm::Action::Parser
 
 #endif // ACTION_PARSER_HPP

--- a/opm/input/eclipse/Schedule/Action/ActionX.cpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.cpp
@@ -23,8 +23,9 @@
 
 #include <opm/io/eclipse/rst/action.hpp>
 
-#include <opm/input/eclipse/Schedule/Action/ActionValue.hpp>
 #include <opm/input/eclipse/Schedule/Action/Actdims.hpp>
+#include <opm/input/eclipse/Schedule/Action/ActionParser.hpp>
+#include <opm/input/eclipse/Schedule/Action/ActionValue.hpp>
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
 

--- a/opm/input/eclipse/Schedule/Action/Condition.cpp
+++ b/opm/input/eclipse/Schedule/Action/Condition.cpp
@@ -157,7 +157,7 @@ Condition::Condition(const std::vector<std::string>& tokens, const KeywordLocati
         if (token_index >= tokens.size())
             break;
 
-        auto comp = comparator( Parser::get_type(tokens[token_index]) );
+        const auto comp = comparator(Parser::tokenType(tokens[token_index]));
         if (comp == Comparator::INVALID) {
             this->lhs.add_arg(tokens[token_index]);
             token_index += 1;
@@ -179,7 +179,7 @@ Condition::Condition(const std::vector<std::string>& tokens, const KeywordLocati
         if (token_index >= tokens.size())
             break;
 
-        auto token_type = Parser::get_type(tokens[token_index]);
+        const auto token_type = Parser::tokenType(tokens[token_index]);
         if (token_type == TokenType::op_and)
             this->logic = Logical::AND;
         else if (token_type == TokenType::op_or)


### PR DESCRIPTION
Client code does not need to know that we have a stateful object which tracks the current "token position" while recursively constructing the condition tree.  To this end, move the "parser" type into the .cpp file and provide a top-level entry point,
```C++
unique_ptr<ASTNode> parseCondition(const vector<string>& tokens)
```
that will form the actual condition evaluation tree (`ASTNode`).  This also removes the otherwise orphaned `ParseNode` type.  We return a `unique_ptr` because that's directly usable in the `AST` type (PR #4442).

While here, also add a bit of documentation to the parser's member functions to help future maintainers understand each function's role&ndash;especially the `parse_*()` functions.