### PR TITLE
prune support for old cmake versions in build system

### DIFF
--- a/cmake/Modules/OpmDefaults.cmake
+++ b/cmake/Modules/OpmDefaults.cmake
@@ -50,17 +50,6 @@ macro (opm_defaults opm)
 
   # Use of OpenMP is considered experimental
   set (USE_OPENMP_DEFAULT ON)
-
-  # if we are on a system where CMake 2.6 is the default (Hi RHEL 6!),
-  # the configuration files for Boost will trip up the library paths
-  # (look for /usr/lib64/lib64/ in the log) when used with FindBoost
-  # module bundled with CMake 2.8. this can be circumvented by turning
-  # off config mode probing if we have not explicitly specified a
-  # directory to look for it. for more details, see
-  # <http://stackoverflow.com/questions/9948375/cmake-find-package-succeeds-but-returns-wrong-path>
-  if (NOT BOOST_ROOT)
-	set (Boost_NO_BOOST_CMAKE ON)
-  endif (NOT BOOST_ROOT)
 endmacro (opm_defaults opm)
 
 # overwrite a cache entry's value, but keep docstring and type

--- a/cmake/Modules/OpmInit.cmake
+++ b/cmake/Modules/OpmInit.cmake
@@ -46,22 +46,6 @@ macro(OpmSetPolicies)
   if(POLICY CMP0074)
     cmake_policy(SET CMP0074 NEW)
   endif()
-
-  # include special
-  if (CMAKE_VERSION VERSION_LESS "2.8.3")
-    message (STATUS "Enabling compatibility modules for CMake 2.8.3")
-    list (APPEND CMAKE_MODULE_PATH "${OPM_MACROS_ROOT}/cmake/Modules/compat-2.8.3")
-  endif (CMAKE_VERSION VERSION_LESS "2.8.3")
-
-  if (CMAKE_VERSION VERSION_LESS "2.8.5")
-    message (STATUS "Enabling compatibility modules for CMake 2.8.5")
-    list (APPEND CMAKE_MODULE_PATH "${OPM_MACROS_ROOT}/cmake/Modules/compat-2.8.5")
-  endif (CMAKE_VERSION VERSION_LESS "2.8.5")
-
-  if (CMAKE_VERSION VERSION_LESS "2.8.7")
-    message (STATUS "Enabling compatibility modules for CMake 2.8.7")
-    list (APPEND CMAKE_MODULE_PATH "${OPM_MACROS_ROOT}/cmake/Modules/compat-2.8.7")
-  endif (CMAKE_VERSION VERSION_LESS "2.8.7")
 endmacro()
 
 

--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -100,15 +100,10 @@ macro (opm_compile_satellites opm satellite excl_all test_regexp)
       if(MPI_FOUND)
         set(_sat_LOC ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 1 ${_sat_LOC})
       endif()
-      if (CMAKE_VERSION VERSION_LESS "2.8.4")
-        add_test (NAME ${_sat_FANCY}
-                  COMMAND ${CMAKE_COMMAND} -E chdir "${PROJECT_BINARY_DIR}/${${satellite}_DIR}" ${_sat_LOC})
-      else (CMAKE_VERSION VERSION_LESS "2.8.4")
       add_test (${_sat_FANCY} ${_sat_LOC})
       # run the test in the directory where the data files are
       set_tests_properties (${_sat_FANCY} PROPERTIES
                             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${${satellite}_DIR})
-      endif (CMAKE_VERSION VERSION_LESS "2.8.4")
       if(NOT TARGET test-suite)
         add_custom_target(test-suite)
       endif()


### PR DESCRIPTION
minimum version (as indicated with cmake_minium_required) is atleast 3.10 which was released in 2017