### PR TITLE
Implement LGR Wells Handling and WELSPECL Keyword Support

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -585,7 +585,8 @@ Well Well::serializationTestObject()
     result.default_well_inj_temperature = 0.0;
     result.well_inj_mult = InjMult::serializationTestObject();
     result.m_filter_concentration = UDAValue::serializationTestObject();
-
+    result.lgr_tag = "LGR-test";
+    result.ref_type = WellRefinementType::LGR;
     return result;
 }
 
@@ -2107,6 +2108,9 @@ bool Well::operator==(const Well& data) const
         && (this->default_well_inj_temperature == data.default_well_inj_temperature)
         && (this->well_inj_mult == data.well_inj_mult)
         && (this->m_filter_concentration == data.m_filter_concentration)
+        && (this->lgr_tag == data.lgr_tag)
+        && (this->ref_type == data.ref_type)
+
         ;
 }
 

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -589,7 +589,6 @@ Well Well::serializationTestObject()
     return result;
 }
 
-
 bool Well::updateWPAVE(const PAvg& pavg)
 {
     if (this->m_pavg == pavg) {
@@ -598,6 +597,29 @@ bool Well::updateWPAVE(const PAvg& pavg)
 
     this->m_pavg = pavg;
     return true;
+}
+
+void Well::flag_lgr_well(void)
+{
+    ref_type = WellRefinementType::LGR;
+}
+
+void Well::set_lgr_well_tag(const std::string& lgr_tag_name)
+{
+    lgr_tag = lgr_tag_name;
+}
+
+const std::string& Well::get_lgr_well_tag(void) const
+{   
+    if (this->ref_type == WellRefinementType::STANDARD)
+        throw std::invalid_argument("Well is not an LGR well.");
+     return lgr_tag;
+}
+
+
+bool Well::is_lgr_well(void) const
+{
+    return this->ref_type == WellRefinementType::LGR;
 }
 
 

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -104,15 +104,10 @@ public:
 
     using GasInflowEquation = WellGasInflowEquation;
 
-    enum WellRefinementType {
-        STANDARD,
-        LGR,
-        MIXED,
-    };
-    void flag_lgr_well(void);
+    void flag_lgr_well();
     void set_lgr_well_tag(const std::string& lgr_tag_name);
-    bool is_lgr_well(void) const;
-    const std::string& get_lgr_well_tag(void) const;
+    bool is_lgr_well() const;
+    const std::string& get_lgr_well_tag() const;
     struct WellGuideRate {
         bool available;
         double guide_rate;
@@ -609,6 +604,8 @@ public:
         serializer(pvt_table);
         serializer(gas_inflow);
         serializer(wtype);
+        serializer(ref_type);
+        serializer(lgr_tag);
         serializer(guide_rate);
         serializer(efficiency_factor);
         serializer(use_efficiency_in_network);
@@ -636,11 +633,14 @@ public:
         serializer(inj_mult_mode);
         serializer(well_inj_mult);
         serializer(m_filter_concentration);
-        serializer(ref_type);
-        serializer(lgr_tag);
     }
 
 private:
+    enum class WellRefinementType {
+        STANDARD,
+        LGR,
+        MIXED,
+    };
     void switchToInjector();
     void switchToProducer();
 
@@ -648,7 +648,7 @@ private:
 
     std::string wname{};
     std::string group_name{};
-    std::string lgr_tag{};
+
     std::size_t init_step{};
     std::size_t insert_index{};
     int headI{};
@@ -668,6 +668,7 @@ private:
     double udq_undefined{};
     WellType wtype{};
     WellRefinementType ref_type{WellRefinementType::STANDARD};
+    std::string lgr_tag{};
     WellGuideRate guide_rate{};
     double efficiency_factor{};
     bool use_efficiency_in_network{};

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -104,6 +104,15 @@ public:
 
     using GasInflowEquation = WellGasInflowEquation;
 
+    enum WellRefinementType {
+        STANDARD,
+        LGR,
+        MIXED,
+    };
+    void flag_lgr_well(void);
+    void set_lgr_well_tag(const std::string& lgr_tag_name);
+    bool is_lgr_well(void) const;
+    const std::string& get_lgr_well_tag(void) const;
     struct WellGuideRate {
         bool available;
         double guide_rate;
@@ -533,11 +542,12 @@ public:
     bool updateWSEGVALV(const std::vector<std::pair<int, Valve> >& valve_pairs);
     bool updateWSEGAICD(const std::vector<std::pair<int, AutoICD> >& aicd_pairs, const KeywordLocation& location);
     bool updateWPAVE(const PAvg& pavg);
+  
+
     void updateWPaveRefDepth(double ref_depth);
     bool updateWVFPDP(std::shared_ptr<WVFPDP> wvfpdp);
     bool updateWVFPEXP(std::shared_ptr<WVFPEXP> wvfpexp);
     bool updateWDFAC(std::shared_ptr<WDFAC> wdfac);
-
 
     bool handleWELSEGS(const DeckKeyword& keyword);
     bool handleCOMPSEGS(const DeckKeyword& keyword, const ScheduleGrid& grid, const ParseContext& parseContext, ErrorGuard& errors);
@@ -626,6 +636,8 @@ public:
         serializer(inj_mult_mode);
         serializer(well_inj_mult);
         serializer(m_filter_concentration);
+        serializer(ref_type);
+        serializer(lgr_tag);
     }
 
 private:
@@ -636,6 +648,7 @@ private:
 
     std::string wname{};
     std::string group_name{};
+    std::string lgr_tag{};
     std::size_t init_step{};
     std::size_t insert_index{};
     int headI{};
@@ -647,12 +660,14 @@ private:
     bool automatic_shutin{false};
     int pvt_table{};
 
+
     // Will NOT be loaded/assigned from restart file
     GasInflowEquation gas_inflow = GasInflowEquation::STD;
 
     const UnitSystem* unit_system{nullptr};
     double udq_undefined{};
     WellType wtype{};
+    WellRefinementType ref_type{WellRefinementType::STANDARD};
     WellGuideRate guide_rate{};
     double efficiency_factor{};
     bool use_efficiency_in_network{};

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -18,7 +18,6 @@
  */
 
 #include "WellKeywordHandlers.hpp"
-
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
 #include <opm/common/utility/String.hpp>
@@ -649,8 +648,9 @@ void handleWELSPECL(HandlerContext& handlerContext)
     handleWELSPECS(handlerContext);
     for (const auto& record : handlerContext.keyword) {
         const auto wellName = getTrimmedName(record.getItem<Kw::WELL>());
-        const auto groupName = getTrimmedName(record.getItem<Kw::GROUP>());
         const auto lgrTag = getTrimmedName(record.getItem<Kw::LGR>());
+        handlerContext.state().wells.get(wellName).flag_lgr_well();
+        handlerContext.state().wells.get(wellName).set_lgr_well_tag(lgrTag);
     }
 }
 

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -635,6 +635,25 @@ Well{0} entered with 'FIELD' parent group:
     }
 }
 
+
+void handleWELSPECL(HandlerContext& handlerContext)
+{
+    using Kw = ParserKeywords::WELSPECL;
+    auto getTrimmedName = [&handlerContext](const auto& item)
+    {
+        return trim_wgname(handlerContext.keyword,
+                           item.template get<std::string>(0),
+                           handlerContext.parseContext,
+                           handlerContext.errors);
+    };
+    handleWELSPECS(handlerContext);
+    for (const auto& record : handlerContext.keyword) {
+        const auto wellName = getTrimmedName(record.getItem<Kw::WELL>());
+        const auto groupName = getTrimmedName(record.getItem<Kw::GROUP>());
+        const auto lgrTag = getTrimmedName(record.getItem<Kw::LGR>());
+    }
+}
+
 /*
   The documentation for the WELTARG keyword says that the well
   must have been fully specified and initialized using one of the
@@ -651,6 +670,7 @@ Well{0} entered with 'FIELD' parent group:
   WCONPROD / WCONHIST before WELTARG is applied, if not the units for the
   rates will be wrong.
 */
+
 void handleWELTARG(HandlerContext& handlerContext)
 {
     const double SiFactorP = handlerContext.static_schedule().m_unit_system.parse("Pressure").getSIScaling();
@@ -926,6 +946,7 @@ getWellHandlers()
         { "WCYCLE",   &handleWCYCLE   },
         { "WELOPEN" , &handleWELOPEN  },
         { "WELSPECS", &handleWELSPECS },
+        { "WELSPECL", &handleWELSPECL },
         { "WELTARG" , &handleWELTARG  },
         { "WELTRAJ" , &handleWELTRAJ  },
         { "WHISTCTL", &handleWHISTCTL },

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -2067,3 +2067,61 @@ END
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(WellLGR)
+{
+    const auto deck = Parser{}.parseString(R"(RUNSPEC
+DIMENS
+3 3 1 /
+GRID
+CARFIN
+-- NAME I1-I2 J1-J2 K1-K2 NX NY NZ
+'LGR1'  1  1  1  1  1  1  3  3  1 /
+ENDFIN
+CARFIN
+-- NAME I1-I2 J1-J2 K1-K2 NX NY NZ
+'LGR2'  3  3  3  3  1  1  3  3  1 /
+ENDFIN
+
+INIT
+DX 
+   	9*1000 /
+DY
+	9*1000 /
+DZ
+	9*50 /
+
+TOPS
+	9*8325 /
+
+PORO
+   	9*0.3 /
+
+PERMX
+	9*500 /
+
+PERMY
+	9*200 /
+
+PERMZ
+	9*200 /
+
+SCHEDULE
+WELSPECL
+-- Item #: 1	 2	3	4	5	 6 7
+	'PROD'	'G1' 'LGR2'	3	3	8400	'OIL' /
+	'INJ'	'G1' 'LGR1'	1	1	8335	'GAS' /
+/
+COMPDATL
+-- Item #: 1	2	3	4	5	6	7	8	9 10
+	'PROD' 'LGR2'	3	3	1	1	'OPEN'	1*	1*	0.5 /
+	'INJ'  'LGR1'   1	1	1	1	'OPEN'	1*	1*	0.5 /
+/
+)");
+
+    const auto es    = EclipseState { deck };
+    const auto sched = Schedule { deck, es };
+
+
+
+}

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -2121,7 +2121,8 @@ COMPDATL
 
     const auto es    = EclipseState { deck };
     const auto sched = Schedule { deck, es };
-
-
-
+    BOOST_CHECK_EQUAL(sched.getWell("PROD", 0).is_lgr_well(), true);
+    BOOST_CHECK_EQUAL(sched.getWell("INJ", 0).is_lgr_well(), true);
+    BOOST_CHECK_EQUAL(sched.getWell("PROD", 0).get_lgr_well_tag(), "LGR2");
+    BOOST_CHECK_EQUAL(sched.getWell("INJ", 0).get_lgr_well_tag(), "LGR1");
 }


### PR DESCRIPTION
## Implement LGR Wells Handling and WELSPECL Keyword Support

### Description
This pull request introduces several enhancements to the well handling capabilities, specifically focusing on Local Grid Refinement (LGR) wells. The main changes include:

- **Implementation of the `WELSPECL` keyword** to handle wells specified in LGR regions.
- **Addition of new methods** in the `Well` class to manage LGR wells, including methods to flag, set, and retrieve LGR well tags.
- **Unit tests** added to verify the correct handling of LGR wells and the `WELSPECL` keyword.

#### Commit Summary:
- Added `WellLGR` test with a string containing a deck with two LGR wells.
- Created `handleWELSPECL` method to manage `WELSPECL` keyword.
- Implemented `WELSPECL` keyword and added unit tests to verify well handling in LGR regions.
