### PR TITLE
Notify Simulator Layer if Well's Efficiency Factor Changes

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -160,6 +160,9 @@ void handleWEFAC(HandlerContext& handlerContext)
             if (well2.updateEfficiencyFactor(efficiencyFactor, useEfficiencyInNetwork)) {
                 handlerContext.state().wells.update(std::move(well2));
 
+                handlerContext.affected_well(well_name);
+                handlerContext.record_well_structure_change();
+
                 handlerContext.state().events()
                     .addEvent(ScheduleEvents::WELLGROUP_EFFICIENCY_UPDATE);
 

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -140,19 +140,31 @@ void handleWECON(HandlerContext& handlerContext)
 
 void handleWEFAC(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WEFAC;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELLNAME").getTrimmedString(0);
+        const auto wellNamePattern = record.getItem<Kw::WELLNAME>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern);
 
-        const double& efficiencyFactor = record.getItem("EFFICIENCY_FACTOR").get<double>(0);
-        const bool useEfficiencyInNetwork = DeckItem::to_bool(record.getItem("USE_WEFAC_IN_NETWORK").getTrimmedString(0));
+        if (well_names.empty()) {
+            handlerContext.invalidNamePattern(wellNamePattern);
+        }
+
+        const auto efficiencyFactor = record.getItem<Kw::EFFICIENCY_FACTOR>().get<double>(0);
+        const bool useEfficiencyInNetwork =
+            DeckItem::to_bool(record.getItem<Kw::USE_WEFAC_IN_NETWORK>().getTrimmedString(0));
 
         for (const auto& well_name : well_names) {
-            auto well2 = handlerContext.state().wells.get( well_name );
-            if (well2.updateEfficiencyFactor(efficiencyFactor, useEfficiencyInNetwork)){
-                handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::WELLGROUP_EFFICIENCY_UPDATE);
-                handlerContext.state().events().addEvent(ScheduleEvents::WELLGROUP_EFFICIENCY_UPDATE);
-                handlerContext.state().wells.update( std::move(well2) );
+            auto well2 = handlerContext.state().wells.get(well_name);
+
+            if (well2.updateEfficiencyFactor(efficiencyFactor, useEfficiencyInNetwork)) {
+                handlerContext.state().wells.update(std::move(well2));
+
+                handlerContext.state().events()
+                    .addEvent(ScheduleEvents::WELLGROUP_EFFICIENCY_UPDATE);
+
+                handlerContext.state().wellgroup_events()
+                    .addEvent(well_name, ScheduleEvents::WELLGROUP_EFFICIENCY_UPDATE);
             }
         }
     }


### PR DESCRIPTION
If the WEFAC keyword is run from an ACTIONX block in the middle of a report step, then we need to notify the simulator in order that the factor be immediately updated in the simulator.  Abuse the "well structure changed" notification (commit 5f0941677, PR #3600) to signal that the simulator's notion of its wells must be updated in this case.

While here, switch to using compiled item names in the WEFAC keyword handler to add a little bit of compile-time error checking if these names ever change.