### PR TITLE
[WIP] Test for changes in parsing random slash with master

### DIFF
--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -297,6 +297,12 @@ BOOST_AUTO_TEST_CASE(TestRandomSlash) {
         "  10 10 10 /\n"
         "   /\n";
 
+    const char * deck3 =
+        "SCHEDULE\n"
+        "TSTEP\n"
+        "  10 10 10 /\n"
+        "   //\n"
+        "/ any comment\n";
 
     ErrorGuard errors;
     ParseContext parseContext;
@@ -310,12 +316,14 @@ BOOST_AUTO_TEST_CASE(TestRandomSlash) {
     parseContext.update(ParseContext::PARSE_RANDOM_TEXT , InputErrorAction::IGNORE);
     BOOST_CHECK_THROW( parser.parseString( deck1 , parseContext, errors ) , OpmInputError);
     BOOST_CHECK_THROW( parser.parseString( deck2 , parseContext, errors ) , OpmInputError);
+    BOOST_CHECK_THROW( parser.parseString( deck3 , parseContext, errors ) , OpmInputError);
 
 
     parseContext.update(ParseContext::PARSE_RANDOM_SLASH , InputErrorAction::IGNORE);
     parseContext.update(ParseContext::PARSE_RANDOM_TEXT , InputErrorAction::THROW_EXCEPTION);
     BOOST_CHECK_NO_THROW( parser.parseString( deck1 , parseContext, errors ) );
     BOOST_CHECK_NO_THROW( parser.parseString( deck2 , parseContext, errors ) );
+    BOOST_CHECK_NO_THROW( parser.parseString( deck3 , parseContext, errors ) );
 }
 
 


### PR DESCRIPTION
This is to show that the tests added in #4462 fail with master. It is just adding the test of the PRE.

The error message is a bit suprising and unhelpful:
```
139: Errors:
139:   PARSE_EXTRA_DATA: Record contains too many items in keyword DIMENS. Expected 3 items, found 4.
139: In file <memory string> at line 2.
139: Record is "10 10 10 10 ".
139: 
```
for this deck:
```
    const char * deck3 =
        "SCHEDULE\n"
        "TSTEP\n"
        "  10 10 10 /\n"
        "   //\n"
       "/ any comment\n";
```