### PR TITLE
PERMFACT for each saturation region

### DIFF
--- a/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -474,7 +474,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         addTables( "SALTVD", m_eqldims.getNumEquilRegions());
         addTables( "SALTPVD", m_eqldims.getNumEquilRegions());
         addTables( "SALTSOL", m_tabdims.getNumPVTTables());
-        addTables( "PERMFACT",  m_tabdims.getNumPVTTables());
+        addTables( "PERMFACT",  m_tabdims.getNumSatTables());
         addTables( "PCFACT",  m_tabdims.getNumSatTables());
 
         addTables( "AQUTAB", m_aqudims.getNumInfluenceTablesCT());
@@ -544,7 +544,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         initSimpleTableContainer<SaltpvdTable>(deck, "SALTPVD" , m_eqldims.getNumEquilRegions());
         initSimpleTableContainer<SaltvdTable>(deck, "SALTVD" , m_eqldims.getNumEquilRegions());
         initSimpleTableContainer<SaltsolTable>(deck, "SALTSOL" , m_tabdims.getNumPVTTables());
-        initSimpleTableContainer<PermfactTable>(deck, "PERMFACT" , m_tabdims.getNumPVTTables());
+        initSimpleTableContainer<PermfactTable>(deck, "PERMFACT" , m_tabdims.getNumSatTables());
         initSimpleTableContainer<PcfactTable>(deck, "PCFACT" , m_tabdims.getNumSatTables());
         initSimpleTableContainer<AqutabTable>(deck, "AQUTAB" , m_aqudims.getNumInfluenceTablesCT());
         {

--- a/opm/input/eclipse/share/keywords/900_OPM/P/PERMFACT
+++ b/opm/input/eclipse/share/keywords/900_OPM/P/PERMFACT
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NTPVT"
+    "item": "NTSFUN"
   },
   "items": [
    {


### PR DESCRIPTION
This adds flexibility to set different `PERMFACT` tables per `SATNUM`.

Relevant for the Reference Manual (I will do a PR to the manual to document this).