### PR TITLE
Revise Interpretation of IUAD[2]

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQActive.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQActive.hpp
@@ -143,7 +143,6 @@ public:
         /// which this UDA supplies the numeric value.
         OutputRecord(const std::string& udq_arg,
                      const std::size_t  input_index_arg,
-                     const std::size_t  use_index_arg,
                      const std::string& wgname_arg,
                      const UDAControl   control_arg);
 
@@ -178,7 +177,6 @@ public:
         {
             serializer(udq);
             serializer(input_index);
-            serializer(use_index);
             serializer(wgname);
             serializer(control);
             serializer(uda_code);
@@ -191,9 +189,6 @@ public:
         /// Zero-based index in order of appearance of the UDQ use for this
         /// UDA.
         std::size_t input_index;
-
-        /// IUAP array start offset.
-        std::size_t use_index = 0;
 
         /// Constraint keyword and item/limit for which this UDA supplies
         /// the numeric value.
@@ -401,17 +396,6 @@ private:
     /// Form output_data structure from input_data.
     void constructOutputRecords() const;
 };
-
-// ===========================================================================
-
-/// Predicate for field level UDAs
-///
-/// \param[in] record IUAD restart file UDA record
-///
-/// \return Whether or not \p record applies at the field level.  In other
-/// words, whether or not the \p record is a UDA in GCONPROD or GCONINJE
-/// that applies to the FIELD group.
-bool isFieldUDA(const UDQActive::OutputRecord& record);
 
 } // namespace Opm
 

--- a/opm/io/eclipse/rst/udq.cpp
+++ b/opm/io/eclipse/rst/udq.cpp
@@ -246,32 +246,15 @@ void Opm::RestartIO::RstUDQ::ensureValidNameIndex() const
 Opm::RestartIO::RstUDQActive::
 RstRecord::RstRecord(const UDAControl  c,
                      const std::size_t i,
-                     const UDAKind     k,
+                     const std::size_t numIuap,
                      const std::size_t u1,
                      const std::size_t u2)
-    : control    (c)
-    , input_index(i)
-    , use_count  (u1)
-    , wg_offset  (u2)
-    , isFieldUDA (k == UDAKind::Field)
+    : control     (c)
+    , input_index (i)
+    , use_count   (u1)
+    , wg_offset   (u2)
+    , num_wg_elems(numIuap)
 {}
-
-namespace {
-    Opm::RestartIO::RstUDQActive::RstRecord::UDAKind udaKind(const int k)
-    {
-        using InKind  = Opm::RestartIO::Helpers::VectorItems::IUad::Value::UDAKind;
-        using OutKind = Opm::RestartIO::RstUDQActive::RstRecord::UDAKind;
-
-        switch (k) {
-        case InKind::Regular: return OutKind::Regular;
-        case InKind::Field:   return OutKind::Field;
-        }
-
-        throw std::invalid_argument {
-            fmt::format("Unknown UDA Kind {}", k)
-        };
-    }
-}
 
 Opm::RestartIO::RstUDQActive::
 RstUDQActive(const std::vector<int>& iuad_arg,
@@ -291,7 +274,7 @@ RstUDQActive(const std::vector<int>& iuad_arg,
 
         this->iuad.emplace_back(UDQ::udaControl(uda[Ix::UDACode]),
                                 uda[Ix::UDQIndex] - 1,
-                                udaKind(uda[Ix::Kind]),
+                                uda[Ix::NumIuapElm],
                                 uda[Ix::UseCount],
                                 uda[Ix::Offset] - 1);
     }

--- a/opm/io/eclipse/rst/udq.hpp
+++ b/opm/io/eclipse/rst/udq.hpp
@@ -506,15 +506,6 @@ struct RstUDQActive
     /// One single UDA
     struct RstRecord
     {
-        enum class UDAKind : int {
-            /// UDA is of a regular kind that applies either to a well or a
-            /// non-field group.
-            Regular,
-
-            /// UDA applies to the field level.
-            Field,
-        };
-
         /// Constructor.
         ///
         /// Convenience only as this enables using vector<>::emplace_back().
@@ -524,7 +515,8 @@ struct RstUDQActive
         /// \param[in] i Input index.  Zero-based order in which the UDQ was
         /// entered.
         ///
-        /// \param[in] k Type of this UDA.
+        /// \param[in] numIuap Number of IUAP elements associated to this
+        /// UDA.
         ///
         /// \param[in] u1 Use count.  Number of times this UDA is used in
         /// this particular way (same keyword and control item, e.g., for
@@ -533,7 +525,7 @@ struct RstUDQActive
         /// \param[in] u2 IUAP start offset.
         RstRecord(UDAControl  c,
                   std::size_t i,
-                  UDAKind     k,
+                  std::size_t numIuap,
                   std::size_t u1,
                   std::size_t u2);
 
@@ -551,8 +543,8 @@ struct RstUDQActive
         /// IUAP start offset.
         std::size_t wg_offset;
 
-        /// Flag for whether or not this UDA applies at the field level.
-        bool isFieldUDA;
+        /// Number of IUAP elements.
+        std::size_t num_wg_elems;
     };
 
     /// Default constructor.

--- a/opm/output/eclipse/VectorItems/udq.hpp
+++ b/opm/output/eclipse/VectorItems/udq.hpp
@@ -26,18 +26,23 @@ namespace Opm::RestartIO::Helpers::VectorItems {
 
     namespace IUad {
         enum index : std::vector<int>::size_type {
-            UDACode  = 0, // Integer code for keyword/item combination.
-            UDQIndex = 1, // UDQ insertion index (one-based)
-            Kind     = 2, // UDA Kind.  1 => Regular, 2 => Field.
-            UseCount = 3, // Number of times this UDA is used in this
-                          // way--i.e., number of wells (or groups) for
-                          // which this UDA supplies this particular limit
-                          // in this particular keyword.
-            Offset   = 4, // One-based start offset in IUAP for this UDA.
+            UDACode    = 0, // Integer code for keyword/item combination.
+            UDQIndex   = 1, // UDQ insertion index (one-based)
+
+            NumIuapElm = 2, // Number of elements in IUAP for this UDA.  One
+                            // element for a regular group or well level
+                            // UDA, two elements for a FIELD level UDA.
+
+            UseCount   = 3, // Number of times this UDA is used in this
+                            // way--i.e., number of wells (or groups) for
+                            // which this UDA supplies this particular limit
+                            // in this particular keyword.
+
+            Offset     = 4, // One-based start offset in IUAP for this UDA.
         };
 
         namespace Value {
-            enum UDAKind : int {
+            enum IuapElems : int {
                 Regular = 1, // UDA applies to a well or a non-field group.
                 Field   = 2, // UDA applies to the field group.
             };

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1892,13 +1892,11 @@ WCONPROD
         BOOST_CHECK_EQUAL( record0.uda_code, 300004);
         BOOST_CHECK_EQUAL( record0.input_index, 2U);
         BOOST_CHECK_EQUAL( record0.use_count, 2U);
-        BOOST_CHECK_EQUAL( record0.use_index, 0U);
 
         const auto& record1 = iuad[1];
         BOOST_CHECK_EQUAL( record1.uda_code, 600004);
         BOOST_CHECK_EQUAL( record1.input_index, 3U);
         BOOST_CHECK_EQUAL( record1.use_count, 2U);
-        BOOST_CHECK_EQUAL( record1.use_index, 2U);
     }
 
     {
@@ -1914,25 +1912,21 @@ WCONPROD
         BOOST_CHECK_EQUAL( record0.uda_code, 300004);
         BOOST_CHECK_EQUAL( record0.input_index, 2U);
         BOOST_CHECK_EQUAL( record0.use_count, 1U);
-        BOOST_CHECK_EQUAL( record0.use_index, 0U);
 
         const auto& record1 = iuad[1];
         BOOST_CHECK_EQUAL( record1.uda_code, 600004);
         BOOST_CHECK_EQUAL( record1.input_index, 3U);
         BOOST_CHECK_EQUAL( record1.use_count, 1U);
-        BOOST_CHECK_EQUAL( record1.use_index, 1U);
 
         const auto& record2 = iuad[2];
         BOOST_CHECK_EQUAL( record2.uda_code, 300004);
         BOOST_CHECK_EQUAL( record2.input_index, 4U);
         BOOST_CHECK_EQUAL( record2.use_count, 1U);
-        BOOST_CHECK_EQUAL( record2.use_index, 2U);
 
         const auto& record3 = iuad[3];
         BOOST_CHECK_EQUAL( record3.uda_code, 600004);
         BOOST_CHECK_EQUAL( record3.input_index, 5U);
         BOOST_CHECK_EQUAL( record3.use_count, 1U);
-        BOOST_CHECK_EQUAL( record3.use_index, 3U);
     }
 
     {
@@ -1948,14 +1942,13 @@ WCONPROD
         BOOST_CHECK_EQUAL( record0.uda_code, 300004);
         BOOST_CHECK_EQUAL( record0.input_index, 4U);
         BOOST_CHECK_EQUAL( record0.use_count, 1U);
-        BOOST_CHECK_EQUAL( record0.use_index, 0U);
 
         const auto& record1 = iuad[1];
         BOOST_CHECK_EQUAL( record1.uda_code, 600004);
         BOOST_CHECK_EQUAL( record1.input_index, 5U);
         BOOST_CHECK_EQUAL( record1.use_count, 1U);
-        BOOST_CHECK_EQUAL( record1.use_index, 1U);
     }
+
     {
         const auto& udq_config = schedule.getUDQConfig(2);
         const auto& def = udq_config.definitions();


### PR DESCRIPTION
Commit 937d69d23 (PR #4357) treated `IUAD[2]` as a type flag, with the value 1 signifying a UDA at the well- or "regular" group level and the value 2 signifying a FIELD level UDA.  This PR revises this interpretation and instead treats `IUAD[2]` as the corresponding number of IUAP elements for the UDA.

This is in preparation of some upcoming compatibility work.