### PR TITLE
Do not flag identical negative numbers as different.

### DIFF
--- a/test_util/EclRegressionTest.hpp
+++ b/test_util/EclRegressionTest.hpp
@@ -159,7 +159,7 @@ private:
     std::vector<double> absDeviation, relDeviation;
 
     // Keywords which should not contain negative values, i.e. uses allowNegativeValues = false in deviationsForCell():
-    const std::vector<std::string> keywordDisallowNegatives = {"SGAS", "SWAT", "PRESSURE"};
+    const std::vector<std::string> keywordDisallowNegatives = {};//{"SGAS", "SWAT", "PRESSURE"};
 
     double strictAbsTol = 1e-6;
     double strictRelTol = 1e-6;


### PR DESCRIPTION
This applies to the comparison program that checks regression failures. With the current approach, keywords in the "keywordDisallowNegatives" set will be treated such that even if the reference and test results are identical, if negative it will still be flagged as a failing test (if the negative values are larger than the absolute tolerance). This is unproductive when applied to the regression tests, and just gives unnecessary failures. If the intention is to disallow any negative values at all in certain fields, the code must be changed to do just that (and not allow negative values with small absolute value), I would support a move in that direction, although it would also require modification to Flow, which currently can indeed produce negative values for SGAS and SWAT.

The change proposed here is a simple disabling of this (in my opinion) strange behavior, but we could discuss more fundamental changes as outlined above.