### PR TITLE
Varnish WELSPECS Report Implementation

### DIFF
--- a/opm/output/eclipse/WriteRPT.hpp
+++ b/opm/output/eclipse/WriteRPT.hpp
@@ -30,21 +30,29 @@ namespace Opm {
     class EclipseGrid;
     class UnitSystem;
 
-    namespace RptIO {
+} // namespace Opm
 
-        void write_report(
-            std::ostream&,
-            const std::string& report,
-            unsigned value,
-            const Schedule& schedule,
-            const EclipseGrid& grid,
-            const UnitSystem& unit_system,
-            std::size_t time_step
-        );
+namespace Opm::RptIO {
 
-        namespace workers {
+    void write_report(std::ostream&      os,
+                      const std::string& reportType,
+                      int                reportSpec,
+                      const Schedule&    schedule,
+                      const EclipseGrid& grid,
+                      const UnitSystem&  unit_system,
+                      std::size_t        time_step);
 
-            void write_WELSPECS(std::ostream&, unsigned, const Schedule&, const EclipseGrid& grid, const UnitSystem&, std::size_t);
+} // namespace Opm::RptIO
 
-}   }   }
+namespace Opm::RptIO::workers {
+
+    void wellSpecification(std::ostream&      os,
+                           int                wellSpecRequest,
+                           const Schedule&    schedule,
+                           const EclipseGrid& grid,
+                           const UnitSystem&  unit_system,
+                           std::size_t        time_step);
+
+} // namespace Opm::RptIO::workers
+
 #endif // OPM_WRITE_RPT_HPP

--- a/opm/output/eclipse/report/WELSPECS.cpp
+++ b/opm/output/eclipse/report/WELSPECS.cpp
@@ -403,9 +403,11 @@ namespace {
             return std::to_string( well.pvt_table_number() );
         }
 
-        std::string shut_status(const context&, std::size_t, std::size_t) const
+        std::string shutin_instruction(const context&, std::size_t, std::size_t) const
         {
-            return Opm::WellStatus2String(well.getStatus());
+            // Shut-in instruction is 'SHUT' if the well automatically shuts
+            // in, and 'STOP' otherwise.
+            return well.getAutomaticShutIn() ? "SHUT" : "STOP";
         }
 
         std::string region_number(const context&, std::size_t, std::size_t) const
@@ -446,19 +448,19 @@ namespace {
     };
 
     const table<WellWrapper, 3> well_specification_table {
-       {  8, { "WELL"       , "NAME"       ,               }, &WellWrapper::well_name        , left_align  },
-       {  8, { "GROUP"      , "NAME"       ,               }, &WellWrapper::group_name       , left_align  },
-       {  8, { "WELLHEAD"   , "LOCATION"   , "( I, J )"    }, &WellWrapper::wellhead_location, left_align  },
-       {  8, { "B.H.REF"    , "DEPTH"      , "METRES"      }, &WellWrapper::reference_depth  , right_align, Opm::UnitSystem::measure::length },
-       {  5, { "PREF-"      , "ERRED"      , "PHASE"       }, &WellWrapper::preferred_phase  ,             },
-       {  8, { "DRAINAGE"   , "RADIUS"     , "METRES"      }, &WellWrapper::drainage_radius  , right_align, Opm::UnitSystem::measure::length },
-       {  4, { "GAS"        , "INFL"       , "EQUN"        }, &WellWrapper::gas_inflow       ,             },
-       {  7, { "SHUT-IN"    , "INSTRCT"    ,               }, &WellWrapper::shut_status      ,             },
-       {  5, { "CROSS"      , "FLOW"       , "ABLTY"       }, &WellWrapper::cross_flow       ,             },
-       {  3, { "PVT"        , "TAB"        ,               }, &WellWrapper::pvt_tab          ,             },
-       {  4, { "WELL"       , "DENS"       , "CALC"        }, &WellWrapper::dens_calc        ,             },
-       {  3, { "FIP"        , "REG"        ,               }, &WellWrapper::region_number    ,             },
-       { 11, { "WELL"       , "D-FACTOR 1" , "DAY/SM3"     }, &WellWrapper::D_factor         ,             },
+       {  8, { "WELL"       , "NAME"       ,               }, &WellWrapper::well_name         , left_align  },
+       {  8, { "GROUP"      , "NAME"       ,               }, &WellWrapper::group_name        , left_align  },
+       {  8, { "WELLHEAD"   , "LOCATION"   , "( I, J )"    }, &WellWrapper::wellhead_location , left_align  },
+       {  8, { "B.H.REF"    , "DEPTH"      , "METRES"      }, &WellWrapper::reference_depth   , right_align, Opm::UnitSystem::measure::length },
+       {  5, { "PREF-"      , "ERRED"      , "PHASE"       }, &WellWrapper::preferred_phase   ,             },
+       {  8, { "DRAINAGE"   , "RADIUS"     , "METRES"      }, &WellWrapper::drainage_radius   , right_align, Opm::UnitSystem::measure::length },
+       {  4, { "GAS"        , "INFL"       , "EQUN"        }, &WellWrapper::gas_inflow        ,             },
+       {  7, { "SHUT-IN"    , "INSTRCT"    ,               }, &WellWrapper::shutin_instruction,             },
+       {  5, { "CROSS"      , "FLOW"       , "ABLTY"       }, &WellWrapper::cross_flow        ,             },
+       {  3, { "PVT"        , "TAB"        ,               }, &WellWrapper::pvt_tab           ,             },
+       {  4, { "WELL"       , "DENS"       , "CALC"        }, &WellWrapper::dens_calc         ,             },
+       {  3, { "FIP"        , "REG"        ,               }, &WellWrapper::region_number     ,             },
+       { 11, { "WELL"       , "D-FACTOR 1" , "DAY/SM3"     }, &WellWrapper::D_factor          ,             },
     };
 
 


### PR DESCRIPTION
In particular,

  - Split long lines.
  - Switch to initialising objects, especially references, using assignment syntax (`=`) instead of construction (`{}`).
  - Move function opening braces to next line.
  - Remove blanks before semicolons.
  - Apply `const` where reasonable.
  - Move static objects into function-local scopes where reasonable.
  - Reverse conditionals to enable "early continue".
  - Rename `workers::write_WELSPECS()` to `workers::wellSpecification()`.

This is in preparation to replacing hard-coded date stamps with dynamic information.