### PR TITLE
Unify parsing lines starting with slash

### DIFF
--- a/opm/input/eclipse/Parser/Parser.cpp
+++ b/opm/input/eclipse/Parser/Parser.cpp
@@ -671,9 +671,9 @@ void ParserState::handleRandomText(const std::string_view& keywordString) const
 
     std::string errorKey{};
     std::string msg{};
-    if (trimmedCopy == "/") {
+    if (trimmedCopy[0] == '/') {
         errorKey = ParseContext::PARSE_RANDOM_SLASH;
-        msg = "Extra '/' detected in {file} line {line}";
+        msg = "Extra line starting with '/' detected in {file} line {line}";
     }
     else if (lastSizeType == OTHER_KEYWORD_IN_DECK) {
         errorKey = ParseContext::PARSE_EXTRA_RECORDS;

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -297,6 +297,12 @@ BOOST_AUTO_TEST_CASE(TestRandomSlash) {
         "  10 10 10 /\n"
         "   /\n";
 
+    const char * deck3 =
+        "SCHEDULE\n"
+        "TSTEP\n"
+        "  10 10 10 /\n"
+        "   //\n"
+        "/ any comment\n";
 
     ErrorGuard errors;
     ParseContext parseContext;
@@ -310,12 +316,14 @@ BOOST_AUTO_TEST_CASE(TestRandomSlash) {
     parseContext.update(ParseContext::PARSE_RANDOM_TEXT , InputErrorAction::IGNORE);
     BOOST_CHECK_THROW( parser.parseString( deck1 , parseContext, errors ) , OpmInputError);
     BOOST_CHECK_THROW( parser.parseString( deck2 , parseContext, errors ) , OpmInputError);
+    BOOST_CHECK_THROW( parser.parseString( deck3 , parseContext, errors ) , OpmInputError);
 
 
     parseContext.update(ParseContext::PARSE_RANDOM_SLASH , InputErrorAction::IGNORE);
     parseContext.update(ParseContext::PARSE_RANDOM_TEXT , InputErrorAction::THROW_EXCEPTION);
     BOOST_CHECK_NO_THROW( parser.parseString( deck1 , parseContext, errors ) );
     BOOST_CHECK_NO_THROW( parser.parseString( deck2 , parseContext, errors ) );
+    BOOST_CHECK_NO_THROW( parser.parseString( deck3 , parseContext, errors ) );
 }
 
 


### PR DESCRIPTION
When the file is parsed, anything after '/' is treated as a comment with one exception. When parser expects a keyword but the line contains something else, the function `handleRandomText` (which body was addressed in this commit) is called. If the line contains only a single '/', the response depends on the `PARSE_RANDOM_SLASH` variable (throw, warn, or ignore). 

This is the only place where the text after '/' makes a difference and this commit removes the irregularity.