### PR TITLE
added: utility function to clear out all events at a given report step

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -978,6 +978,12 @@ Defaulted grid coordinates is not allowed for COMPDAT as part of ACTIONX)"
         this->snapshots[report_step].update_events(events);
     }
 
+    void Schedule::clearEvents(const std::size_t report_step)
+    {
+        this->snapshots[report_step].events().reset();
+        this->snapshots[report_step].wellgroup_events().reset();
+    }
+
 
     bool Schedule::updateWPAVE(const std::string& wname, std::size_t report_step, const PAvg& pavg) {
         const auto& well = this->getWell(wname, report_step);

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -312,6 +312,9 @@ namespace Opm {
         void add_event(ScheduleEvents::Events, std::size_t report_step);
         void applyWellProdIndexScaling(const std::string& well_name, const std::size_t reportStep, const double scalingFactor);
 
+        //! \brief Clear out all registered events at a given report step.
+        void clearEvents(const std::size_t report_step);
+
         WellProducerCMode getGlobalWhistctlMmode(std::size_t timestep) const;
 
         const UDQConfig& getUDQConfig(std::size_t timeStep) const;


### PR DESCRIPTION
this will be used in action handling to avoid re-processing events that only should execute at start of a report step