### PR TITLE
Fix OpenMP

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -475,7 +475,6 @@ list (APPEND TEST_SOURCE_FILES
       tests/test_RootFinders.cpp
       tests/test_SegmentMatcher.cpp
       tests/test_sparsevector.cpp
-      tests/test_ThreadSafeMapBuilder.cpp
       tests/test_uniformtablelinear.cpp
       tests/material/test_2dtables.cpp
       tests/material/test_blackoilfluidstate.cpp
@@ -488,6 +487,12 @@ list (APPEND TEST_SOURCE_FILES
       tests/test_Visitor.cpp
       tests/ml/ml_model_test.cpp
 )
+
+if(OpenMP_FOUND)
+list (APPEND TEST_SOURCE_FILES
+      tests/test_ThreadSafeMapBuilder.cpp
+)
+endif()
 
 # tests that need to be linked to dune-common
 list(APPEND DUNE_TEST_SOURCE_FILES

--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -23,7 +23,6 @@ set (opm-common_DEPS
 list(APPEND opm-common_DEPS
       # various runtime library enhancements
       "Boost 1.44.0 COMPONENTS system unit_test_framework REQUIRED"
-      "OpenMP QUIET"
       "cjson"
       # Still it produces compile errors complaining that it
       # cannot format UDQVarType. Hence we use the same version


### PR DESCRIPTION
There is a buildsystem global way to enable/disable OpenMP. We should not be manually looking for it in prereqs.

Also disable openmp-only test when openmp is disabled.