### PR TITLE
Iterate in Brine_CO2::calculateMoleFractions above critical temperature.

### DIFF
--- a/opm/material/binarycoefficients/Brine_CO2.hpp
+++ b/opm/material/binarycoefficients/Brine_CO2.hpp
@@ -112,7 +112,8 @@ public:
 
         // Iterate or not?
         bool iterate = false;
-        if ((activityModel == 1 && salinity > 0.0) || (activityModel == 2 && temperature > 372.15)) {
+        if ((activityModel == 1 && salinity > 0.0) || (activityModel == 2 &&
+                                                       ( temperature > 372.15 || temperature > CO2::criticalTemperature()))) {
             iterate = true;
         }
 


### PR DESCRIPTION
Otherwise we will compute std::pow(1-T/T_critical, 1.5) for a negative base in  CO2.hpp line 148 when computing the vapor pressure.

This fixes CO2Store with ACTCO2S value 2 for me. See #4912