### PR TITLE
BlackoilFluidSystem: use int for component indices

### DIFF
--- a/opm/material/fluidsystems/BlackOilDefaultIndexTraits.hpp
+++ b/opm/material/fluidsystems/BlackOilDefaultIndexTraits.hpp
@@ -37,18 +37,18 @@ class BlackOilDefaultIndexTraits
 {
 public:
     //! Index of the water phase
-    static const unsigned waterPhaseIdx = 0;
+    static constexpr unsigned waterPhaseIdx = 0;
     //! Index of the oil phase
-    static const unsigned oilPhaseIdx = 1;
+    static constexpr unsigned oilPhaseIdx = 1;
     //! Index of the gas phase
-    static const unsigned gasPhaseIdx = 2;
+    static constexpr unsigned gasPhaseIdx = 2;
 
     //! Index of the oil component
-    static const unsigned oilCompIdx = 0;
+    static constexpr int oilCompIdx = 0;
     //! Index of the water component
-    static const unsigned waterCompIdx = 1;
+    static constexpr int waterCompIdx = 1;
     //! Index of the gas component
-    static const unsigned gasCompIdx = 2;
+    static constexpr int gasCompIdx = 2;
 };
 
 } // namespace Opm

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -385,11 +385,11 @@ public:
     static constexpr unsigned numComponents = 3;
 
     //! Index of the oil component
-    static constexpr unsigned oilCompIdx = IndexTraits::oilCompIdx;
+    static constexpr int oilCompIdx = IndexTraits::oilCompIdx;
     //! Index of the water component
-    static constexpr unsigned waterCompIdx = IndexTraits::waterCompIdx;
+    static constexpr int waterCompIdx = IndexTraits::waterCompIdx;
     //! Index of the gas component
-    static constexpr unsigned gasCompIdx = IndexTraits::gasCompIdx;
+    static constexpr int gasCompIdx = IndexTraits::gasCompIdx;
 
 protected:
     static unsigned char numActivePhases_;


### PR DESCRIPTION
The one/two phase indices class uses negative values for inactive components (though not really relevant, but it's a source of confusion). Likewise, the GenericOilGasFluidSystem uses ints. 

To avoid nasty casts in generic code, make the fluidsystems consistently use int, even though the blackoil indices are always positive.