### PR TITLE
Get COMPDAT Properties From Numerical Aquifer if Needed

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -464,6 +464,7 @@ endif()
 list (APPEND TEST_SOURCE_FILES
       tests/test_calculateCellVol.cpp
       tests/test_cmp.cpp
+      tests/test_CompletedCells.cpp
       tests/test_ConditionalStorage.cpp
       tests/test_critical_error.cpp
       tests/test_cubic.cpp
@@ -476,6 +477,7 @@ list (APPEND TEST_SOURCE_FILES
       tests/test_OpmLog.cpp
       tests/test_param.cpp
       tests/test_RootFinders.cpp
+      tests/test_ScheduleGrid.cpp
       tests/test_SegmentMatcher.cpp
       tests/test_sparsevector.cpp
       tests/test_uniformtablelinear.cpp

--- a/opm/input/eclipse/Schedule/CompletedCells.hpp
+++ b/opm/input/eclipse/Schedule/CompletedCells.hpp
@@ -30,29 +30,61 @@
 
 namespace Opm {
 
+/// Sparse collection of cells, and their properties, intersected by one or
+/// more well connections.
 class CompletedCells
 {
 public:
+    /// Identification and associate properties of cell intersected by one
+    /// or more well connections.
     struct Cell
     {
-        std::size_t global_index{};
-        std::size_t i{}, j{}, k{};
-
+        /// Property data of intersected cell
         struct Props
         {
+            /// Cell's active index in the range [0 .. #active).
+            ///
+            /// Relative to current grid--e.g., an LGR or the main grid.
             std::size_t active_index{};
+
+            /// Cell's permeability component in the grid's X direction.
             double permx{};
+
+            /// Cell's permeability component in the grid's Y direction.
             double permy{};
+
+            /// Cell's permeability component in the grid's Z direction.
             double permz{};
+
+            /// Cell's porosity.
             double poro{};
-            int satnum{};
-            int pvtnum{};
+
+            /// Cell's net-to-gross ratio.
             double ntg{};
 
+            /// Cell's saturation region.
+            int satnum{};
+
+            /// Cell's PVT region index.
+            int pvtnum{};
+
+            /// Equality predicate.
+            ///
+            /// \param[in] other Object against which \code *this \endcode
+            /// will be tested for equality.
+            ///
+            /// \return Whether or not \code *this \endcode is the same as
+            /// \p other.
             bool operator==(const Props& other) const;
 
+            /// Create a serialisation test object.
             static Props serializationTestObject();
 
+            /// Convert between byte array and object representation.
+            ///
+            /// \tparam Serializer Byte array conversion protocol.
+            ///
+            /// \param[in,out] serializer Byte array conversion object.
             template<class Serializer>
             void serializeOp(Serializer& serializer)
             {
@@ -67,17 +99,85 @@ public:
             }
         };
 
-        std::optional<Props> props{};
-        std::size_t active_index() const;
-        bool is_active() const;
+        /// Default constructor.
+        ///
+        /// Creates a Cell object that's mostly usable as the target of a
+        /// deserialisation operation.
+        Cell() = default;
 
+        /// Constructor
+        ///
+        /// \param[in] g Cell's linearised Cartesian index relative to
+        /// grid's origin.
+        ///
+        /// \param[in] i_ Cell's Cartesian I index relative to grid's
+        /// origin.
+        ///
+        /// \param[in] j_ Cell's Cartesian J index relative to grid's
+        /// origin.
+        ///
+        /// \param[in] k_ Cell's Cartesian K index relative to grid's
+        /// origin.
+        Cell(const std::size_t g,
+             const std::size_t i_,
+             const std::size_t j_,
+             const std::size_t k_)
+            : global_index(g)
+            , i(i_)
+            , j(j_)
+            , k(k_)
+        {}
+
+        /// Linearised Cartesian cell index
+        ///
+        /// Relative to grid origin--e.g., in an LGR or in the main grid.
+        std::size_t global_index{};
+
+        /// Cartesian I index relative to grid origin.
+        std::size_t i{};
+
+        /// Cartesian J index relative to grid origin.
+        std::size_t j{};
+
+        /// Cartesian K index relative to grid origin.
+        std::size_t k{};
+
+        /// Depth of cell centre.
         double depth{};
+
+        /// Physical cell extents.
         std::array<double, 3> dimensions{};
 
+        /// Cell property data.
+        ///
+        /// Nullopt if cell has not yet been discovered.
+        std::optional<Props> props{};
+
+        /// Check if cell is discovered and has associated property data.
+        bool is_active() const;
+
+        /// Retrieve cell's active index grid.
+        ///
+        /// Will throw an exception unless cell is_active().
+        std::size_t active_index() const;
+
+        /// Equality predicate.
+        ///
+        /// \param[in] other Object against which \code *this \endcode will be
+        /// tested for equality.
+        ///
+        /// \return Whether or not \code *this \endcode is the same as \p
+        /// other.
         bool operator==(const Cell& other) const;
 
+        /// Create a serialisation test object.
         static Cell serializationTestObject();
 
+        /// Convert between byte array and object representation.
+        ///
+        /// \tparam Serializer Byte array conversion protocol.
+        ///
+        /// \param[in,out] serializer Byte array conversion object.
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
@@ -89,28 +189,70 @@ public:
             serializer(this->depth);
             serializer(this->dimensions);
         }
-
-        Cell(std::size_t g, std::size_t i_, std::size_t j_, std::size_t k_)
-            : global_index(g)
-            , i(i_)
-            , j(j_)
-            , k(k_)
-        {}
-
-        Cell() = default;
     };
 
+    /// Default constructor.
+    ///
+    /// Creates a collection that is only usable as the target of a
+    /// deserialisation operation.
     CompletedCells() = default;
-    ~CompletedCells() = default;
+
+    /// Constructor.
+    ///
+    /// \param[in] dims Host grid's Cartesian dimensions.  Needed to
+    /// translate between linearised Cartesian indices and (I,J,K) tuples.
     explicit CompletedCells(const GridDims& dims);
+
+    /// Constructor.
+    ///
+    /// \param[in] nx Host grid's Cartesian dimension in the X direction.
+    /// \param[in] ny Host grid's Cartesian dimension in the Y direction.
+    /// \param[in] nz Host grid's Cartesian dimension in the Z direction.
     CompletedCells(std::size_t nx, std::size_t ny, std::size_t nz);
 
+    /// Retrieve intersected cell.
+    ///
+    /// Will throw an exception if the cell does not exist in the current
+    /// collection.
+    ///
+    /// \param[in] i Cell's Cartesian I index relative to grid's origin.
+    /// \param[in] j Cell's Cartesian J index relative to grid's origin.
+    /// \param[in] k Cell's Cartesian K index relative to grid's origin.
+    ///
+    /// \return Intersected cell at specified coordinates.
     const Cell& get(std::size_t i, std::size_t j, std::size_t k) const;
-    std::pair<bool, Cell&> try_get(std::size_t i, std::size_t j, std::size_t k);
 
+    /// Retrieve, and possibly create, an intersected cell.
+    ///
+    /// Will insert a cell object into the collection if none exist at
+    /// specified coordinate.
+    ///
+    /// \param[in] i Cell's Cartesian I index relative to grid's origin.
+    /// \param[in] j Cell's Cartesian J index relative to grid's origin.
+    /// \param[in] k Cell's Cartesian K index relative to grid's origin.
+    ///
+    /// \return Cell object and existence status.  The existence status is
+    /// 'false' if a new cell object was inserted into the collection as a
+    /// result of this request and 'true' otherwise.
+    std::pair<Cell*, bool>
+    try_get(std::size_t i, std::size_t j, std::size_t k);
+
+    /// Equality predicate.
+    ///
+    /// \param[in] other Object against which \code *this \endcode will be
+    /// tested for equality.
+    ///
+    /// \return Whether or not \code *this \endcode is the same as \p other.
     bool operator==(const CompletedCells& other) const;
+
+    /// Create a serialisation test object.
     static CompletedCells serializationTestObject();
 
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
@@ -119,9 +261,15 @@ public:
     }
 
 private:
+    /// Host grid's Cartesian dimensions.
     GridDims dims;
-    std::unordered_map<std::size_t, Cell> cells;
+
+    /// Sparse collection of intersected cells.
+    ///
+    /// Keyed by linearised Cartesian index.
+    std::unordered_map<std::size_t, Cell> cells{};
 };
-}
+
+} // namespace Opm
 
 #endif  // COMPLETED_CELLS

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -62,11 +62,9 @@ namespace Opm {
     class GuideRateModel;
     class HandlerContext;
     enum class InputErrorAction;
+    class NumericalAquifers;
     class ParseContext;
     class Python;
-    namespace ReservoirCoupling {
-        class CouplingInfo;
-    }
     class Runspec;
     class RPTConfig;
     class ScheduleGrid;
@@ -83,6 +81,10 @@ namespace Opm {
     class WelSegsSet;
     class WellTestConfig;
 } // namespace Opm
+
+namespace Opm::ReservoirCoupling {
+    class CouplingInfo;
+} // namespace Opm::ReservoirCoupling
 
 namespace Opm::Action {
     class ActionX;
@@ -119,6 +121,7 @@ namespace Opm {
         Schedule(const Deck& deck,
                  const EclipseGrid& grid,
                  const FieldPropsManager& fp,
+                 const NumericalAquifers& numAquifers,
                  const Runspec &runspec,
                  const ParseContext& parseContext,
                  ErrorGuard& errors,
@@ -134,6 +137,7 @@ namespace Opm {
         Schedule(const Deck& deck,
                  const EclipseGrid& grid,
                  const FieldPropsManager& fp,
+                 const NumericalAquifers& numAquifers,
                  const Runspec &runspec,
                  const ParseContext& parseContext,
                  T&& errors,
@@ -148,6 +152,7 @@ namespace Opm {
         Schedule(const Deck& deck,
                  const EclipseGrid& grid,
                  const FieldPropsManager& fp,
+                 const NumericalAquifers& numAquifers,
                  const Runspec &runspec,
                  std::shared_ptr<const Python> python,
                  const bool lowActionParsingStrictness = false,

--- a/opm/input/eclipse/Schedule/ScheduleGrid.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleGrid.cpp
@@ -20,6 +20,7 @@
 #include <opm/input/eclipse/Schedule/ScheduleGrid.hpp>
 
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.hpp>
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 
@@ -87,6 +88,10 @@ Opm::ScheduleGrid::ScheduleGrid(const EclipseGrid&           ecl_grid,
     , label_to_index { std::cref(label_to_index_) }
 {}
 
+void Opm::ScheduleGrid::include_numerical_aquifers(const NumericalAquifers& num_aquifers)
+{
+    this->num_aqu_cells = num_aquifers.allAquiferCells();
+}
 
 const Opm::CompletedCells::Cell&
 Opm::ScheduleGrid::get_cell(const std::size_t i,
@@ -295,7 +300,12 @@ populate_props_lgr(const std::string& tag, CompletedCells::Cell& cell) const
 }
 
 const Opm::NumericalAquiferCell*
-Opm::ScheduleGrid::get_num_aqu_cell([[maybe_unused]] const std::size_t global_index) const
+Opm::ScheduleGrid::get_num_aqu_cell(const std::size_t global_index) const
 {
-    return nullptr;
+    auto cellPos = this->num_aqu_cells.find(global_index);
+    if (cellPos == this->num_aqu_cells.end()) {
+        return nullptr;
+    }
+
+    return cellPos->second;
 }

--- a/opm/input/eclipse/Schedule/ScheduleGrid.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleGrid.hpp
@@ -32,6 +32,7 @@ namespace Opm {
 
 class EclipseGrid;
 class FieldPropsManager;
+class NumericalAquifers;
 class NumericalAquiferCell;
 
 } // namespace Opm
@@ -120,6 +121,14 @@ public:
                  std::vector<CompletedCells>& completed_cells_lgr,
                  const std::unordered_map<std::string, std::size_t>& label_to_index_);
 
+    /// Make collection aware of numerical aquifers
+    ///
+    /// Wells intersected in numerical aquifers should have properties from
+    /// the numerical aquifer itself rather than from the main property
+    /// container.
+    ///
+    /// \param[in] num_aquifers Run's collection of numerical aquifers.
+    void include_numerical_aquifers(const NumericalAquifers& num_aquifers);
 
     /// Retrieve particular intersected cell in main grid.
     ///

--- a/opm/input/eclipse/Schedule/ScheduleGrid.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleGrid.hpp
@@ -20,57 +20,253 @@
 #define SCHEDULE_GRID
 
 #include <opm/input/eclipse/Schedule/CompletedCells.hpp>
+
 #include <cstddef>
+#include <functional>
+#include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace Opm {
 
 class EclipseGrid;
 class FieldPropsManager;
+class NumericalAquiferCell;
 
 } // namespace Opm
 
 namespace Opm {
 
+/// Collection of intersected cells and associate properties for all
+/// simulation grids, i.e., the main grid and all LGRs in the simulation
+/// run.
+///
+/// Holds references to mutable collections of CompletedCells and will
+/// populate these as needed.  Those collections must outlive the
+/// ScheduleGrid object.
 class ScheduleGrid
 {
 public:
-    ScheduleGrid(const EclipseGrid& ecl_grid,
-                 const FieldPropsManager& fpm,
-                 CompletedCells& completed_cells,
-                 std::vector<CompletedCells>& completed_cells_lgr,
-                 const std::unordered_map<std::string, std::size_t>& label_to_index_);
-    ScheduleGrid(CompletedCells& completed_cells, 
-                 std::vector<CompletedCells>& completed_cells_lgr,
-                 const std::unordered_map<std::string, std::size_t>& label_to_index_);
-    ScheduleGrid(const EclipseGrid& ecl_grid,
-                 const FieldPropsManager& fpm,
-                 CompletedCells& completed_cells);
-    explicit ScheduleGrid(Opm::CompletedCells& completed_cells);
+    /// Constructor.
+    ///
+    /// Applies to main grid only.  Will not be able to create new cell
+    /// objects even if such objects are needed.
+    ///
+    /// \param[in,out] completed_cells Intersected cells and associate
+    /// properties.  Reference to a mutable collection which must outlive
+    /// the ScheduleGrid object.
+    explicit ScheduleGrid(CompletedCells& completed_cells);
 
-    ~ScheduleGrid() = default;
+    /// Constructor.
+    ///
+    /// Applies to main grid and any LGRs.  Will not be able to create new
+    /// cell objects even if such objects are needed.
+    ///
+    /// \param[in,out] completed_cells Intersected cells and associate
+    /// properties.  Reference to a mutable collection which must outlive
+    /// the ScheduleGrid object.
+    ///
+    /// \param[in,out] completed_cells_lgr Intersected cells and associate
+    /// properties for all LGRs.  Reference to a mutable collection which
+    /// must outlive the ScheduleGrid object.  Empty if there are no LGRs.
+    ///
+    /// \param[in] label_to_index_ Translation table from LGR names to LGR
+    /// indices.  Empty if there are no LGRs.
+    ScheduleGrid(CompletedCells&              completed_cells,
+                 std::vector<CompletedCells>& completed_cells_lgr,
+                 const std::unordered_map<std::string, std::size_t>& label_to_index_);
+
+    /// Constructor.
+    ///
+    /// Will populate collection of completed cells if needed.
+    ///
+    /// \param[in] ecl_grid Grid object with which to associate intersected
+    /// cells.
+    ///
+    /// \param[in] fpm Property container from which to extract property
+    /// data of intersected cells.
+    ///
+    /// \param[in,out] completed_cells Intersected cells and associate
+    /// properties.  Reference to a mutable collection which must outlive
+    /// the ScheduleGrid object.
+    ScheduleGrid(const EclipseGrid&       ecl_grid,
+                 const FieldPropsManager& fpm,
+                 CompletedCells&          completed_cells);
+
+    /// Constructor.
+    ///
+    /// Will populate collection of completed cells if needed.
+    ///
+    /// \param[in] ecl_grid Grid object with which to associate intersected
+    /// cells.
+    ///
+    /// \param[in] fpm Property container from which to extract property
+    /// data of intersected cells.
+    ///
+    /// \param[in,out] completed_cells Intersected cells and associate
+    /// properties.  Reference to a mutable collection which must outlive
+    /// the ScheduleGrid object.
+    ///
+    /// \param[in,out] completed_cells_lgr Intersected cells and associate
+    /// properties for all LGRs.  Reference to a mutable collection which
+    /// must outlive the ScheduleGrid object.  Empty if there are no LGRs.
+    ///
+    /// \param[in] label_to_index_ Translation table from LGR names to LGR
+    /// indices.  Empty if there are no LGRs.
+    ScheduleGrid(const EclipseGrid&           ecl_grid,
+                 const FieldPropsManager&     fpm,
+                 CompletedCells&              completed_cells,
+                 std::vector<CompletedCells>& completed_cells_lgr,
+                 const std::unordered_map<std::string, std::size_t>& label_to_index_);
+
+
+    /// Retrieve particular intersected cell in main grid.
+    ///
+    /// May as a side effect insert a new element into the collection of
+    /// CompletedCells, so this operation isn't really 'const' in the strict
+    /// sense of the word.  Will throw an exception if unable to create a
+    /// new cell object when needed.
+    ///
+    /// \param[in] i Cell's Cartesian I index relative to main grid's origin.
+    /// \param[in] j Cell's Cartesian J index relative to main grid's origin.
+    /// \param[in] k Cell's Cartesian K index relative to main grid's origin.
+    ///
+    /// \return Intersected cell object with associate property data.
     const CompletedCells::Cell&
     get_cell(std::size_t i, std::size_t j, std::size_t k) const;
+
+    /// Retrieve particular intersected cell.
+    ///
+    /// May as a side effect insert a new element into the collection of
+    /// CompletedCells, so this operation isn't really 'const' in the strict
+    /// sense of the word.  Will throw an exception if unable to create a
+    /// new cell object when needed.
+    ///
+    /// \param[in] i Cell's Cartesian I index relative to grid's origin.
+    ///
+    /// \param[in] j Cell's Cartesian J index relative to grid's origin.
+    ///
+    /// \param[in] k Cell's Cartesian K index relative to grid's origin.
+    ///
+    /// \param[in] tag Grid identifier.  Nullopt for main grid, and an LGR
+    /// name otherwise.
+    ///
+    /// \return Intersected cell object with associate property data.
     const CompletedCells::Cell&
-    get_cell(std::size_t i, std::size_t j, std::size_t k, std::optional<std::string> tag) const;
-    const CompletedCells::Cell&
-    get_cell_lgr(std::size_t i, std::size_t j, std::size_t k, std::string tag) const; 
-    const Opm::EclipseGrid* get_grid() const;
-    int get_lgr_grid_number(std::optional<std::string> lgr_label) const;
+    get_cell(std::size_t i, std::size_t j, std::size_t k, const std::optional<std::string>& tag) const;
+
+    /// Retrieve underlying grid object.
+    ///
+    /// Usable only if the ScheduleGrid was created with a reference to a
+    /// grid object.
+    const EclipseGrid* get_grid() const;
+
+    /// Translate LGR name into a numeric grid index.
+    ///
+    /// Will throw an exception if the name identifies an unknown LGR.
+    ///
+    /// \param[in] lgr_label LGR name.  Nullopt for main grid.
+    ///
+    /// \return Numeric grid index.
+    int get_lgr_grid_number(const std::optional<std::string>& lgr_label) const;
 
 private:
+    /// Underlying grid object.
     const EclipseGrid* grid{nullptr};
+
+    /// Property container.
     const FieldPropsManager* fp{nullptr};
-    CompletedCells& cells; 
-    std::vector<CompletedCells>& cells_lgr; 
-    const std::unordered_map<std::string, std::size_t>& label_to_index;
-    // setting default values for cells_lgr and label_to_index when not provided
-    std::vector<CompletedCells> cells_lgr_empty{};
-    const std::unordered_map<std::string, std::size_t> label_to_index_empty;
 
+    /// Collection of intersected cells in main grid.
+    ///
+    /// Reference to a mutable object that must outlive the ScheduleGrid.
+    std::reference_wrapper<CompletedCells> cells;
 
+    /// Collection of intersected cells in LGRs.
+    ///
+    /// Reference to a mutable object that must outlive the ScheduleGrid.
+    std::reference_wrapper<std::vector<CompletedCells>> cells_lgr;
 
+    /// Translation table for LGR names.
+    ///
+    /// Reference to an immutable object that must outlive the ScheduleGrid.
+    std::reference_wrapper<const std::unordered_map<std::string, std::size_t>> label_to_index;
+
+    /// Run's cells, including property data, in numerical aquifers.
+    ///
+    /// Keyed by Cartesian cell index.
+    std::unordered_map<std::size_t, const NumericalAquiferCell*> num_aqu_cells{};
+
+    /// Retrieve particular intersected cell in local grid.
+    ///
+    /// May as a side effect insert a new element into the collection of
+    /// CompletedCells, so this operation isn't really 'const' in the strict
+    /// sense of the word.  Will throw an exception if unable to create a
+    /// new cell object when needed.
+    ///
+    /// \param[in] i Cell's Cartesian I index relative to grid's origin.
+    ///
+    /// \param[in] j Cell's Cartesian J index relative to grid's origin.
+    ///
+    /// \param[in] k Cell's Cartesian K index relative to grid's origin.
+    ///
+    /// \param[in] tag Local grid name.
+    ///
+    /// \return Intersected cell object with associate property data.
+    const CompletedCells::Cell&
+    get_cell_lgr(std::size_t i, std::size_t j, std::size_t k, const std::string& tag) const;
+
+    /// Populate intersected cell property data for cell in main grid
+    ///
+    /// Knows how to distinguish regular cells from those that happen to be
+    /// in numerical aquifers.
+    ///
+    /// \param[in,out] cell Intersected cell object.  This function will
+    /// populate its Cell::Props sub-object.
+    void populate_props_from_main_grid(CompletedCells::Cell& cell) const;
+
+    /// Populate intersected cell property data for cell in main grid.
+    ///
+    /// Typical case.  The cell is a "regular" cell so we extract property
+    /// values from the main property container.
+    ///
+    /// \param[in,out] cell Intersected cell object.  This function will
+    /// populate its Cell::Props sub-object.
+    void populate_props_from_main_grid_cell(CompletedCells::Cell& cell) const;
+
+    /// Populate intersected cell property data for cell in main grid.
+    ///
+    /// Uncommon case.  The cell is in a numerical aquifer so we extract
+    /// property values from that aquifer object.
+    ///
+    /// \param[in] numAquCell Property data pertaining to the particular
+    /// numerical aquifer cell.
+    ///
+    /// \param[in,out] cell Intersected cell object.  This function will
+    /// populate its Cell::Props sub-object.
+    void populate_props_from_num_aquifer(const NumericalAquiferCell& numAquCell,
+                                         CompletedCells::Cell&       cell) const;
+
+    /// Populate intersected cell property data for cell in local grid.
+    ///
+    /// \param[in] tag Local grid name.
+    ///
+    /// \param[in,out] cell Intersected cell object in local grid.  This
+    /// function will populate its Cell::Props sub-object.
+    void populate_props_lgr(const std::string&    tag,
+                            CompletedCells::Cell& cell) const;
+
+    /// Retrieve numerical aquifer property data for particular main grid
+    /// cell.
+    ///
+    /// \param[in] global_index Linearised Cartesian cell index in main
+    /// grid.
+    ///
+    /// \return Numerical aquifer property data.  Nullptr if \p global_index
+    /// is not in a numerical aquifer.
+    const NumericalAquiferCell*
+    get_num_aqu_cell(const std::size_t global_index) const;
 };
 
 } // namespace Opm

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -33,6 +33,7 @@
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
@@ -89,8 +90,11 @@ Schedule make_schedule(const std::string& deck_string,
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid1, table);
     const Runspec runspec(deck);
 
-    ErrorGuard errors;
-    return { deck, grid1, fp, runspec, parseContext, errors, std::make_shared<Python>() };
+    ErrorGuard errors{};
+    return {
+        deck, grid1, fp, NumericalAquifers{}, runspec,
+        parseContext, errors, std::make_shared<Python>()
+    };
 }
 
 } // Anonymous namespace
@@ -937,7 +941,7 @@ TSTEP
     auto python = std::make_shared<Python>();
 
     Runspec runspec (deck);
-    Schedule sched(deck, grid1, fp, runspec, python);
+    Schedule sched(deck, grid1, fp, NumericalAquifers{}, runspec, python);
     const auto& actions0 = sched[0].actions.get();
     BOOST_CHECK_EQUAL(actions0.ecl_size(), 0U);
 
@@ -1099,7 +1103,10 @@ ENDACTIO
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid1, table);
 
     const Runspec runspec(deck);
-    const Schedule sched(deck, grid1, fp, runspec, std::make_shared<Python>());
+    const Schedule sched {
+        deck, grid1, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
     const auto& action1 = sched[0].actions.get()["A"];
 
     SummaryState st(TimeService::now(), runspec.udqParams().undefinedValue());
@@ -1149,7 +1156,7 @@ WOPR 'OPX'  = 1000 /
 /
 
 ENDACTIO
-        )"};
+)"};
 
     const auto deck = Parser{}.parseString(deck_string);
     EclipseGrid grid1(10,10,10);
@@ -1157,7 +1164,10 @@ ENDACTIO
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid1, table);
 
     const Runspec runspec (deck);
-    const Schedule sched(deck, grid1, fp, runspec, std::make_shared<Python>());
+    const Schedule sched {
+        deck, grid1, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
     const auto& action1 = sched[1].actions.get()["A"];
     const auto& action2 = sched[2].actions.get()["A"];
 

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -32,6 +32,7 @@
 
 #include <opm/common/utility/OpmInputError.hpp>
 
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
@@ -3134,8 +3135,11 @@ MULTZ
     TableManager tables;
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, tables);
     Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    Schedule sched(deck, grid, fp, runspec, python);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
+
     const auto& multz0 = fp.get_double("MULTZ");
     for (std::size_t k=0; k < 2; k++) {
         for (std::size_t ij=0; ij < 100; ij++)

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -15,21 +15,21 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
- */
-
-#include <stdexcept>
+*/
 
 #define BOOST_TEST_MODULE GroupTests
 #include <boost/test/unit_test.hpp>
-#include <opm/input/eclipse/Python/Python.hpp>
 
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
+
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+
+#include <opm/input/eclipse/Python/Python.hpp>
+
 #include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
 #include <opm/input/eclipse/Schedule/Group/GSatProd.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
@@ -42,6 +42,15 @@
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 #include <opm/common/utility/TimeService.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <stdexcept>
 
 using namespace Opm;
 
@@ -56,7 +65,7 @@ Schedule create_schedule(const std::string& deck_string)
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec(deck);
 
-    return { deck, grid, fp, runspec, std::make_shared<Python>() };
+    return { deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>() };
 }
 
 } // Anonymous namespace

--- a/tests/parser/MessageLimitTests.cpp
+++ b/tests/parser/MessageLimitTests.cpp
@@ -23,21 +23,24 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <opm/input/eclipse/Python/Python.hpp>
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+
+#include <opm/input/eclipse/Python/Python.hpp>
+
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/MessageLimits.hpp>
+
 #include <opm/input/eclipse/Deck/Deck.hpp>
+
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
 using namespace Opm;
 
-
 BOOST_AUTO_TEST_CASE(MESSAGES) {
-    Opm::Parser parser;
     const std::string input = R"(
 START             -- 0
 19 JUN 2007 /
@@ -82,15 +85,17 @@ DATES             -- 2
 /
 MESSAGES
   10 /
-     )";
+)";
 
-    auto deck = parser.parseString(input);
-    auto python = std::make_shared<Python>();
+    auto deck = Parser{}.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid, fp, runspec, python);
+    const Schedule schedule {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK_EQUAL( schedule[0].message_limits().getBugPrintLimit( ) , 77 );   // The pre Schedule initialization
 

--- a/tests/parser/NetworkTests.cpp
+++ b/tests/parser/NetworkTests.cpp
@@ -23,6 +23,7 @@
 
 #include <opm/common/utility/OpmInputError.hpp>
 
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
@@ -43,16 +44,18 @@
 using namespace Opm;
 
 namespace {
-Schedule make_schedule(const std::string& schedule_string) {
-    Parser parser;
-    auto python = std::make_shared<Python>();
-    Deck deck = parser.parseString(schedule_string);
+Schedule make_schedule(const std::string& schedule_string)
+{
+    const auto deck = Parser{}.parseString(schedule_string);
     EclipseGrid grid(10,10,10);
-    TableManager table ( deck );
-    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    Schedule schedule(deck, grid , fp, runspec, python);
-    return schedule;
+    const TableManager table ( deck );
+    const FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+
+    return {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 }
 }
 

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -20,9 +20,27 @@
 #define BOOST_TEST_MODULE ParseContextTests
 #include <boost/test/unit_test.hpp>
 
+#include <opm/input/eclipse/Parser/InputErrorAction.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+
+#include <opm/common/utility/OpmInputError.hpp>
+
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+
 #include <opm/input/eclipse/Python/Python.hpp>
+
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
 #include <opm/input/eclipse/Parser/Parser.hpp>
+
 #include <opm/input/eclipse/Parser/ParserKeywords/D.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
@@ -30,17 +48,6 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
-#include <opm/input/eclipse/Parser/InputErrorAction.hpp>
-#include <opm/input/eclipse/Parser/ParseContext.hpp>
-#include <opm/common/utility/OpmInputError.hpp>
-
-
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
-#include <opm/input/eclipse/EclipseState/Runspec.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
 
 #include <cstdlib>
 #include <memory>
@@ -720,7 +727,7 @@ BOOST_AUTO_TEST_CASE( test_invalid_wtemplate_config ) {
         FieldPropsManager fp( deckUnSupported, Phases{true, true, true}, grid, table);
         Runspec runspec( deckUnSupported);
 
-        BOOST_CHECK_THROW( Schedule( deckUnSupported , grid , fp, runspec , parseContext, errors, python), OpmInputError);
+        BOOST_CHECK_THROW( Schedule( deckUnSupported, grid, fp, NumericalAquifers{}, runspec, parseContext, errors, python), OpmInputError);
     }
 }
 

--- a/tests/parser/ReservoirCouplingTests.cpp
+++ b/tests/parser/ReservoirCouplingTests.cpp
@@ -16,53 +16,72 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "config.h"
+
+#include <config.h>
+
 #define BOOST_TEST_MODULE ReservoirCouplingTests
 
 #include <boost/test/unit_test.hpp>
+
 #include <opm/input/eclipse/Schedule/ResCoup/ReservoirCouplingInfo.hpp>
 #include <opm/input/eclipse/Schedule/ResCoup/WriteCouplingFile.hpp>
 #include <opm/input/eclipse/Schedule/ResCoup/GrupSlav.hpp>
 #include <opm/input/eclipse/Schedule/ResCoup/MasterGroup.hpp>
 #include <opm/input/eclipse/Schedule/ResCoup/Slaves.hpp>
 
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
+
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
-#include <opm/input/eclipse/Python/Python.hpp>
-#include <opm/input/eclipse/Units/Units.hpp>
-#include <opm/common/utility/OpmInputError.hpp>
-#include <opm/common/OpmLog/OpmLog.hpp>
-#include <opm/common/OpmLog/StreamLog.hpp>
 
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Python/Python.hpp>
+
+#include <opm/input/eclipse/Units/Units.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <cstddef>
+#include <memory>
 #include <sstream>
 #include <string>
+#include <vector>
 
 using namespace Opm;
+
 namespace {
-Schedule makeSchedule(const std::string& schedule_string, bool slave_mode) {
-    Parser parser;
-    auto python = std::make_shared<Python>();
-    Deck deck = parser.parseString(schedule_string);
+Schedule makeSchedule(const std::string& schedule_string, const bool slave_mode)
+{
+    const auto deck = Parser{}.parseString(schedule_string);
+
     EclipseGrid grid(10,10,10);
-    TableManager table ( deck );
-    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    Schedule schedule(
-        deck, grid , fp, runspec, python, /*lowActionParsingStrictness=*/false, slave_mode
-    );
-    return schedule;
+    const TableManager table ( deck );
+    const FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+
+    return {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>(),
+        /*lowActionParsingStrictness = */ false,
+        slave_mode
+    };
 }
 
-void addStringLogger(std::ostringstream& stream_buffer) {
+void addStringLogger(std::ostringstream& stream_buffer)
+{
     auto string_logger = std::make_shared<StreamLog>(stream_buffer, Log::DefaultMessageTypes);
     OpmLog::addBackend("MYLOGGER", string_logger);
 }
 
-void assertRaisesInputErrorException(const std::string& schedule_string, bool slave_mode, const std::string& exception_string) {
+void assertRaisesInputErrorException(const std::string& schedule_string,
+                                     const bool slave_mode,
+                                     const std::string& exception_string)
+{
     BOOST_CHECK_THROW(makeSchedule(schedule_string, slave_mode), Opm::OpmInputError);
     try {
         // Now that we know that it will throw the specific exception Opm::OpmInputError,
@@ -74,11 +93,10 @@ void assertRaisesInputErrorException(const std::string& schedule_string, bool sl
     }
 }
 
-void checkLastLineStringBuffer(
-    const std::ostringstream& stream_buffer,
-    const std::string& expected,
-    size_t offset  // Line offset from the end of the string
-) {
+void checkLastLineStringBuffer(const std::ostringstream& stream_buffer,
+                               const std::string& expected,
+                               const std::size_t offset)   // Line offset from the end of the string
+{
     std::string output = stream_buffer.str();
     std::istringstream iss(output);
     std::vector<std::string> lines;
@@ -98,7 +116,7 @@ void checkLastLineStringBuffer(
     }
 }
 
-std::string getMinimumMasterTimeStepDeckString(const std::string &end_of_deck_string)
+std::string getMinimumMasterTimeStepDeckString(const std::string& end_of_deck_string)
 {
     std::string prefix = R"(
 SCHEDULE
@@ -130,12 +148,13 @@ GRUPMAST
     return prefix + end_of_deck_string;
 }
 
-std::string getCouplingFileDeckString(const std::string &end_of_deck_string)
+std::string getCouplingFileDeckString(const std::string& end_of_deck_string)
 {
     return getMinimumMasterTimeStepDeckString(end_of_deck_string);
 }
 
-void removeStringLogger() {
+void removeStringLogger()
+{
     OpmLog::removeBackend("MYLOGGER");
 }
 

--- a/tests/parser/ScheduleSerializeTest.cpp
+++ b/tests/parser/ScheduleSerializeTest.cpp
@@ -31,6 +31,7 @@
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
@@ -318,13 +319,15 @@ DATES             -- 7
 
 static Schedule make_schedule(const std::string& deck_string)
 {
-    const auto& deck = Parser{}.parseString(deck_string);
-    auto python = std::make_shared<Python>();
+    const auto deck = Parser{}.parseString(deck_string);
     EclipseGrid grid(10,10,10);
-    TableManager table ( deck );
-    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    return Schedule(deck, grid , fp, runspec, python);
+    const TableManager table ( deck );
+    const FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    return {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 }
 
 BOOST_AUTO_TEST_CASE(SerializeWTest)

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -26,6 +26,7 @@
 
 #include <opm/io/eclipse/rst/udq.hpp>
 
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
@@ -82,11 +83,14 @@ namespace {
         }
         else {
             EclipseGrid grid(10,10,10);
-            TableManager table(deck);
-            FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-            Runspec runspec(deck);
+            const TableManager table(deck);
+            const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+            const Runspec runspec(deck);
 
-            return { deck, grid, fp, runspec, std::make_shared<Python>() };
+            return {
+                deck, grid, fp, NumericalAquifers{},
+                runspec, std::make_shared<Python>()
+            };
         }
     }
 

--- a/tests/parser/UDTTests.cpp
+++ b/tests/parser/UDTTests.cpp
@@ -23,15 +23,20 @@
 
 #include <opm/common/utility/OpmInputError.hpp>
 
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
+
 #include <opm/input/eclipse/Python/Python.hpp>
+
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDT.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
 
 using namespace Opm;
 
@@ -88,7 +93,7 @@ UDT
     TableManager table(deck);
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
-    BOOST_CHECK_NO_THROW(Schedule schedule(deck, grid, fp, runspec, std::make_shared<Python>()));
+    BOOST_CHECK_NO_THROW(Schedule schedule(deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>()));
 }
 
 BOOST_AUTO_TEST_CASE(ParseUDT_LC)
@@ -111,7 +116,7 @@ UDT
     TableManager table(deck);
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
-    BOOST_CHECK_NO_THROW(Schedule schedule(deck, grid, fp, runspec, std::make_shared<Python>()));
+    BOOST_CHECK_NO_THROW(Schedule schedule(deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>()));
 }
 
 BOOST_AUTO_TEST_CASE(ParseUDT_LL)
@@ -134,7 +139,7 @@ UDT
     TableManager table(deck);
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
-    BOOST_CHECK_NO_THROW(Schedule schedule(deck, grid, fp, runspec, std::make_shared<Python>()));
+    BOOST_CHECK_NO_THROW(Schedule schedule(deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>()));
 }
 
 BOOST_AUTO_TEST_CASE(ParseUDT_NonAscending)
@@ -157,7 +162,7 @@ UDT
     TableManager table(deck);
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
-    BOOST_CHECK_THROW(Schedule schedule(deck, grid, fp, runspec, std::make_shared<Python>()),
+    BOOST_CHECK_THROW(Schedule schedule(deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>()),
                       Opm::OpmInputError);
 }
 
@@ -181,7 +186,7 @@ UDT
     TableManager table(deck);
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
-    BOOST_CHECK_THROW(Schedule schedule(deck, grid, fp, runspec, std::make_shared<Python>()),
+    BOOST_CHECK_THROW(Schedule schedule(deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>()),
                       Opm::OpmInputError);
 }
 
@@ -205,6 +210,6 @@ UDT
     TableManager table(deck);
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
-    BOOST_CHECK_THROW(Schedule schedule(deck, grid, fp, runspec, std::make_shared<Python>()),
+    BOOST_CHECK_THROW(Schedule schedule(deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>()),
                       Opm::OpmInputError);
 }

--- a/tests/parser/WLIST.cpp
+++ b/tests/parser/WLIST.cpp
@@ -15,7 +15,7 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
 
 #include <stdexcept>
 #include <algorithm>
@@ -24,15 +24,19 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <opm/input/eclipse/Python/Python.hpp>
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+
+#include <opm/input/eclipse/Python/Python.hpp>
+
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/Well/WList.hpp>
 #include <opm/input/eclipse/Schedule/Well/WListManager.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
+
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
 using namespace Opm;
@@ -100,8 +104,7 @@ static std::string WELSPECS() {
 }
 
 static Opm::Schedule createSchedule(const std::string& schedule) {
-    Opm::Parser parser;
-    std::string input =
+    const std::string input =
         "START             -- 0 \n"
         "10 MAI 2007 / \n"
         "SCHEDULE\n"+ schedule;
@@ -124,13 +127,15 @@ static Opm::Schedule createSchedule(const std::string& schedule) {
         "/\n";
     */
 
-    auto deck = parser.parseString(input);
+    auto deck = Parser{}.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    return Schedule(deck, grid , fp, runspec, python );
+    return Schedule {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 }
 
 

--- a/tests/parser/WellSolventTests.cpp
+++ b/tests/parser/WellSolventTests.cpp
@@ -23,6 +23,7 @@
 
 #include <opm/input/eclipse/Python/Python.hpp>
 
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
@@ -205,7 +206,10 @@ BOOST_AUTO_TEST_CASE(TestNoSolvent)
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec(deck);
-    const Schedule schedule(deck, grid, fp, runspec, std::make_shared<Python>());
+    const Schedule schedule {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK(!deck.hasKeyword("WSOLVENT"));
 }
@@ -216,7 +220,10 @@ BOOST_AUTO_TEST_CASE(TestGasInjector) {
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec(deck);
-    const Schedule schedule(deck, grid, fp, runspec, std::make_shared<Python>());
+    const Schedule schedule {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK(deck.hasKeyword("WSOLVENT"));
 }
@@ -228,7 +235,10 @@ BOOST_AUTO_TEST_CASE(TestDynamicWSOLVENT)
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec(deck);
-    const Schedule schedule(deck, grid, fp, runspec, std::make_shared<Python>());
+    const Schedule schedule {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK(deck.hasKeyword("WSOLVENT"));
 
@@ -252,7 +262,7 @@ BOOST_AUTO_TEST_CASE(TestOilInjector)
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec(deck);
 
-    BOOST_CHECK_THROW (Schedule(deck, grid, fp, runspec, std::make_shared<Python>()), std::exception);
+    BOOST_CHECK_THROW(Schedule(deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>()), std::exception);
 }
 
 BOOST_AUTO_TEST_CASE(TestWaterInjector)
@@ -263,5 +273,5 @@ BOOST_AUTO_TEST_CASE(TestWaterInjector)
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec(deck);
 
-    BOOST_CHECK_THROW (Schedule(deck, grid , fp, runspec, std::make_shared<Python>()), std::exception);
+    BOOST_CHECK_THROW(Schedule(deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>()), std::exception);
 }

--- a/tests/parser/WellTracerTests.cpp
+++ b/tests/parser/WellTracerTests.cpp
@@ -25,6 +25,7 @@
 
 #include <opm/input/eclipse/Python/Python.hpp>
 
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
@@ -161,7 +162,10 @@ BOOST_AUTO_TEST_CASE(TestNoTracer)
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec (deck);
-    const Schedule schedule(deck, grid, fp, runspec, std::make_shared<Python>());
+    const Schedule schedule {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK(!deck.hasKeyword("WTRACER"));
 }
@@ -175,7 +179,10 @@ BOOST_AUTO_TEST_CASE(TestDynamicWTRACER)
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec (deck);
-    const Schedule schedule(deck, grid, fp, runspec, std::make_shared<Python>());
+    const Schedule schedule {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK(deck.hasKeyword("WTRACER"));
 
@@ -202,5 +209,5 @@ BOOST_AUTO_TEST_CASE(TestTracerInProducerTHROW)
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec (deck);
 
-    BOOST_CHECK_THROW(Schedule(deck, grid, fp, runspec, std::make_shared<Python>()), OpmInputError);
+    BOOST_CHECK_THROW(Schedule(deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>()), OpmInputError);
 }

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -21,8 +21,10 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
+
 #include <boost/version.hpp>
 
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
@@ -81,7 +83,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule) {
         TableManager table ( deck );
         FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
         Runspec runspec (deck);
-        Schedule sched(deck,  grid , fp, runspec, python);
+        Schedule sched(deck, grid, fp, NumericalAquifers{}, runspec, python);
         BOOST_CHECK_EQUAL(asTimeT(TimeStampUTC(2007 , 5 , 10)), sched.getStartTime());
         BOOST_CHECK_EQUAL(9U, sched.size());
         BOOST_CHECK( deck.hasKeyword("NETBALAN") );
@@ -98,7 +100,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_Comments_After_Keywords) {
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     auto python = std::make_shared<Python>();
-    Schedule sched(deck,  grid , fp, runspec, python);
+    Schedule sched(deck, grid, fp, NumericalAquifers{}, runspec, python);
     BOOST_CHECK_EQUAL(asTimeT(TimeStampUTC(2007, 5 , 10)) , sched.getStartTime());
     BOOST_CHECK_EQUAL(9U, sched.size());
 }
@@ -113,7 +115,7 @@ BOOST_AUTO_TEST_CASE(WCONPROD_MissingCmode) {
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     auto python = std::make_shared<Python>();
     Runspec runspec (deck);
-    BOOST_CHECK_NO_THROW( Schedule(deck, grid , fp, runspec, python) );
+    BOOST_CHECK_NO_THROW( Schedule(deck, grid, fp, NumericalAquifers{}, runspec, python) );
 }
 
 
@@ -126,20 +128,21 @@ BOOST_AUTO_TEST_CASE(WCONPROD_Missing_DATA) {
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     auto python = std::make_shared<Python>();
-    BOOST_CHECK_THROW( Schedule(deck, grid , fp, runspec, python) , std::exception );
+    BOOST_CHECK_THROW( Schedule(deck, grid, fp, NumericalAquifers{}, runspec, python) , std::exception );
 }
 
 
 BOOST_AUTO_TEST_CASE(WellTestRefDepth) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS2");
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS2");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(40,60,30);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    Schedule sched(deck , grid , fp, runspec, python);
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     const auto& well1 = sched.getWellatEnd("W_1");
     const auto& well2 = sched.getWellatEnd("W_2");
@@ -150,19 +153,17 @@ BOOST_AUTO_TEST_CASE(WellTestRefDepth) {
 }
 
 
-
-
-
 BOOST_AUTO_TEST_CASE(WellTesting) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS2");
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS2");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(40,60,30);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    Schedule sched(deck,  grid , fp, runspec, python);
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK_EQUAL(4U, sched.numWells());
     BOOST_CHECK(sched.hasWell("W_1"));
@@ -292,28 +293,30 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
 
 
 BOOST_AUTO_TEST_CASE(WellTestCOMPDAT_DEFAULTED_ITEMS) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_COMPDAT1");
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_COMPDAT1");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(10,10,10);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    Schedule sched(deck,  grid , fp, runspec, python);
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 }
 
 
 BOOST_AUTO_TEST_CASE(WellTestCOMPDAT) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS2");
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS2");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(40,60,30);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    Schedule sched(deck,  grid , fp, runspec, python);
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK_EQUAL(4U, sched.numWells());
     BOOST_CHECK(sched.hasWell("W_1"));
@@ -341,15 +344,16 @@ BOOST_AUTO_TEST_CASE(WellTestCOMPDAT) {
 
 
 BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_correct) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELSPECS_GRUPTREE");
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELSPECS_GRUPTREE");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    Schedule schedule(deck,  grid , fp, runspec, python);
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule schedule {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK( schedule.back().groups.has( "FIELD" ));
     BOOST_CHECK( schedule.back().groups.has( "PROD" ));
@@ -364,15 +368,16 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_correct) {
 
 
 BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_GROUPS_REPARENT");
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_GROUPS_REPARENT");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    Schedule sched(deck,  grid , fp, runspec, python);
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     const auto& field_group = sched.getGroup("FIELD", 1);
     const auto& new_group = sched.getGroup("GROUP_NEW", 1);
@@ -389,15 +394,17 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
 }
 
 BOOST_AUTO_TEST_CASE( WellTestGroups ) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_GROUPS");
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_GROUPS");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    Schedule sched(deck,  grid , fp, runspec, python);
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
+
     SummaryState st(TimeService::now(), runspec.udqParams().undefinedValue());
 
     BOOST_CHECK_EQUAL( 3U , sched.back().groups.size() );
@@ -441,15 +448,16 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
 
 
 BOOST_AUTO_TEST_CASE( WellTestGroupAndWellRelation ) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS_AND_GROUPS");
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS_AND_GROUPS");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    Schedule sched(deck,  grid , fp, runspec, python);
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     {
         auto& group1 = sched.getGroup("GROUP1", 0);
@@ -503,15 +511,16 @@ BOOST_AUTO_TEST_CASE(WellTestWELOPENControlsSet) {
 
 
 BOOST_AUTO_TEST_CASE(WellTestWGRUPCONWellPropertiesSet) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WGRUPCON");
-    auto deck =  parser.parseFile(scheduleFile);
-    auto python = std::make_shared<Python>();
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WGRUPCON");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(10,10,10);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    Schedule sched(deck,  grid , fp, runspec, python);
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     const auto& well1 = sched.getWell("W_1", 0);
     BOOST_CHECK(well1.isAvailableForGroupControl( ));
@@ -564,7 +573,10 @@ END
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec (deck);
-    const Schedule sched(deck, grid, fp, runspec, std::make_shared<Python>());
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     const auto& connections = sched.getWell("W1", 0).getConnections();
     BOOST_CHECK_EQUAL( 10 , connections.get(0).getI() );
@@ -577,30 +589,28 @@ END
    certain we can parse it.
 */
 BOOST_AUTO_TEST_CASE(OpmCode) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/wells_group.data");
-    auto deck =  parser.parseFile(scheduleFile);
-    auto python = std::make_shared<Python>();
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/wells_group.data");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(10,10,5);
-    TableManager table ( deck );
-    Runspec runspec (deck);
-    FieldPropsManager fp(deck, runspec.phases(), grid, table);
-    BOOST_CHECK_NO_THROW( Schedule(deck , grid , fp, runspec, python) );
+    const TableManager table ( deck );
+    const Runspec runspec (deck);
+    const FieldPropsManager fp(deck, runspec.phases(), grid, table);
+    BOOST_CHECK_NO_THROW( Schedule(deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>()) );
 }
 
 
 
 BOOST_AUTO_TEST_CASE(WELLS_SHUT) {
-    Parser parser;
-    auto python = std::make_shared<Python>();
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_SHUT_WELL");
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_SHUT_WELL");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(20,40,1);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    Schedule sched(deck,  grid , fp, runspec, python);
-
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     {
         const auto& well1 = sched.getWell("W1", 1);
@@ -622,16 +632,16 @@ BOOST_AUTO_TEST_CASE(WELLS_SHUT) {
 
 
 BOOST_AUTO_TEST_CASE(WellTestWPOLYMER) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_POLYMER");
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_POLYMER");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(30,30,30);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    Schedule sched(deck,  grid , fp, runspec, python);
-
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK_EQUAL(4U, sched.numWells());
     BOOST_CHECK(sched.hasWell("INJE01"));
@@ -690,16 +700,16 @@ BOOST_AUTO_TEST_CASE(WellTestWPOLYMER) {
 
 
 BOOST_AUTO_TEST_CASE(WellTestWFOAM) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_FOAM");
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_FOAM");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(30,30,30);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    Schedule sched(deck,  grid , fp, runspec, python);
-
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK_EQUAL(4U, sched.numWells());
     BOOST_CHECK(sched.hasWell("INJE01"));
@@ -758,15 +768,16 @@ BOOST_AUTO_TEST_CASE(WellTestWFOAM) {
 
 
 BOOST_AUTO_TEST_CASE(WellTestWECON) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WECON");
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WECON");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(30,30,30);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    Schedule sched(deck,  grid , fp, runspec, python);
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK_EQUAL(3U, sched.numWells());
     BOOST_CHECK(sched.hasWell("INJE01"));
@@ -868,16 +879,16 @@ BOOST_AUTO_TEST_CASE(WellTestWECON) {
 
 
 BOOST_AUTO_TEST_CASE(TestEvents) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_EVENTS");
-
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_EVENTS");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(40,40,30);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck);
-    auto python = std::make_shared<Python>();
-    Schedule sched(deck , grid , fp, runspec, python);
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec (deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK(  sched[0].events().hasEvent(ScheduleEvents::NEW_WELL) );
     BOOST_CHECK( !sched[1].events().hasEvent(ScheduleEvents::NEW_WELL) );
@@ -902,16 +913,16 @@ BOOST_AUTO_TEST_CASE(TestEvents) {
 
 
 BOOST_AUTO_TEST_CASE(TestWellEvents) {
-    Parser parser;
-    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_EVENTS");
-
-    auto deck =  parser.parseFile(scheduleFile);
+    const std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_EVENTS");
+    const auto deck = Parser{}.parseFile(scheduleFile);
     EclipseGrid grid(40,40,30);
-    TableManager table ( deck );
-    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Runspec runspec(deck);
-    auto python = std::make_shared<Python>();
-    Schedule sched(deck , grid , fp, runspec, python);
+    const TableManager table ( deck );
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec(deck);
+    const Schedule sched {
+        deck, grid, fp, NumericalAquifers{},
+        runspec, std::make_shared<Python>()
+    };
 
     BOOST_CHECK(  sched[0].wellgroup_events().hasEvent( "W_1", ScheduleEvents::NEW_WELL));
     BOOST_CHECK(  sched[2].wellgroup_events().hasEvent( "W_2", ScheduleEvents::NEW_WELL));

--- a/tests/test_CompletedCells.cpp
+++ b/tests/test_CompletedCells.cpp
@@ -1,0 +1,155 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+
+/*
+  Copyright 2025 Equinor
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE Completed_Cells_Collection
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/input/eclipse/Schedule/CompletedCells.hpp>
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <stdexcept>
+#include <utility>              // std::pair<>
+
+BOOST_AUTO_TEST_SUITE(Basic_Operations)
+
+BOOST_AUTO_TEST_CASE(Try_Get_Insert_New)
+{
+    auto cc = Opm::CompletedCells { 10, 10, 3 };
+
+    auto [cellPtr, is_existing_cell] = cc.try_get(0, 0, 0);
+    BOOST_REQUIRE_MESSAGE(cellPtr != nullptr, "Try_get() must generate cell object");
+
+    BOOST_CHECK_MESSAGE(! is_existing_cell, "New cell must not be existing cell");
+
+    BOOST_CHECK_EQUAL(cellPtr->global_index, std::size_t{0});
+    BOOST_CHECK_EQUAL(cellPtr->i, std::size_t{0});
+    BOOST_CHECK_EQUAL(cellPtr->j, std::size_t{0});
+    BOOST_CHECK_EQUAL(cellPtr->k, std::size_t{0});
+
+    BOOST_CHECK_CLOSE(cellPtr->depth, 0.0, 1.0e-8);
+
+    BOOST_CHECK_CLOSE(cellPtr->dimensions[0], 0.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(cellPtr->dimensions[1], 0.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(cellPtr->dimensions[2], 0.0, 1.0e-8);
+
+    BOOST_CHECK_MESSAGE(! cellPtr->props.has_value(),
+                        "New cell object must not have property data");
+
+    BOOST_CHECK_MESSAGE(! cellPtr->is_active(), "New cell object must not be active");
+}
+
+BOOST_AUTO_TEST_CASE(Try_Get_Existing)
+{
+    auto cc = Opm::CompletedCells { 10, 10, 3 };
+
+    {
+        auto cellPair = cc.try_get(0, 0, 0);
+
+        auto& props = cellPair.first->props
+            .emplace(Opm::CompletedCells::Cell::Props{});
+
+        props.active_index = 1729;
+        props.permx = 1.1;
+        props.permy = 2.2;
+        props.permz = 3.3;
+        props.poro = -0.123;
+        props.ntg = 5;
+
+        props.satnum = 42;
+        props.pvtnum = -1;
+    }
+
+    auto [cellPtr, is_existing_cell] = cc.try_get(0, 0, 0);
+    BOOST_REQUIRE_MESSAGE(cellPtr != nullptr, "Try_get() existing must generate cell object");
+
+    BOOST_CHECK_MESSAGE(is_existing_cell, "Existing cell must be tagged as such");
+
+    BOOST_CHECK_MESSAGE(cellPtr->props.has_value(),
+                        "Existing cell object must have property data");
+
+    BOOST_CHECK_MESSAGE(cellPtr->is_active(), "Existing cell object must be active");
+
+    BOOST_CHECK_EQUAL(cellPtr->active_index(), 1729);
+    BOOST_CHECK_EQUAL(cellPtr->props->active_index, 1729);
+
+    BOOST_CHECK_CLOSE(cellPtr->props->permx,  1.1  , 1.0e-8);
+    BOOST_CHECK_CLOSE(cellPtr->props->permy,  2.2  , 1.0e-8);
+    BOOST_CHECK_CLOSE(cellPtr->props->permz,  3.3  , 1.0e-8);
+    BOOST_CHECK_CLOSE(cellPtr->props->poro , -0.123, 1.0e-8);
+    BOOST_CHECK_CLOSE(cellPtr->props->ntg  ,  5.0  , 1.0e-8);
+
+    BOOST_CHECK_EQUAL(cellPtr->props->satnum, 42);
+    BOOST_CHECK_EQUAL(cellPtr->props->pvtnum, -1);
+}
+
+BOOST_AUTO_TEST_CASE(Get_Existing)
+{
+    auto cc = Opm::CompletedCells { 10, 10, 3 };
+
+    {
+        auto cellPair = cc.try_get(0, 0, 0);
+
+        auto& props = cellPair.first->props
+            .emplace(Opm::CompletedCells::Cell::Props{});
+
+        props.active_index = 1729;
+        props.permx = 1.1;
+        props.permy = 2.2;
+        props.permz = 3.3;
+        props.poro = -0.123;
+        props.ntg = 5;
+
+        props.satnum = 42;
+        props.pvtnum = -1;
+    }
+
+    const auto& cell = cc.get(0, 0, 0);
+
+    BOOST_CHECK_MESSAGE(cell.props.has_value(),
+                        "Existing cell object must have property data");
+
+    BOOST_CHECK_MESSAGE(cell.is_active(), "Existing cell object must be active");
+
+    BOOST_CHECK_EQUAL(cell.active_index(), 1729);
+    BOOST_CHECK_EQUAL(cell.props->active_index, 1729);
+
+    BOOST_CHECK_CLOSE(cell.props->permx,  1.1  , 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.props->permy,  2.2  , 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.props->permz,  3.3  , 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.props->poro , -0.123, 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.props->ntg  ,  5.0  , 1.0e-8);
+
+    BOOST_CHECK_EQUAL(cell.props->satnum, 42);
+    BOOST_CHECK_EQUAL(cell.props->pvtnum, -1);
+}
+
+BOOST_AUTO_TEST_CASE(Get_Non_Existing)
+{
+    const auto cc = Opm::CompletedCells { 10, 10, 3 };
+
+    BOOST_CHECK_THROW(cc.get(9, 9, 2), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Basic_Operations

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -23,17 +23,22 @@
 
 #include <opm/output/eclipse/InteHEAD.hpp>
 
+#include <opm/io/eclipse/rst/header.hpp>
+
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
-#include <opm/input/eclipse/Parser/ParseContext.hpp>
+
 #include <opm/input/eclipse/Python/Python.hpp>
 
-#include <opm/io/eclipse/rst/header.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
 
 #include <algorithm>
 #include <array>
@@ -513,7 +518,10 @@ namespace {
         const Opm::FieldPropsManager fp(deck, Opm::Phases{true, true, true}, grid, table);
         const Opm::Runspec runspec(deck);
 
-        return Opm::Schedule(deck, grid, fp, runspec, std::make_shared<Opm::Python>());
+        return Opm::Schedule {
+            deck, grid, fp, Opm::NumericalAquifers{},
+            runspec, std::make_shared<Opm::Python>()
+        };
     }
 }
 

--- a/tests/test_ScheduleGrid.cpp
+++ b/tests/test_ScheduleGrid.cpp
@@ -1,0 +1,209 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+
+/*
+  Copyright 2025 Equinor
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE Schedule_Grid
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/input/eclipse/Schedule/ScheduleGrid.hpp>
+
+#include <opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.hpp>
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+
+#include <opm/input/eclipse/Schedule/CompletedCells.hpp>
+
+#include <opm/input/eclipse/Units/Units.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <optional>
+#include <stdexcept>
+
+BOOST_AUTO_TEST_SUITE(Main_Grid_Only)
+
+BOOST_AUTO_TEST_SUITE(No_New_Cell_Objects)
+
+BOOST_AUTO_TEST_CASE(Empty_Cell_Collection)
+{
+    // Recall: CompletedCells collection must be mutable and outlive the
+    // ScheduleGrid.
+    auto cc = Opm::CompletedCells { 10, 10, 3 };
+    const auto grid = Opm::ScheduleGrid { cc };
+
+    BOOST_CHECK_THROW(grid.get_cell(0, 0, 0), std::out_of_range);
+
+    BOOST_CHECK_EQUAL(grid.get_grid(), nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(Empty_Cell_Collection_Unknown_LGR)
+{
+    // Recall: CompletedCells collection must be mutable and outlive the
+    // ScheduleGrid.
+    auto cc = Opm::CompletedCells { 10, 10, 3 };
+    const auto grid = Opm::ScheduleGrid { cc };
+
+    BOOST_CHECK_THROW(grid.get_cell(0, 0, 0, "LGR1"), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE(NonEmpty_Cell_Collection)
+{
+    // Recall: CompletedCells collection must be mutable and outlive the
+    // ScheduleGrid.
+    auto cc = Opm::CompletedCells { 10, 10, 3 };
+
+    {
+        auto cellPair = cc.try_get(0, 0, 0);
+
+        auto& props = cellPair.first->props
+            .emplace(Opm::CompletedCells::Cell::Props{});
+
+        props.active_index = 1729;
+        props.permx = 1.1;
+        props.permy = 2.2;
+        props.permz = 3.3;
+        props.poro = -0.123;
+        props.ntg = 5;
+
+        props.satnum = 42;
+        props.pvtnum = -1;
+    }
+
+    const auto grid = Opm::ScheduleGrid { cc };
+
+    const auto& cell = grid.get_cell(0, 0, 0);
+
+    BOOST_CHECK_MESSAGE(cell.props.has_value(),
+                        "Existing cell object must have property data");
+
+    BOOST_CHECK_MESSAGE(cell.is_active(), "Existing cell object must be active");
+
+    BOOST_CHECK_EQUAL(cell.active_index(), 1729);
+    BOOST_CHECK_EQUAL(cell.props->active_index, 1729);
+
+    BOOST_CHECK_CLOSE(cell.props->permx,  1.1  , 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.props->permy,  2.2  , 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.props->permz,  3.3  , 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.props->poro , -0.123, 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.props->ntg  ,  5.0  , 1.0e-8);
+
+    BOOST_CHECK_EQUAL(cell.props->satnum, 42);
+    BOOST_CHECK_EQUAL(cell.props->pvtnum, -1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // No_New_Cell_Objects
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(With_Existing_Property_Data)
+
+namespace {
+    Opm::Deck singleStrip()
+    {
+        return Opm::Parser{}.parseString(R"(RUNSPEC
+DIMENS
+1 5 2 /
+GRID
+DXV
+100 /
+DYV
+5*50 /
+DZV
+2*10 /
+TOPS
+5*2000 /
+PERMX
+  10 20 30 40  50
+  60 70 80 90 100 /
+PERMY
+  100 200 300 400  500
+  600 700 800 900 1000 /
+PERMZ
+  10 9 8 7 6
+   5 4 3 2 1 /
+PORO
+  0.1 1   0.2 0.9 0.3
+  0.8 0.4 0.7 0.5 0.6 /
+END
+)");
+    }
+
+    struct Case
+    {
+        Case(const Opm::Deck& deck)
+            : es { deck }
+        {}
+
+        Opm::EclipseState es{};
+    };
+
+    auto mD() { return Opm::prefix::milli*Opm::unit::darcy; }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(Insert_New_Cell)
+{
+    const auto cse = Case { singleStrip() };
+
+    auto cc = Opm::CompletedCells { cse.es.getInputGrid() };
+    auto grid = Opm::ScheduleGrid {
+        cse.es.getInputGrid(),
+        cse.es.fieldProps(),
+        cc
+    };
+
+    const auto& cell = grid.get_cell(0, 2, 1);
+
+    BOOST_CHECK_MESSAGE(cell.props.has_value(),
+                        "Existing cell object must have property data");
+
+    BOOST_CHECK_MESSAGE(cell.is_active(), "Existing cell object must be active");
+
+    BOOST_CHECK_EQUAL(cell.global_index, std::size_t{7});
+    BOOST_CHECK_EQUAL(cell.i,            std::size_t{0});
+    BOOST_CHECK_EQUAL(cell.j,            std::size_t{2});
+    BOOST_CHECK_EQUAL(cell.k,            std::size_t{1});
+
+    BOOST_CHECK_CLOSE(cell.dimensions[0], 100.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.dimensions[1],  50.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.dimensions[2],  10.0, 1.0e-8);
+
+    BOOST_CHECK_CLOSE(cell.depth, 2015.0, 1.0e-8);
+
+    BOOST_CHECK_EQUAL(cell.active_index(), 7);
+    BOOST_CHECK_EQUAL(cell.props->active_index, 7);
+
+    BOOST_CHECK_CLOSE(cell.props->permx,  80.0*mD(), 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.props->permy, 800.0*mD(), 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.props->permz,   3.0*mD(), 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.props->poro ,   0.7     , 1.0e-8);
+    BOOST_CHECK_CLOSE(cell.props->ntg  ,   1.0     , 1.0e-8);
+
+    BOOST_CHECK_EQUAL(cell.props->satnum, 1);
+    BOOST_CHECK_EQUAL(cell.props->pvtnum, 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // With_Existing_Property_Data
+
+BOOST_AUTO_TEST_SUITE_END()     // Main_Grid_Only


### PR DESCRIPTION
This PR adds support for numerical aquifers to the main grid portion of the `ScheduleGrid` dynamic container.  In turn, this means we extract properties such as the permability, porosity, and net-to-gross ratio from the numerical aquifer object instead of the main grid's property container if a `CompletedCells::Cell` happens to be in a numerical aquifer.  This enables inferring proper values for the $Kh$ product and the connection length which go into various reports and, importantly, the `SCON` restart file array.  Prior to this, we would risk getting NaN values for these quantities as the main grid's permeability value would be [explicitly reset to zero](https://github.com/OPM/opm-common/blob/09c29a356fa81db03ba2b8a1db500d765941cc40/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp#L2315-L2318) in numerical aquifer cells.

As a practical matter, this change mostly impacts the `WELSPECS` report of the `RPTSCHED` keyword, but since the `Schedule` object's constructor now gets a new `NumericalAquifers` parameter, the overall code change here is rather large and must be accompanied by a downstream PR in the opm-simulators repository.