### PR TITLE
Add Virtual Destructor to SimpleTable

### DIFF
--- a/opm/input/eclipse/EclipseState/Tables/SimpleTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/SimpleTable.hpp
@@ -39,6 +39,8 @@ namespace Opm {
         SimpleTable(TableSchema, const std::string& tableName, const DeckItem& deckItem, const int tableID);
         explicit SimpleTable( TableSchema );
 
+        virtual ~SimpleTable() = default;
+
         static SimpleTable serializationTestObject();
 
         void addColumns();


### PR DESCRIPTION
The `TableContainer` manages pointers to types derived from this base class so for orderly destruction we really should have virtual destructors here.