### PR TITLE
Avoid excessive output from PyAction schedule.insert_keywords

### DIFF
--- a/opm/input/eclipse/Parser/Parser.cpp
+++ b/opm/input/eclipse/Parser/Parser.cpp
@@ -984,6 +984,7 @@ std::unique_ptr<RawKeyword> tryParseKeyword( ParserState& parserState, const Par
     std::unique_ptr<RawKeyword> rawKeyword;
     std::string_view record_buffer(str::emptystr);
     std::optional<ParserKeyword> parserKeyword;
+    const bool silent = parser.silent();
     while( !parserState.done() ) {
         auto line = parserState.getline();
 
@@ -994,11 +995,19 @@ std::unique_ptr<RawKeyword> tryParseKeyword( ParserState& parserState, const Par
         if (parserState.parseContext.isActiveSkipKeyword(deck_name)) {
             skip = true;
             auto msg = fmt::format("{:5} Reading {:<8} in {} line {} \n      ... ignoring everything until 'ENDSKIP' ... ", "", "SKIP", parserState.current_path().string(), parserState.line());
-            OpmLog::info(msg);
+            if (!silent) {
+                OpmLog::info(msg);
+            } else {
+                OpmLog::debug(msg, Parser::SILENT_MODE_MIN_DEBUG_VERBOSITY_LEVEL);
+            }
         } else if (deck_name == "ENDSKIP") {
             skip = false;
             auto msg = fmt::format("{:5} Reading {:<8} in {} line {}", "", "ENDSKIP", parserState.current_path().string(), parserState.line());
-            OpmLog::info(msg);
+            if (!silent) {
+                OpmLog::info(msg);
+            } else {
+                OpmLog::debug(msg, Parser::SILENT_MODE_MIN_DEBUG_VERBOSITY_LEVEL);
+            }
             continue;
         }
         if (skip) continue;
@@ -1434,7 +1443,11 @@ bool parseState( ParserState& parserState, const Parser& parser, ErrorGuard& err
             {
                 const auto& location = rawKeyword->location();
                 auto msg = fmt::format("{:5} Reading {:<8} in {} line {}", parserState.deck.size(), rawKeyword->getKeywordName(), location.filename, location.lineno);
-                OpmLog::info(msg);
+                if (!parser.silent()) {
+                    OpmLog::info(msg);
+                } else {
+                    OpmLog::debug(msg, Parser::SILENT_MODE_MIN_DEBUG_VERBOSITY_LEVEL);
+                }
             }
             try {
                 if (rawKeyword->getKeywordName() ==  Opm::RawConsts::pyinput) {

--- a/opm/input/eclipse/Parser/Parser.hpp
+++ b/opm/input/eclipse/Parser/Parser.hpp
@@ -168,8 +168,12 @@ namespace Opm {
 
         const std::vector<std::pair<std::string,std::string>> codeKeywords() const;
 
+        bool silent() const { return silentMode; }
+        void silent(bool newSilentMode) { silentMode = newSilentMode; }
+        static constexpr int SILENT_MODE_MIN_DEBUG_VERBOSITY_LEVEL {3}; // Debug level at which to emit silenced messeages to the debug log
     private:
         bool hasWildCardKeyword(const std::string& keyword) const;
+        bool silentMode {false}; // Silence information messages (warnings and errors are still emitted)
         const ParserKeyword* matchingKeyword(const std::string_view& keyword) const;
         void addDefaultKeywords();
 

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1715,7 +1715,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         this->snapshots.resize(reportStep + 1);
 
         auto& input_block = this->m_sched_deck[reportStep];
-        ScheduleLogger logger(ScheduleLogger::select_stream(false, false), // will log to OpmLog::info
+        ScheduleLogger logger(ScheduleLogger::select_stream(true, false), // will log to OpmLog::debug
                               prefix, this->m_sched_deck.location());
 
         for (const auto& keyword : keywords) {
@@ -1764,7 +1764,8 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
                                          grid,
                                          &target_wellpi,
                                          prefix,
-                                         /* keepKeywords = */ true);
+                                         /* keepKeywords = */ true,
+                                         /* log_to_debug = */ true);
             this->simUpdateFromPython->delayed_iteration =
                 SimulatorUpdate::DelayedIteration::Off;
         }

--- a/python/cxx/schedule.cpp
+++ b/python/cxx/schedule.cpp
@@ -151,8 +151,10 @@ namespace {
     std::vector<std::unique_ptr<DeckKeyword>> parseKeywords(const std::string& deck_string, const UnitSystem& unit_system)
     {
         Parser parser;
+        parser.silent(true);
         std::string str {unit_system.deck_name() + "\n\n" + deck_string};
         auto deck = parser.parseString(str);
+        deck.remove_keywords(0, 1);
         std::vector<std::unique_ptr<DeckKeyword>> keywords;
         for (auto &keyword : deck) {
             keywords.push_back(std::make_unique<DeckKeyword>(keyword));


### PR DESCRIPTION
Processing PYACTIONs that use `schedule.insert_keywords` at every time step currently produces a LOT of output. This PR silences the output from re-parsing the schedule section, unless --debug-verbosity-level >= 3 (in which case the output goes to OpmLog::debug). 