### PR TITLE
Use numpy.sum instead of sum to fix test with Python 3.12 

### DIFF
--- a/python/tests/test_emodel.py
+++ b/python/tests/test_emodel.py
@@ -48,7 +48,7 @@ class TestEModel(unittest.TestCase):
 
         refVol1 = 2.79083e8
 
-        # The algorithm for sum in Python 3.12 changed to Neumaier summatio
+        # The algorithm for sum in Python 3.12 changed to Neumaier summation
         # which breaks the following test. Using numpy.sum now to get the
         # old behaviour. For 3.11 they yield the same result.
         self.assertTrue( abs((np.sum(celvol1) - refVol1)/refVol1) < 1.0e-5)

--- a/python/tests/test_emodel.py
+++ b/python/tests/test_emodel.py
@@ -48,7 +48,10 @@ class TestEModel(unittest.TestCase):
 
         refVol1 = 2.79083e8
 
-        self.assertTrue( abs((sum(celvol1) - refVol1)/refVol1) < 1.0e-5)
+        # The algorithm for sum in Python 3.12 changed to Neumaier summatio
+        # which breaks the following test. Using numpy.sum now to get the
+        # old behaviour. For 3.11 they yield the same result.
+        self.assertTrue( abs((np.sum(celvol1) - refVol1)/refVol1) < 1.0e-5)
 
         mod1.add_filter("EQLNUM","eq", 1);
         mod1.add_filter("DEPTH","lt", 2645.21);


### PR DESCRIPTION
The sum function in Python 3.12 switched to using Neumaier summation for floats for better accuracy. This broke one of the unit tests. With this change we use numpy.sum to fix the failing test, which still uses the not so accurate summation algorithm of sum as in Python 3.11

Not really a patch that I am proud of. Our way of testing is a bit shaky here.