### PR TITLE
Add CONVERGENCE as closing reason

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WellTestConfig.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestConfig.hpp
@@ -60,6 +60,7 @@ enum class Reason {
     GROUP = 4,
     THP_DESIGN=8,
     COMPLETION=16,
+    CONVERGENCE=32,
 };
 
 }

--- a/opm/input/eclipse/Schedule/Well/WellTestState.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestState.cpp
@@ -32,6 +32,7 @@
 #include <string>
 #include <unordered_set>
 #include <vector>
+#include "WellTestState.hpp"
 
 namespace Opm {
 
@@ -119,6 +120,13 @@ namespace Opm {
         return iter->second.closed;
     }
 
+    bool WellTestState::well_is_closed_due_to_convergence_issues(const std::string& well_name) const {
+        auto iter = this->wells.find(well_name);
+        if (iter == this->wells.end())
+            return false;
+
+        return iter->second.closed && iter->second.reason == WellTestConfig::Reason::CONVERGENCE;
+    }
 
     void WellTestState::filter_wells(const std::vector<std::string>& existing_wells) {
         std::unordered_set<std::string> well_set{ existing_wells.begin(), existing_wells.end() };
@@ -135,11 +143,18 @@ namespace Opm {
 
     std::vector<std::string>
     WellTestState::test_wells(const WellTestConfig& config,
-                               double sim_time) {
+                              double sim_time) {
         std::vector<std::string> output;
 
         for (auto& [wname, well] : this->wells) {
             if (!well.closed)
+                continue;
+
+            // we always try to open well shut due to convergence issues
+            if (well.reason == WellTestConfig::Reason::CONVERGENCE)
+                output.push_back(well.name);
+
+            if (config.empty())
                 continue;
 
             if (config.has(wname, well.reason)) {

--- a/opm/input/eclipse/Schedule/Well/WellTestState.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestState.hpp
@@ -217,6 +217,7 @@ public:
     */
     void close_well(const std::string& well_name, WTest::Reason reason, double sim_time);
     bool well_is_closed(const std::string& well_name) const;
+    bool well_is_closed_due_to_convergence_issues(const std::string& well_name) const;
     void open_well(const std::string& well_name);
     std::size_t num_closed_wells() const;
     double lastTestTime(const std::string& well_name) const;


### PR DESCRIPTION
Motivation is to make it easy always to try to reopen wells that are shut due to convergence. 

See  https://github.com/OPM/opm-simulators/pull/6067