### PR TITLE
Introduced the CriticalError exception class.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -825,6 +825,7 @@ if(ENABLE_ECL_INPUT)
 endif()
 
 list( APPEND PUBLIC_HEADER_FILES
+      opm/common/CriticalError.hpp
       opm/common/ErrorMacros.hpp
       opm/common/Exceptions.hpp
       opm/common/TimingMacros.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -463,6 +463,7 @@ list (APPEND TEST_SOURCE_FILES
       tests/test_calculateCellVol.cpp
       tests/test_cmp.cpp
       tests/test_ConditionalStorage.cpp
+      tests/test_critical_error.cpp
       tests/test_cubic.cpp
       tests/test_EvaluationFormat.cpp
       tests/test_densead.cpp

--- a/opm/common/CriticalError.hpp
+++ b/opm/common/CriticalError.hpp
@@ -23,6 +23,8 @@
 #include <stdexcept>
 #include <string>
 
+#include <fmt/format.h>
+
 namespace Opm
 {
 /**
@@ -36,23 +38,11 @@ class CriticalError : public std::exception
 {
 public:
     /**
-     * @brief Constructs a CriticalError with an optional inner exception.
-     *
-     * @param inner_exception An optional std::exception_ptr to an inner exception.
-     */
-    CriticalError(std::exception_ptr inner_exception = nullptr)
-        : m_message("Unknown error message.")
-        , m_innerException(inner_exception)
-    {
-    }
-
-    /**
      * @brief Constructs a CriticalError with a specified message and an optional inner exception.
      *
      * @param message A string_view containing the error message.
      * @param inner_exception An optional std::exception_ptr to an inner exception.
      */
-
     CriticalError(const std::string_view& message, std::exception_ptr inner_exception = nullptr)
         : m_message(message)
         , m_innerException(inner_exception)
@@ -97,11 +87,15 @@ private:
     }                                                                                                                  \
     catch (const std::exception& exp)                                                                                  \
     {                                                                                                                  \
-        throw Opm::CriticalError(exp.what(), std::current_exception());                                                \
+        const auto messageForCriticalError = fmt::format(                                                              \
+            "Error rethrown as CriticalError at [{}:{}].\n\nOriginal error: {}", __FILE__, __LINE__, exp.what());     \
+        throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                   \
     }                                                                                                                  \
     catch (...)                                                                                                        \
     {                                                                                                                  \
-        throw Opm::CriticalError(std::current_exception());                                                            \
+        const auto messageForCriticalError                                                                             \
+            = fmt::format("Error rethrown as CriticalError at [{}:{}]. Unknown original error.", __FILE__, __LINE__);  \
+        throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                   \
     }
 
 /**
@@ -113,9 +107,13 @@ private:
     try {                                                                                                              \
         expr;                                                                                                          \
     } catch (const std::exception& exp) {                                                                              \
-        throw Opm::CriticalError(exp.what(), std::current_exception());                                                \
+        const auto messageForCriticalError = fmt::format(                                                              \
+            "Error rethrown as CriticalError at [{}:{}]\n\n. Original error: {}", __FILE__, __LINE__, exp.what());     \
+        throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                   \
     } catch (...) {                                                                                                    \
-        throw Opm::CriticalError(std::current_exception());                                                            \
+        const auto messageForCriticalError                                                                             \
+            = fmt::format("Error rethrown as CriticalError at [{}:{}]. Unknown original error.", __FILE__, __LINE__);  \
+        throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                   \
     }
 
 } // namespace Opm

--- a/opm/common/CriticalError.hpp
+++ b/opm/common/CriticalError.hpp
@@ -1,0 +1,122 @@
+/*
+  Copyright 2025 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_COMMON_CRITICAL_ERROR_HPP
+#define OPM_COMMON_CRITICAL_ERROR_HPP
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace Opm
+{
+/**
+ * @class CriticalError
+ * @brief A custom exception class that extends std::exception to handle critical errors.
+ *
+ * This class provides a way to encapsulate critical error messages and optionally
+ * store an inner exception for more detailed error information.
+ */
+class CriticalError : public std::exception
+{
+public:
+    /**
+     * @brief Constructs a CriticalError with an optional inner exception.
+     *
+     * @param inner_exception An optional std::exception_ptr to an inner exception.
+     */
+    CriticalError(std::exception_ptr inner_exception = nullptr)
+        : m_message("Unknown error message.")
+        , m_innerException(inner_exception)
+    {
+    }
+
+    /**
+     * @brief Constructs a CriticalError with a specified message and an optional inner exception.
+     *
+     * @param message A string_view containing the error message.
+     * @param inner_exception An optional std::exception_ptr to an inner exception.
+     */
+
+    CriticalError(const std::string_view& message, std::exception_ptr inner_exception = nullptr)
+        : m_message(message)
+        , m_innerException(inner_exception)
+    {
+    }
+
+
+    /**
+     * @brief Returns the error message.
+     *
+     * @return A C-style string containing the error message.
+     */
+    const char* what() const noexcept override
+    {
+        return m_message.c_str();
+    }
+
+    /**
+     * @brief Retrieves the inner exception.
+     *
+     * @return A std::exception_ptr to the inner exception, or nullptr if no inner exception is set.
+     */
+    std::exception_ptr getInnerException() const
+    {
+        return m_innerException;
+    }
+
+private:
+    std::string m_message;
+    std::exception_ptr m_innerException;
+};
+
+/**
+ * @brief Begins try-catch block and rethrows any caught exceptions as CriticalError.
+ */
+#define OPM_BEGIN_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR() try {
+
+/**
+ * @brief Ends try-catch block and rethrows any caught exceptions as CriticalError.
+ */
+#define OPM_END_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR()                                                                  \
+    }                                                                                                                  \
+    catch (const std::exception& exp)                                                                                  \
+    {                                                                                                                  \
+        throw Opm::CriticalError(exp.what(), std::current_exception());                                                \
+    }                                                                                                                  \
+    catch (...)                                                                                                        \
+    {                                                                                                                  \
+        throw Opm::CriticalError(std::current_exception());                                                            \
+    }
+
+/**
+ * @brief Tries to execute an expression and rethrows any caught exceptions as CriticalError.
+ *
+ * @param expr The expression to execute.
+ */
+#define OPM_TRY_THROW_AS_CRITICAL_ERROR(expr)                                                                          \
+    try {                                                                                                              \
+        expr;                                                                                                          \
+    } catch (const std::exception& exp) {                                                                              \
+        throw Opm::CriticalError(exp.what(), std::current_exception());                                                \
+    } catch (...) {                                                                                                    \
+        throw Opm::CriticalError(std::current_exception());                                                            \
+    }
+
+} // namespace Opm
+#endif // OPM_COMMON_CRITICAL_ERROR_HPP

--- a/opm/common/CriticalError.hpp
+++ b/opm/common/CriticalError.hpp
@@ -73,31 +73,40 @@ private:
     std::exception_ptr m_innerException;
 };
 
-/**
- * @brief Begins try-catch block and rethrows any caught exceptions as CriticalError.
- */
-#define OPM_BEGIN_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR() try {
+namespace detail
+{
+    inline std::string makeCriticalErrorMessageErrorHint(const std::string& text)
+    {
+        return std::string("\nError hint: ") + text;
+    }
+
+    inline std::string makeCriticalErrorMessageErrorHint()
+    {
+        return std::string("");
+    }
+} // namespace detail
 
 /**
  * @brief Ends try-catch block and rethrows any caught exceptions as CriticalError.
  */
-#define OPM_END_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR()                                                                   \
-    }                                                                                                                   \
-    catch (const Opm::CriticalError&)                                                                                   \
-    {                                                                                                                   \
-        throw;                                                                                                          \
-    }                                                                                                                   \
-    catch (const std::exception& exp)                                                                                   \
-    {                                                                                                                   \
-        const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"       \
-            + std::to_string(__LINE__) + "].\n\nOriginal error: " + exp.what();                                         \
-        throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                    \
-    }                                                                                                                   \
-    catch (...)                                                                                                         \
-    {                                                                                                                   \
-        const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"       \
-            + std::to_string(__LINE__) + "]. Unknown original error.";                                                  \
-        throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                    \
+#define OPM_CATCH_AND_RETHROW_AS_CRITICAL_ERROR(...)                                                                   \
+    catch (const ::Opm::CriticalError&)                                                                                \
+    {                                                                                                                  \
+        throw;                                                                                                         \
+    }                                                                                                                  \
+    catch (const std::exception& exp)                                                                                  \
+    {                                                                                                                  \
+        const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"      \
+            + std::to_string(__LINE__) + "].\nOriginal error: " + exp.what()                                           \
+            + ::Opm::detail::makeCriticalErrorMessageErrorHint(__VA_ARGS__);                                           \
+        throw ::Opm::CriticalError(messageForCriticalError, std::current_exception());                                 \
+    }                                                                                                                  \
+    catch (...)                                                                                                        \
+    {                                                                                                                  \
+        const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"      \
+            + std::to_string(__LINE__) + "]. Unknown original error."                                                  \
+            + ::Opm::detail::makeCriticalErrorMessageErrorHint(__VA_ARGS__);                                           \
+        throw ::Opm::CriticalError(messageForCriticalError, std::current_exception());                                 \
     }
 
 /**
@@ -105,19 +114,21 @@ private:
  *
  * @param expr The expression to execute.
  */
-#define OPM_TRY_THROW_AS_CRITICAL_ERROR(expr)                                                                          \
+#define OPM_TRY_THROW_AS_CRITICAL_ERROR(expr, ...)                                                                     \
     try {                                                                                                              \
         expr;                                                                                                          \
-    } catch (const Opm::CriticalError&) {                                                                              \
+    } catch (const ::Opm::CriticalError&) {                                                                            \
         throw;                                                                                                         \
     } catch (const std::exception& exp) {                                                                              \
         const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"      \
-            + std::to_string(__LINE__) + "]\n\n. Original error: " + exp.what();                                       \
-        throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                   \
+            + std::to_string(__LINE__) + "].\nOriginal error: " + exp.what()                                           \
+            + ::Opm::detail::makeCriticalErrorMessageErrorHint(__VA_ARGS__);                                           \
+        throw ::Opm::CriticalError(messageForCriticalError, std::current_exception());                                 \
     } catch (...) {                                                                                                    \
         const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"      \
-            + std::to_string(__LINE__) + "]. Unknown original error.";                                                 \
-        throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                   \
+            + std::to_string(__LINE__) + "]. Unknown original error."                                                  \
+            + ::Opm::detail::makeCriticalErrorMessageErrorHint(__VA_ARGS__);                                           \
+        throw ::Opm::CriticalError(messageForCriticalError, std::current_exception());                                 \
     }
 
 } // namespace Opm

--- a/opm/common/CriticalError.hpp
+++ b/opm/common/CriticalError.hpp
@@ -24,6 +24,44 @@
 #include <string>
 
 namespace Opm
+/**
+ * @file CriticalError.hpp
+ * @brief Provides error handling mechanisms for critical errors in the OPM framework
+ *
+ * This file contains the CriticalError exception class and macros for handling
+ * critical errors in a consistent way across the OPM codebase.
+ *
+ * The key components are:
+ * - CriticalError class: A custom exception for critical errors
+ * - OPM_CATCH_AND_RETHROW_AS_CRITICAL_ERROR macro: Catches and rethrows exceptions
+ * - OPM_TRY_THROW_AS_CRITICAL_ERROR macro: Wraps code execution with error handling
+ *
+ * Both macros support an optional hint string that provides additional error context:
+ * @code{.cpp}
+ * try {
+ *     riskyOperation();
+ * }
+ * OPM_CATCH_AND_RETHROW_AS_CRITICAL_ERROR("Check input file permissions");
+ *
+ * // Or using the try macro:
+ * OPM_TRY_THROW_AS_CRITICAL_ERROR(riskyOperation(),
+ *                                "Operation requires valid config");
+ * @endcode
+ *
+ * When an error occurs, the macros will:
+ * 1. Catch the exception
+ * 2. Create a detailed error message including:
+ *    - File and line location
+ *    - Original error message
+ *    - Optional hint string if provided
+ * 3. Wrap in a CriticalError while preserving the original exception
+ *
+ * The hint string is especially useful for providing:
+ * - Troubleshooting guidance
+ * - Required preconditions
+ * - Suggested fixes
+ * - Context about the operation
+ */
 {
 /**
  * @class CriticalError
@@ -88,6 +126,11 @@ namespace detail
 
 /**
  * @brief Ends try-catch block and rethrows any caught exceptions as CriticalError.
+ *
+ * This macro is used to catch exceptions and rethrow them as CriticalError.
+ * It also provides a way to add an optional hint string to the error message.
+ *
+ * @param ... An optional hint string to provide additional error context.
  */
 #define OPM_CATCH_AND_RETHROW_AS_CRITICAL_ERROR(...)                                                                   \
     catch (const ::Opm::CriticalError&)                                                                                \
@@ -113,6 +156,7 @@ namespace detail
  * @brief Tries to execute an expression and rethrows any caught exceptions as CriticalError.
  *
  * @param expr The expression to execute.
+ * @param ... An optional hint string to provide additional error context.
  */
 #define OPM_TRY_THROW_AS_CRITICAL_ERROR(expr, ...)                                                                     \
     try {                                                                                                              \

--- a/opm/common/CriticalError.hpp
+++ b/opm/common/CriticalError.hpp
@@ -81,19 +81,23 @@ private:
 /**
  * @brief Ends try-catch block and rethrows any caught exceptions as CriticalError.
  */
-#define OPM_END_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR()                                                                  \
-    }                                                                                                                  \
-    catch (const std::exception& exp)                                                                                  \
-    {                                                                                                                  \
-        const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"      \
-            + std::to_string(__LINE__) + "].\n\nOriginal error: " + exp.what();                                        \
-        throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                   \
-    }                                                                                                                  \
-    catch (...)                                                                                                        \
-    {                                                                                                                  \
-        const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"      \
-            + std::to_string(__LINE__) + "]. Unknown original error.";                                                 \
-        throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                   \
+#define OPM_END_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR()                                                                   \
+    }                                                                                                                   \
+    catch (const Opm::CriticalError&)                                                                                   \
+    {                                                                                                                   \
+        throw;                                                                                                          \
+    }                                                                                                                   \
+    catch (const std::exception& exp)                                                                                   \
+    {                                                                                                                   \
+        const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"       \
+            + std::to_string(__LINE__) + "].\n\nOriginal error: " + exp.what();                                         \
+        throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                    \
+    }                                                                                                                   \
+    catch (...)                                                                                                         \
+    {                                                                                                                   \
+        const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"       \
+            + std::to_string(__LINE__) + "]. Unknown original error.";                                                  \
+        throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                    \
     }
 
 /**
@@ -104,6 +108,8 @@ private:
 #define OPM_TRY_THROW_AS_CRITICAL_ERROR(expr)                                                                          \
     try {                                                                                                              \
         expr;                                                                                                          \
+    } catch (const Opm::CriticalError&) {                                                                              \
+        throw;                                                                                                         \
     } catch (const std::exception& exp) {                                                                              \
         const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"      \
             + std::to_string(__LINE__) + "]\n\n. Original error: " + exp.what();                                       \

--- a/opm/common/CriticalError.hpp
+++ b/opm/common/CriticalError.hpp
@@ -23,8 +23,6 @@
 #include <stdexcept>
 #include <string>
 
-#include <fmt/format.h>
-
 namespace Opm
 {
 /**
@@ -87,14 +85,14 @@ private:
     }                                                                                                                  \
     catch (const std::exception& exp)                                                                                  \
     {                                                                                                                  \
-        const auto messageForCriticalError = fmt::format(                                                              \
-            "Error rethrown as CriticalError at [{}:{}].\n\nOriginal error: {}", __FILE__, __LINE__, exp.what());     \
+        const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"      \
+            + std::to_string(__LINE__) + "].\n\nOriginal error: " + exp.what();                                        \
         throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                   \
     }                                                                                                                  \
     catch (...)                                                                                                        \
     {                                                                                                                  \
-        const auto messageForCriticalError                                                                             \
-            = fmt::format("Error rethrown as CriticalError at [{}:{}]. Unknown original error.", __FILE__, __LINE__);  \
+        const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"      \
+            + std::to_string(__LINE__) + "]. Unknown original error.";                                                 \
         throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                   \
     }
 
@@ -107,12 +105,12 @@ private:
     try {                                                                                                              \
         expr;                                                                                                          \
     } catch (const std::exception& exp) {                                                                              \
-        const auto messageForCriticalError = fmt::format(                                                              \
-            "Error rethrown as CriticalError at [{}:{}]\n\n. Original error: {}", __FILE__, __LINE__, exp.what());     \
+        const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"      \
+            + std::to_string(__LINE__) + "]\n\n. Original error: " + exp.what();                                       \
         throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                   \
     } catch (...) {                                                                                                    \
-        const auto messageForCriticalError                                                                             \
-            = fmt::format("Error rethrown as CriticalError at [{}:{}]. Unknown original error.", __FILE__, __LINE__);  \
+        const auto messageForCriticalError = std::string("Error rethrown as CriticalError at [") + __FILE__ + ":"      \
+            + std::to_string(__LINE__) + "]. Unknown original error.";                                                 \
         throw Opm::CriticalError(messageForCriticalError, std::current_exception());                                   \
     }
 

--- a/tests/test_critical_error.cpp
+++ b/tests/test_critical_error.cpp
@@ -25,8 +25,12 @@ BOOST_AUTO_TEST_CASE(TestCriticalError)
         OPM_TRY_THROW_AS_CRITICAL_ERROR(throw std::runtime_error("test"));
         BOOST_FAIL("Should have thrown");
     } catch (const Opm::CriticalError& e) {
-        BOOST_CHECK_EQUAL(e.what(), "test");
         BOOST_CHECK(e.getInnerException() != nullptr);
+        try {
+            std::rethrow_exception(e.getInnerException());
+        } catch (const std::runtime_error& e) {
+            BOOST_CHECK_EQUAL(e.what(), "test");
+        }
     }
 }
 
@@ -38,7 +42,11 @@ BOOST_AUTO_TEST_CASE(TestCriticalErrorBeginEnd)
         BOOST_FAIL("Should have thrown");
         OPM_END_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR();
     } catch (const Opm::CriticalError& e) {
-        BOOST_CHECK_EQUAL(e.what(), "test");
         BOOST_CHECK(e.getInnerException() != nullptr);
+        try {
+            std::rethrow_exception(e.getInnerException());
+        } catch (const std::runtime_error& e) {
+            BOOST_CHECK_EQUAL(e.what(), "test");
+        }
     }
 }

--- a/tests/test_critical_error.cpp
+++ b/tests/test_critical_error.cpp
@@ -1,0 +1,44 @@
+/*
+  Copyright 2025 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <config.h>
+#define BOOST_TEST_MODULE TestCriticalError
+
+#include <boost/test/unit_test.hpp>
+#include <opm/common/CriticalError.hpp>
+
+BOOST_AUTO_TEST_CASE(TestCriticalError)
+{
+    try {
+        OPM_TRY_THROW_AS_CRITICAL_ERROR(throw std::runtime_error("test"));
+        BOOST_FAIL("Should have thrown");
+    } catch (const Opm::CriticalError& e) {
+        BOOST_CHECK_EQUAL(e.what(), "test");
+        BOOST_CHECK(e.getInnerException() != nullptr);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(TestCriticalErrorBeginEnd)
+{
+    try {
+        OPM_BEGIN_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR();
+        throw std::runtime_error("test");
+        BOOST_FAIL("Should have thrown");
+        OPM_END_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR();
+    } catch (const Opm::CriticalError& e) {
+        BOOST_CHECK_EQUAL(e.what(), "test");
+        BOOST_CHECK(e.getInnerException() != nullptr);
+    }
+}

--- a/tests/test_critical_error.cpp
+++ b/tests/test_critical_error.cpp
@@ -50,3 +50,26 @@ BOOST_AUTO_TEST_CASE(TestCriticalErrorBeginEnd)
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(TestCriticalErrorBeginEndPassCriticalError)
+{
+    // make sure we simply rethrow CriticalError without decorating it
+    try { 
+        OPM_BEGIN_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR();
+        throw Opm::CriticalError("test");
+        BOOST_FAIL("Should have thrown");
+        OPM_END_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR();
+    } catch (const Opm::CriticalError& e) {
+        BOOST_CHECK_EQUAL(e.what(), "test");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(TestCriticalErrorMacroPassCriticalError) {
+    // make sure we simply rethrow CriticalError without decorating it
+    try {
+        OPM_TRY_THROW_AS_CRITICAL_ERROR(throw Opm::CriticalError("test"));
+        BOOST_FAIL("Should have thrown");
+    } catch (const Opm::CriticalError& e) {
+        BOOST_CHECK_EQUAL(e.what(), "test");
+    }
+}

--- a/tests/test_critical_error.cpp
+++ b/tests/test_critical_error.cpp
@@ -24,12 +24,12 @@ BOOST_AUTO_TEST_CASE(TestCriticalError)
     try {
         OPM_TRY_THROW_AS_CRITICAL_ERROR(throw std::runtime_error("test"));
         BOOST_FAIL("Should have thrown");
-    } catch (const Opm::CriticalError& e) {
-        BOOST_CHECK(e.getInnerException() != nullptr);
+    } catch (const Opm::CriticalError& outerException) {
+        BOOST_CHECK(outerException.getInnerException() != nullptr);
         try {
-            std::rethrow_exception(e.getInnerException());
-        } catch (const std::runtime_error& e) {
-            BOOST_CHECK_EQUAL(e.what(), "test");
+            std::rethrow_exception(outerException.getInnerException());
+        } catch (const std::runtime_error& innerException) {
+            BOOST_CHECK_EQUAL(innerException.what(), "test");
         }
     }
 }
@@ -41,12 +41,12 @@ BOOST_AUTO_TEST_CASE(TestCriticalErrorBeginEnd)
         throw std::runtime_error("test");
         BOOST_FAIL("Should have thrown");
         OPM_END_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR();
-    } catch (const Opm::CriticalError& e) {
-        BOOST_CHECK(e.getInnerException() != nullptr);
+    } catch (const Opm::CriticalError& outerException) {
+        BOOST_CHECK(outerException.getInnerException() != nullptr);
         try {
-            std::rethrow_exception(e.getInnerException());
-        } catch (const std::runtime_error& e) {
-            BOOST_CHECK_EQUAL(e.what(), "test");
+            std::rethrow_exception(outerException.getInnerException());
+        } catch (const std::runtime_error& innerException) {
+            BOOST_CHECK_EQUAL(innerException.what(), "test");
         }
     }
 }


### PR DESCRIPTION
I have added a simple exception class `CriticalError` which is supposed to wrap normal exceptions and rethrow them as critical exceptions where errors can not be recovered easily.

This is relevant for the linear solver system where a caught exception is typically treated by lowering time steps. This leads to the unfortunate side effect that some errors^* in the JSON file will be treated by reducing time steps until the limit is reached and the simulation is crashed, with few error messages to the actual problem that caused the problem.

One could also add a constructor that only takes an error message to let coders directly throw a critical error message.

^* Setting `--linear-solver` to point to the following json will cause this behaviour:
```JSON
{
    "preconditioner": "ParOverILU0"
}
```

since `ISTLSolver::initPrepare` tries to access ```"preconditioner.type"```. 

See the [opm-simulators PR 5969](https://github.com/OPM/opm-simulators/pull/5969) on this can be used.