### PR TITLE
Fix clang warning

### DIFF
--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -1745,7 +1745,8 @@ template<> std::vector<std::array<T, 3>> BOFS<T>::referenceDensity_; \
 template<> std::vector<std::array<T, 3>> BOFS<T>::molarMass_; \
 template<> std::vector<std::array<T, 9>> BOFS<T>::diffusionCoefficients_; \
 template<> bool BOFS<T>::isInitialized_; \
-template<> bool BOFS<T>::useSaturatedTables_;
+template<> bool BOFS<T>::useSaturatedTables_; \
+template<> bool BOFS<T>::enthalpy_eq_energy_;
 
 DECLARE_INSTANCE(float)
 DECLARE_INSTANCE(double)

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -1725,27 +1725,27 @@ private:
 
 template <typename T> using BOFS = BlackOilFluidSystem<T, BlackOilDefaultIndexTraits>;
 
-#define DECLARE_INSTANCE(T) \
-template<> unsigned char BOFS<T>::numActivePhases_; \
-template<> std::array<bool, BOFS<T>::numPhases> BOFS<T>::phaseIsActive_; \
+#define DECLARE_INSTANCE(T)                                                           \
+template<> unsigned char BOFS<T>::numActivePhases_;                                   \
+template<> std::array<bool, BOFS<T>::numPhases> BOFS<T>::phaseIsActive_;              \
 template<> std::array<short, BOFS<T>::numPhases> BOFS<T>::activeToCanonicalPhaseIdx_; \
 template<> std::array<short, BOFS<T>::numPhases> BOFS<T>::canonicalToActivePhaseIdx_; \
-template<> T BOFS<T>::surfaceTemperature; \
-template<> T BOFS<T>::surfacePressure; \
-template<> T BOFS<T>::reservoirTemperature_; \
-template<> bool BOFS<T>::enableDissolvedGas_; \
-template<> bool BOFS<T>::enableDissolvedGasInWater_; \
-template<> bool BOFS<T>::enableVaporizedOil_; \
-template<> bool BOFS<T>::enableVaporizedWater_; \
-template<> bool BOFS<T>::enableDiffusion_; \
-template<> std::shared_ptr<OilPvtMultiplexer<T>> BOFS<T>::oilPvt_; \
-template<> std::shared_ptr<GasPvtMultiplexer<T>> BOFS<T>::gasPvt_; \
-template<> std::shared_ptr<WaterPvtMultiplexer<T>> BOFS<T>::waterPvt_; \
-template<> std::vector<std::array<T, 3>> BOFS<T>::referenceDensity_; \
-template<> std::vector<std::array<T, 3>> BOFS<T>::molarMass_; \
-template<> std::vector<std::array<T, 9>> BOFS<T>::diffusionCoefficients_; \
-template<> bool BOFS<T>::isInitialized_; \
-template<> bool BOFS<T>::useSaturatedTables_; \
+template<> T BOFS<T>::surfaceTemperature;                                             \
+template<> T BOFS<T>::surfacePressure;                                                \
+template<> T BOFS<T>::reservoirTemperature_;                                          \
+template<> bool BOFS<T>::enableDissolvedGas_;                                         \
+template<> bool BOFS<T>::enableDissolvedGasInWater_;                                  \
+template<> bool BOFS<T>::enableVaporizedOil_;                                         \
+template<> bool BOFS<T>::enableVaporizedWater_;                                       \
+template<> bool BOFS<T>::enableDiffusion_;                                            \
+template<> std::shared_ptr<OilPvtMultiplexer<T>> BOFS<T>::oilPvt_;                    \
+template<> std::shared_ptr<GasPvtMultiplexer<T>> BOFS<T>::gasPvt_;                    \
+template<> std::shared_ptr<WaterPvtMultiplexer<T>> BOFS<T>::waterPvt_;                \
+template<> std::vector<std::array<T, 3>> BOFS<T>::referenceDensity_;                  \
+template<> std::vector<std::array<T, 3>> BOFS<T>::molarMass_;                         \
+template<> std::vector<std::array<T, 9>> BOFS<T>::diffusionCoefficients_;             \
+template<> bool BOFS<T>::isInitialized_;                                              \
+template<> bool BOFS<T>::useSaturatedTables_;                                         \
 template<> bool BOFS<T>::enthalpy_eq_energy_;
 
 DECLARE_INSTANCE(float)


### PR DESCRIPTION
I accidentially introduced a warning with clang in https://github.com/OPM/opm-common/commit/bb20bbfaeed39e1b70e0ac95003f34447f496a3c

While at it align