### PR TITLE
Do not try to restore UDQ unit strings as UDQ vars

### DIFF
--- a/opm/output/eclipse/LoadRestart.cpp
+++ b/opm/output/eclipse/LoadRestart.cpp
@@ -1523,7 +1523,10 @@ namespace {
             ? multiSegmentWells(schedule[simStep], allWells)
             : std::vector<std::string>{};
 
+        std::size_t i = 0;
         for (const auto& udq : udqs.zudn()) {
+            if(i++ % 2) continue; // Odd elements are the UDQ unit strings
+
             switch (udq.front()) {
             case 'F':
                 restoreFieldUDQValue(udqs, udq, smry);


### PR DESCRIPTION
Empty UDQ names ('________') may be written to the restart file, which cause empty UDQ strings upon load, and assertion failure in `udq.front()`...