### PR TITLE
Support Report Generation With Integer Controls

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -227,6 +227,8 @@ if(ENABLE_ECL_INPUT)
     opm/input/eclipse/Schedule/OilVaporizationProperties.cpp
     opm/input/eclipse/Schedule/RFTConfig.cpp
     opm/input/eclipse/Schedule/RPTConfig.cpp
+    opm/input/eclipse/Schedule/RPTKeywordNormalisation.cpp
+    opm/input/eclipse/Schedule/RptschedKeywordNormalisation.cpp
     opm/input/eclipse/Schedule/RSTConfig.cpp
     opm/input/eclipse/Schedule/RXXKeywordHandlers.cpp
     opm/input/eclipse/Schedule/Schedule.cpp
@@ -237,6 +239,7 @@ if(ENABLE_ECL_INPUT)
     opm/input/eclipse/Schedule/ScheduleState.cpp
     opm/input/eclipse/Schedule/ScheduleStatic.cpp
     opm/input/eclipse/Schedule/ScheduleTypes.cpp
+    opm/input/eclipse/Schedule/SimpleRPTIntegerControlHandler.cpp
     opm/input/eclipse/Schedule/Source.cpp
     opm/input/eclipse/Schedule/SummaryState.cpp
     opm/input/eclipse/Schedule/Tuning.cpp
@@ -529,6 +532,7 @@ if(ENABLE_ECL_INPUT)
     tests/test_ExtESmry.cpp
     tests/test_FIPRegionStatistics.cpp
     tests/test_RegionSetMatcher.cpp
+    tests/test_RPTConfig.cpp
     tests/test_PAvgCalculator.cpp
     tests/test_PAvgDynamicSourceData.cpp
     tests/test_Serialization.cpp
@@ -1400,6 +1404,8 @@ if(ENABLE_ECL_INPUT)
        opm/input/eclipse/Schedule/SummaryState.hpp
        opm/input/eclipse/Schedule/RFTConfig.hpp
        opm/input/eclipse/Schedule/RPTConfig.hpp
+       opm/input/eclipse/Schedule/RPTKeywordNormalisation.hpp
+       opm/input/eclipse/Schedule/RptschedKeywordNormalisation.hpp
        opm/input/eclipse/Schedule/RSTConfig.hpp
        opm/input/eclipse/Schedule/Schedule.hpp
        opm/input/eclipse/Schedule/ScheduleBlock.hpp
@@ -1409,6 +1415,7 @@ if(ENABLE_ECL_INPUT)
        opm/input/eclipse/Schedule/ScheduleState.hpp
        opm/input/eclipse/Schedule/ScheduleStatic.hpp
        opm/input/eclipse/Schedule/ScheduleTypes.hpp
+       opm/input/eclipse/Schedule/SimpleRPTIntegerControlHandler.hpp
        opm/input/eclipse/Schedule/Source.hpp
        opm/input/eclipse/Schedule/Tuning.hpp
        opm/input/eclipse/Schedule/WriteRestartFileEvents.hpp

--- a/opm/input/eclipse/Schedule/RPTConfig.cpp
+++ b/opm/input/eclipse/Schedule/RPTConfig.cpp
@@ -18,61 +18,99 @@
 */
 
 #include <opm/input/eclipse/Schedule/RPTConfig.hpp>
-#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 
 #include <opm/common/ErrorMacros.hpp>
 
+#include <opm/input/eclipse/Schedule/RPTKeywordNormalisation.hpp>
+#include <opm/input/eclipse/Schedule/RptschedKeywordNormalisation.hpp>
+
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+
+#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 namespace {
-
-    std::pair<std::string, unsigned> parse_mnemonic(const std::string& mnemonic) {
-        const auto pivot { mnemonic.find('=') } ;
-
-        if (pivot == std::string::npos) {
-            return { mnemonic, 1 } ;
-        } else {
-            const auto int_value { std::stoi(mnemonic.substr(pivot + 1)) } ;
-
-            if (!(int_value >= 0)) {
-                OPM_THROW(std::invalid_argument, "RPTSCHED - " + mnemonic + " - mnemonic value must be an integer >= 0");
-            }
-
-            return { mnemonic.substr(0, pivot), int_value } ;
+    class AcceptAllMnemonics
+    {
+    public:
+        bool operator()([[maybe_unused]] const std::string& mnemonic) const
+        {
+            return true;
         }
-    }
+    };
 
+    class NoIntegerControls
+    {
+    public:
+        Opm::RPTKeywordNormalisation::MnemonicMap
+        operator()([[maybe_unused]] const std::vector<int>& controlValues) const
+        {
+            return {};
+        }
+    };
+} // Anonymous namespace
+
+Opm::RPTConfig::RPTConfig(const DeckKeyword& keyword)
+{
+    const auto parseContext = ParseContext{};
+    auto errors = ErrorGuard{};
+
+    const auto mnemonics = RPTKeywordNormalisation {
+        NoIntegerControls{}, AcceptAllMnemonics{}
+    }.normaliseKeyword(keyword, parseContext, errors);
+
+    this->assignMnemonics(mnemonics);
 }
 
-namespace Opm {
+Opm::RPTConfig::RPTConfig(const DeckKeyword&  keyword,
+                          const RPTConfig*    prev,
+                          const ParseContext& parseContext,
+                          ErrorGuard&         errors)
+{
+    if (prev != nullptr) {
+        this->mnemonics_ = prev->mnemonics_;
+    }
 
-RPTConfig RPTConfig::serializationTestObject() {
+    const auto mnemonics =
+        normaliseRptSchedKeyword(keyword, parseContext, errors);
+
+    this->assignMnemonics(mnemonics);
+}
+
+bool Opm::RPTConfig::contains(const std::string& key) const
+{
+    return this->mnemonics_.find(key) != this->mnemonics_.end();
+}
+
+bool Opm::RPTConfig::operator==(const RPTConfig& other) const
+{
+    return this->mnemonics_ == other.mnemonics_;
+}
+
+Opm::RPTConfig Opm::RPTConfig::serializationTestObject()
+{
     RPTConfig rptc;
-    rptc.m_mnemonics.emplace( "KEY", 100 );
+    rptc.mnemonics_.emplace( "KEY", 100 );
     return rptc;
 }
 
+// ---------------------------------------------------------------------------
+// Private member functions below separator
+// ---------------------------------------------------------------------------
 
-RPTConfig::RPTConfig(const DeckKeyword& keyword, const RPTConfig* prev) {
-    if (prev)
-        this->m_mnemonics = prev->m_mnemonics;
-
-    const auto& mnemonics { keyword.getStringData() } ;
-    for (const auto& mnemonic : mnemonics) {
-        if (mnemonic == "NOTHING")
-            this->m_mnemonics.clear();
+void Opm::RPTConfig::assignMnemonics(const std::vector<std::pair<std::string, int>>& mnemonics)
+{
+    for (const auto& [mnemonic, value] : mnemonics) {
+        if (mnemonic == "NOTHING") {
+            this->mnemonics_.clear();
+        }
         else {
-            const auto key_value = parse_mnemonic(mnemonic);
-            this->m_mnemonics.insert_or_assign(key_value.first, key_value.second);
+            this->mnemonics_.insert_or_assign(mnemonic, value);
         }
     }
-}
-
-
-bool RPTConfig::operator==(const RPTConfig& other) const {
-    return this->m_mnemonics == other.m_mnemonics;
-}
-
-bool RPTConfig::contains(const std::string& key) const {
-    return this->m_mnemonics.find(key) != this->m_mnemonics.end();
-}
-
 }

--- a/opm/input/eclipse/Schedule/RPTConfig.hpp
+++ b/opm/input/eclipse/Schedule/RPTConfig.hpp
@@ -16,42 +16,144 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #ifndef RPT_CONFIG_HPP
 #define RPT_CONFIG_HPP
 
 #include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace Opm {
 
-class DeckKeyword;
+    class DeckKeyword;
+    class ParseContext;
+    class ErrorGuard;
 
-class RPTConfig {
+} // namespace Opm
+
+namespace Opm {
+
+/// Configuration manager for RPTSCHED and RPTSOL keywords.
+class RPTConfig
+{
 public:
-    using Map = std::unordered_map<std::string, unsigned>;
+    /// Default constructor.
+    ///
+    /// Creates a configuration object that's mostly usable as a target for
+    /// a deserialisation operation.
     RPTConfig() = default;
-    explicit RPTConfig(const DeckKeyword&, const RPTConfig* prev = nullptr);
+
+    /// Constructor.
+    ///
+    /// Internalises and normalises the specification of an RPTSOL keyword
+    /// into a set of mnemonics and associate values.  Supports both regular
+    /// mnemonics and integer controls.  Performs no error checking and
+    /// therefore accepts all mnemonics.
+    ///
+    /// \param[in] keyword RPTSCHED keyword specification.
+    explicit RPTConfig(const DeckKeyword& keyword);
+
+    /// Constructor.
+    ///
+    /// Internalises and normalises the specification of an RPTSCHED keyword
+    /// into a set of mnemonics and associate values.  Checks the input
+    /// specification against a known set of mnemonics and rejects unknown
+    /// mnemonics.  Expands an existing set of mnemonics if provided as
+    /// input.  Supports both regular mnemonics and integer controls.
+    ///
+    /// \param[in] keyword RPTSCHED keyword specification.
+    ///
+    /// \param[in] prev Existing set of mnemonics that will potentially be
+    /// expanded by the requests in \p keyword.  Pass \c nullptr if there is
+    /// no existing set of mnemonics.
+    ///
+    /// \param[in] parseContext Error handling controls.
+    ///
+    /// \param[in,out] errors Collection of parse errors encountered thus
+    /// far.  Behaviour controlled by \p parseContext.
+    explicit RPTConfig(const DeckKeyword&  keyword,
+                       const RPTConfig*    prev,
+                       const ParseContext& parseContext,
+                       ErrorGuard&         errors);
+
+    /// Mnemonic existence predicate.
+    ///
+    /// Queries the internal, normalised collection, for whether or not a
+    /// particular mnemonic exists.
+    ///
+    /// \param[in] key Mnemonic string.
+    ///
+    /// \returns Whether or not \p key exists in the internal collection.
     bool contains(const std::string& key) const;
 
+    /// Start of internal mnemonic sequence.
+    ///
+    /// To support iteration.
+    auto begin() const { return this->mnemonics_.begin(); }
+
+    /// End of internal mnemonic sequence.
+    ///
+    /// To support iteration.
+    auto end() const { return this->mnemonics_.end(); }
+
+    /// Number of mnemonics in internal sequence.
+    auto size() const { return this->mnemonics_.size(); }
+
+    /// Get read/write access to particular mnemonic value.
+    ///
+    /// Will throw an exception if the mnemonic does not exist in the
+    /// internal collection.  Use predicate contains() to check existence.
+    ///
+    /// \param[in] key Mnemonic string.
+    ///
+    /// \return Reference to mutable mnemonic value for \p key.
+    unsigned& at(const std::string& key) { return this->mnemonics_.at(key); }
+
+    /// Get read-only access to particular mnemonic value.
+    ///
+    /// Will throw an exception if the mnemonic does not exist in the
+    /// internal collection.  Use predicate contains() to check existence.
+    ///
+    /// \param[in] key Mnemonic string.
+    ///
+    /// \return Mnemonic value for \p key.
+    unsigned at(const std::string& key) const { return this->mnemonics_.at(key); }
+
+    /// Equality predicate.
+    ///
+    /// \param[in] other Object against which \code *this \endcode will be
+    /// tested for equality.
+    ///
+    /// \return Whether or not \code *this \endcode is the same as \p other.
+    bool operator==(const RPTConfig& other) const;
+
+    /// Create a serialisation test object.
+    static RPTConfig serializationTestObject();
+
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
-        serializer(m_mnemonics);
+        serializer(this->mnemonics_);
     }
 
-    std::unordered_map<std::string, unsigned>::const_iterator begin() const { return this->m_mnemonics.begin(); };
-    std::unordered_map<std::string, unsigned>::const_iterator end() const { return this->m_mnemonics.end(); };
-    std::size_t size() const { return this->m_mnemonics.size(); };
-    unsigned& at(const std::string& key) { return this->m_mnemonics.at(key); };
-    unsigned at(const std::string& key) const { return this->m_mnemonics.at(key); };
-
-    static RPTConfig serializationTestObject();
-    bool operator==(const RPTConfig& other) const;
-
 private:
-    std::unordered_map<std::string, unsigned> m_mnemonics;
+    /// Collection of RPTSCHED mnemonics and their associate values.
+    std::unordered_map<std::string, unsigned int> mnemonics_{};
+
+    /// Assign mnemonic values from RPTSCHED keyword.
+    ///
+    /// \param[in] mnemonics List of mnemonics and associate values.
+    /// Typically from normalising an RPTSCHED specification.
+    void assignMnemonics(const std::vector<std::pair<std::string, int>>& mnemonics);
 };
 
-}
+} // namespace Opm
 
-#endif
+#endif // RPT_CONFIG_HPP

--- a/opm/input/eclipse/Schedule/RPTKeywordNormalisation.cpp
+++ b/opm/input/eclipse/Schedule/RPTKeywordNormalisation.cpp
@@ -1,0 +1,227 @@
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/Schedule/RPTKeywordNormalisation.hpp>
+
+#include <opm/common/OpmLog/KeywordLocation.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
+
+#include <opm/input/eclipse/Utility/Functional.hpp>
+
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+
+#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <functional>
+#include <iterator>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+
+namespace {
+
+    bool isInteger(const std::string& x)
+    {
+        auto is_digit = [](char c) { return std::isdigit(c); };
+
+        return !x.empty()
+            && ((x.front() == '-') || is_digit(x.front()))
+            && std::all_of(x.begin() + 1, x.end(), is_digit);
+    }
+
+    std::vector<int>
+    getIntegerControlValues(const std::vector<std::string>& deckItems)
+    {
+        auto controlValues = std::vector<int>{};
+        controlValues.reserve(deckItems.size());
+
+        std::transform(deckItems.begin(), deckItems.end(),
+                       std::back_inserter(controlValues),
+                       [](const std::string& controlItem)
+                       { return std::stoi(controlItem); });
+
+        return controlValues;
+    }
+
+    std::pair<bool, bool>
+    classifyRptKeywordSpecification(const std::vector<std::string>& deckItems)
+    {
+        return {
+            std::any_of(deckItems.begin(), deckItems.end(), isInteger),
+            ! std::all_of(deckItems.begin(), deckItems.end(), isInteger)
+        };
+    }
+
+    void recordUnknownMnemonic(const std::string&          mnemonic,
+                               const Opm::KeywordLocation& location,
+                               const Opm::ParseContext&    parseContext,
+                               Opm::ErrorGuard&            errors)
+    {
+        const auto msg_fmt =
+            fmt::format("Error in keyword {{keyword}}, "
+                        "unrecognized mnemonic {}\n"
+                        "In {{file}} line {{line}}.", mnemonic);
+
+        parseContext.handleError(Opm::ParseContext::RPT_UNKNOWN_MNEMONIC,
+                                 msg_fmt, location, errors);
+    }
+
+    int parseMnemonicValue(const std::string&           item,
+                           const std::string::size_type sepPos)
+    {
+        if (sepPos == std::string::npos) {
+            return 1;
+        }
+
+        const auto valuePos =
+            item.find_first_not_of("= ", sepPos);
+
+        return (valuePos != std::string::npos)
+            ? std::stoi(item.substr(valuePos))
+            : 1;
+    }
+
+} // Anonymous namespace
+
+Opm::RPTKeywordNormalisation::MnemonicMap
+Opm::RPTKeywordNormalisation::normaliseKeyword(const DeckKeyword&  kw,
+                                               const ParseContext& parseContext,
+                                               ErrorGuard&         errors) const
+{
+    const auto [hasIntegerControls, hasMnemonicControls] =
+        classifyRptKeywordSpecification(kw.getStringData());
+
+    if (! (hasIntegerControls || hasMnemonicControls)) {
+        // Neither regular mnemonics nor integer controls.  This is an empty
+        // keyword.
+        return {};
+    }
+
+    if (! hasMnemonicControls) {
+        // Integer controls only.  Defer processing to client's integer
+        // control handler.
+        return this->integerControlHandler_
+            (getIntegerControlValues(kw.getStringData()));
+    }
+
+    if (! hasIntegerControls) {
+        // Regular mnemonics only.  Handle in normal way.
+        return this->parseMnemonics(kw.getStringData(),
+                                    kw.location(),
+                                    parseContext, errors);
+    }
+
+    // If we get here, we have both regular mnemonics *and* integer
+    // controls.  This is strictly speaking an error, but we sometimes see
+    // input which happens to have blanks on either side of an equals sign,
+    // e.g.,
+    //
+    //   RPTRST
+    //     BASIC = 2 /
+    //
+    // Depending on RPT_MIXED_STYLE, we heuristically interpret the
+    // specification as a set of mnemonics.
+    const auto msg = std::string {
+        "Keyword {keyword} mixes mnemonics and integer controls.\n"
+        "This is not permitted.\n"
+        "In {file} line {line}."
+    };
+
+    parseContext.handleError(ParseContext::RPT_MIXED_STYLE,
+                             msg, kw.location(), errors);
+
+    return this->parseMixedStyle(kw, parseContext, errors);
+}
+
+// ===========================================================================
+// Private member functions of class RPTKeywordNormalisation below
+// ===========================================================================
+
+Opm::RPTKeywordNormalisation::MnemonicMap
+Opm::RPTKeywordNormalisation::
+parseMnemonics(const std::vector<std::string>& deckItems,
+               const KeywordLocation&          location,
+               const ParseContext&             parseContext,
+               ErrorGuard&                     errors) const
+{
+    auto mnemonics = MnemonicMap{};
+
+    for (const auto& item : deckItems) {
+        const auto sepPos   = item.find_first_of( "= " );
+        const auto mnemonic = item.substr(0, sepPos);
+
+        if (! this->isMnemonic_(mnemonic)) {
+            recordUnknownMnemonic(mnemonic, location, parseContext, errors);
+            continue;
+        }
+
+        mnemonics.emplace_back(mnemonic, parseMnemonicValue(item, sepPos));
+    }
+
+    return mnemonics;
+}
+
+Opm::RPTKeywordNormalisation::MnemonicMap
+Opm::RPTKeywordNormalisation::
+parseMixedStyle(const DeckKeyword&  kw,
+                const ParseContext& parseContext,
+                ErrorGuard&         errors) const
+{
+    const auto& deckItems = kw.getStringData();
+
+    auto items = std::vector<std::string>{};
+    items.reserve(deckItems.size()); // Best estimate.
+
+    for (const auto& item : deckItems) {
+        if (! isInteger(item)) {
+            // Regular mnemonic or equals sign.
+            items.push_back(item);
+            continue;
+        }
+
+        // If we get here, then 'item' is an integer.  This is okay if the
+        // previous two tokens were exactly
+        //
+        //   "MNEMONIC"  (e.g., 'BASIC')
+        //   "="
+        //
+        // Otherwise, we have an unrecoverable parse error.
+
+        if ((items.size() < 2) || (items.back() != "=")) {
+            throw OpmInputError {
+                "Problem processing {keyword}\n"
+                "In {file} line {line}.",
+                kw.location()
+            };
+        }
+
+        // Drop '='
+        items.pop_back();
+
+        // Make last item be "MNEMONIC=INT".
+        items.back() += "=" + item;
+    }
+
+    return this->parseMnemonics(items, kw.location(), parseContext, errors);
+}

--- a/opm/input/eclipse/Schedule/RPTKeywordNormalisation.hpp
+++ b/opm/input/eclipse/Schedule/RPTKeywordNormalisation.hpp
@@ -1,0 +1,146 @@
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_RPT_KEYWORD_NORMALISATION_HPP_INCLUDED
+#define OPM_RPT_KEYWORD_NORMALISATION_HPP_INCLUDED
+
+#include <functional>
+#include <initializer_list>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Opm {
+    class DeckKeyword;
+    class ErrorGuard;
+    class KeywordLocation;
+    class ParseContext;
+} // namespace Opm
+
+namespace Opm {
+
+/// Normalise disparate input sources into sequence of report keyword
+/// mnemonics and associate values.
+class RPTKeywordNormalisation
+{
+public:
+    /// Mnemonic sequence.  Preserves input ordering.
+    using MnemonicMap = std::vector<std::pair<std::string, int>>;
+
+    /// Callback for translating a sequence of integer controls into a
+    /// sequence of mnemonics.
+    using IntegerControlHandler = std::function<MnemonicMap(const std::vector<int>&)>;
+
+    /// Mnemonic validity predicate.
+    using MnemonicPredicate = std::function<bool(const std::string&)>;
+
+    /// Constructor.
+    ///
+    /// \param[in] integerControlHandler Callback for translating a sequence
+    /// of integer controls, typically from the RPTSCHED, RPTRST, or RPTSOL
+    /// keywords, into a sequence of mnemonics.  It is the caller's
+    /// responsibility to provide a callback that matches the current report
+    /// keyword context.
+    ///
+    /// \param[in] isMnemonic Callback for checking the validity of a report
+    /// mnemonic string.
+    explicit RPTKeywordNormalisation(IntegerControlHandler integerControlHandler,
+                                     MnemonicPredicate     isMnemonic)
+        : integerControlHandler_ { std::move(integerControlHandler) }
+        , isMnemonic_            { std::move(isMnemonic) }
+    {}
+
+    /// Normalise report keyword specification into sequence of mnemonics
+    /// and associate integer values.
+    ///
+    /// \param[in] kw Report keyword specification, typically from RPTSCHED,
+    /// RPTRST, or RPTSOL.
+    ///
+    /// \param[in] parseContext Error handling controls.
+    ///
+    /// \param[in,out] errors Collection of parse errors encountered thus
+    /// far.  Behaviour controlled by \p parseContext.
+    ///
+    /// \return Sequence of mnemonics and associate integer values.
+    MnemonicMap normaliseKeyword(const DeckKeyword&  kw,
+                                 const ParseContext& parseContext,
+                                 ErrorGuard&         errors) const;
+
+private:
+    /// User-controlled callback for translating sequences of integer
+    /// controls into sequences of mnemonics.
+    IntegerControlHandler integerControlHandler_{};
+
+    /// User-controlled callback for checking validity of report mnemonic
+    /// string.
+    MnemonicPredicate isMnemonic_{};
+
+    /// Normalise sequence of mnemonics.
+    ///
+    /// Mnemonic values are one (1) unless the mnemonic uses assignment
+    /// syntax (e.g., BASIC=3).
+    ///
+    /// \param[in] deckItems Sequence of mnemonics, possibly including value
+    /// assignment.
+    ///
+    /// \param[in] location Input location of the keyword.  Used for
+    /// diagnostic generation.
+    ///
+    /// \param[in] parseContext Error handling controls.
+    ///
+    /// \param[in,out] errors Collection of parse errors encountered thus
+    /// far.  Behaviour controlled by \p parseContext.
+    ///
+    /// \return Sequence of mnemonics and associate integer values.
+    MnemonicMap parseMnemonics(const std::vector<std::string>& deckItems,
+                               const KeywordLocation&          location,
+                               const ParseContext&             parseContext,
+                               ErrorGuard&                     errors) const;
+
+    /// Normalise sequence of mnemonics.
+    ///
+    /// Input sequence contains a mix of mnemonic strings and integer
+    /// controls.  This is strictly speaking an error, but we sometimes see
+    /// inputs which happen to have blanks on either side of an equals sign,
+    /// e.g.,
+    ///
+    ///   RPTRST
+    ///     BASIC = 2 /
+    ///
+    /// Depending on RPT_MIXED_STYLE, we heuristically interpret the
+    /// specification as a set of mnemonics.
+    ///
+    /// \param[in] kw Report keyword specification, typically from RPTSCHED,
+    /// RPTRST, or RPTSOL.
+    ///
+    /// \param[in] parseContext Error handling controls.
+    ///
+    /// \param[in,out] errors Collection of parse errors encountered thus
+    /// far.  Behaviour controlled by \p parseContext.
+    ///
+    /// \return Sequence of mnemonics and associate integer values.
+    MnemonicMap parseMixedStyle(const DeckKeyword&  kw,
+                                const ParseContext& parseContext,
+                                ErrorGuard&         errors) const;
+};
+
+} // namespace Opm
+
+#endif // OPM_RPT_KEYWORD_NORMALISATION_HPP_INCLUDED

--- a/opm/input/eclipse/Schedule/RXXKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/RXXKeywordHandlers.cpp
@@ -43,8 +43,14 @@ void handleRPTONLYO(HandlerContext& handlerContext)
 
 void handleRPTSCHED(HandlerContext& handlerContext)
 {
-    const RPTConfig& prev = handlerContext.state().rpt_config.get();
-    handlerContext.state().rpt_config.update( RPTConfig(handlerContext.keyword, &prev));
+    auto rpt_config = RPTConfig {
+        handlerContext.keyword,
+        &handlerContext.state().rpt_config(),
+        handlerContext.parseContext,
+        handlerContext.errors
+    };
+    handlerContext.state().rpt_config.update(std::move(rpt_config));
+
     auto rst_config = handlerContext.state().rst_config();
     rst_config.update(handlerContext.keyword,
                       handlerContext.parseContext,

--- a/opm/input/eclipse/Schedule/RptschedKeywordNormalisation.cpp
+++ b/opm/input/eclipse/Schedule/RptschedKeywordNormalisation.cpp
@@ -1,0 +1,171 @@
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/Schedule/RptschedKeywordNormalisation.hpp>
+
+#include <opm/input/eclipse/Schedule/SimpleRPTIntegerControlHandler.hpp>
+
+#include <opm/input/eclipse/Schedule/RPTKeywordNormalisation.hpp>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace {
+    Opm::SimpleRPTIntegerControlHandler makeIntegerControlHandler()
+    {
+        return Opm::SimpleRPTIntegerControlHandler {
+            "PRES",     // 1
+            "SOIL",     // 2
+            "SWAT",     // 3
+            "SGAS",     // 4
+            "RS",       // 5
+            "RV",       // 6
+            "RESTART",  // 7
+            "FIP",      // 8
+            "WELLS",    // 9
+            "VFPPROD",  // 10
+            "SUMMARY",  // 11
+            "CPU",      // 12
+            "AQUCT",    // 13
+            "WELSPECS", // 14
+            "NEWTON",   // 15
+            "POILD",    // 16
+            "PWAT",     // 17
+            "PWATD",    // 18
+            "PGAS",     // 19
+            "PGASD",    // 20
+            "FIPVE",    // 21
+            "WOC",      // 22
+            "GOC",      // 23
+            "WOCDIFF",  // 24
+            "GOCDIFF",  // 25
+            "WOCGOC",   // 26
+            "ODGAS",    // 27
+            "ODWAT",    // 28
+            "GDOWAT",   // 29
+            "WDOGAS",   // 30
+            "OILAPI",   // 31
+            "FIPITR",   // 32
+            "TBLK",     // 33
+            "PBLK",     // 34
+            "SALT",     // 35
+            "PLYADS",   // 36
+            "RK",       // 37
+            "FIPSALT",  // 38
+            "TUNING",   // 39
+            "GI",       // 40
+            "ROCKC",    // 41
+            "SPENWAT",  // 42
+            "FIPSOL",   // 43
+            "SURFBLK",  // 44
+            "SURFADS",  // 45
+            "FIPSURF",  // 46
+            "TRADS",    // 47
+            "VOIL",     // 48
+            "VWAT",     // 49
+            "VGAS",     // 50
+            "DENO",     // 51
+            "DENW",     // 52
+            "DENG",     // 53
+            "GASCONC",  // 54
+            "PB",       // 55
+            "PD",       // 56
+            "KRW",      // 57
+            "KRO",      // 58
+            "KRG",      // 59
+            "MULT",     // 60
+            "UNKNOWN",  // 61
+            "UNKNOWN",  // 62
+            "FOAM",     // 63
+            "FIPFOAM",  // 64
+            "TEMP",     // 65
+            "FIPTEMP",  // 66
+            "POTC",     // 67
+            "FOAMADS",  // 68
+            "FOAMDCY",  // 69
+            "FOAMMOB",  // 70
+            "RECOV",    // 71
+            "FLOOIL",   // 72
+            "FLOWAT",   // 73
+            "FLOGAS",   // 74
+            "SGTRAP",   // 75
+            "FIPRESV",  // 76
+            "FLOSOL",   // 77
+            "KRN",      // 78
+            "GRAD",     // 79
+        };
+    }
+
+    class IsRptSchedMnemonic
+    {
+    public:
+        IsRptSchedMnemonic();
+
+        bool operator()(const std::string& mnemonic) const;
+
+    private:
+        std::vector<std::string> mnemonics_{};
+    };
+
+    IsRptSchedMnemonic::IsRptSchedMnemonic()
+        : mnemonics_ {
+                // Note: This list of mnemonics *must* be in alphabetically
+                // sorted order.
+                "ALKALINE", "ANIONS",  "AQUCT",    "AQUFET",   "AQUFETP",  "BFORG",
+                "CATIONS",  "CPU",     "DENG",     "DENO",     "DENW",     "ESALPLY",
+                "ESALSUR",  "FFORG",   "FIP",      "FIPFOAM",  "FIPHEAT",  "FIPRESV",
+                "FIPSALT",  "FIPSOL",  "FIPSURF",  "FIPTEMP",  "FIPTR",    "FIPVE",
+                "FLOGAS",   "FLOOIL",  "FLOSOL",   "FLOWAT",   "FMISC",    "FOAM",
+                "FOAMADS",  "FOAMCNM", "FOAMDCY",  "FOAMMOB",  "GASCONC",  "GASSATC",
+                "GDOWAT",   "GI",      "GOC",      "GOCDIFF",  "GRAD",     "KRG",
+                "KRN",      "KRO",     "KRW",      "MULT",     "NEWTON",   "NOTHING",
+                "NPMREB",   "ODGAS",   "ODWAT",    "OILAPI",   "PB",       "PBLK",
+                "PBU",      "PD",      "PDEW",     "PGAS",     "PGASD",    "PLYADS",
+                "POIL",     "POILD",   "POLYMER",  "POTC",     "POTG",     "POTO",
+                "POTW",     "PRES",    "PRESSURE", "PWAT",     "PWATD",    "RECOV",
+                "RESTART",  "ROCKC",   "RS",       "RSSAT",    "RV",       "RVSAT",
+                "SALT",     "SGAS",    "SGTRAP",   "SIGM_MOD", "SOIL",     "SSOL",
+                "SUMMARY",  "SURFADS", "SURFBLK",  "SWAT",     "TBLK",     "TEMP",
+                "TRACER",   "TRADS",   "TRDCY",    "TUNING",   "VFPPROD",  "VGAS",
+                "VOIL",     "VWAT",    "WDOGAS",   "WELLS",    "WELSPECL", "WELSPECS",
+                "WOC",      "WOCDIFF", "WOCGOC",
+            }
+    {}
+
+    bool IsRptSchedMnemonic::operator()(const std::string& mnemonic) const
+    {
+        return std::binary_search(this->mnemonics_.begin(),
+                                  this->mnemonics_.end(), mnemonic);
+    }
+} // Anonymous namespace
+
+// ===========================================================================
+// Public interface below
+// ===========================================================================
+
+Opm::RPTKeywordNormalisation::MnemonicMap
+Opm::normaliseRptSchedKeyword(const DeckKeyword&  kw,
+                              const ParseContext& parseContext,
+                              ErrorGuard&         errors)
+{
+    return RPTKeywordNormalisation {
+        makeIntegerControlHandler(), IsRptSchedMnemonic{}
+    }.normaliseKeyword(kw, parseContext, errors);
+}

--- a/opm/input/eclipse/Schedule/RptschedKeywordNormalisation.hpp
+++ b/opm/input/eclipse/Schedule/RptschedKeywordNormalisation.hpp
@@ -1,0 +1,54 @@
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_RPTSHCED_KEYWORD_NORMALISATION_HPP_INCLUDED
+#define OPM_RPTSHCED_KEYWORD_NORMALISATION_HPP_INCLUDED
+
+#include <opm/input/eclipse/Schedule/RPTKeywordNormalisation.hpp>
+
+namespace Opm {
+    class DeckKeyword;
+    class ParseContext;
+    class ErrorGuard;
+} // namespace Opm
+
+namespace Opm {
+
+    /// Normalise RPTSHCED keyword specification into sequence of mnemonics
+    /// and associate values.
+    ///
+    /// Simple convenience/helper function only.
+    ///
+    /// \param[in] kw Report keyword specification, typically from RPTSCHED,
+    /// RPTRST, or RPTSOL.
+    ///
+    /// \param[in] parseContext Error handling controls.
+    ///
+    /// \param[in,out] errors Collection of parse errors encountered thus
+    /// far.  Behaviour controlled by \p parseContext.
+    ///
+    /// \return Sequence of mnemonics and associate integer values.
+    RPTKeywordNormalisation::MnemonicMap
+    normaliseRptSchedKeyword(const DeckKeyword&  kw,
+                             const ParseContext& parseContext,
+                             ErrorGuard&         errors);
+
+} // namespace Opm
+
+#endif // OPM_RPTSHCED_KEYWORD_NORMALISATION_HPP_INCLUDED

--- a/opm/input/eclipse/Schedule/SimpleRPTIntegerControlHandler.cpp
+++ b/opm/input/eclipse/Schedule/SimpleRPTIntegerControlHandler.cpp
@@ -1,0 +1,42 @@
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/Schedule/SimpleRPTIntegerControlHandler.hpp>
+
+#include <opm/input/eclipse/Schedule/RPTKeywordNormalisation.hpp>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+Opm::RPTKeywordNormalisation::MnemonicMap
+Opm::SimpleRPTIntegerControlHandler::
+operator()(const std::vector<int>& controlValues) const
+{
+    auto mnemonics = RPTKeywordNormalisation::MnemonicMap{};
+
+    const auto numValues =
+        std::min(controlValues.size(), this->keywords_.size());
+
+    for (auto i = 0*numValues; i < numValues; ++i) {
+        mnemonics.emplace_back(this->keywords_[i], controlValues[i]);
+    }
+
+    return mnemonics;
+}

--- a/opm/input/eclipse/Schedule/SimpleRPTIntegerControlHandler.hpp
+++ b/opm/input/eclipse/Schedule/SimpleRPTIntegerControlHandler.hpp
@@ -1,0 +1,64 @@
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_SIMPLE_RPT_INTEGER_CONTROL_HANDLER_HPP_INCLUDED
+#define OPM_SIMPLE_RPT_INTEGER_CONTROL_HANDLER_HPP_INCLUDED
+
+#include <opm/input/eclipse/Schedule/RPTKeywordNormalisation.hpp>
+
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+namespace Opm {
+
+/// Report keyword integer control handler from sequence of mnemonic
+/// strings.
+class SimpleRPTIntegerControlHandler
+{
+public:
+    /// Constructor.
+    ///
+    /// Internalises sequence of mnemonic strings from which to infer an
+    /// integer control handler.
+    ///
+    /// \param[in] keywords Mnemonic strings.
+    explicit SimpleRPTIntegerControlHandler(std::initializer_list<const char*> keywords)
+        : keywords_ { keywords.begin(), keywords.end() }
+    {}
+
+    /// Function call operator.
+    ///
+    /// Creates sequence of mnemonics along with associate integer mnemonic
+    /// values.
+    ///
+    /// \param[in] controlValues Integer control values.
+    ///
+    /// \return Mnemonics and their associate integer values.
+    RPTKeywordNormalisation::MnemonicMap
+    operator()(const std::vector<int>& controlValues) const;
+
+private:
+    /// Sequence of mnemonic strings.  Defined by user's constructor call.
+    std::vector<std::string> keywords_{};
+};
+
+} // namespace Opm
+
+#endif // OPM_OPM_SIMPLE_RPT_INTEGER_CONTROL_HANDLER_HPP_INCLUDED

--- a/tests/test_RPTConfig.cpp
+++ b/tests/test_RPTConfig.cpp
@@ -1,0 +1,396 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+
+/*
+  Copyright 2025 Equinor
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE RPT_Config
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/input/eclipse/Schedule/RPTConfig.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+
+#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Basic_Operations)
+
+namespace {
+    Opm::DeckKeyword getRptSched(const std::string& input)
+    {
+        return Opm::Parser{}.parseString(input)
+            .get<Opm::ParserKeywords::RPTSCHED>()
+            .back();
+    }
+} // Anonymous keyword
+
+BOOST_AUTO_TEST_SUITE(Accepts_All_Mnemonics)
+
+BOOST_AUTO_TEST_CASE(No_Mnemonics)
+{
+    const auto cfg = Opm::RPTConfig { getRptSched(R"(SCHEDULE
+RPTSCHED
+/
+END
+)") };
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{0});
+    BOOST_CHECK_MESSAGE(! cfg.contains("No such mnemonic"),
+                        R"("No such mnemonic" must not exist)");
+    BOOST_CHECK_THROW(cfg.at("HELLO"), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE(Selected_Mnemonics)
+{
+    const auto cfg = Opm::RPTConfig { getRptSched(R"(SCHEDULE
+RPTSCHED
+  WELLS=2 WELSPECS KRO PRESSURE=42 FIPRESV FIP=2
+/
+END
+)") };
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{6});
+    BOOST_CHECK_MESSAGE(! cfg.contains("No such mnemonic"),
+                        R"("No such mnemonic" must not exist)");
+    BOOST_CHECK_THROW(cfg.at("HELLO"), std::out_of_range);
+
+    BOOST_CHECK_MESSAGE(cfg.contains("WELLS"), R"(Mnemonic "WELLS" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("WELSPECS"), R"(Mnemonic "WELSPECS" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("KRO"), R"(Mnemonic "KRO" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("PRESSURE"), R"(Mnemonic "PRESSURE" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("FIPRESV"), R"(Mnemonic "FIPRESV" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("FIP"), R"(Mnemonic "FIP" must exist)");
+
+    BOOST_CHECK_EQUAL(cfg.at("WELLS"), 2u);
+    BOOST_CHECK_EQUAL(cfg.at("WELSPECS"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("KRO"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("PRESSURE"), 42u);
+    BOOST_CHECK_EQUAL(cfg.at("FIPRESV"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("FIP"), 2u);
+}
+
+BOOST_AUTO_TEST_CASE(Unknown_Mnemonics)
+{
+    const auto cfg = Opm::RPTConfig { getRptSched(R"(SCHEDULE
+RPTSCHED
+  ACUTE=17 CAPTIONS
+/
+END
+)") };
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{2});
+
+    BOOST_CHECK_MESSAGE(cfg.contains("ACUTE"), R"(Mnemonic "ACUTE" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("CAPTIONS"), R"(Mnemonic "CAPTIONS" must exist)");
+
+    BOOST_CHECK_EQUAL(cfg.at("ACUTE"), 17u);
+    BOOST_CHECK_EQUAL(cfg.at("CAPTIONS"), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(With_Extra_Spaces)
+{
+    const auto cfg = Opm::RPTConfig { getRptSched(R"(SCHEDULE
+RPTSCHED
+  WELLS = 2
+/
+END
+)") };
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{1});
+
+    BOOST_CHECK_MESSAGE(cfg.contains("WELLS"), R"(Mnemonic "WELLS" must exist)");
+
+    BOOST_CHECK_EQUAL(cfg.at("WELLS"), 2u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Accepts_All_Mnemonics
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Mnemonic_Validity_Checking)
+
+BOOST_AUTO_TEST_SUITE(No_Existing_Mnemonics)
+
+namespace {
+    Opm::RPTConfig makeConfigObject(const std::string& input)
+    {
+        const auto* prev = static_cast<const Opm::RPTConfig*>(nullptr);
+        const auto parseContext = Opm::ParseContext{};
+        auto errors = Opm::ErrorGuard{};
+
+        return Opm::RPTConfig {
+            getRptSched(input), prev, parseContext, errors
+        };
+    }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(No_Mnemonics)
+{
+    const auto cfg = makeConfigObject(R"(SCHEDULE
+RPTSCHED
+/
+END
+)");
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{0});
+    BOOST_CHECK_MESSAGE(! cfg.contains("No such mnemonic"),
+                        R"("No such mnemonic" must not exist)");
+    BOOST_CHECK_THROW(cfg.at("HELLO"), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE(Selected_Mnemonics)
+{
+    const auto cfg = makeConfigObject(R"(SCHEDULE
+RPTSCHED
+  WELLS=2 WELSPECS KRO PRESSURE=42 FIPRESV FIP=2
+/
+END
+)");
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{6});
+    BOOST_CHECK_MESSAGE(! cfg.contains("No such mnemonic"),
+                        R"("No such mnemonic" must not exist)");
+    BOOST_CHECK_THROW(cfg.at("HELLO"), std::out_of_range);
+
+    BOOST_CHECK_MESSAGE(cfg.contains("WELLS"), R"(Mnemonic "WELLS" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("WELSPECS"), R"(Mnemonic "WELSPECS" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("KRO"), R"(Mnemonic "KRO" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("PRESSURE"), R"(Mnemonic "PRESSURE" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("FIPRESV"), R"(Mnemonic "FIPRESV" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("FIP"), R"(Mnemonic "FIP" must exist)");
+
+    BOOST_CHECK_EQUAL(cfg.at("WELLS"), 2u);
+    BOOST_CHECK_EQUAL(cfg.at("WELSPECS"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("KRO"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("PRESSURE"), 42u);
+    BOOST_CHECK_EQUAL(cfg.at("FIPRESV"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("FIP"), 2u);
+}
+
+BOOST_AUTO_TEST_CASE(Unknown_Mnemonics)
+{
+    const auto cfg = makeConfigObject(R"(SCHEDULE
+RPTSCHED
+  ACUTE=17 CAPTIONS
+/
+END
+)");
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{0});
+
+    BOOST_CHECK_MESSAGE(! cfg.contains("ACUTE"), R"(Mnemonic "ACUTE" must NOT exist)");
+    BOOST_CHECK_MESSAGE(! cfg.contains("CAPTIONS"), R"(Mnemonic "CAPTIONS" must NOT exist)");
+}
+
+BOOST_AUTO_TEST_CASE(With_Extra_Spaces)
+{
+    const auto cfg = makeConfigObject(R"(SCHEDULE
+RPTSCHED
+  WELLS = 2
+/
+END
+)");
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{1});
+
+    BOOST_CHECK_MESSAGE(cfg.contains("WELLS"), R"(Mnemonic "WELLS" must exist)");
+
+    BOOST_CHECK_EQUAL(cfg.at("WELLS"), 2u);
+}
+
+BOOST_AUTO_TEST_CASE(Integer_Controls)
+{
+    const auto cfg = makeConfigObject(R"(SCHEDULE
+RPTSCHED
+ 0 0 0 0 0 0 2 2 2 0 1 1 0 1 1 0 0 /
+END
+)");
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{17});
+
+    BOOST_CHECK_MESSAGE(cfg.contains("PRES"), R"(Mnemonic "PRES" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("SOIL"), R"(Mnemonic "SOIL" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("SWAT"), R"(Mnemonic "SWAT" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("SGAS"), R"(Mnemonic "SGAS" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("RS"), R"(Mnemonic "RS" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("RV"), R"(Mnemonic "RV" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("RESTART"), R"(Mnemonic "RESTART" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("FIP"), R"(Mnemonic "FIP" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("WELLS"), R"(Mnemonic "WELLS" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("VFPPROD"), R"(Mnemonic "VFPPROD" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("SUMMARY"), R"(Mnemonic "SUMMARY" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("CPU"), R"(Mnemonic "CPU" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("AQUCT"), R"(Mnemonic "AQUCT" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("WELSPECS"), R"(Mnemonic "WELSPECS" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("NEWTON"), R"(Mnemonic "NEWTON" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("POILD"), R"(Mnemonic "POILD" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("PWAT"), R"(Mnemonic "PWAT" must exist)");
+
+    BOOST_CHECK_EQUAL(cfg.at("PRES"), 0u);
+    BOOST_CHECK_EQUAL(cfg.at("SOIL"), 0u);
+    BOOST_CHECK_EQUAL(cfg.at("SWAT"), 0u);
+    BOOST_CHECK_EQUAL(cfg.at("SGAS"), 0u);
+    BOOST_CHECK_EQUAL(cfg.at("RS"), 0u);
+    BOOST_CHECK_EQUAL(cfg.at("RV"), 0u);
+    BOOST_CHECK_EQUAL(cfg.at("RESTART"), 2u);
+    BOOST_CHECK_EQUAL(cfg.at("FIP"), 2u);
+    BOOST_CHECK_EQUAL(cfg.at("WELLS"), 2u);
+    BOOST_CHECK_EQUAL(cfg.at("VFPPROD"), 0u);
+    BOOST_CHECK_EQUAL(cfg.at("SUMMARY"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("CPU"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("AQUCT"), 0u);
+    BOOST_CHECK_EQUAL(cfg.at("WELSPECS"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("NEWTON"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("POILD"), 0u);
+    BOOST_CHECK_EQUAL(cfg.at("PWAT"), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(Nothing_Mnemonic_Clears_List)
+{
+    const auto cfg = makeConfigObject(R"(SCHEDULE
+RPTSCHED
+  WELLS=2 WELSPECS KRO PRESSURE=42 FIPRESV FIP=2
+  NOTHING -- Clears mnemonic list
+/
+END
+)");
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{0});
+
+    BOOST_CHECK_MESSAGE(! cfg.contains("WELLS"), R"(Mnemonic "WELLS" must NOT exist)");
+    BOOST_CHECK_MESSAGE(! cfg.contains("WELSPECS"), R"(Mnemonic "WELSPECS" must NOT exist)");
+    BOOST_CHECK_MESSAGE(! cfg.contains("KRO"), R"(Mnemonic "KRO" must NOT exist)");
+    BOOST_CHECK_MESSAGE(! cfg.contains("PRESSURE"), R"(Mnemonic "PRESSURE" must NOT exist)");
+    BOOST_CHECK_MESSAGE(! cfg.contains("FIPRESV"), R"(Mnemonic "FIPRESV" must NOT exist)");
+    BOOST_CHECK_MESSAGE(! cfg.contains("FIP"), R"(Mnemonic "FIP" must NOT exist)");
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // No_Existing_Mnemonics
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(With_Existing_Mnemonics)
+
+namespace {
+    Opm::RPTConfig makeConfigObject(const std::string& input)
+    {
+        const auto prev = Opm::RPTConfig { getRptSched(R"(SCHEDULE
+RPTSCHED
+  WELLS FIP=2 /
+)") };
+        const auto parseContext = Opm::ParseContext{};
+        auto errors = Opm::ErrorGuard{};
+
+        return Opm::RPTConfig {
+            getRptSched(input), &prev, parseContext, errors
+        };
+    }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(No_Mnemonics)
+{
+    const auto cfg = makeConfigObject(R"(RPTSCHED
+/
+END
+)");
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{2});
+
+    BOOST_CHECK_MESSAGE(cfg.contains("WELLS"), R"(Mnemonic "WELLS" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("FIP"), R"(Mnemonic "FIP" must exist)");
+
+    BOOST_CHECK_EQUAL(cfg.at("WELLS"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("FIP"), 2u);
+}
+
+BOOST_AUTO_TEST_CASE(Selected_Mnemonics)
+{
+    const auto cfg = makeConfigObject(R"(RPTSCHED
+  WELLS=2 WELSPECS KRO PRESSURE=42 FIPRESV
+/
+END
+)");
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{6});
+    BOOST_CHECK_MESSAGE(! cfg.contains("No such mnemonic"),
+                        R"("No such mnemonic" must not exist)");
+    BOOST_CHECK_THROW(cfg.at("HELLO"), std::out_of_range);
+
+    BOOST_CHECK_MESSAGE(cfg.contains("WELLS"), R"(Mnemonic "WELLS" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("WELSPECS"), R"(Mnemonic "WELSPECS" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("KRO"), R"(Mnemonic "KRO" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("PRESSURE"), R"(Mnemonic "PRESSURE" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("FIPRESV"), R"(Mnemonic "FIPRESV" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("FIP"), R"(Mnemonic "FIP" must exist)");
+
+    BOOST_CHECK_EQUAL(cfg.at("WELLS"), 2u);
+    BOOST_CHECK_EQUAL(cfg.at("WELSPECS"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("KRO"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("PRESSURE"), 42u);
+    BOOST_CHECK_EQUAL(cfg.at("FIPRESV"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("FIP"), 2u);
+}
+
+BOOST_AUTO_TEST_CASE(Unknown_Mnemonics)
+{
+    const auto cfg = makeConfigObject(R"(RPTSCHED
+  ACUTE=17 CAPTIONS
+/
+END
+)");
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{2});
+
+    BOOST_CHECK_MESSAGE(! cfg.contains("ACUTE"), R"(Mnemonic "ACUTE" must NOT exist)");
+    BOOST_CHECK_MESSAGE(! cfg.contains("CAPTIONS"), R"(Mnemonic "CAPTIONS" must NOT exist)");
+}
+
+BOOST_AUTO_TEST_CASE(With_Extra_Spaces)
+{
+    const auto cfg = makeConfigObject(R"(RPTSCHED
+  FIP = 3
+/
+END
+)");
+
+    BOOST_CHECK_EQUAL(cfg.size(), std::size_t{2});
+
+    BOOST_CHECK_MESSAGE(cfg.contains("WELLS"), R"(Mnemonic "WELLS" must exist)");
+    BOOST_CHECK_MESSAGE(cfg.contains("FIP"), R"(Mnemonic "FIP" must exist)");
+
+    BOOST_CHECK_EQUAL(cfg.at("WELLS"), 1u);
+    BOOST_CHECK_EQUAL(cfg.at("FIP"), 3u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // With_Existing_Mnemonics
+
+BOOST_AUTO_TEST_SUITE_END()     // Mnemonic_Validity_Checking
+
+BOOST_AUTO_TEST_SUITE_END()     // Basic_Operations


### PR DESCRIPTION
The "integer control" format support in `RPTSCHED` influenced only the restart-like processing in `RSTConfig` and had no counterpart in the `RPTConfig` class.  This commit corrects this omission and restores PRT file report generation for the older style `RPTSCHED` keyword.  As an example, the `NORNE_ATW2013` example model now gets injection, production, cumulative and `WELSPECS` reports whereas this was missing before.

We don't expect that there are many new cases using this format, but this commit does at ensure that we don't remove useful reports for some existing simulation models.

To this end, extract the restart-like integer control handling to a new helper class, `RPTKeywordNormalisation`, which consumes both mnemonics and integer controls and generates a `map<string,int>` of strictly mnemonic-like values.  This class uses a callback function to process integer controls and we extract the `RPTSCHED` format handling to another pair of helper components

  - `SimpleRPTIntegerControls`
  - `RptschedKeywordNormalisation`

The former is constructed from an ordered list of mnemonic strings and assigns the mnemonic map given a vector of integer control values.  The latter uses the `RPTKeywordNormalisation` and an instance of the `SimpleRPTIntegerControls` constructed from `RPTSCHED`'s curated list extracted from `RSTConfig.cpp`.

We then use these components to form the `RPTConfig` instance in the `RPTSCHED` keyword handler while preserving the single argument `RPTConfig` constructor for use in the context of `RPTSOL` handling. This constructor does currently not support integer controls.