### PR TITLE
FastSmallVector: initialize array member

### DIFF
--- a/opm/material/common/FastSmallVector.hpp
+++ b/opm/material/common/FastSmallVector.hpp
@@ -210,7 +210,7 @@ private:
             dataPtr_ = smallBuf_.data();
     }
 
-    std::array<ValueType, N> smallBuf_;
+    std::array<ValueType, N> smallBuf_{};
     std::vector<ValueType> data_;
     size_type size_;
     ValueType* dataPtr_;


### PR DESCRIPTION
Quells downstream warning

```
In file included from /home/akva/kode/opm/opm-common/opm/material/densead/EvaluationSpecializations.hpp:34,
                 from /home/akva/kode/opm/opm-common/opm/material/densead/Evaluation.hpp:631,
                 from /home/akva/kode/opm/opm-simulators/opm/simulators/aquifers/AquiferAnalytical.hpp:32,
                 from /home/akva/kode/opm/opm-simulators/opm/simulators/aquifers/AquiferCarterTracy.hpp:30,
                 from /home/akva/kode/opm/opm-simulators/opm/simulators/aquifers/BlackoilAquiferModel.hpp:32,
                 from /home/akva/kode/opm/opm-simulators/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp:43,
                 from /home/akva/kode/opm/opm-simulators/flow/flow_oilwater_polymer.cpp:25:
In member function ‘Opm::DenseAd::Evaluation<ValueT, -1, staticSize>& Opm::DenseAd::Evaluation<ValueT, -1, staticSize>::operator-=(const RhsValueType&) [with RhsValueType = double; ValueT = double; unsigned int staticSize = 7]’,
    inlined from ‘Opm::DenseAd::Evaluation<ValueT, -1, staticSize> Opm::DenseAd::Evaluation<ValueT, -1, staticSize>::operator-(const RhsValueType&) const [with RhsValueType = double; ValueT = double; unsigned int staticSize = 7]’ at /home/akva/kode/opm/opm-common/opm/material/densead/DynamicEvaluation.hpp:382:16,
    inlined from ‘Evaluation Opm::Tabulated1DFunction<Scalar>::eval(const Evaluation&, Opm::SegmentIndex) const [with Evaluation = Opm::DenseAd::Evaluation<double, -1, 7>; Scalar = double]’ at /home/akva/kode/opm/opm-common/opm/material/common/Tabulated1DFunction.hpp:278:34,
    inlined from ‘Evaluation Opm::Tabulated1DFunction<Scalar>::eval(const Evaluation&, bool) const [with Evaluation = Opm::DenseAd::Evaluation<double, -1, 7>; Scalar = double]’ at /home/akva/kode/opm/opm-common/opm/material/common/Tabulated1DFunction.hpp:265:30,
    inlined from ‘Opm::BlackOilPolymerModule<Opm::Properties::TTag::FlowOilWaterPolymerProblem, true>::computeShearFactor<Opm::DenseAd::Evaluation<double, -1, 7> >(const Opm::DenseAd::Evaluation<double, -1, 7>&, unsigned int, const Opm::DenseAd::Evaluation<double, -1, 7>&)::<lambda(const Opm::DenseAd::Evaluation<double, -1, 7>&)>’ at /home/akva/kode/opm/opm-simulators/opm/models/blackoil/blackoilpolymermodules.hh:499:53,
    inlined from ‘static Evaluation Opm::BlackOilPolymerModule<TypeTag, enablePolymerV>::computeShearFactor(const Evaluation&, unsigned int, const Evaluation&) [with Evaluation = Opm::DenseAd::Evaluation<double, -1, 7>; TypeTag = Opm::Properties::TTag::FlowOilWaterPolymerProblem; bool enablePolymerV = true]’ at /home/akva/kode/opm/opm-simulators/opm/models/blackoil/blackoilpolymermodules.hh:512:18:
/home/akva/kode/opm/opm-common/opm/material/densead/DynamicEvaluation.hpp:274:28: warning: ‘<unnamed>.Opm::DenseAd::Evaluation<double, -1, 7>::data_.Opm::FastSmallVector<double, 7>::smallBuf_.std::array<double, 7>::_M_elems[0]’ may be used uninitialized [-Wmaybe-uninitialized]
  274 |         data_[valuepos_()] -= other;
      |         ~~~~~~~~~~~~~~~~~~~^~~~~~~~
```