### PR TITLE
Add vertex merging functionality to CSRGraphFromCoordinates

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -514,6 +514,7 @@ if(ENABLE_ECL_INPUT)
     tests/test_ActiveGridCells.cpp
     tests/test_CopyablePtr.cpp
     tests/test_CSRGraphFromCoordinates.cpp
+    tests/test_CSRGraphFromCoordinates_Merge.cpp
     tests/test_DatumDepth.cpp
     tests/test_ERsm.cpp
     tests/test_GuideRate.cpp

--- a/opm/common/utility/CSRGraphFromCoordinates.hpp
+++ b/opm/common/utility/CSRGraphFromCoordinates.hpp
@@ -168,6 +168,13 @@ namespace Opm { namespace utility {
         /// \param[in] target_vertex The vertex ID that will represent the merged group
         void mergeVertices(const std::vector<VertexID>& vertices, VertexID target_vertex);
 
+        /// Get the final vertex ID after all merges and renumbering for a given original vertex ID.
+        /// Returns the original ID if no merging or renumbering has been done.
+        ///
+        /// \param[in] originalVertexID The original vertex ID to look up
+        /// \return The final vertex ID after merges and renumbering
+        VertexID getFinalVertexID(VertexID originalVertexID) const;
+
     private:
         /// Coordinate format representation of individual contributions to
         /// inter-region flows.
@@ -227,10 +234,10 @@ namespace Opm { namespace utility {
             const Neighbours& columnIndices() const;
 
             /// Helper function to get the final vertex ID after all merges
-            VertexID getFinalVertexID(VertexID v, const std::map<VertexID, VertexID>& vertex_merges) const;
+            VertexID findMergedVertexID(VertexID v, const std::map<VertexID, VertexID>& vertex_merges) const;
 
             /// Apply vertex merges to the stored connections and create compact numbering
-            void applyVertexMerges(const std::map<VertexID, VertexID>& vertex_merges);
+            std::map<VertexID, VertexID> applyVertexMerges(const std::map<VertexID, VertexID>& vertex_merges);
 
         private:
             /// Zero-based row/source region indices.
@@ -541,6 +548,8 @@ namespace Opm { namespace utility {
         /// Map of vertices to be merged during compression
         std::map<VertexID, VertexID> vertex_merges_{};
 
+        /// Mapping from original vertex IDs to final vertex IDs after merging and renumbering
+        std::map<VertexID, VertexID> vertex_mapping_{};
     };
 
 }} // namespace Opm::utility

--- a/opm/common/utility/CSRGraphFromCoordinates.hpp
+++ b/opm/common/utility/CSRGraphFromCoordinates.hpp
@@ -85,6 +85,10 @@ namespace Opm { namespace utility {
         /// this function does nothing.
         void addConnection(VertexID v1, VertexID v2);
 
+        /// Apply vertex merges to all vertex groups
+        Offset applyVertexMerges();
+
+
         /// Form CSR adjacency matrix representation of input graph from
         /// connections established in previous calls to addConnection().
         ///
@@ -161,12 +165,11 @@ namespace Opm { namespace utility {
                      other.columnIndices());
         }
 
-        /// Merge a group of vertices into a single vertex.
+        /// Add a group of vertices that should be merged together.
         /// Must be called before compress().
         ///
         /// \param[in] vertices Vector of vertex IDs to merge
-        /// \param[in] target_vertex The vertex ID that will represent the merged group
-        void mergeVertices(const std::vector<VertexID>& vertices, VertexID target_vertex);
+        void addVertexGroup(const std::vector<VertexID>& vertices);
 
         /// Get the final vertex ID after all merges and renumbering for a given original vertex ID.
         /// Returns the original ID if no merging or renumbering has been done.
@@ -545,11 +548,14 @@ namespace Opm { namespace utility {
         /// Canonical representation of unique inter-region flow rates.
         CSR csr_;
 
-        /// Map of vertices to be merged during compression
-        std::map<VertexID, VertexID> vertex_merges_{};
+        /// Groups of vertices that should be merged together
+        std::vector<std::vector<VertexID>> vertex_groups_{};
 
         /// Mapping from original vertex IDs to final vertex IDs after merging and renumbering
         std::map<VertexID, VertexID> vertex_mapping_{};
+
+        /// Find connected components in vertex groups that share vertices
+        void findConnectedGroups();
     };
 
 }} // namespace Opm::utility

--- a/opm/common/utility/CSRGraphFromCoordinates.hpp
+++ b/opm/common/utility/CSRGraphFromCoordinates.hpp
@@ -25,10 +25,9 @@
 #include <cstddef>
 #include <optional>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
-#include <map>
-
 /// \file
 ///
 /// Facility for converting collection of region ID pairs into a sparse
@@ -237,10 +236,10 @@ namespace Opm { namespace utility {
             const Neighbours& columnIndices() const;
 
             /// Helper function to get the final vertex ID after all merges
-            VertexID findMergedVertexID(VertexID v, const std::map<VertexID, VertexID>& vertex_merges) const;
+            VertexID findMergedVertexID(VertexID v, const std::unordered_map<VertexID, VertexID>& vertex_merges) const;
 
             /// Apply vertex merges to the stored connections and create compact numbering
-            std::map<VertexID, VertexID> applyVertexMerges(const std::map<VertexID, VertexID>& vertex_merges);
+            std::unordered_map<VertexID, VertexID> applyVertexMerges(const std::unordered_map<VertexID, VertexID>& vertex_merges);
 
         private:
             /// Zero-based row/source region indices.
@@ -548,14 +547,17 @@ namespace Opm { namespace utility {
         /// Canonical representation of unique inter-region flow rates.
         CSR csr_;
 
-        /// Groups of vertices that should be merged together
-        std::vector<std::vector<VertexID>> vertex_groups_{};
+        /// Disjoint-set union parent pointers
+        std::unordered_map<VertexID, VertexID> parent_{};
 
         /// Mapping from original vertex IDs to final vertex IDs after merging and renumbering
-        std::map<VertexID, VertexID> vertex_mapping_{};
+        std::unordered_map<VertexID, VertexID> vertex_mapping_{};
 
-        /// Find connected components in vertex groups that share vertices
-        void findConnectedGroups();
+        /// Find the root of a disjoint set with path compression
+        VertexID find(VertexID v);
+
+        /// Union two sets by rank (using vertex ID as a simple rank)
+        void unionSets(VertexID a, VertexID b);
     };
 
 }} // namespace Opm::utility

--- a/opm/common/utility/CSRGraphFromCoordinates.hpp
+++ b/opm/common/utility/CSRGraphFromCoordinates.hpp
@@ -27,6 +27,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include <map>
 
 /// \file
 ///
@@ -160,6 +161,13 @@ namespace Opm { namespace utility {
                      other.columnIndices());
         }
 
+        /// Merge a group of vertices into a single vertex.
+        /// Must be called before compress().
+        ///
+        /// \param[in] vertices Vector of vertex IDs to merge
+        /// \param[in] target_vertex The vertex ID that will represent the merged group
+        void mergeVertices(const std::vector<VertexID>& vertices, VertexID target_vertex);
+
     private:
         /// Coordinate format representation of individual contributions to
         /// inter-region flows.
@@ -217,6 +225,12 @@ namespace Opm { namespace utility {
 
             /// Read-only access to uncompressed column indices.
             const Neighbours& columnIndices() const;
+
+            /// Helper function to get the final vertex ID after all merges
+            VertexID getFinalVertexID(VertexID v, const std::map<VertexID, VertexID>& vertex_merges) const;
+
+            /// Apply vertex merges to the stored connections and create compact numbering
+            void applyVertexMerges(const std::map<VertexID, VertexID>& vertex_merges);
 
         private:
             /// Zero-based row/source region indices.
@@ -514,6 +528,7 @@ namespace Opm { namespace utility {
             ///   compress() when TrackCompressedIdx is true.
             void remapCompressedIndex(Start&&                                  compressedIdx,
                                       std::optional<typename Start::size_type> numOrigNNZ = std::nullopt);
+
         };
 
         /// Accumulated coordinate format contributions that have not yet
@@ -522,6 +537,10 @@ namespace Opm { namespace utility {
 
         /// Canonical representation of unique inter-region flow rates.
         CSR csr_;
+
+        /// Map of vertices to be merged during compression
+        std::map<VertexID, VertexID> vertex_merges_{};
+
     };
 
 }} // namespace Opm::utility

--- a/tests/test_CSRGraphFromCoordinates_Merge.cpp
+++ b/tests/test_CSRGraphFromCoordinates_Merge.cpp
@@ -1,0 +1,1350 @@
+/*
+  Copyright 2025 SINTEF
+  Copyright 2025 Equinor
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE CSR_Graph_From_Coordinates_Merge
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/common/utility/CSRGraphFromCoordinates.hpp>
+
+#include <cstddef>
+#include <stdexcept>
+
+BOOST_AUTO_TEST_SUITE(No_Self_Connections)
+
+BOOST_AUTO_TEST_SUITE(Untracked)
+
+namespace {
+    // Vertex = int, TrackCompressedIdx = false, PermitSelfConnections = false
+    using CSRGraph = Opm::utility::CSRGraphFromCoordinates<>;
+}
+
+BOOST_AUTO_TEST_CASE(Linear_4x1x1_Symmetric_Multiple_Add_Single_Merge)
+{
+    auto graph = CSRGraph{};
+
+    // +-----+-----+-----+-----+
+    // |  0  |  1  |  2  |  3  |
+    // +-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0  0 ]
+    //    [ 1  0  1  0 ]
+    //    [ 0  1  0  1 ]
+    //    [ 0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,     5,  6 ]
+    //         JA = [ 1  | 0, 2 | 1, 3 | 2 ]
+
+    for (auto i = 0; i < 4 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+        graph.addConnection(i + 1, i);
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i, i + 1);
+    }
+
+    graph.mergeVertices({1, 2}, 1);
+
+    // +-----+-----+-----+-----+
+    // |  0  |     1     |  2  |
+    // +-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0 ]
+    //    [ 1  0  1 ]
+    //    [ 0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,  4 ]
+    //         JA = [ 1  | 0, 2 | 1 ]
+
+    graph.compress(3);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{3});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{4});
+
+    {
+        const auto& ia = graph.startPointers();
+        const auto expect = std::vector { 0, 1, 3, 4 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ia.begin(), ia.end(), expect.begin(), expect.end());
+    }
+
+    {
+        const auto& ja = graph.columnIndices();
+        const auto expect = std::vector { 1, 0, 2, 1 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ja.begin(), ja.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Disjoint_Merges)
+{
+    auto graph = CSRGraph{};
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |  0  |  1  |  2  |  3  |  4  |  5  |  6  |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0  0  0  0  0 ]
+    //    [ 1  0  1  0  0  0  0 ]
+    //    [ 0  1  0  1  0  0  0 ]
+    //    [ 0  0  1  0  0  0  0 ]
+    //    [ 0  0  0  1  0  1  0 ]
+    //    [ 0  0  0  0  1  0  1 ]
+    //    [ 0  0  0  0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,     5,     7,     9,     11, 12 ]
+    //         JA = [ 1  | 0, 2 | 1, 3 | 2, 4 | 3, 5 | 4, 6 |  5 ]
+
+    for (auto i = 0; i < 4 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 0; i < 4; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    for (auto i = 4 - 1; i < 7 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 4; i < 7; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    // Merge vertices 1 and 2 into vertex 0
+    graph.mergeVertices({1, 2}, 0);
+    // Merge vertices 5 and 6 into vertex 6
+    graph.mergeVertices({5, 6}, 6);
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |        0        |  1  |  2  |     3     |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0  0 ]
+    //    [ 1  0  1  0 ]
+    //    [ 0  1  0  1 ]
+    //    [ 0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,     5,  6 ]
+    //         JA = [ 1  | 0, 2 | 1, 3 | 2 ]
+
+    graph.compress(4);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{4});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{6});
+
+    {
+        const auto& ia = graph.startPointers();
+        const auto expect = std::vector { 0, 1, 3, 5, 6 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ia.begin(), ia.end(), expect.begin(), expect.end());
+    }
+
+    {
+        const auto& ja = graph.columnIndices();
+        const auto expect = std::vector { 1, 0, 2, 1, 3, 2 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ja.begin(), ja.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Intersecting_Merges)
+{
+    auto graph = CSRGraph{};
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |  0  |  1  |  2  |  3  |  4  |  5  |  6  |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0  0  0  0  0 ]
+    //    [ 1  0  1  0  0  0  0 ]
+    //    [ 0  1  0  1  0  0  0 ]
+    //    [ 0  0  1  0  0  0  0 ]
+    //    [ 0  0  0  1  0  1  0 ]
+    //    [ 0  0  0  0  1  0  1 ]
+    //    [ 0  0  0  0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,     5,     7,     9,     11, 12 ]
+    //         JA = [ 1  | 0, 2 | 1, 3 | 2, 4 | 3, 5 | 4, 6 |  5 ]
+
+    for (auto i = 0; i < 4 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 0; i < 4; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    for (auto i = 4 - 1; i < 7 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 4; i < 7; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    // Merge vertices 1 2 3 into vertex 1
+    graph.mergeVertices({1, 2, 3}, 1);
+    // Merge vertices 3 4 into vertex 3
+    graph.mergeVertices({3, 4}, 3);
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |  0  |        1              |  2  |  3  |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0  0 ]
+    //    [ 1  0  1  0 ]
+    //    [ 0  1  0  1 ]
+    //    [ 0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,     5,  6 ]
+    //         JA = [ 1  | 0, 2 | 1, 3 | 2 ]
+
+    graph.compress(4);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{4});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{6});
+
+    {
+        const auto& ia = graph.startPointers();
+        const auto expect = std::vector { 0, 1, 3, 5, 6 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ia.begin(), ia.end(), expect.begin(), expect.end());
+    }
+
+    {
+        const auto& ja = graph.columnIndices();
+        const auto expect = std::vector { 1, 0, 2, 1, 3, 2 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ja.begin(), ja.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Directed_Graph_With_Merges)
+{
+    auto graph = CSRGraph{};
+    // Initial directed graph structure:
+    //
+    // 0 -----> 1 -----> 2
+    //          |        ^
+    //          |        |
+    //          v        |
+    //          3 -----> 4
+    //
+    // => Laplacian (adjacency matrix for directed graph)
+    //    [ 0  1  0  0  0 ]
+    //    [ 0  0  1  1  0 ]
+    //    [ 0  0  0  0  0 ]
+    //    [ 0  0  0  0  1 ]
+    //    [ 0  0  1  0  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,  3,  4,  5 ]
+    //         JA = [ 1  | 2, 3 |   | 4 | 2 ]
+    // Add directed edges
+    graph.addConnection(0, 1);  // 0 -> 1
+    graph.addConnection(1, 2);  // 1 -> 2
+    graph.addConnection(1, 3);  // 1 -> 3
+    graph.addConnection(3, 4);  // 3 -> 4
+    graph.addConnection(4, 2);  // 4 -> 2
+    // Merge vertices 3 and 4 into vertex 3
+    // After merge:
+    // 0 -----> 1 -----> 2
+    //          |        ^
+    //          |        |
+    //          v        |
+    //          3 -------'
+    //
+    // => Laplacian (adjacency matrix for directed graph)
+    //    [ 0  1  0  0 ]
+    //    [ 0  0  1  1 ]
+    //    [ 0  0  0  0 ]
+    //    [ 0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,  3,  4 ]
+    //         JA = [ 1  | 2, 3 |   | 2 ]
+    graph.mergeVertices({3, 4}, 3);
+    graph.compress(4);
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{4});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{4});
+    {
+        const auto& ia = graph.startPointers();
+        const auto expect = std::vector { 0, 1, 3, 3, 4 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ia.begin(), ia.end(), expect.begin(), expect.end());
+    }
+    {
+        const auto& ja = graph.columnIndices();
+        const auto expect = std::vector { 1, 2, 3, 2 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ja.begin(), ja.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Untracked
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Tracked)
+
+namespace {
+    // Vertex = int, TrackCompressedIdx = true, PermitSelfConnections = false
+    using CSRGraph = Opm::utility::CSRGraphFromCoordinates<int, true>;
+}
+
+BOOST_AUTO_TEST_CASE(Linear_4x1x1_Symmetric_Multiple_Add_Single_Merge)
+{
+    auto graph = CSRGraph{};
+
+    // +-----+-----+-----+-----+
+    // |  0  |  1  |  2  |  3  |
+    // +-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0  0 ]
+    //    [ 1  0  1  0 ]
+    //    [ 0  1  0  1 ]
+    //    [ 0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,     5,  6 ]
+    //         JA = [ 1  | 0, 2 | 1, 3 | 2 ]
+    //
+    // One-pass construction, with repetition, gives
+    //   MAP = [
+    //     0, 1, 1, 0, 0   -- i = 0: (0->1, 1->0, 1->0, 0->1, 0->1)
+    //     2, 3, 3, 2, 2   -- i = 1: (1->2, 2->1, 2->1, 1->2, 1->2)
+    //     4, 5, 5, 4, 4   -- i = 2: (2->3, 3->2, 3->2, 2->3, 2->3)
+    //   ]
+
+    for (auto i = 0; i < 4 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+        graph.addConnection(i + 1, i);
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i, i + 1);
+    }
+
+    graph.mergeVertices({1, 2}, 1);
+
+    // +-----+-----+-----+-----+
+    // |  0  |     1     |  2  |
+    // +-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0 ]
+    //    [ 1  0  1 ]
+    //    [ 0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,  4 ]
+    //         JA = [ 1  | 0, 2 | 1 ]
+    //
+    // One-pass construction, with repetition, gives
+    //   MAP = [
+    //     0, 1, 1, 0, 0   -- i = 0: (0->1, 1->0, 1->0, 0->1, 0->1)
+    //     x, x, x, x, x   -- i = 1: (1->1, 1->1, 1->1, 1->1, 1->1)
+    //     2, 3, 3, 2, 2   -- i = 2: (1->2, 2->1, 2->1, 1->2, 1->2)
+    //   ]
+    //
+    // Note that in the current implementation, when tracking compressed
+    // indices, and not permitting self connections, the newly introduced
+    // self connections are removed from the graph.
+
+    graph.compress(3);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{3});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{4});
+
+    {
+        const auto& nzMap = graph.compressedIndexMap();
+        const auto expect = std::vector {
+            0, 1, 1, 0, 0,      // i = 0
+        //  x, x, x, x, x,      // i = 1
+            2, 3, 3, 2, 2,      // i = 2
+        };
+        BOOST_CHECK_EQUAL_COLLECTIONS(nzMap .begin(), nzMap .end(),
+                                      expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Disjoint_Merges)
+{
+    auto graph = CSRGraph{};
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |  0  |  1  |  2  |  3  |  4  |  5  |  6  |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0  0  0  0  0 ]
+    //    [ 1  0  1  0  0  0  0 ]
+    //    [ 0  1  0  1  0  0  0 ]
+    //    [ 0  0  1  0  0  0  0 ]
+    //    [ 0  0  0  1  0  1  0 ]
+    //    [ 0  0  0  0  1  0  1 ]
+    //    [ 0  0  0  0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,     5,     7,     9,     11, 12 ]
+    //         JA = [ 1  | 0, 2 | 1, 3 | 2, 4 | 3, 5 | 4, 6 |  5 ]
+    //
+    // One-pass construction edges:
+    // 0->1
+    // 1->0
+    // 1->2
+    // 2->1
+    // 2->3
+    // 3->2
+    // x - (0->0)
+    // x - (1->1)
+    // x - (2->2)
+    // x - (3->3)
+    // 3->4
+    // 4->3
+    // 4->5
+    // 5->4
+    // 5->6
+    // 6->5
+    // x - (4->4)
+    // x - (5->5)
+    // x - (6->6)
+
+    for (auto i = 0; i < 4 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 0; i < 4; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    for (auto i = 4 - 1; i < 7 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 4; i < 7; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    // Merge vertices 1 and 2 into vertex 0
+    graph.mergeVertices({1, 2}, 0);
+    // Merge vertices 5 and 6 into vertex 6
+    graph.mergeVertices({5, 6}, 6);
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |        0        |  1  |  2  |     3     |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0  0 ]
+    //    [ 1  0  1  0 ]
+    //    [ 0  1  0  1 ]
+    //    [ 0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,     5,  6 ]
+    //         JA = [ 1  | 0, 2 | 1, 3 | 2 ]
+
+    graph.compress(4);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{4});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{6});
+
+    {
+        const auto& nzMap = graph.compressedIndexMap();
+        const auto expect = std::vector {
+                // One-pass construction edges, after merging vertices 1,2 into 0 and 5,6 into 6:
+                // x - (0->0)
+                // x - (0->0)
+                // x - (0->0)
+                // x - (0->0)
+            0,  // 0->1
+            1,  // 1->0
+                // x - (0->0)
+                // x - (0->0)
+                // x - (0->0)
+                // x - (1->1)
+            2,  // 1->2
+            3,  // 2->1
+            4,  // 2->3
+            5,  // 3->2
+                // x - (3->3)
+                // x - (3->3)
+                // x - (2->2)
+                // x - (3->3)
+                // x - (3->3)
+        };
+        BOOST_CHECK_EQUAL_COLLECTIONS(nzMap .begin(), nzMap .end(),
+                                      expect.begin(), expect.end());
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Intersecting_Merges)
+{
+    auto graph = CSRGraph{};
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |  0  |  1  |  2  |  3  |  4  |  5  |  6  |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0  0  0  0  0 ]
+    //    [ 1  0  1  0  0  0  0 ]
+    //    [ 0  1  0  1  0  0  0 ]
+    //    [ 0  0  1  0  0  0  0 ]
+    //    [ 0  0  0  1  0  1  0 ]
+    //    [ 0  0  0  0  1  0  1 ]
+    //    [ 0  0  0  0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,     5,     7,     9,     11, 12 ]
+    //         JA = [ 1  | 0, 2 | 1, 3 | 2, 4 | 3, 5 | 4, 6 |  5 ]
+    // One-pass construction edges:
+    // 0->1
+    // 1->0
+    // 1->2
+    // 2->1
+    // 2->3
+    // 3->2
+    // x - (0->0)
+    // x - (1->1)
+    // x - (2->2)
+    // x - (3->3)
+    // 3->4
+    // 4->3
+    // 4->5
+    // 5->4
+    // 5->6
+    // 6->5
+    // x - (4->4)
+    // x - (5->5)
+    // x - (6->6)
+
+    for (auto i = 0; i < 4 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 0; i < 4; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    for (auto i = 4 - 1; i < 7 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 4; i < 7; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    // Merge vertices 1 2 3 into vertex 1
+    graph.mergeVertices({1, 2, 3}, 1);
+    // Merge vertices 3 4 into vertex 3
+    graph.mergeVertices({3, 4}, 3);
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |  0  |        1              |  2  |  3  |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0  0 ]
+    //    [ 1  0  1  0 ]
+    //    [ 0  1  0  1 ]
+    //    [ 0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,     5,  6 ]
+    //         JA = [ 1  | 0, 2 | 1, 3 | 2 ]
+
+    graph.compress(4);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{4});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{6});
+
+    {
+        const auto& nzMap = graph.compressedIndexMap();
+        const auto expect = std::vector {
+                // One-pass construction edges, after merging vertices 1,2,3 into 1 and 3,4 into 3:
+            0,  // 0->1
+            1,  // 1->0
+                // x - (1->1)
+                // x - (1->1)
+                // x - (1->1)
+                // x - (1->1)
+                // x - (0->0)
+                // x - (1->1)
+                // x - (1->1)
+                // x - (1->1)
+                // x - (1->1)
+                // x - (1->1)
+            2,  // 1->2
+            3,  // 2->1
+            4,  // 2->3
+            5   // 3->2
+                // x - (1->1)
+                // x - (2->2)
+                // x - (3->3)
+        };
+        BOOST_CHECK_EQUAL_COLLECTIONS(nzMap .begin(), nzMap .end(),
+                                      expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Directed_Graph_With_Merge)
+{
+    auto graph = CSRGraph{};
+
+    // Initial directed graph structure:
+    //
+    // 0 -----> 1 -----> 2
+    //          |        ^
+    //          |        |
+    //          v        |
+    //          3 -----> 4
+    //
+    // => Laplacian (adjacency matrix for directed graph)
+    //    [ 0  1  0  0  0 ]
+    //    [ 0  0  1  1  0 ]
+    //    [ 0  0  0  0  0 ]
+    //    [ 0  0  0  0  1 ]
+    //    [ 0  0  1  0  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,  3,  4,  5 ]
+    //         JA = [ 1  | 2, 3 |   | 4 | 2 ]
+
+    // Add directed edges
+    graph.addConnection(0, 1);  // 0 -> 1
+    graph.addConnection(1, 2);  // 1 -> 2
+    graph.addConnection(1, 3);  // 1 -> 3
+    graph.addConnection(3, 4);  // 3 -> 4
+    graph.addConnection(4, 2);  // 4 -> 2
+
+    graph.mergeVertices({3, 4}, 3);
+
+    // Merge vertices 3 and 4 into vertex 3
+    // After merge:
+    // 0 -----> 1 -----> 2
+    //          |        ^
+    //          |        |
+    //          v        |
+    //          3 -------'
+    //
+    // => Laplacian (adjacency matrix for directed graph)
+    //    [ 0  1  0  0 ]
+    //    [ 0  0  1  1 ]
+    //    [ 0  0  0  0 ]
+    //    [ 0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,  3,  4 ]
+    //         JA = [ 1  | 2, 3 |   | 2 ]
+    //
+    // One-pass construction, with tracking, gives
+    //   MAP = [
+    //     0,  // 0->1
+    //     1,  // 1->2
+    //     2,  // 1->3
+    //     x,  // (3->4 becomes 3->3, removed as self-connection)
+    //     3   // (4->2 becomes 3->2)
+    //   ]
+
+    graph.compress(4);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{4});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{4});
+
+    {
+        const auto& nzMap = graph.compressedIndexMap();
+        const auto expect = std::vector {
+            0,  // 0->1
+            1,  // 1->2
+            2,  // 1->3
+                // x - (3->3)
+            3   // (4->2 becomes 3->2)
+        };
+        BOOST_CHECK_EQUAL_COLLECTIONS(nzMap.begin(), nzMap.end(),
+                                    expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Tracked
+
+BOOST_AUTO_TEST_SUITE_END()     // No_Self_Connections
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Permit_Self_Connections)
+
+BOOST_AUTO_TEST_SUITE(Untracked)
+
+namespace {
+    // Vertex = int, TrackCompressedIdx = false, PermitSelfConnections = true
+    using CSRGraph = Opm::utility::CSRGraphFromCoordinates<int, false, true>;
+}
+
+BOOST_AUTO_TEST_CASE(Linear_4x1x1_Symmetric_Multiple_Add_Single_Merge)
+{
+    auto graph = CSRGraph{};
+
+    // +-----+-----+-----+-----+
+    // |  0  |  1  |  2  |  3  |
+    // +-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0  0 ]
+    //    [ 1  0  1  0 ]
+    //    [ 0  1  0  1 ]
+    //    [ 0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,     5,  6 ]
+    //         JA = [ 1  | 0, 2 | 1, 3 | 2 ]
+
+    for (auto i = 0; i < 4 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+        graph.addConnection(i + 1, i);
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i, i + 1);
+    }
+
+    graph.mergeVertices({1, 2}, 1);
+
+    // +-----+-----+-----+-----+
+    // |  0  |     1     |  2  |
+    // +-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0 ]
+    //    [ 1  1  1 ]
+    //    [ 0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,        4,  5 ]
+    //         JA = [ 1  | 0, 1, 2 | 1 ]
+
+    graph.compress(3);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{3});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{5});
+
+    {
+        const auto& ia = graph.startPointers();
+        const auto expect = std::vector { 0, 1, 4, 5 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ia.begin(), ia.end(), expect.begin(), expect.end());
+    }
+
+    {
+        const auto& ja = graph.columnIndices();
+        const auto expect = std::vector { 1, 0, 1, 2, 1 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ja.begin(), ja.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Disjoint_Merges)
+{
+    auto graph = CSRGraph{};
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |  0  |  1  |  2  |  3  |  4  |  5  |  6  |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 1  1  0  0  0  0  0 ]
+    //    [ 1  1  1  0  0  0  0 ]
+    //    [ 0  1  1  1  0  0  0 ]
+    //    [ 0  0  1  1  0  0  0 ]
+    //    [ 0  0  0  1  1  1  0 ]
+    //    [ 0  0  0  0  1  1  1 ]
+    //    [ 0  0  0  0  0  1  1 ]
+    //
+    // => CSR: IA = [ 0,      2,        5,        8,        11,       14,        17, 19 ]
+    //         JA = [ 0, 1  | 0, 1, 2 | 1, 2, 3 | 2, 3, 4 | 3, 4, 5 | 4, 5, 6 |  5, 6 ]
+
+    for (auto i = 0; i < 4 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 0; i < 4; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    for (auto i = 4 - 1; i < 7 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 4; i < 7; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    // Merge vertices 1 and 2 into vertex 0
+    graph.mergeVertices({1, 2}, 0);
+    // Merge vertices 5 and 6 into vertex 6
+    graph.mergeVertices({5, 6}, 6);
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |        0        |  1  |  2  |     3     |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 1  1  0  0 ]
+    //    [ 1  1  1  0 ]
+    //    [ 0  1  1  1 ]
+    //    [ 0  0  1  1 ]
+    //
+    // => CSR: IA = [ 0,     2,        5,        8,  10 ]
+    //         JA = [ 0, 1 | 0, 1, 2 | 1, 2, 3 | 2, 3 ]
+
+    graph.compress(4);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{4});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{10});
+
+    {
+        const auto& ia = graph.startPointers();
+        const auto expect = std::vector { 0, 2, 5, 8, 10 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ia.begin(), ia.end(), expect.begin(), expect.end());
+    }
+
+    {
+        const auto& ja = graph.columnIndices();
+        const auto expect = std::vector { 0, 1, 0, 1, 2, 1, 2, 3, 2, 3 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ja.begin(), ja.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Intersecting_Merges)
+{
+
+    auto graph = CSRGraph{};
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |  0  |  1  |  2  |  3  |  4  |  5  |  6  |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 1  1  0  0  0  0  0 ]
+    //    [ 1  1  1  0  0  0  0 ]
+    //    [ 0  1  1  1  0  0  0 ]
+    //    [ 0  0  1  1  0  0  0 ]
+    //    [ 0  0  0  1  1  1  0 ]
+    //    [ 0  0  0  0  1  1  1 ]
+    //    [ 0  0  0  0  0  1  1 ]
+    //
+    // => CSR: IA = [ 0,      2,        5,        8,        11,       14,        17, 19 ]
+    //         JA = [ 0, 1  | 0, 1, 2 | 1, 2, 3 | 2, 3, 4 | 3, 4, 5 | 4, 5, 6 |  5, 6 ]
+
+    for (auto i = 0; i < 4 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 0; i < 4; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    for (auto i = 4 - 1; i < 7 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 4; i < 7; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    // Merge vertices 1 2 3 into vertex 1
+    graph.mergeVertices({1, 2, 3}, 1);
+    // Merge vertices 3 4 into vertex 3
+    graph.mergeVertices({3, 4}, 3);
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |  0  |        1              |  2  |  3  |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 1  1  0  0 ]
+    //    [ 1  1  1  0 ]
+    //    [ 0  1  1  1 ]
+    //    [ 0  0  1  1 ]
+    //
+    // => CSR: IA = [ 0,     2,        5,        8,  10 ]
+    //         JA = [ 0, 1 | 0, 1, 2 | 1, 2, 3 | 2, 3 ]
+
+    graph.compress(4);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{4});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{10});
+
+    {
+        const auto& ia = graph.startPointers();
+        const auto expect = std::vector { 0, 2, 5, 8, 10 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ia.begin(), ia.end(), expect.begin(), expect.end());
+    }
+
+    {
+        const auto& ja = graph.columnIndices();
+        const auto expect = std::vector { 0, 1, 0, 1, 2, 1, 2, 3, 2, 3 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ja.begin(), ja.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Directed_Graph_With_Merges)
+{
+    auto graph = CSRGraph{};
+    // Initial directed graph structure:
+    //
+    // 0 -----> 1 -----> 2
+    //          |        ^
+    //          |        |
+    //          v        |
+    //          3 -----> 4
+    //
+    // => Laplacian (adjacency matrix for directed graph)
+    //    [ 0  1  0  0  0 ]
+    //    [ 0  0  1  1  0 ]
+    //    [ 0  0  0  0  0 ]
+    //    [ 0  0  0  0  1 ]
+    //    [ 0  0  1  0  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,  3,  4, 5 ]
+    //         JA = [ 1  | 2, 3 |   | 4 | 2 ]
+    // Add directed edges
+    graph.addConnection(0, 1);  // 0 -> 1
+    graph.addConnection(1, 2);  // 1 -> 2
+    graph.addConnection(1, 3);  // 1 -> 3
+    graph.addConnection(3, 4);  // 3 -> 4
+    graph.addConnection(4, 2);  // 4 -> 2
+
+    graph.mergeVertices({3, 4}, 3);
+
+    // Merge vertices 3 and 4 into vertex 3
+    // After merge:
+    // 0 -----> 1 -----> 2
+    //          |        ^
+    //          |        |
+    //          v        |
+    //          3 -------'
+    //
+    // => Laplacian (adjacency matrix for directed graph)
+    //    [ 0  1  0  0 ]
+    //    [ 0  0  1  1 ]
+    //    [ 0  0  0  0 ]
+    //    [ 0  0  1  1 ]
+    //
+    // => CSR: IA = [ 0,  1,     3,  3,   5 ]
+    //         JA = [ 1 | 2, 3 |   | 2, 3 ]
+
+    graph.compress(4);
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{4});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{5});
+    {
+        const auto& ia = graph.startPointers();
+        const auto expect = std::vector { 0, 1, 3, 3, 5 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ia.begin(), ia.end(), expect.begin(), expect.end());
+    }
+    {
+        const auto& ja = graph.columnIndices();
+        const auto expect = std::vector { 1, 2, 3, 2, 3 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(ja.begin(), ja.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Untracked
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Tracked)
+
+namespace {
+    // Vertex = int, TrackCompressedIdx = true, PermitSelfConnections = true
+    using CSRGraph = Opm::utility::CSRGraphFromCoordinates<int, true, true>;
+}
+
+BOOST_AUTO_TEST_CASE(Linear_4x1x1_Symmetric_Multiple_Add_Single_Merge)
+{
+    auto graph = CSRGraph{};
+
+    // +-----+-----+-----+-----+
+    // |  0  |  1  |  2  |  3  |
+    // +-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0  0 ]
+    //    [ 1  0  1  0 ]
+    //    [ 0  1  0  1 ]
+    //    [ 0  0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,     5,  6 ]
+    //         JA = [ 1  | 0, 2 | 1, 3 | 2 ]
+    //
+    // One-pass construction, with repetition, gives
+    //   MAP = [
+    //     0, 1, 1, 0, 0   -- i = 0: (0->1, 1->0, 1->0, 0->1, 0->1)
+    //     2, 3, 3, 2, 2   -- i = 1: (1->2, 2->1, 2->1, 1->2, 1->2)
+    //     4, 5, 5, 4, 4   -- i = 2: (2->3, 3->2, 3->2, 2->3, 2->3)
+    //   ]
+
+    for (auto i = 0; i < 4 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+        graph.addConnection(i + 1, i);
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i, i + 1);
+    }
+
+    graph.mergeVertices({1, 2}, 1);
+
+    // +-----+-----+-----+-----+
+    // |  0  |     1     |  2  |
+    // +-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 0  1  0 ]
+    //    [ 1  1  1 ]
+    //    [ 0  1  0 ]
+    //
+    // => CSR: IA = [ 0,   1,        4,  5 ]
+    //         JA = [ 1  | 0, 1, 2 | 1 ]
+    //
+    // One-pass construction, with repetition, gives
+    //   MAP = [
+    //     0, 1, 1, 0, 0   -- i = 0: (0->1, 1->0, 1->0, 0->1, 0->1)
+    //     2, 2, 2, 2, 2   -- i = 1: (1->1, 1->1, 1->1, 1->1, 1->1)
+    //     3, 4, 4, 3, 3   -- i = 2: (1->2, 2->1, 2->1, 1->2, 1->2)
+    //   ]
+    //
+
+    graph.compress(3);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{3});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{5});
+
+    {
+        const auto& nzMap = graph.compressedIndexMap();
+        const auto expect = std::vector {
+            0, 1, 1, 0, 0,      // i = 0
+            2, 2, 2, 2, 2,      // i = 1
+            3, 4, 4, 3, 3,      // i = 2
+        };
+        BOOST_CHECK_EQUAL_COLLECTIONS(nzMap .begin(), nzMap .end(),
+                                      expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Disjoint_Merges)
+{
+    auto graph = CSRGraph{};
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |  0  |  1  |  2  |  3  |  4  |  5  |  6  |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 1  1  0  0  0  0  0 ]
+    //    [ 1  1  1  0  0  0  0 ]
+    //    [ 0  1  1  1  0  0  0 ]
+    //    [ 0  0  1  1  0  0  0 ]
+    //    [ 0  0  0  1  1  1  0 ]
+    //    [ 0  0  0  0  1  1  1 ]
+    //    [ 0  0  0  0  0  1  1 ]
+    //
+    // => CSR: IA = [ 0,      2,        5,        8,        11,       14,        17, 19 ]
+    //         JA = [ 0, 1  | 0, 1, 2 | 1, 2, 3 | 2, 3, 4 | 3, 4, 5 | 4, 5, 6 |  5, 6 ]
+    //
+    // One-pass construction edges:
+    // 0->1
+    // 1->0
+    // 1->2
+    // 2->1
+    // 2->3
+    // 3->2
+    // 0->0
+    // 1->1
+    // 2->2
+    // 3->3
+    // 3->4
+    // 4->3
+    // 4->5
+    // 5->4
+    // 5->6
+    // 6->5
+    // 4->4
+    // 5->5
+    // 6->6
+
+    for (auto i = 0; i < 4 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 0; i < 4; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    for (auto i = 4 - 1; i < 7 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 4; i < 7; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    // Merge vertices 1 and 2 into vertex 0
+    graph.mergeVertices({1, 2}, 0);
+    // Merge vertices 5 and 6 into vertex 6
+    graph.mergeVertices({5, 6}, 6);
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |        0        |  1  |  2  |     3     |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 1  1  0  0 ]
+    //    [ 1  1  1  0 ]
+    //    [ 0  1  1  1 ]
+    //    [ 0  0  1  1 ]
+    //
+    // => CSR: IA = [ 0,     2,        5,        8,  10 ]
+    //         JA = [ 0, 1 | 0, 1, 2 | 1, 2, 3 | 2, 3 ]
+
+    graph.compress(4);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{4});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{10});
+
+    {
+        const auto& nzMap = graph.compressedIndexMap();
+        const auto expect = std::vector {
+                // One-pass construction edges, after merging vertices 1,2 into 0 and 5,6 into 6:
+            0,  // 0->0
+            0,  // 0->0
+            0,  // 0->0
+            0,  // 0->0
+            1,  // 0->1
+            2,  // 1->0
+            0,  // 0->0
+            0,  // 0->0
+            0,  // 0->0
+            3,  // 1->1
+            4,  // 1->2
+            5,  // 2->1
+            7,  // 2->3
+            8,  // 3->2
+            9,  // 3->3
+            9,  // 3->3
+            6,  // 2->2
+            9,  // 3->3
+            9,  // 3->3
+        };
+        BOOST_CHECK_EQUAL_COLLECTIONS(nzMap .begin(), nzMap .end(),
+                                      expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Intersecting_Merges)
+{
+
+    auto graph = CSRGraph{};
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |  0  |  1  |  2  |  3  |  4  |  5  |  6  |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 1  1  0  0  0  0  0 ]
+    //    [ 1  1  1  0  0  0  0 ]
+    //    [ 0  1  1  1  0  0  0 ]
+    //    [ 0  0  1  1  0  0  0 ]
+    //    [ 0  0  0  1  1  1  0 ]
+    //    [ 0  0  0  0  1  1  1 ]
+    //    [ 0  0  0  0  0  1  1 ]
+    //
+    // => CSR: IA = [ 0,      2,        5,        8,        11,       14,        17, 19 ]
+    //         JA = [ 0, 1  | 0, 1, 2 | 1, 2, 3 | 2, 3, 4 | 3, 4, 5 | 4, 5, 6 |  5, 6 ]
+    // One-pass construction edges:
+    // 0->1
+    // 1->0
+    // 1->2
+    // 2->1
+    // 2->3
+    // 3->2
+    // 0->0
+    // 1->1
+    // 2->2
+    // 3->3
+    // 3->4
+    // 4->3
+    // 4->5
+    // 5->4
+    // 5->6
+    // 6->5
+    // 4->4
+    // 5->5
+    // 6->6
+
+    for (auto i = 0; i < 4 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 0; i < 4; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    for (auto i = 4 - 1; i < 7 - 1; ++i) {
+        graph.addConnection(i, i + 1);
+        graph.addConnection(i + 1, i);
+    }
+
+    for (auto i = 4; i < 7; ++i) {
+        graph.addConnection(i, i);
+    }
+
+    // Merge vertices 1 2 3 into vertex 1
+    graph.mergeVertices({1, 2, 3}, 1);
+    // Merge vertices 3 4 into vertex 3
+    graph.mergeVertices({3, 4}, 3);
+
+
+    // +-----+-----+-----+-----+-----+-----+-----+
+    // |  0  |        1              |  2  |  3  |
+    // +-----+-----+-----+-----+-----+-----+-----+
+    //
+    // => Laplacian
+    //    [ 1  1  0  0 ]
+    //    [ 1  1  1  0 ]
+    //    [ 0  1  1  1 ]
+    //    [ 0  0  1  1 ]
+    //
+    // => CSR: IA = [ 0,     2,        5,        8,  10 ]
+    //         JA = [ 0, 1 | 0, 1, 2 | 1, 2, 3 | 2, 3 ]
+
+    graph.compress(4);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{4});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{10});
+
+    {
+        const auto& nzMap = graph.compressedIndexMap();
+        const auto expect = std::vector {
+                // One-pass construction edges, after merging vertices 1,2,3 into 1 and 3,4 into 3:
+            1,  // 0->1
+            2,  // 1->0
+            3,  // 1->1
+            3,  // 1->1
+            3,  // 1->1
+            3,  // 1->1
+            0,  // 0->0
+            3,  // 1->1
+            3,  // 1->1
+            3,  // 1->1
+            3,  // 1->1
+            3,  // 1->1
+            4,  // 1->2
+            5,  // 2->1
+            7,  // 2->3
+            8,  // 3->2
+            3,  // 1->1
+            6,  // 2->2
+            9,  // 3->3
+        };
+        BOOST_CHECK_EQUAL_COLLECTIONS(nzMap .begin(), nzMap .end(),
+                                      expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Directed_Graph_With_Merge)
+{
+    auto graph = CSRGraph{};
+
+    // Initial directed graph structure:
+    //
+    // 0 -----> 1 -----> 2
+    //          |        ^
+    //          |        |
+    //          v        |
+    //          3 -----> 4
+    //
+    // => Laplacian (adjacency matrix for directed graph)
+    //    [ 0  1  0  0  0 ]
+    //    [ 0  0  1  1  0 ]
+    //    [ 0  0  0  0  0 ]
+    //    [ 0  0  0  0  1 ]
+    //    [ 0  0  1  0  0 ]
+    //
+    // => CSR: IA = [ 0,   1,     3,  3,  4,  5 ]
+    //         JA = [ 1  | 2, 3 |   | 4 | 2 ]
+
+    // Add directed edges
+    graph.addConnection(0, 1);  // 0 -> 1
+    graph.addConnection(1, 2);  // 1 -> 2
+    graph.addConnection(1, 3);  // 1 -> 3
+    graph.addConnection(3, 4);  // 3 -> 4
+    graph.addConnection(4, 2);  // 4 -> 2
+
+    graph.mergeVertices({3, 4}, 3);
+
+    // Merge vertices 3 and 4 into vertex 3
+    // After merge:
+    // 0 -----> 1 -----> 2
+    //          |        ^
+    //          |        |
+    //          v        |
+    //          3 -------'
+    //
+    // => Laplacian (adjacency matrix for directed graph)
+    //    [ 0  1  0  0 ]
+    //    [ 0  0  1  1 ]
+    //    [ 0  0  0  0 ]
+    //    [ 0  0  1  1 ]
+    //
+    // => CSR: IA = [ 0,  1,     3,  3,   5 ]
+    //         JA = [ 1 | 2, 3 |   | 2, 3 ]
+    //
+    // One-pass construction, with tracking, gives
+    //   MAP = [
+    //     0,  // 0->1
+    //     1,  // 1->2
+    //     2,  // 1->3
+    //     3,  // (3->4 becomes 3->3)
+    //     4   // (4->2 becomes 3->2)
+    //   ]
+
+    graph.compress(4);
+
+    BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{4});
+    BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{5});
+
+    {
+        const auto& nzMap = graph.compressedIndexMap();
+        const auto expect = std::vector {
+            0,  // 0->1
+            1,  // 1->2
+            2,  // 1->3
+            4,  // 3->3
+            3,  // 3->2
+        };
+        BOOST_CHECK_EQUAL_COLLECTIONS(nzMap.begin(), nzMap.end(),
+                                    expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Tracked
+
+BOOST_AUTO_TEST_SUITE_END()     // Permit_Self_Connections

--- a/tests/test_CSRGraphFromCoordinates_Merge.cpp
+++ b/tests/test_CSRGraphFromCoordinates_Merge.cpp
@@ -61,7 +61,8 @@ BOOST_AUTO_TEST_CASE(Linear_4x1x1_Symmetric_Multiple_Add_Single_Merge)
         graph.addConnection(i, i + 1);
     }
 
-    graph.mergeVertices({1, 2}, 1);
+    // Group vertices 1,2 together - they will be merged into a single vertex
+    graph.addVertexGroup({1, 2});
 
     // +-----+-----+-----+-----+
     // |  0  |     1     |  2  |
@@ -131,10 +132,10 @@ BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Disjoint_Merges)
         graph.addConnection(i, i);
     }
 
-    // Merge vertices 1 and 2 into vertex 0
-    graph.mergeVertices({1, 2}, 0);
-    // Merge vertices 5 and 6 into vertex 6
-    graph.mergeVertices({5, 6}, 6);
+    // Group vertices 1,2 together - they will be merged into a single vertex
+    graph.addVertexGroup({0, 1, 2});
+    // Group vertices 5,6 together - they will be merged into a single vertex
+    graph.addVertexGroup({5, 6});
 
     // +-----+-----+-----+-----+-----+-----+-----+
     // |        0        |  1  |  2  |     3     |
@@ -205,10 +206,12 @@ BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Intersecting_Merges)
         graph.addConnection(i, i);
     }
 
-    // Merge vertices 1 2 3 into vertex 1
-    graph.mergeVertices({1, 2, 3}, 1);
-    // Merge vertices 3 4 into vertex 3
-    graph.mergeVertices({3, 4}, 3);
+    // Group vertices 1,2,3 together - they will be merged into a single vertex
+    graph.addVertexGroup({1, 2, 3});
+    
+    // Group vertices 3,4 together - they will be merged into a single vertex
+    // Note: Since vertex 3 appears in both groups, these groups will be merged
+    graph.addVertexGroup({3, 4});
 
     // +-----+-----+-----+-----+-----+-----+-----+
     // |  0  |        1              |  2  |  3  |
@@ -283,7 +286,7 @@ BOOST_AUTO_TEST_CASE(Directed_Graph_With_Merges)
     //
     // => CSR: IA = [ 0,   1,     3,  3,  4 ]
     //         JA = [ 1  | 2, 3 |   | 2 ]
-    graph.mergeVertices({3, 4}, 3);
+    graph.addVertexGroup({3, 4});
     graph.compress(4);
     BOOST_CHECK_EQUAL(graph.numVertices(), std::size_t{4});
     BOOST_CHECK_EQUAL(graph.numEdges(), std::size_t{4});
@@ -342,7 +345,8 @@ BOOST_AUTO_TEST_CASE(Linear_4x1x1_Symmetric_Multiple_Add_Single_Merge)
         graph.addConnection(i, i + 1);
     }
 
-    graph.mergeVertices({1, 2}, 1);
+    // Group vertices 1,2 together - they will be merged into a single vertex
+    graph.addVertexGroup({1, 2});
 
     // +-----+-----+-----+-----+
     // |  0  |     1     |  2  |
@@ -376,7 +380,7 @@ BOOST_AUTO_TEST_CASE(Linear_4x1x1_Symmetric_Multiple_Add_Single_Merge)
         const auto& nzMap = graph.compressedIndexMap();
         const auto expect = std::vector {
             0, 1, 1, 0, 0,      // i = 0
-        //  x, x, x, x, x,      // i = 1
+        //  x, x, x, x, x,      // i = 1: (1->1, 1->1, 1->1, 1->1, 1->1)
             2, 3, 3, 2, 2,      // i = 2
         };
         BOOST_CHECK_EQUAL_COLLECTIONS(nzMap .begin(), nzMap .end(),
@@ -443,10 +447,10 @@ BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Disjoint_Merges)
         graph.addConnection(i, i);
     }
 
-    // Merge vertices 1 and 2 into vertex 0
-    graph.mergeVertices({1, 2}, 0);
-    // Merge vertices 5 and 6 into vertex 6
-    graph.mergeVertices({5, 6}, 6);
+    // Group vertices 0, 1,2 together - they will be merged into a single vertex
+    graph.addVertexGroup({0,1, 2});
+    // Group vertices 5,6 together - they will be merged into a single vertex
+    graph.addVertexGroup({5, 6});
 
     // +-----+-----+-----+-----+-----+-----+-----+
     // |        0        |  1  |  2  |     3     |
@@ -554,10 +558,12 @@ BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Intersecting_Merges)
         graph.addConnection(i, i);
     }
 
-    // Merge vertices 1 2 3 into vertex 1
-    graph.mergeVertices({1, 2, 3}, 1);
-    // Merge vertices 3 4 into vertex 3
-    graph.mergeVertices({3, 4}, 3);
+    // Group vertices 1,2,3 together - they will be merged into a single vertex
+    graph.addVertexGroup({1, 2, 3});
+    
+    // Group vertices 3,4 together - they will be merged into a single vertex
+    // Note: Since vertex 3 appears in both groups, these groups will be merged
+    graph.addVertexGroup({3, 4});
 
     // +-----+-----+-----+-----+-----+-----+-----+
     // |  0  |        1              |  2  |  3  |
@@ -635,9 +641,9 @@ BOOST_AUTO_TEST_CASE(Directed_Graph_With_Merge)
     graph.addConnection(3, 4);  // 3 -> 4
     graph.addConnection(4, 2);  // 4 -> 2
 
-    graph.mergeVertices({3, 4}, 3);
+    // Group vertices 3,4 together - they will be merged into a single vertex
+    graph.addVertexGroup({3, 4});
 
-    // Merge vertices 3 and 4 into vertex 3
     // After merge:
     // 0 -----> 1 -----> 2
     //          |        ^
@@ -722,7 +728,8 @@ BOOST_AUTO_TEST_CASE(Linear_4x1x1_Symmetric_Multiple_Add_Single_Merge)
         graph.addConnection(i, i + 1);
     }
 
-    graph.mergeVertices({1, 2}, 1);
+    // Group vertices 1,2 together - they will be merged into a single vertex
+    graph.addVertexGroup({1, 2});
 
     // +-----+-----+-----+-----+
     // |  0  |     1     |  2  |
@@ -792,10 +799,10 @@ BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Disjoint_Merges)
         graph.addConnection(i, i);
     }
 
-    // Merge vertices 1 and 2 into vertex 0
-    graph.mergeVertices({1, 2}, 0);
-    // Merge vertices 5 and 6 into vertex 6
-    graph.mergeVertices({5, 6}, 6);
+    // Group vertices 0,1,2 together - they will be merged into a single vertex
+    graph.addVertexGroup({0, 1, 2});
+    // Group vertices 5,6 together - they will be merged into a single vertex
+    graph.addVertexGroup({5, 6});
 
     // +-----+-----+-----+-----+-----+-----+-----+
     // |        0        |  1  |  2  |     3     |
@@ -867,10 +874,12 @@ BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Intersecting_Merges)
         graph.addConnection(i, i);
     }
 
-    // Merge vertices 1 2 3 into vertex 1
-    graph.mergeVertices({1, 2, 3}, 1);
-    // Merge vertices 3 4 into vertex 3
-    graph.mergeVertices({3, 4}, 3);
+    // Group vertices 1,2,3 together - they will be merged into a single vertex
+    graph.addVertexGroup({1, 2, 3});
+    
+    // Group vertices 3,4 together - they will be merged into a single vertex
+    // Note: Since vertex 3 appears in both groups, these groups will be merged
+    graph.addVertexGroup({3, 4});
 
     // +-----+-----+-----+-----+-----+-----+-----+
     // |  0  |        1              |  2  |  3  |
@@ -930,9 +939,9 @@ BOOST_AUTO_TEST_CASE(Directed_Graph_With_Merges)
     graph.addConnection(3, 4);  // 3 -> 4
     graph.addConnection(4, 2);  // 4 -> 2
 
-    graph.mergeVertices({3, 4}, 3);
+    // Group vertices 3,4 together - they will be merged into a single vertex
+    graph.addVertexGroup({3, 4});
 
-    // Merge vertices 3 and 4 into vertex 3
     // After merge:
     // 0 -----> 1 -----> 2
     //          |        ^
@@ -1007,7 +1016,8 @@ BOOST_AUTO_TEST_CASE(Linear_4x1x1_Symmetric_Multiple_Add_Single_Merge)
         graph.addConnection(i, i + 1);
     }
 
-    graph.mergeVertices({1, 2}, 1);
+    // Group vertices 1,2 together - they will be merged into a single vertex
+    graph.addVertexGroup({1, 2});
 
     // +-----+-----+-----+-----+
     // |  0  |     1     |  2  |
@@ -1105,10 +1115,10 @@ BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Disjoint_Merges)
         graph.addConnection(i, i);
     }
 
-    // Merge vertices 1 and 2 into vertex 0
-    graph.mergeVertices({1, 2}, 0);
-    // Merge vertices 5 and 6 into vertex 6
-    graph.mergeVertices({5, 6}, 6);
+    // Group vertices 1,2 together - they will be merged into a single vertex
+    graph.addVertexGroup({0,1, 2});
+    // Group vertices 5,6 together - they will be merged into a single vertex
+    graph.addVertexGroup({5, 6});
 
     // +-----+-----+-----+-----+-----+-----+-----+
     // |        0        |  1  |  2  |     3     |
@@ -1216,10 +1226,12 @@ BOOST_AUTO_TEST_CASE(Linear_7x1x1_Two_Intersecting_Merges)
         graph.addConnection(i, i);
     }
 
-    // Merge vertices 1 2 3 into vertex 1
-    graph.mergeVertices({1, 2, 3}, 1);
-    // Merge vertices 3 4 into vertex 3
-    graph.mergeVertices({3, 4}, 3);
+    // Group vertices 1,2,3 together - they will be merged into a single vertex
+    graph.addVertexGroup({1, 2, 3});
+    
+    // Group vertices 3,4 together - they will be merged into a single vertex
+    // Note: Since vertex 3 appears in both groups, these groups will be merged
+    graph.addVertexGroup({3, 4});
 
 
     // +-----+-----+-----+-----+-----+-----+-----+
@@ -1298,9 +1310,10 @@ BOOST_AUTO_TEST_CASE(Directed_Graph_With_Merge)
     graph.addConnection(3, 4);  // 3 -> 4
     graph.addConnection(4, 2);  // 4 -> 2
 
-    graph.mergeVertices({3, 4}, 3);
+    // Group vertices 3,4 together - they will be merged into a single vertex
+    graph.addVertexGroup({3, 4});
 
-    // Merge vertices 3 and 4 into vertex 3
+    // Merge vertices 3 and 4
     // After merge:
     // 0 -----> 1 -----> 2
     //          |        ^


### PR DESCRIPTION
# Support for Vertex Merging in CSRGraphFromCoordinates

## Purpose

This PR adds vertex merging functionality to the `CSRGraphFromCoordinates` class. This class is used as a backend for creating the input to the partitioner in nonlinear domain decomposition (NLDD). The main purpose of this new functionality is to support grouping cells perforated by a well into a single entity before subdomain partitioning. However, the implementation is general and can be used for other methods that use this class. This ensures that no well can be split across NLDD subdomains, which allows supporting NLDD for more complicated field cases and creating better partitions around wells.

## Implementation

The implementation uses a disjoint-set (union-find) data structure to efficiently track vertex groups and their relationships. Overlapping vertex groups are automatically merged. When merges are applied, connections are updated to reference the merged vertex IDs, and a compact renumbering is performed to take into account the vertices that have been merged away.

## Changes

1. Added new public methods:
   - `addVertexGroup()`: Define a group of vertices that should be merged into a single entity
   - `applyVertexMerges()`: Process all vertex groups and update the graph
   - `getFinalVertexID()`: Translate between original and final vertex IDs

2. Added private implementation:
   - The implementation uses a disjoint-set (union-find) data structure with path compression to efficiently track and merge vertex groups
   - Connection remapping and self-connection handling
   - Vertex ID translation and mapping
   - The class should have identical behaviour as before if no vertex groups have been added.

4. Testing
   - A suite of comprehensive tests has been added to `tests/test_CSRGraphFromCoordinates_Merge.cpp`
   - The method has been tested on a large collection of different complex real field cases, with no errors.


## Usage Example

```cpp
// Create graph and add connections
CSRGraphFromCoordinates<int> graph;
graph.addConnection(0, 1);
graph.addConnection(1, 2);
graph.addConnection(2, 3);
graph.addConnection(3, 4);

// Group vertices 1, 2, and 3 (e.g., cells perforated by a well)
graph.addVertexGroup({1, 2, 3});

// Compress graph - merging happens automatically
graph.compress();

// Access the merged graph structure
auto numVertices = graph.numVertices();  // Will be 3 instead of 5
auto vertexID = graph.getFinalVertexID(2);  // Returns 1 (which is now the same ID as vertices 1 and 3)
```