### PR TITLE
Load ALQ Types From Restart Step's VFP Tables if Available

### DIFF
--- a/opm/input/eclipse/Schedule/VFPProdTable.cpp
+++ b/opm/input/eclipse/Schedule/VFPProdTable.cpp
@@ -17,23 +17,24 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
+
+#include <opm/common/OpmLog/OpmLog.hpp>
+
+#include <opm/input/eclipse/Units/Dimension.hpp>
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+
+#include <opm/input/eclipse/Deck/DeckItem.hpp>
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/input/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/input/eclipse/Parser/ParserKeywords/V.hpp>
+
 #include <algorithm>
 #include <cassert>
 #include <cmath>
 
 #include <fmt/format.h>
-
-#include <opm/common/OpmLog/OpmLog.hpp>
-
-#include <opm/input/eclipse/Deck/DeckItem.hpp>
-#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/Parser/ParserKeywords/V.hpp>
-#include <opm/input/eclipse/Units/Dimension.hpp>
-#include <opm/input/eclipse/Units/UnitSystem.hpp>
-
-#include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
-
 
 namespace Opm {
 
@@ -117,13 +118,10 @@ VFPProdTable::ALQ_TYPE getALQType( const DeckItem& item, bool gaslift_opt_active
     }
 }
 
-}
-
+} // Anonymous namespace
 
 VFPProdTable::VFPProdTable()
-{
-}
-
+{}
 
 VFPProdTable::VFPProdTable(int table_num,
                            double datum_depth,
@@ -181,8 +179,10 @@ VFPProdTable VFPProdTable::serializationTestObject()
   If the gaslift_opt flag is set to true the ALQ_TYPE item will default to GRAT.
 */
 
-VFPProdTable::VFPProdTable( const DeckKeyword& table, bool gaslift_opt_active, const UnitSystem& deck_unit_system) :
-    m_location(table.location())
+VFPProdTable::VFPProdTable(const DeckKeyword& table,
+                           const bool         gaslift_opt_active,
+                           const UnitSystem&  deck_unit_system)
+    : m_location(table.location())
 {
     using ParserKeywords::VFPPROD;
 
@@ -331,8 +331,17 @@ VFPProdTable::VFPProdTable( const DeckKeyword& table, bool gaslift_opt_active, c
     check();
 }
 
+std::pair<int, VFPProdTable::ALQ_TYPE>
+VFPProdTable::getALQType(const DeckKeyword& inputTable,
+                         const bool         gaslift_opt_active)
+{
+    const auto& header = inputTable.getRecord(0);
 
-
+    return {
+        header.getItem<ParserKeywords::VFPPROD::TABLE>().get<int>(0),
+        ::Opm::getALQType(header.getItem<ParserKeywords::VFPPROD::ALQ_DEF>(), gaslift_opt_active)
+    };
+}
 
 namespace {
 

--- a/opm/input/eclipse/Schedule/VFPProdTable.hpp
+++ b/opm/input/eclipse/Schedule/VFPProdTable.hpp
@@ -20,17 +20,23 @@
 #ifndef OPM_PARSER_ECLIPSE_ECLIPSESTATE_TABLES_VFPPRODTABLE_HPP_
 #define OPM_PARSER_ECLIPSE_ECLIPSESTATE_TABLES_VFPPRODTABLE_HPP_
 
+#include <opm/common/OpmLog/KeywordLocation.hpp>
+
+#include <opm/input/eclipse/Units/Dimension.hpp>
 
 #include <array>
+#include <utility>
 #include <vector>
-#include <opm/input/eclipse/Units/Dimension.hpp>
-#include <opm/common/OpmLog/KeywordLocation.hpp>
 
 namespace Opm {
 
     class DeckItem;
     class DeckKeyword;
     class UnitSystem;
+
+} // namespace Opm
+
+namespace Opm {
 
 /**
  * Class for reading data from a VFPPROD (vertical flow performance production) table
@@ -80,7 +86,11 @@ public:
                  const std::vector<double>& gfr_data,
                  const std::vector<double>& alq_data,
                  const std::vector<double>& data);
+
     static Dimension ALQDimension(const ALQ_TYPE& alq_type, const UnitSystem& unit_system);
+
+    static std::pair<int, ALQ_TYPE>
+    getALQType(const DeckKeyword& inputTable, bool gaslift_opt_active);
 
     static VFPProdTable serializationTestObject();
 
@@ -219,9 +229,6 @@ private:
                                const UnitSystem& unit_system);
 };
 
+} // namespace Opm
 
-
-}
-
-
-#endif
+#endif // OPM_PARSER_ECLIPSE_ECLIPSESTATE_TABLES_VFPPRODTABLE_HPP_


### PR DESCRIPTION
This commit amends the ALQ restart dimension handling of commit dac5e4ec7 (PR #4271) to also include VFP tables that are defined at the restart step itself.  The most common case for this is when the restart run does not use SKIPREST, but instead proceeds directly to begin the simulation based on objects from the restart file.  In this case, the input is typically structured as

    SOLUTION
    RESTART
      'BASE' 42 /

    SUMMARY
    -- ...

    SCHEDULE

    INCLUDE
      'vfp-tables.inc' /

    TSTEP
      9*10.11 /

    -- ...
    END

and we need to be sure that the VFP tables from 'vfp-tables.inc' are usable for determining the ALQ types and their corresponding Dimension objects.

To this end, we create a simple helper class,

    ALQTypesAtRestartTime

which aggregates the ALQ types of any previously loaded VFP tables (`Schedule::snapshots.back().vfpprod`) with those become available at the restart step itself (`Schedule::m_sched_deck[restart_step]`).  We then look up the ALQ types of producing wells in this helper structure when forming the 'Well' objects at restart time.

We use a new helper function,
```C++
static pair<int, ALQ_TYPE>
VFPProdTable::getALQType(inputTable, gasLift)
```
to actually derive the ALQ types using existing logic in the `VFPProdTable` class.