### PR TITLE
Throw for complex std::pow results in CO2::vaporPressure

### DIFF
--- a/opm/material/components/CO2.hpp
+++ b/opm/material/components/CO2.hpp
@@ -143,9 +143,17 @@ public:
 
         // this is on page 1524 of the reference
         Evaluation exponent = 0;
+        Evaluation critTemp = criticalTemperature();
         Evaluation Tred = T/criticalTemperature();
+
+        if (T > critTemp) {
+            OPM_THROW(std::runtime_error,
+                      "Non-integer exponent for pow function of negative value"
+                      " (because temperature of CO2 is larger than critical temperature.");
+        }
+
         for (int i = 0; i < 4; ++i)
-            exponent += a[i]*pow(1 - Tred, t[i]);
+            exponent += a[i]*pow(1 - T/critTemp, t[i]);
         exponent *= 1.0/Tred;
 
         return exp(exponent)*criticalPressure();


### PR DESCRIPTION
std::pow may throw for negative base and non-integer exponent, g++ doesn't. Here we add an explicit throw.