### PR TITLE
Use Dynamic Elapsed Time and Dates for WELSPECS Report

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -459,7 +459,7 @@ if(ENABLE_ECL_OUTPUT)
           opm/output/eclipse/WriteInit.cpp
           opm/output/eclipse/WriteRFT.cpp
           opm/output/eclipse/WriteRPT.cpp
-          opm/output/eclipse/report/WELSPECS.cpp
+          opm/output/eclipse/report/WellSpecification.cpp
           opm/utility/EModel.cpp
       )
 endif()
@@ -1559,6 +1559,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/eclipse/WriteRFT.hpp
         opm/output/eclipse/WriteRPT.hpp
         opm/output/eclipse/WriteRestartHelpers.hpp
+        opm/output/eclipse/report/WellSpecification.hpp
         opm/utility/CopyablePtr.hpp
         opm/utility/EModel.hpp
         )

--- a/opm/output/eclipse/WriteRPT.cpp
+++ b/opm/output/eclipse/WriteRPT.cpp
@@ -19,6 +19,8 @@
 
 #include <opm/output/eclipse/WriteRPT.hpp>
 
+#include <opm/output/eclipse/report/WellSpecification.hpp>
+
 #include <cstddef>
 #include <functional>
 #include <optional>
@@ -27,18 +29,19 @@
 namespace {
 
     using ReportHandler = std::function<void(std::ostream&,
-                                             unsigned,
+                                             const unsigned,
+                                             const double,
+                                             const std::size_t,
                                              const Opm::Schedule&,
                                              const Opm::EclipseGrid&,
-                                             const Opm::UnitSystem&,
-                                             std::size_t)>;
+                                             const Opm::UnitSystem&)>;
 
     std::optional<ReportHandler>
     findReportHandler(const std::string& reportType)
     {
         if (reportType == "WELSPECS") {
             return {
-                ReportHandler { Opm::RptIO::workers::wellSpecification }
+                ReportHandler { Opm::PrtFile::Reports::wellSpecification }
             };
         }
 
@@ -47,15 +50,16 @@ namespace {
 
 } // Anonymous namespace
 
-namespace Opm::RptIO {
+namespace Opm::PrtFile {
 
-    void write_report(std::ostream&      os,
-                      const std::string& reportType,
-                      const int          reportSpec,
-                      const Schedule&    schedule,
-                      const EclipseGrid& grid,
-                      const UnitSystem&  unit_system,
-                      const std::size_t  report_step)
+    void report(std::ostream&      os,
+                const std::string& reportType,
+                const int          reportSpec,
+                const double       elapsed_secs,
+                const std::size_t  report_step,
+                const Schedule&    schedule,
+                const EclipseGrid& grid,
+                const UnitSystem&  unit_system)
     {
         const auto handler = findReportHandler(reportType);
         if (! handler.has_value()) {
@@ -63,8 +67,8 @@ namespace Opm::RptIO {
         }
 
         std::invoke(*handler, os, reportSpec,
-                    schedule, grid,
-                    unit_system, report_step);
+                    elapsed_secs, report_step,
+                    schedule, grid, unit_system);
     }
 
 } // namespace Opm::RptIO

--- a/opm/output/eclipse/report/WellSpecification.hpp
+++ b/opm/output/eclipse/report/WellSpecification.hpp
@@ -17,8 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef OPM_WRITE_RPT_HPP
-#define OPM_WRITE_RPT_HPP
+#ifndef OPM_REPORT_WELL_SPECIFICATION_HPP_INCLUDED
+#define OPM_REPORT_WELL_SPECIFICATION_HPP_INCLUDED
 
 #include <cstddef>
 #include <iosfwd>
@@ -32,17 +32,16 @@ namespace Opm {
 
 } // namespace Opm
 
-namespace Opm::PrtFile {
+namespace Opm::PrtFile::Reports {
 
-    void report(std::ostream&      os,
-                const std::string& reportType,
-                const int          reportSpec,
-                const double       elapsed_secs,
-                const std::size_t  report_step,
-                const Schedule&    schedule,
-                const EclipseGrid& grid,
-                const UnitSystem&  unit_system);
+    void wellSpecification(std::ostream&      os,
+                           const int          wellSpecRequest,
+                           const double       elapsedTime,
+                           const std::size_t  reportStep,
+                           const Schedule&    schedule,
+                           const EclipseGrid& grid,
+                           const UnitSystem&  unit_system);
 
-} // namespace Opm::RptIO
+} // namespace Opm::PrtFile::Reports
 
-#endif // OPM_WRITE_RPT_HPP
+#endif // OPM_REPORT_WELL_SPECIFICATION_HPP_INCLUDED


### PR DESCRIPTION
This PR replaces the hard-coded "REPORT" and "WELSPECS" strings with ones derived from the actual elapsed time and report step dates.

While here, rename the `WELSPECS.cpp` file to something slightly more human friendly and move the function declaration to a separate header.  Furthermore, pull the MSW reports for individual wells out to separate helper functions to limit the cognitive load for readers of the main `wellSpecification()` function.