### PR TITLE
changed: always write step 0 to restart file

### DIFF
--- a/opm/input/eclipse/Schedule/RSTConfig.cpp
+++ b/opm/input/eclipse/Schedule/RSTConfig.cpp
@@ -501,7 +501,7 @@ RSTConfig::RSTConfig(const SOLUTIONSection& solution_section,
                      const ParseContext&    parseContext,
                      const bool compositional_arg,
                      ErrorGuard&            errors)
-    : write_rst_file(false)
+    : write_rst_file(true)
     , compositional(compositional_arg)
 {
     for (const auto& keyword : solution_section) {
@@ -666,7 +666,9 @@ void RSTConfig::handleRPTRSTSOLUTION(const DeckKeyword&  keyword,
         this->solution_only_keywords.erase(kw.first);
     }
 
-    this->write_rst_file = true;
+    if (this->basic.has_value() && this->basic.value() == 0) {
+        this->write_rst_file = false;
+    }
 }
 
 void RSTConfig::handleRPTSCHED(const DeckKeyword&  keyword,

--- a/opm/input/eclipse/Schedule/RSTConfig.hpp
+++ b/opm/input/eclipse/Schedule/RSTConfig.hpp
@@ -244,8 +244,11 @@ private:
 
     void handleRPTRST(const DeckKeyword& keyword,
                       const ParseContext& parse_context,
-                      ErrorGuard& errors,
-                      bool in_solution = false);
+                      ErrorGuard& errors);
+
+    void handleRPTRSTSOLUTION(const DeckKeyword& keyword,
+                              const ParseContext& parse_context,
+                              ErrorGuard& errors);
 
     void handleRPTSCHED(const DeckKeyword& keyword,
                         const ParseContext& parse_context,

--- a/opm/io/eclipse/RestartFileView.cpp
+++ b/opm/io/eclipse/RestartFileView.cpp
@@ -158,6 +158,9 @@ public:
         return this->getKeyword<double>(dhkw, 0);
     }
 
+    bool valid() const
+    { return rst_file_.operator bool(); }
+
 private:
     using RstFile = std::shared_ptr<ERst>;
 
@@ -271,6 +274,11 @@ const std::vector<bool>& Opm::EclIO::RestartFileView::logihead() const
 const std::vector<double>& Opm::EclIO::RestartFileView::doubhead() const
 {
     return this->pImpl_->doubhead();
+}
+
+bool Opm::EclIO::RestartFileView::valid() const
+{
+    return this->pImpl_->valid();
 }
 
 template <typename ElmType>

--- a/opm/io/eclipse/RestartFileView.hpp
+++ b/opm/io/eclipse/RestartFileView.hpp
@@ -61,6 +61,8 @@ public:
     const std::vector<bool>& logihead() const;
     const std::vector<double>& doubhead() const;
 
+    bool valid() const;
+
 private:
     class Implementation;
     std::unique_ptr<Implementation> pImpl_;

--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -135,6 +135,9 @@ public:
                              Action::State&                 action_state,
                              SummaryState&                  summary_state) const;
 
+    data::Solution loadRestartSolution(const std::vector<RestartKey>& solution_keys,
+                                       const int                      report_step) const;
+
     void writeInitial(data::Solution                          simProps,
                       std::map<std::string, std::vector<int>> int_data,
                       const std::vector<NNCdata>&             nnc) const;
@@ -304,6 +307,18 @@ Opm::EclipseIO::Impl::loadRestart(const std::vector<RestartKey>& solution_keys,
                            this->grid_,
                            this->schedule_,
                            extra_keys);
+}
+
+Opm::data::Solution
+Opm::EclipseIO::Impl::loadRestartSolution(const std::vector<RestartKey>& solution_keys,
+                                          const int                      report_step) const
+{
+    const auto& initConfig  = this->es_.get().getInitConfig();
+    const auto  filename    = this->es_.get().getIOConfig()
+        .getRestartFileName(initConfig.getRestartRootName(), report_step, false);
+
+    return RestartIO::load_solution_only(filename, report_step, solution_keys,
+                                         this->es_, this->grid_);
 }
 
 void Opm::EclipseIO::Impl::writeInitial(data::Solution                          simProps,
@@ -568,6 +583,13 @@ Opm::EclipseIO::loadRestart(Action::State&                 action_state,
 {
     return this->impl->loadRestart(solution_keys, extra_keys,
                                    action_state, summary_state);
+}
+
+Opm::data::Solution
+Opm::EclipseIO::loadRestartSolution(const std::vector<RestartKey>& solution_keys,
+                                    const int                      report_step) const
+{
+    return this->impl->loadRestartSolution(solution_keys, report_step);
 }
 
 const Opm::out::Summary& Opm::EclipseIO::summary() const

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -186,6 +186,29 @@ public:
                              const std::vector<RestartKey>& solution_keys,
                              const std::vector<RestartKey>& extra_keys = {}) const;
 
+    /// Will load solution data from the restart file.  This
+    /// method will consult the IOConfig object to get filename.
+    ///
+    /// The map keys should be a map of keyword names and their
+    /// corresponding dimension object.  In other words, loading the state
+    /// from a simple two phase simulation you would pass:
+    ///
+    ///    keys = {
+    ///        {"PRESSURE" , UnitSystem::measure::pressure },
+    ///        {"SWAT"     , UnitSystem::measure::identity },
+    ///    }
+    ///
+    /// For a three phase black oil simulation you would add pairs for SGAS,
+    /// RS and RV.  If you request keys which are not found in the restart
+    /// file an exception will be raised.  This also happens if the size of
+    /// a vector does not match the expected size.
+    ///
+    /// The function will consult the InitConfig object in the EclipseState
+    /// object to determine which file and report step to load.
+    ///
+    data::Solution loadRestartSolution(const std::vector<RestartKey>& solution_keys,
+                                       const int                      report_step) const;
+
     const out::Summary& summary() const;
     const SummaryConfig& finalSummaryConfig() const;
 

--- a/opm/output/eclipse/LoadRestart.cpp
+++ b/opm/output/eclipse/LoadRestart.cpp
@@ -1601,7 +1601,7 @@ namespace {
     }
 } // Anonymous namespace
 
-namespace Opm { namespace RestartIO  {
+namespace Opm::RestartIO  {
 
     RestartValue
     load(const std::string&             filename,
@@ -1643,4 +1643,20 @@ namespace Opm { namespace RestartIO  {
         return rst_value;
     }
 
-}} // Opm::RestartIO
+    data::Solution
+    load_solution_only(const std::string&             filename,
+                       int                            report_step,
+                       const std::vector<RestartKey>& solution_keys,
+                       const EclipseState&            es,
+                       const EclipseGrid&             grid)
+    {
+        auto rst_view = std::make_shared<Opm::EclIO::RestartFileView>
+            (std::make_shared<Opm::EclIO::ERst>(filename), report_step);
+
+        auto sol =  restoreSOLUTION(solution_keys, grid.getNumActive(), *rst_view);
+        sol.convertToSI(es.getUnits());
+
+        return sol;
+    }
+
+} // Opm::RestartIO

--- a/opm/output/eclipse/LoadRestart.cpp
+++ b/opm/output/eclipse/LoadRestart.cpp
@@ -1653,6 +1653,10 @@ namespace Opm::RestartIO  {
         auto rst_view = std::make_shared<Opm::EclIO::RestartFileView>
             (std::make_shared<Opm::EclIO::ERst>(filename), report_step);
 
+        if (!rst_view->valid()) {
+            return {};
+        }
+
         auto sol =  restoreSOLUTION(solution_keys, grid.getNumActive(), *rst_view);
         sol.convertToSI(es.getUnits());
 

--- a/opm/output/eclipse/RestartIO.hpp
+++ b/opm/output/eclipse/RestartIO.hpp
@@ -75,7 +75,7 @@ namespace Opm { namespace Action {
    will read from and write to the file "CASE.X0010" - completely ignoring
    the report step argument '99'.
 */
-namespace Opm { namespace RestartIO {
+namespace Opm::RestartIO {
 
     void save(EclIO::OutputStream::Restart&                 rstFile,
               int                                           report_step,
@@ -102,6 +102,12 @@ namespace Opm { namespace RestartIO {
                       const Schedule&                schedule,
                       const std::vector<RestartKey>& extra_keys = {});
 
-}} // namespace Opm::RestartIO
+    data::Solution load_solution_only(const std::string&             filename,
+                                      int                            report_step,
+                                      const std::vector<RestartKey>& solution_keys,
+                                      const EclipseState&            es,
+                                      const EclipseGrid&             grid);
+
+} // namespace Opm::RestartIO
 
 #endif  // RESTART_IO_HPP


### PR DESCRIPTION
This will be used to generate initial FIP report in restarted runs.

Also adds a related helper function which only loads solution data from the restart file. This is needed, as
the output at report step 0 does not contain all data.