### PR TITLE
Save and Restore Network Node's Lift Gas as Produced Gas Setting

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -21,13 +21,16 @@
 
 #include <opm/io/eclipse/rst/state.hpp>
 
+#include <opm/output/eclipse/VectorItems/group.hpp>
+
 #include <opm/common/OpmLog/LogUtil.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
-#include <opm/input/eclipse/Parser/InputErrorAction.hpp>
 #include <opm/common/utility/String.hpp>
 #include <opm/common/utility/numeric/cmp.hpp>
 #include <opm/common/utility/shmatch.hpp>
+
+#include <opm/input/eclipse/Parser/InputErrorAction.hpp>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
@@ -2546,7 +2549,19 @@ namespace {
                     node.as_choke(rst_node.as_choke.value());
                 }
 
-                node.add_gas_lift_gas(rst_node.add_lift_gas);
+                network.update_node(std::move(node));
+            }
+
+            for (const auto& rst_group : rst_state.groups) {
+                if (! network.has_node(rst_group.name)) {
+                    continue;
+                }
+
+                auto node = network.node(rst_group.name);
+                node.add_gas_lift_gas
+                    (rst_group.add_gas_lift_gas ==
+                     RestartIO::Helpers::VectorItems::
+                     IGroup::Value::GLiftGas::Yes);
 
                 network.update_node(std::move(node));
             }

--- a/opm/io/eclipse/rst/group.cpp
+++ b/opm/io/eclipse/rst/group.cpp
@@ -3,7 +3,8 @@
 
   This file is part of the Open Porous Media project (OPM).
 
-  OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
@@ -16,32 +17,32 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <opm/io/eclipse/rst/group.hpp>
+
 #include <opm/common/utility/String.hpp>
 
 #include <opm/io/eclipse/rst/header.hpp>
-#include <opm/io/eclipse/rst/group.hpp>
 
 #include <opm/output/eclipse/VectorItems/group.hpp>
+
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
-
 namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
+using M = ::Opm::UnitSystem::measure;
 
-namespace Opm {
-namespace RestartIO {
+Opm::RestartIO::RstGroup::RstGroup(const ::Opm::UnitSystem& unit_system,
+                                   const RstHeader&         header,
+                                   const std::string*       zwel,
+                                   const int*               igrp,
+                                   const float*             sgrp,
+                                   const double*            xgrp) :
+    // -------------------------------------------------------------------------
 
-using M  = ::Opm::UnitSystem::measure;
-
-
-RstGroup::RstGroup(const ::Opm::UnitSystem& unit_system,
-                   const RstHeader& header,
-                   const std::string* zwel,
-                   const int * igrp,
-                   const float * sgrp,
-                   const double * xgrp) :
     name(trim_copy(zwel[0])),
-    parent_group(igrp[header.nwgmax + VI::IGroup::ParentGroup] ),
-    // prod_active_cmode(igrp[header.nwgmax + VI::IGroup::ProdActiveCMode]),
+
+    // -------------------------------------------------------------------------
+
+    parent_group(igrp[header.nwgmax + VI::IGroup::ParentGroup]),
     prod_cmode(igrp[header.nwgmax + VI::IGroup::GConProdCMode]),
     winj_cmode(igrp[header.nwgmax + VI::IGroup::GConInjeWInjCMode]),
     ginj_cmode(igrp[header.nwgmax + VI::IGroup::GConInjeGInjCMode]),
@@ -50,6 +51,10 @@ RstGroup::RstGroup(const ::Opm::UnitSystem& unit_system,
     inj_water_guide_rate_def(igrp[header.nwgmax + VI::IGroup::GConInjeWaterGuideRateMode]),
     inj_gas_guide_rate_def(igrp[header.nwgmax + VI::IGroup::GConInjeGasGuideRateMode]),
     voidage_group_index(igrp[header.nwgmax + VI::IGroup::VoidageGroupIndex]),
+    add_gas_lift_gas(igrp[header.nwgmax + VI::IGroup::AddGLiftGasAsProducedGas]),
+
+    // -------------------------------------------------------------------------
+
     // The values oil_rate_limit -> gas_voidage_limit will be used in UDA
     // values. The UDA values are responsible for unit conversion and raw values
     // are internalized here.
@@ -72,6 +77,9 @@ RstGroup::RstGroup(const ::Opm::UnitSystem& unit_system,
     inj_gas_guide_rate(            sgrp[VI::SGroup::gasGuideRate]),
     gas_consumption_rate(          sgrp[VI::SGroup::GasConsumptionRate]),      // UDA, stored in output units
     gas_import_rate(               sgrp[VI::SGroup::GasImportRate]),           // UDA, stored in output units
+
+    // -------------------------------------------------------------------------
+
     oil_production_rate(           unit_system.to_si(M::liquid_surface_rate,   xgrp[VI::XGroup::OilPrRate])),
     water_production_rate(         unit_system.to_si(M::liquid_surface_rate,   xgrp[VI::XGroup::WatPrRate])),
     gas_production_rate(           unit_system.to_si(M::gas_surface_rate,      xgrp[VI::XGroup::GasPrRate])),
@@ -96,9 +104,4 @@ RstGroup::RstGroup(const ::Opm::UnitSystem& unit_system,
     history_total_gas_injection(   unit_system.to_si(M::gas_surface_volume,    xgrp[VI::XGroup::HistGasInjTotal])),
     gas_consumption_total(         unit_system.to_si(M::gas_surface_volume,    xgrp[VI::XGroup::GasConsumptionTotal])),
     gas_import_total(              unit_system.to_si(M::gas_surface_volume,    xgrp[VI::XGroup::GasImportTotal]))
-{
-}
-
-
-}
-}
+{}

--- a/opm/io/eclipse/rst/group.hpp
+++ b/opm/io/eclipse/rst/group.hpp
@@ -3,7 +3,8 @@
 
   This file is part of the Open Porous Media project (OPM).
 
-  OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
@@ -20,23 +21,27 @@
 #define RST_GROUP
 
 #include <array>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace Opm {
-class UnitSystem;
+    class UnitSystem;
+} // namespace Opm
 
-namespace RestartIO {
+namespace Opm::RestartIO {
+    struct RstHeader;
+} // namespace Opm::RestartIO
 
-struct RstHeader;
+namespace Opm::RestartIO {
 
-struct RstGroup {
-    RstGroup(const UnitSystem& unit_system,
-             const RstHeader& header,
+struct RstGroup
+{
+    RstGroup(const UnitSystem&  unit_system,
+             const RstHeader&   header,
              const std::string* zwel,
-             const int * igrp,
-             const float * sgrp,
-             const double * xgrp);
+             const int*         igrp,
+             const float*       sgrp,
+             const double*      xgrp);
 
     std::string name;
 
@@ -49,6 +54,7 @@ struct RstGroup {
     int inj_water_guide_rate_def;
     int inj_gas_guide_rate_def;
     int voidage_group_index;
+    int add_gas_lift_gas;
 
     float oil_rate_limit;
     float water_rate_limit;
@@ -98,11 +104,6 @@ struct RstGroup {
     static constexpr auto UNDEFINED_VALUE = 1.0e20f;
 };
 
+} // namespace Opm::RestartIO
 
-}
-}
-
-
-
-
-#endif
+#endif // RST_GROUP

--- a/opm/io/eclipse/rst/network.hpp
+++ b/opm/io/eclipse/rst/network.hpp
@@ -65,10 +65,6 @@ namespace Opm { namespace RestartIO {
             /// choking is disabled.
             std::optional<std::string> as_choke{};
 
-            /// Whether or not to include lift gas of subordinate wells as
-            /// part of the produced gas entering the network at this node.
-            bool add_lift_gas{false};
-
             /// Node pressure
             double pressure{};
         };

--- a/opm/output/eclipse/AggregateGroupData.cpp
+++ b/opm/output/eclipse/AggregateGroupData.cpp
@@ -25,11 +25,12 @@
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
 
 #include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
-#include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
-#include <opm/input/eclipse/Schedule/SummaryState.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
+#include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
+#include <opm/input/eclipse/Schedule/Network/Node.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 #include <algorithm>
@@ -38,8 +39,8 @@
 #include <exception>
 #include <map>
 #include <optional>
-#include <string>
 #include <stdexcept>
+#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -56,7 +57,6 @@
 // Class Opm::RestartIO::Helpers::AggregateGroupData
 // ---------------------------------------------------------------------
 
-
 namespace {
 
 // maximum number of groups
@@ -70,8 +70,11 @@ int nwgmax(const std::vector<int>& inteHead)
 {
     return inteHead[Opm::RestartIO::Helpers::VectorItems::NWGMAX];
 }
- namespace value = ::Opm::RestartIO::Helpers::VectorItems::IGroup::Value;
- value::GuideRateMode GuideRateModeFromGuideRateProdTarget(Opm::Group::GuideRateProdTarget grpt) {
+
+namespace value = ::Opm::RestartIO::Helpers::VectorItems::IGroup::Value;
+value::GuideRateMode
+GuideRateModeFromGuideRateProdTarget(Opm::Group::GuideRateProdTarget grpt)
+{
     switch (grpt) {
         case Opm::Group::GuideRateProdTarget::OIL:
             return value::GuideRateMode::Oil;
@@ -104,7 +107,6 @@ int nwgmax(const std::vector<int>& inteHead)
     }
 }
 
-
 template <typename GroupOp>
 void groupLoop(const std::vector<const Opm::Group*>& groups,
                GroupOp&&                             groupOp)
@@ -121,16 +123,9 @@ void groupLoop(const std::vector<const Opm::Group*>& groups,
     }
 }
 
-template <typename T>
-std::optional<int> findInVector(const std::vector<T>  & vecOfElements, const T  & element)
-{
-    // Find given element in vector
-    auto it = std::find(vecOfElements.begin(), vecOfElements.end(), element);
-
-    return (it != vecOfElements.end()) ? std::optional<int>{std::distance(vecOfElements.begin(), it)} : std::nullopt;
-}
-
-int currentGroupLevel(const Opm::Schedule& sched, const Opm::Group& group, const size_t simStep)
+int currentGroupLevel(const Opm::Schedule& sched,
+                      const Opm::Group& group,
+                      const std::size_t simStep)
 {
     auto current = group;
     int level = 0;
@@ -142,7 +137,11 @@ int currentGroupLevel(const Opm::Schedule& sched, const Opm::Group& group, const
     return level;
 }
 
-void groupCurrentlyProductionControllable(const Opm::Schedule& sched, const Opm::SummaryState& sumState, const Opm::Group& group, const size_t simStep, bool& controllable)
+void groupCurrentlyProductionControllable(const Opm::Schedule& sched,
+                                          const Opm::SummaryState& sumState,
+                                          const Opm::Group& group,
+                                          const std::size_t simStep,
+                                          bool& controllable)
 {
     using wellCtrlMode   = ::Opm::RestartIO::Helpers::VectorItems::IWell::Value::WellCtrlMode;
     if (controllable)
@@ -175,15 +174,22 @@ void groupCurrentlyProductionControllable(const Opm::Schedule& sched, const Opm:
     }
 }
 
-
-bool groupCurrentlyProductionControllable(const Opm::Schedule& sched, const Opm::SummaryState& sumState, const Opm::Group& group, const size_t simStep) {
+bool groupCurrentlyProductionControllable(const Opm::Schedule& sched,
+                                          const Opm::SummaryState& sumState,
+                                          const Opm::Group& group,
+                                          const std::size_t simStep)
+{
     bool controllable = false;
     groupCurrentlyProductionControllable(sched, sumState, group, simStep, controllable);
     return controllable;
 }
 
-
-void groupCurrentlyInjectionControllable(const Opm::Schedule& sched, const Opm::SummaryState& sumState, const Opm::Group& group, const Opm::Phase& iPhase, const size_t simStep, bool& controllable)
+void groupCurrentlyInjectionControllable(const Opm::Schedule& sched,
+                                         const Opm::SummaryState& sumState,
+                                         const Opm::Group& group,
+                                         const Opm::Phase& iPhase,
+                                         const std::size_t simStep,
+                                         bool& controllable)
 {
     using wellCtrlMode   = ::Opm::RestartIO::Helpers::VectorItems::IWell::Value::WellCtrlMode;
     if (controllable)
@@ -223,7 +229,12 @@ void groupCurrentlyInjectionControllable(const Opm::Schedule& sched, const Opm::
     }
 }
 
-bool groupCurrentlyInjectionControllable(const Opm::Schedule& sched, const Opm::SummaryState& sumState, const Opm::Group& group, const Opm::Phase& iPhase, const size_t simStep) {
+bool groupCurrentlyInjectionControllable(const Opm::Schedule& sched,
+                                         const Opm::SummaryState& sumState,
+                                         const Opm::Group& group,
+                                         const Opm::Phase& iPhase,
+                                         const std::size_t simStep)
+{
     bool controllable = false;
     groupCurrentlyInjectionControllable(sched, sumState, group, iPhase, simStep, controllable);
     return controllable;
@@ -236,10 +247,12 @@ bool groupCurrentlyInjectionControllable(const Opm::Schedule& sched, const Opm::
   optional if no such group can be found.
 */
 
-std::optional<Opm::Group> controlGroup(const Opm::Schedule& sched,
-                                       const Opm::SummaryState& sumState,
-                                       const Opm::Group& group,
-                                       const std::size_t simStep) {
+std::optional<Opm::Group>
+controlGroup(const Opm::Schedule& sched,
+             const Opm::SummaryState& sumState,
+             const Opm::Group& group,
+             const std::size_t simStep)
+{
     auto current = group;
     bool isField = false;
     while (!isField) {
@@ -262,16 +275,17 @@ std::optional<Opm::Group> controlGroup(const Opm::Schedule& sched,
     return {};
 }
 
-
-std::optional<Opm::Group>  injectionControlGroup(const Opm::Schedule& sched,
-        const Opm::SummaryState& sumState,
-        const Opm::Group& group,
-        const std::string& curGroupInjCtrlKey,
-        const std::string& curFieldInjCtrlKey,
-        const size_t simStep)
 //
-// returns group of higher (highest) level group with active control different from (NONE or FLD)
+// returns group of higher (highest) level group with active control
+// different from (NONE or FLD)
 //
+std::optional<Opm::Group>
+injectionControlGroup(const Opm::Schedule& sched,
+                      const Opm::SummaryState& sumState,
+                      const Opm::Group& group,
+                      const std::string& curGroupInjCtrlKey,
+                      const std::string& curFieldInjCtrlKey,
+                      const std::size_t simStep)
 {
     auto current = group;
     bool isField = false;
@@ -298,7 +312,7 @@ std::optional<Opm::Group>  injectionControlGroup(const Opm::Schedule& sched,
         }
     }
     return {};
-} // namespace
+}
 
 namespace IGrp {
 std::size_t entriesPerGroup(const std::vector<int>& inteHead)
@@ -317,18 +331,16 @@ allocate(const std::vector<int>& inteHead)
     };
 }
 
-
-
 template <class IGrpArray>
 void gconprodCMode(const Opm::Group& group,
                    const int nwgmax,
-                   IGrpArray& iGrp) {
+                   IGrpArray& iGrp)
+{
     using IGroup = ::Opm::RestartIO::Helpers::VectorItems::IGroup::index;
 
     const auto& prod_cmode = group.prod_cmode();
     iGrp[nwgmax + IGroup::GConProdCMode] = Opm::Group::ProductionCMode2Int(prod_cmode);
 }
-
 
 template <class IGrpArray>
 void productionGroup(const Opm::Schedule&     sched,
@@ -562,8 +574,6 @@ std::tuple<int, int, int, int> injectionGroup(const Opm::Schedule&     sched,
     return {high_level_ctrl, current_cmode, gconinje_cmode, guide_rate_def};
 }
 
-
-
 template <class IGrpArray>
 void injectionGroup(const Opm::Schedule&     sched,
                     const Opm::Group&        group,
@@ -573,28 +583,33 @@ void injectionGroup(const Opm::Schedule&     sched,
                     IGrpArray&               iGrp)
 {
     using IGroup = ::Opm::RestartIO::Helpers::VectorItems::IGroup::index;
+
     const bool is_field = group.name() == "FIELD";
-    using IGroup = ::Opm::RestartIO::Helpers::VectorItems::IGroup::index;
 
-
-    // set "default value" for production higher level control in case a group is only injection group
+    // Set "default value" for production higher level control in case a
+    // group is only injection group
     if (group.isInjectionGroup() && !group.isProductionGroup()) {
         iGrp[nwgmax + IGroup::ProdHighLevCtrl] = 1;
     }
-    //Special treatment of groups with no GCONINJE data
+
+    // Special treatment of groups with no GCONINJE data
     if (group.getGroupType() == Opm::Group::GroupType::NONE) {
         if (is_field) {
             iGrp[nwgmax + IGroup::WInjHighLevCtrl] = 0;
             iGrp[nwgmax + IGroup::GInjHighLevCtrl] = 0;
-        } else {
+        }
+        else {
             //set default value for the group's availability for higher level control for injection
             iGrp[nwgmax + IGroup::WInjHighLevCtrl] = (groupCurrentlyInjectionControllable(sched, sumState, group, Opm::Phase::WATER, simStep) ) ? 1 : -1;
             iGrp[nwgmax + IGroup::GInjHighLevCtrl] = (groupCurrentlyInjectionControllable(sched, sumState, group, Opm::Phase::GAS, simStep) ) ? 1 : -1;
         }
+
         return;
     }
+
     {
         iGrp[nwgmax + IGroup::VoidageGroupIndex] = group.insert_index();
+
         for (const auto& [phase, inj_prop] : group.injectionProperties()) {
             if (inj_prop.cmode == Opm::Group::InjectionCMode::VREP &&
                 inj_prop.voidage_group.has_value()) {
@@ -607,17 +622,20 @@ void injectionGroup(const Opm::Schedule&     sched,
         }
     }
 
-    {
-        if (group.hasInjectionControl(Opm::Phase::WATER)) {
-            auto [high_level_ctrl, active_cmode, gconinje_cmode, guide_rate_def] = injectionGroup(sched, group, nwgmax, simStep, sumState, Opm::Phase::WATER);
-            iGrp[nwgmax + IGroup::WInjHighLevCtrl] = high_level_ctrl;
-            iGrp[nwgmax + IGroup::WInjActiveCMode] = active_cmode;
-            iGrp[nwgmax + IGroup::GConInjeWInjCMode] = gconinje_cmode;
-            iGrp[nwgmax + IGroup::GConInjeWaterGuideRateMode] = guide_rate_def;
-        }
+    if (group.hasInjectionControl(Opm::Phase::WATER)) {
+        const auto& [high_level_ctrl, active_cmode, gconinje_cmode, guide_rate_def] =
+            injectionGroup(sched, group, nwgmax, simStep, sumState, Opm::Phase::WATER);
+
+        iGrp[nwgmax + IGroup::WInjHighLevCtrl] = high_level_ctrl;
+        iGrp[nwgmax + IGroup::WInjActiveCMode] = active_cmode;
+        iGrp[nwgmax + IGroup::GConInjeWInjCMode] = gconinje_cmode;
+        iGrp[nwgmax + IGroup::GConInjeWaterGuideRateMode] = guide_rate_def;
     }
+
     {
-        auto [high_level_ctrl, active_cmode, gconinje_cmode, guide_rate_def] = injectionGroup(sched, group, nwgmax, simStep, sumState, Opm::Phase::GAS);
+        const auto& [high_level_ctrl, active_cmode, gconinje_cmode, guide_rate_def] =
+            injectionGroup(sched, group, nwgmax, simStep, sumState, Opm::Phase::GAS);
+
         iGrp[nwgmax + IGroup::GInjHighLevCtrl] = high_level_ctrl;
         iGrp[nwgmax + IGroup::GInjActiveCMode] = active_cmode;
         iGrp[nwgmax + IGroup::GConInjeGInjCMode] = gconinje_cmode;
@@ -626,21 +644,41 @@ void injectionGroup(const Opm::Schedule&     sched,
 }
 
 template <class IGrpArray>
-void storeNodeSequenceNo(const Opm::Schedule& sched,
-                    const Opm::Group& group,
-                    const int nwgmax,
-                    const std::size_t simStep,
-                    IGrpArray& iGrp) {
+void storeNetworkNodeInformation(const Opm::Schedule& sched,
+                                 const std::string&   group,
+                                 const int            nwgmax,
+                                 const std::size_t    simStep,
+                                 IGrpArray&           iGrp)
+{
+    namespace IGroup = ::Opm::RestartIO::Helpers::VectorItems::IGroup;
+    using Ix = IGroup::index;
 
-    using IGroup = ::Opm::RestartIO::Helpers::VectorItems::IGroup::index;
+    const auto& network = sched[simStep].network();
+    if (! network.active()) {
+        return;
+    }
 
-    const auto& netwrk = sched[simStep].network();
-    const auto seq_ind = findInVector(netwrk.node_names(), group.name());
+    auto& nodeNumber = iGrp[nwgmax + Ix::NodeNumber];
+    auto& addGLiftGas = iGrp[nwgmax + Ix::AddGLiftGasAsProducedGas];
 
-    // The igrp node number is equal to the node sequence number from the BRANPROP keyword
-    // for the groups that also are nodes in the external network (BRANPROP, NODEPROP)
-    // If not - the node numbr is zero.
-    iGrp[nwgmax + IGroup::NodeNumber] = seq_ind ? seq_ind.value()+1 : 0;
+    // For groups that are also nodes in the extended network (BRANPROP,
+    // NODEPROP), the IGRP node number is the 1-based node sequence number
+    // from the BRANPROP keyword.  For all other groups, the node number is
+    // zero.
+    const auto& nodeNames = network.node_names();
+    const auto seqIndPos = std::find(nodeNames.begin(), nodeNames.end(), group);
+    if (seqIndPos == nodeNames.end()) {
+        nodeNumber = 0;
+        addGLiftGas = IGroup::Value::GLiftGas::No;
+    }
+    else {
+        nodeNumber = 1 + static_cast<int>
+            (std::distance(nodeNames.begin(), seqIndPos));
+
+        addGLiftGas = network.node(group).add_gas_lift_gas()
+            ? IGroup::Value::GLiftGas::Yes
+            : IGroup::Value::GLiftGas::No;
+    }
 }
 
 template <class IGrpArray>
@@ -649,7 +687,8 @@ void storeGroupTree(const Opm::Schedule& sched,
                     const int nwgmax,
                     const int ngmaxz,
                     const std::size_t simStep,
-                    IGrpArray& iGrp) {
+                    IGrpArray& iGrp)
+{
 
     namespace Value = ::Opm::RestartIO::Helpers::VectorItems::IGroup::Value;
     using IGroup = ::Opm::RestartIO::Helpers::VectorItems::IGroup::index;
@@ -691,19 +730,18 @@ void storeGroupTree(const Opm::Schedule& sched,
     iGrp[nwgmax + IGroup::GroupLevel] = currentGroupLevel(sched, group, simStep);
 }
 
-
 template <class IGrpArray>
 void storeFlowingWells(const Opm::Group&        group,
                        const int                nwgmax,
                        const Opm::SummaryState& sumState,
-                       IGrpArray&               iGrp) {
+                       IGrpArray&               iGrp)
+{
     using IGroup = ::Opm::RestartIO::Helpers::VectorItems::IGroup::index;
     const bool is_field = group.name() == "FIELD";
     const double g_act_pwells = is_field ? sumState.get("FMWPR", 0) : sumState.get_group_var(group.name(), "GMWPR", 0);
     const double g_act_iwells = is_field ? sumState.get("FMWIN", 0) : sumState.get_group_var(group.name(), "GMWIN", 0);
     iGrp[nwgmax + IGroup::FlowingWells] = static_cast<int>(g_act_pwells) + static_cast<int>(g_act_iwells);
 }
-
 
 template <class IGrpArray>
 void staticContrib(const Opm::Schedule&     sched,
@@ -719,15 +757,16 @@ void staticContrib(const Opm::Schedule&     sched,
 
     storeGroupTree(sched, group, nwgmax, ngmaxz, simStep, iGrp);
 
-    //node-number for groups in external network (according to sequence in BRANPROP)
-    storeNodeSequenceNo(sched, group, nwgmax, simStep, iGrp);
+    // Node number and other node properties for groups, i.e., leaf nodes,
+    // in extended network model.
+    storeNetworkNodeInformation(sched, group.name(), nwgmax, simStep, iGrp);
 
     storeFlowingWells(group, nwgmax, sumState, iGrp);
 
-    // Treat all groups for production controls
+    // Treat all groups for production controls.
     productionGroup(sched, group, nwgmax, simStep, sumState, iGrp);
 
-    // Treat all groups for injection controls
+    // Treat all groups for injection controls.
     injectionGroup(sched, group, nwgmax, simStep, sumState, iGrp);
 
     if (is_field)
@@ -1157,9 +1196,8 @@ void staticContrib(const Opm::Group& group, ZGroupArray& zGroup)
     zGroup[0] = group.name();
 }
 } // ZGrp
-} // Anonymous
 
-
+} // Namespace anonymous
 
 // =====================================================================
 

--- a/opm/output/eclipse/VectorItems/group.hpp
+++ b/opm/output/eclipse/VectorItems/group.hpp
@@ -22,7 +22,70 @@
 
 #include <vector>
 
-namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems {
+namespace Opm::RestartIO::Helpers::VectorItems {
+
+    namespace IGroup {
+        // Observe that these value should not be used as ordinary indices
+        // into the the IGRP vector.  Instead, they should all be treated as
+        // offsets from the "child group" portion of IGRP.  In other words,
+        // the actual index into IGRP should be formed as
+        //
+        //   IGRP[NWGMAX + index]
+        //
+        enum index : std::vector<int>::size_type {
+            NoOfChildGroupsWells = 0,
+            ProdActiveCMode = 1,
+            ProdHighLevCtrl = 5,
+            GuideRateDef = 6,
+            ExceedAction = 7,
+            GConProdCMode = 10,
+            WInjActiveCMode = 16,
+            WInjHighLevCtrl = 17,
+            GConInjeWInjCMode = 19,
+            GConInjeWaterGuideRateMode = 20,
+            GInjActiveCMode = 21,
+            GInjHighLevCtrl = 22,
+            GConInjeGInjCMode = 24,
+            GConInjeGasGuideRateMode = 25,
+            GroupType = 26,
+            GroupLevel = 27,
+            ParentGroup = 28,
+            FlowingWells = 33,
+            NodeNumber = 39,
+
+            // Whether or not lift gas from node's corresponding group's
+            // subordinate groups should be added to the produced gas
+            // entering the network at this node in the extended network
+            // model (NODEPROP(4)).
+            AddGLiftGasAsProducedGas = 53,
+
+            VoidageGroupIndex = 89,
+        };
+
+        namespace Value {
+            enum GuideRateMode : int {
+                None = 0,
+                Oil = 1,
+                Water = 2,
+                Gas = 3,
+                Liquid = 4,
+                Resv = 6,  // need to be verified!!!
+                Potn = 7,
+                Form = 8,
+                Comb = 9,
+            };
+
+            enum GroupType : int {
+                WellGroup = 0,
+                TreeGroup = 1,
+            };
+
+            enum GLiftGas : int {
+                No = 0,
+                Yes = 1,
+            };
+        } // namespace Value
+    } // namespace IGroup
 
     namespace SGroup {
         enum index : std::vector<float>::size_type {
@@ -88,56 +151,6 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             constexpr auto NoGLOLimit = -10.0f;
         } // namespace Value
     } // SGroup
-
-
-    namespace IGroup {
-    // Observe that these value should not be used as ordinary indices into
-    // the the IGRP vector, they should all be used as IGRP[NWGMAX + $index]
-    enum index : std::vector<int>::size_type {
-        NoOfChildGroupsWells = 0,
-        ProdActiveCMode = 1,
-        ProdHighLevCtrl = 5,
-        GuideRateDef = 6,
-        ExceedAction = 7,
-        GConProdCMode = 10,
-        WInjActiveCMode = 16,
-        WInjHighLevCtrl = 17,
-        GConInjeWInjCMode = 19,
-        GConInjeWaterGuideRateMode = 20,
-        GInjActiveCMode = 21,
-        GInjHighLevCtrl = 22,
-        GConInjeGInjCMode = 24,
-        GConInjeGasGuideRateMode = 25,
-        GroupType = 26,
-        GroupLevel = 27,
-        ParentGroup = 28,
-        FlowingWells = 33,
-        NodeNumber = 39,
-        VoidageGroupIndex = 89
-    };
-
-    namespace Value {
-    enum GuideRateMode : int {
-        None = 0,
-        Oil = 1,
-        Water = 2,
-        Gas = 3,
-        Liquid = 4,
-        Resv = 6,  // need to be verified!!!
-        Potn = 7,
-        Form = 8,
-        Comb = 9,
-    };
-
-    enum GroupType : int {
-        WellGroup = 0,
-        TreeGroup = 1,
-    };
-
-    }
-
-    }
-
 
     namespace XGroup {
         enum index : std::vector<double>::size_type {
@@ -209,6 +222,6 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         };
     } // XGroup
 
-}}}} // Opm::RestartIO::Helpers::VectorItems
+} // Opm::RestartIO::Helpers::VectorItems
 
 #endif // OPM_OUTPUT_ECLIPSE_VECTOR_GROUP_HPP


### PR DESCRIPTION
This PR ensures that the setting for whether or not the lift gas of a leaf node's corresponding group's subordinate wells should be added to the node's produced gas entering the node in an extended model production network.  In short, this commit saves and restores [item 4](https://github.com/OPM/opm-common/blob/a6e4b524da7ee6edf3d5ac07540fcb9d3fbaf4b2/opm/input/eclipse/share/keywords/000_Eclipse100/N/NODEPROP#L26-L31) of `NODEPROP` for leaf nodes in an extended network.