### PR TITLE
restarting from case with GCONINJE setup

### DIFF
--- a/opm/input/eclipse/Schedule/Group/Group.cpp
+++ b/opm/input/eclipse/Schedule/Group/Group.cpp
@@ -203,6 +203,9 @@ namespace {
         injection.guide_rate_def = Opm::Group::GuideRateInjTargetFromInt(rst_group.inj_water_guide_rate_def);
         injection.guide_rate = is_defined(rst_group.inj_water_guide_rate) ? rst_group.inj_water_guide_rate : 0;
 
+        //Note: InjectionProperties::available_group_control is not recovered during the RESTART reading
+        //      when InjectionProperties::cmode is FLD, this will not be recovered during the RESTART reading
+
         assign_injection_controls(active, injection);
 
         return injection;
@@ -248,11 +251,11 @@ Group::Group(const RestartIO::RstGroup& rst_group, std::size_t insert_index_arg,
         this->updateProduction(make_production_properties(rst_group, prod_limits, unit_system_arg));
     }
 
-    if ((rst_group.ginj_cmode != 0) || has_active(gas_inj_limits)) {
+    if ((rst_group.ginj_cmode != 0) || has_active(gas_inj_limits) || (rst_group.inj_gas_guide_rate_def != 0)) {
         this->updateInjection(make_injection_properties(rst_group, gas_inj_limits));
     }
 
-    if ((rst_group.winj_cmode != 0) || has_active(water_inj_limits)) {
+    if ((rst_group.winj_cmode != 0) || has_active(water_inj_limits) || (rst_group.inj_water_guide_rate_def != 0)) {
         this->updateInjection(make_injection_properties(rst_group, water_inj_limits));
     }
 }

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1477,6 +1477,18 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         const auto insert_index = this->snapshots.back().groups.size();
         auto new_group = Group(rst_group, insert_index, udq_undefined, this->m_static.m_unit_system);
         if (rst_group.name != "FIELD") {
+            // we also update the GuideRateConfig
+            auto guide_rate_config = this->snapshots.back().guide_rate();
+            if (new_group.isInjectionGroup()) {
+                for (const auto& [_, inj_prop] : new_group.injectionProperties()) {
+                    guide_rate_config.update_injection_group(new_group.name(), inj_prop);
+                }
+            }
+            if (new_group.isProductionGroup()) {
+                guide_rate_config.update_production_group(new_group);
+            }
+            this->snapshots.back().guide_rate.update( std::move(guide_rate_config) );
+
             // Common case.  Add new group.
             this->addGroup( std::move(new_group) );
             return;


### PR DESCRIPTION
It needs https://github.com/OPM/opm-common/pull/4439 to have the fully support to restart from case with GCONINJE setup. 

This PR only contains how to recover the running from the RESTART information, https://github.com/OPM/opm-common/pull/4439  will output the relative information to the RESTART file. 