### PR TITLE
Some improvements to EclHysteresisConfig

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
@@ -71,6 +71,9 @@ public:
     int pcHysteresisModel() const
     { return pcHysteresisModel_; }
 
+    bool enablePCHysteresis() const
+    { return enableHysteresis() && pcHysteresisModel_ >= 0; }
+
     /*!
      * \brief Set the type of the hysteresis model which is used for relative permeability.
      *
@@ -86,6 +89,12 @@ public:
      */
     void setKrHysteresisModel(int value)
     { krHysteresisModel_ = value; }
+
+    bool enableWettingHysteresis() const
+    { return enableHysteresis() && krHysteresisModel_ >= 4; }
+
+    bool enableNonWettingHysteresis() const
+    { return enableHysteresis() && krHysteresisModel_ >= 0; }
 
     /*!
      * \brief Return the type of the hysteresis model which is used for relative permeability.

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -310,6 +310,9 @@ public:
     bool enablePpcwmax() const
     { return enablePpcwmax_; }
 
+    const EclHysteresisConfig& hysteresisConfig() const
+    { return *hysteresisConfig_; }
+
     bool enableHysteresis() const
     { return hysteresisConfig_->enableHysteresis(); }
 

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -314,13 +314,13 @@ public:
     { return hysteresisConfig_->enableHysteresis(); }
 
     bool enablePCHysteresis() const
-    { return (enableHysteresis() && hysteresisConfig_->pcHysteresisModel() >= 0); }
+    { return hysteresisConfig_->enablePCHysteresis(); }
 
     bool enableWettingHysteresis() const
-    { return (enableHysteresis() && hysteresisConfig_->krHysteresisModel() >= 4); }
+    { return hysteresisConfig_->enableWettingHysteresis(); }
 
     bool enableNonWettingHysteresis() const
-    { return (enableHysteresis() && hysteresisConfig_->krHysteresisModel() >= 0); }
+    { return hysteresisConfig_->enableNonWettingHysteresis(); }
 
     MaterialLawParams& materialLawParams(unsigned elemIdx)
     {


### PR DESCRIPTION
In particular move some simplified query functions from the manager to the config class.
This allows downstreams to only work with the config class, and still not know the internal magic numbers.