### PR TITLE
Use Dynamic Timestamp in WELSPECS Report

### DIFF
--- a/opm/output/eclipse/report/WELSPECS.cpp
+++ b/opm/output/eclipse/report/WELSPECS.cpp
@@ -40,6 +40,9 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
+#include <fmt/chrono.h>
+
 namespace {
 
     constexpr char field_separator   {  ':' };
@@ -335,8 +338,16 @@ namespace {
 
     std::string run_time()
     {
-        const std::string header_run_time_string { "RUN AT 12:41 ON 12 SEP 2016" };
-        return wrap_string_for_header(header_run_time_string); // TODO: Calculate properly
+        using namespace fmt::literals;
+
+        auto now = std::time(0);
+        const auto timepoint = *std::localtime(&now);
+
+        const auto header_run_time_string =
+            fmt::format("Run at {timepoint:%d-%b-%Y %H:%M}",
+                        "timepoint"_a = timepoint);
+
+        return wrap_string_for_header(header_run_time_string);
     }
 
     void write_report_header(std::ostream&        os,


### PR DESCRIPTION
This PR replaces the static "RUN AT" timestamp currently used in the `WELSPECS` report (`RPTSCHED` keyword) with the current (local) time when the report is emitted.

As an example, following #4526, the NORNE_ATW2013 PRT file contains well specification report headers of the form
```
Report step  7/247 at day 143/3312, date = 29-Mar-1998
                             **************************************************************************                             
 WELSPECS AT       0.00 DAYS *                                                                        * FLOW                        
 REPORT   0     31 DEC 2007  *                                                                        * RUN AT 12:41 ON 12 SEP 2016 
                             **************************************************************************                             

                                                  WELL SPECIFICATION DATA                                                 
                                                  -----------------------                                                 
```
With this PR, the header might look something like the following instead
```
Report step  7/247 at day 143/3312, date = 29-Mar-1998
                             **************************************************************************                             
 WELSPECS AT       0.00 DAYS *                                                                        * FLOW                        
 REPORT   0     31 DEC 2007  *                                                                        * Run at 19-Mar-2025 17:41    
                             **************************************************************************                             

                                                  WELL SPECIFICATION DATA                                                 
                                                  -----------------------                                                 
```

Note: Fixing the "0.00 DAYS" and "REPORT 0 31 DEC 2007" parts is the subject of follow-up work.