### PR TITLE
Add utility methods to parse LGR refinement.

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -1982,6 +1982,14 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
         }
     }
 
+    void EclipseGrid::set_lgr_refinement(const std::string& lgr_tag, const std::vector<double>& coords, 
+                                                                            const std::vector<double> & zcorn){              
+        for (auto& lgr_cell : lgr_children_cells) {
+            lgr_cell.set_lgr_refinement(lgr_tag, coords, zcorn);
+        }                                                                             
+    }
+
+
     void EclipseGrid::init_children_host_cells(){
         auto getAllCellCorners = [this](const auto& father_list){
             std::vector<std::array<double, 8>> X(father_list.size());
@@ -2478,6 +2486,18 @@ namespace Opm {
     {
         std::transform(hostnum.begin(),hostnum.end(), hostnum.begin(), [](int a){return a+1;});
         m_hostnum = hostnum;
+    }
+    void EclipseGridLGR::set_lgr_refinement(const std::string& lgr_tag, const std::vector<double>& coord, const std::vector<double>& zcorn)
+    {
+        if (lgr_tag == lgr_label)
+        {
+            this->set_lgr_refinement(coord, zcorn);
+        } else
+        {
+            for (auto& lgr_cell : lgr_children_cells) {
+                lgr_cell.set_lgr_refinement(lgr_tag, coord, zcorn);
+            }   
+        }
     }
     void EclipseGridLGR::set_lgr_refinement(const std::vector<double>& coord, const std::vector<double>& zcorn)
     {

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <unordered_set>
 #include <vector>
 #include <map>
@@ -260,6 +261,7 @@ namespace Opm {
         static bool hasEqualDVDEPTHZ(const Deck&);
         static bool allEqual(const std::vector<double> &v);
         std::vector<EclipseGridLGR> lgr_children_cells;
+        virtual void set_lgr_refinement(const std::string&, const std::vector<double>&, const std::vector<double> &);                 
 
     protected:
         std::size_t lgr_global_counter = 0;
@@ -385,6 +387,8 @@ namespace Opm {
         return father_global;
       }
      void set_hostnum(std::vector<int>&);
+     void set_lgr_refinement(const std::string&, const std::vector<double>&, const std::vector<double> &) override;                 
+
      void set_lgr_refinement(const std::vector<double>&, const std::vector<double> &);                 
     private:
       void init_father_global();

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -263,10 +263,10 @@ namespace Opm {
         std::vector<EclipseGridLGR> lgr_children_cells;
         /**
         * @brief Sets Local Grid Refinement for the EclipseGrid.
-        * 
-        * @param lgr_tag The string that contains of a given LGR.
-        * @param coords The coordinates of the LGR in COORDS CPG format.
-        * @param zcorn The z-coordinatesvalues of the LGR in ZCORN CPG format.
+          * 
+        * @param lgr_tag The string that contains the name of a given LGR cell. 
+        * @param coords The coordinates of a given LGR cell in  CPG COORDSformat.
+        * @param zcorn The z-coordinates values of a given LGR cell in CPG ZCORN format.
         */
         virtual void set_lgr_refinement(const std::string& lgr_tag, const std::vector<double>& coords, const std::vector<double>& zcorn);
                
@@ -399,9 +399,9 @@ namespace Opm {
       /**
       * @brief Sets Local Grid Refinement for the EclipseGridLGR.
       * 
-      * @param lgr_tag The string that contains of a given LGR.
-      * @param coords The coordinates of the LGR in COORDS CPG format.
-      * @param zcorn The z-coordinatesvalues of the LGR in ZCORN CPG format.
+      * @param lgr_tag The string that contains the name of a given LGR cell. 
+      * @param coords The coordinates of a given LGR cell in  CPG COORDSformat.
+      * @param zcorn The z-coordinates values of a given LGR cell in CPG ZCORN format.
       */
       void set_lgr_refinement(const std::string& lgr_tag, const std::vector<double>& coord, const std::vector<double>& zcorn) override;                 
 

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -264,9 +264,9 @@ namespace Opm {
         /**
         * @brief Sets Local Grid Refinement for the EclipseGrid.
         * 
-        * @param lgr_tag The tag of the LGR.
-        * @param coords The coordinates for the LGR in CPG format.
-        * @param zcorn The ZCORN values for the LGR in CPG format.
+        * @param lgr_tag The string that contains of a given LGR.
+        * @param coords The coordinates of the LGR in COORDS CPG format.
+        * @param zcorn The z-coordinatesvalues of the LGR in ZCORN CPG format.
         */
         virtual void set_lgr_refinement(const std::string& lgr_tag, const std::vector<double>& coords, const std::vector<double>& zcorn);
                
@@ -397,11 +397,11 @@ namespace Opm {
      void set_hostnum(std::vector<int>&);
 
       /**
-      * @brief Sets Local Grid Refinement for the EclipseGrid.
+      * @brief Sets Local Grid Refinement for the EclipseGridLGR.
       * 
-      * @param lgr_tag The tag of the LGR.
-      * @param coords The coordinates for the LGR in CPG format.
-      * @param zcorn The ZCORN values for the LGR in CPG format.
+      * @param lgr_tag The string that contains of a given LGR.
+      * @param coords The coordinates of the LGR in COORDS CPG format.
+      * @param zcorn The z-coordinatesvalues of the LGR in ZCORN CPG format.
       */
       void set_lgr_refinement(const std::string& lgr_tag, const std::vector<double>& coord, const std::vector<double>& zcorn) override;                 
 

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -261,7 +261,15 @@ namespace Opm {
         static bool hasEqualDVDEPTHZ(const Deck&);
         static bool allEqual(const std::vector<double> &v);
         std::vector<EclipseGridLGR> lgr_children_cells;
-        virtual void set_lgr_refinement(const std::string&, const std::vector<double>&, const std::vector<double> &);                 
+        /**
+        * @brief Sets Local Grid Refinement for the EclipseGrid.
+        * 
+        * @param lgr_tag The tag of the LGR.
+        * @param coords The coordinates for the LGR in CPG format.
+        * @param zcorn The ZCORN values for the LGR in CPG format.
+        */
+        virtual void set_lgr_refinement(const std::string& lgr_tag, const std::vector<double>& coords, const std::vector<double>& zcorn);
+               
 
     protected:
         std::size_t lgr_global_counter = 0;
@@ -387,7 +395,15 @@ namespace Opm {
         return father_global;
       }
      void set_hostnum(std::vector<int>&);
-     void set_lgr_refinement(const std::string&, const std::vector<double>&, const std::vector<double> &) override;                 
+
+      /**
+      * @brief Sets Local Grid Refinement for the EclipseGrid.
+      * 
+      * @param lgr_tag The tag of the LGR.
+      * @param coords The coordinates for the LGR in CPG format.
+      * @param zcorn The ZCORN values for the LGR in CPG format.
+      */
+      void set_lgr_refinement(const std::string& lgr_tag, const std::vector<double>& coord, const std::vector<double>& zcorn) override;                 
 
      void set_lgr_refinement(const std::vector<double>&, const std::vector<double> &);                 
     private:

--- a/tests/parser/LgrOutputTests.cpp
+++ b/tests/parser/LgrOutputTests.cpp
@@ -125,7 +125,7 @@ SCHEDULE
     //  LgrCollection is used to initalize LGR Cells in the Eclipse Grid.
     eclipse_grid_file.init_lgr_cells(lgr_col);
     // LGR COORD and ZCORN is parsed to EclipseGridLGR children cell. (Simulates the process of recieving the LGR refinement.)   
-    eclipse_grid_file.lgr_children_cells[0].set_lgr_refinement(coord_l,zcorn_l);
+    eclipse_grid_file.set_lgr_refinement("LGR1",coord_l,zcorn_l);
     // Intialize host_cell numbering.
     eclipse_grid_file.init_children_host_cells();
     // Save EclipseGrid.
@@ -139,7 +139,7 @@ SCHEDULE
 //  LgrCollection is used to initalize LGR Cells in the Eclipse Grid.
     eclipse_grid_OPM.init_lgr_cells(lgr_col);
     // LGR COORD and ZCORN is parsed to EclipseGridLGR children cell. (Simulates the process of recieving the LGR refinement.)   
-    eclipse_grid_OPM.lgr_children_cells[0].set_lgr_refinement(coord_l_opm,zcorn_l_opm);
+    eclipse_grid_OPM.set_lgr_refinement("LGR1",coord_l_opm,zcorn_l_opm);
     // Intialize host_cell numbering.
     eclipse_grid_OPM.init_children_host_cells();
     BOOST_CHECK_EQUAL( coord_g_opm.size() , coord_g.size());
@@ -226,7 +226,7 @@ SCHEDULE
     //  LgrCollection is used to initalize LGR Cells in the Eclipse Grid.
     eclipse_grid_file.init_lgr_cells(lgr_col);
     // LGR COORD and ZCORN is parsed to EclipseGridLGR children cell. (Simulates the process of recieving the LGR refinement.)   
-    eclipse_grid_file.lgr_children_cells[0].set_lgr_refinement(coord_l,zcorn_l);
+    eclipse_grid_file.set_lgr_refinement("LGR1",coord_l,zcorn_l);
     // Intialize host_cell numbering.
     eclipse_grid_file.init_children_host_cells();
     // Save EclipseGrid.
@@ -448,8 +448,8 @@ SCHEDULE
     //  LgrCollection is used to initalize LGR Cells in the Eclipse Grid.
     eclipse_grid_file.init_lgr_cells(lgr_col);
     // LGR COORD and ZCORN is parsed to EclipseGridLGR children cell. (Simulates the process of recieving the LGR refinement.)   
-    eclipse_grid_file.lgr_children_cells[0].set_lgr_refinement(coord_l1,zcorn_l1);
-    eclipse_grid_file.lgr_children_cells[0].lgr_children_cells[0].set_lgr_refinement(coord_l2,zcorn_l2);
+    eclipse_grid_file.set_lgr_refinement("LGR1",coord_l1,zcorn_l1);
+    eclipse_grid_file.set_lgr_refinement("LGR2",coord_l2,zcorn_l2);
     // Intialize host_cell numbering.
     eclipse_grid_file.init_children_host_cells();
     // Save EclipseGrid.


### PR DESCRIPTION
**PR Description:**  

This PR introduces routines for parsing the refinement into `EclipseGrid` object. The key changes include:

### **New Methods:**  
- `EclipseGrid::set_lgr_refinement` and `EclipseGridLGR::set_lgr_refinement` now allow applying LGR refinements based on a specified tag (`lgr_tag`), coordinates (`coord`), and `zcorn` values.  
### **Code Refactoring:**  
- The `set_lgr_refinement` calls in `LgrOutputTests.cpp` were updated to use the new method with `lgr_tag`.