### PR TITLE
Store GLO Limits as Double Precision on Restart

### DIFF
--- a/opm/io/eclipse/rst/group.hpp
+++ b/opm/io/eclipse/rst/group.hpp
@@ -68,8 +68,8 @@ struct RstGroup
     float gas_reservoir_limit;
     float gas_reinject_limit;
     float gas_voidage_limit;
-    float glift_max_supply;
-    float glift_max_rate;
+    double glift_max_supply;
+    double glift_max_rate;
     float efficiency_factor;
     float inj_water_guide_rate;
     float inj_gas_guide_rate;

--- a/opm/io/eclipse/rst/well.hpp
+++ b/opm/io/eclipse/rst/well.hpp
@@ -122,10 +122,10 @@ struct RstWell
     float wtest_interval;
     float wtest_startup;
     float grupcon_gr_scaling;
-    float glift_max_rate;
-    float glift_min_rate;
-    float glift_weight_factor;
-    float glift_inc_weight_factor;
+    double glift_max_rate;
+    double glift_min_rate;
+    double glift_weight_factor;
+    double glift_inc_weight_factor;
     float dfac_corr_coeff_a{};
     float dfac_corr_exponent_b{};
     float dfac_corr_exponent_c{};


### PR DESCRIPTION
That way we don't impose a second `double` :arrow_right: `float` conversion after `float` :arrow_right: `double` for unit conversion.  This enables reaching the maximum lift gas injection rate in an example model, but is nevertheless at best a stop-gap measure.  GLO results in restarted runs typically do not yet match those of the base run.