### PR TITLE
Faster SOURCE lookup with many entries

### DIFF
--- a/opm/input/eclipse/Schedule/Source.cpp
+++ b/opm/input/eclipse/Schedule/Source.cpp
@@ -100,14 +100,10 @@ Source::SourceCell Source::SourceCell::serializationTestObject()
 }
 
 bool Source::SourceCell::operator==(const Source::SourceCell& other) const {
-    return this->isSame(other.component) && 
+    return this->component == other.component && 
            this->rate == other.rate &&
            this->hrate == other.hrate &&
            this->temperature == other.temperature;
-}
-
-bool Source::SourceCell::isSame(const SourceComponent& other) const {
-    return this->component == other;
 }
 
 // Source functions

--- a/opm/input/eclipse/Schedule/Source.cpp
+++ b/opm/input/eclipse/Schedule/Source.cpp
@@ -63,11 +63,10 @@ SourceComponent component(const std::string& s) {
 }
 }
 
+// SourceCell functions
+// --------------------
 using SOURCEKEY = ParserKeywords::SOURCE;
 Source::SourceCell::SourceCell(const DeckRecord& record) :
-    ijk({record.getItem<SOURCEKEY::I>().get<int>(0)-1,
-        record.getItem<SOURCEKEY::J>().get<int>(0)-1,
-        record.getItem<SOURCEKEY::K>().get<int>(0)-1}),
     component(fromstring::component(record.getItem<SOURCEKEY::COMPONENT>().get<std::string>(0))),
     rate(record.getItem<SOURCEKEY::RATE>().getSIDouble(0)),
     hrate(std::nullopt),
@@ -85,7 +84,6 @@ Source::SourceCell::SourceCell(const DeckRecord& record) :
 Source::SourceCell Source::SourceCell::serializationTestObject()
 {
     SourceCell result;
-    result.ijk = {1,1,1};
     result.component = SourceComponent::GAS;
     result.rate = 101.0;
     result.hrate = 201.0;
@@ -93,146 +91,119 @@ Source::SourceCell Source::SourceCell::serializationTestObject()
     return result;
 }
 
-
 bool Source::SourceCell::operator==(const Source::SourceCell& other) const {
-    return this->isSame(other) && 
+    return this->isSame(other.component) && 
            this->rate == other.rate &&
            this->hrate == other.hrate &&
            this->temperature == other.temperature;
 }
 
-bool Source::SourceCell::isSame(const Source::SourceCell& other) const {
-    return this->ijk == other.ijk &&
-           this->component == other.component;
+bool Source::SourceCell::isSame(const SourceComponent& other) const {
+    return this->component == other;
 }
 
-bool Source::SourceCell::isSame(const std::pair<std::array<int, 3>, SourceComponent>& other) const {
-    return this->ijk == other.first &&
-           this->component == other.second;
-}
-
-
+// Source functions
+// ----------------
 void Source::updateSource(const DeckRecord& record)
 {
     const Source::SourceCell sourcenew(record);
-    auto it = std::find_if(m_cells.begin(), m_cells.end(),
-                           [&sourcenew](const auto& source)
-                           {
-                               return source.isSame(sourcenew);
-                           });
+    std::array<int, 3> ijk {record.getItem<SOURCEKEY::I>().get<int>(0)-1, 
+                             record.getItem<SOURCEKEY::J>().get<int>(0)-1,
+                             record.getItem<SOURCEKEY::K>().get<int>(0)-1};
 
+    auto it = m_cells.find(ijk);
     if (it != m_cells.end()) {
-        *it = sourcenew;
+        auto it2 = std::find_if(it->second.begin(), it->second.end(),
+                               [&sourcenew](const auto& source)
+                               {
+                                   return source.isSame(sourcenew.component);
+                               });
+        if (it2 != it->second.end()) {
+            *it2 = sourcenew;
+        }
+        else {
+            it->second.emplace_back(sourcenew);
+        }
     } else {
-        this->m_cells.emplace_back(sourcenew);
+        m_cells.insert({ijk, {sourcenew}});
     }
 }
-
-
 
 Source Source::serializationTestObject()
 {
     Source result;
-    result.m_cells = {SourceCell::serializationTestObject()};
+    std::array<int, 3> ijk = {1,1,1};
+    result.m_cells = {{ijk, {SourceCell::serializationTestObject()}}};
 
     return result;
 }
-
 
 std::size_t Source::size() const {
     return this->m_cells.size();
 }
 
-std::vector<Source::SourceCell>::const_iterator Source::begin() const {
+std::map<std::array<int, 3>, std::vector<Source::SourceCell>>::const_iterator Source::begin() const {
     return this->m_cells.begin();
 }
 
-std::vector<Source::SourceCell>::const_iterator Source::end() const {
+std::map<std::array<int, 3>, std::vector<Source::SourceCell>>::const_iterator Source::end() const {
     return this->m_cells.end();
 }
 
 bool Source::hasSource(const std::array<int, 3>& input) const
 {
-    return std::any_of(m_cells.begin(), m_cells.end(),
-                       [&input](const auto& source)
-                       {
-                           return source.ijk == input;
-                       });
+    return m_cells.find(input) != m_cells.end();
 }
 
-double Source::rate(const std::pair<std::array<int, 3>, SourceComponent>& input) const
+double Source::rate(const std::array<int, 3>& ijk, SourceComponent input) const
 {
-    const auto it = std::find_if(m_cells.begin(), m_cells.end(),
-                                 [&input](const auto& source)
-                                 {
-                                     return source.isSame(input);
-                                 });
-
+    auto it = m_cells.find(ijk);
     if (it != m_cells.end()) {
-        return it->rate;
+        const auto it2 = std::find_if(it->second.begin(), it->second.end(),
+                                     [&input](const auto& source)
+                                     {
+                                         return source.isSame(input);
+                                     });
+                            
+        return (it2 != it->second.end()) ? it2->rate : 0.0;
     }
-
-    return 0.0;
+    else {
+        return 0.0;
+    }
 }
 
-double Source::hrate(const std::pair<std::array<int, 3>, SourceComponent>& input) const
+std::optional<double> Source::hrate(const std::array<int, 3>& ijk, SourceComponent input) const
 {
-    const auto it = std::find_if(m_cells.begin(), m_cells.end(),
-                                 [&input](const auto& source)
-                                 {
-                                     return source.isSame(input);
-                                 });
-
+    auto it = m_cells.find(ijk);
     if (it != m_cells.end()) {
-        return it->hrate.value();
-    }
+        const auto it2 = std::find_if(it->second.begin(), it->second.end(),
+                                     [&input](const auto& source)
+                                     {
+                                         return source.isSame(input);
+                                     });
 
-    return 0.0;
+        return (it2 != it->second.end()) ? it2->hrate : std::nullopt;
+    }
+    else {
+        return std::nullopt;
+    }
 }
 
-bool Source::hasHrate(const std::pair<std::array<int, 3>, SourceComponent>& input) const
+std::optional<double> Source::temperature(const std::array<int, 3>& ijk, SourceComponent input) const
 {
-    const auto it = std::find_if(m_cells.begin(), m_cells.end(),
-                                 [&input](const auto& source)
-                                 {
-                                     return source.isSame(input);
-                                 });
-
+    auto it = m_cells.find(ijk);
     if (it != m_cells.end()) {
-        return it->hrate.has_value();
+        const auto it2 = std::find_if(it->second.begin(), it->second.end(),
+                                     [&input](const auto& source)
+                                     {
+                                         return source.isSame(input);
+                                     });
+
+        return (it2 != it->second.end()) ? it2->temperature : std::nullopt;
     }
-
-    return false;
-}
-
-bool Source::hasTemperature(const std::pair<std::array<int, 3>, SourceComponent>& input) const
-{
-    const auto it = std::find_if(m_cells.begin(), m_cells.end(),
-                                 [&input](const auto& source)
-                                 {
-                                     return source.isSame(input);
-                                 });
-
-    if (it != m_cells.end()) {
-        return it->temperature.has_value();
+    else {
+        return std::nullopt;
     }
-
-    return false;
-}
-
-double Source::temperature(const std::pair<std::array<int, 3>, SourceComponent>& input) const
-{
-    const auto it = std::find_if(m_cells.begin(), m_cells.end(),
-                                 [&input](const auto& source)
-                                 {
-                                     return source.isSame(input);
-                                 });
-
-    if (it != m_cells.end()) {
-        return it->temperature.value();
-    }
-
-    return 0.0;
 }
 
 bool Source::operator==(const Source& other) const {

--- a/opm/input/eclipse/Schedule/Source.hpp
+++ b/opm/input/eclipse/Schedule/Source.hpp
@@ -96,9 +96,6 @@ public:
 
 private:
     std::map<std::array<int, 3>, std::vector<SourceCell>> m_cells;
-
-    std::vector<SourceCell>::iterator findSourceCell(std::vector<SourceCell>& source_vec, SourceComponent input);
-    std::vector<SourceCell>::const_iterator findSourceCell(const std::vector<SourceCell>& source_vec, SourceComponent input) const;
 };
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/Source.hpp
+++ b/opm/input/eclipse/Schedule/Source.hpp
@@ -60,7 +60,6 @@ public:
         static SourceCell serializationTestObject();
 
         bool operator==(const SourceCell& other) const;
-        bool isSame(const SourceComponent& other) const;
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)

--- a/opm/input/eclipse/Schedule/Source.hpp
+++ b/opm/input/eclipse/Schedule/Source.hpp
@@ -25,6 +25,7 @@
 #include <vector>
 #include <cstddef>
 #include <optional>
+#include <map>
 
 namespace Opm {
 
@@ -48,7 +49,6 @@ class Source
 public:
     struct SourceCell
     {
-        std::array<int, 3> ijk{};
         SourceComponent component{SourceComponent::NONE};
         double rate{};
         std::optional<double> hrate{};
@@ -60,13 +60,11 @@ public:
         static SourceCell serializationTestObject();
 
         bool operator==(const SourceCell& other) const;
-        bool isSame(const SourceCell& other) const;
-        bool isSame(const std::pair<std::array<int, 3>, SourceComponent>& other) const;
+        bool isSame(const SourceComponent& other) const;
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
-            serializer(ijk);
             serializer(component);
             serializer(rate);
             serializer(hrate);
@@ -79,24 +77,16 @@ public:
     static Source serializationTestObject();
 
     std::size_t size() const;
-    std::vector<SourceCell>::const_iterator begin() const;
-    std::vector<SourceCell>::const_iterator end() const;
+    std::map<std::array<int, 3>, std::vector<SourceCell>>::const_iterator begin() const;
+    std::map<std::array<int, 3>, std::vector<SourceCell>>::const_iterator end() const;
     bool operator==(const Source& other) const;
 
-    double rate(const std::pair<std::array<int, 3>, SourceComponent>& input ) const;
-    double hrate(const std::pair<std::array<int, 3>, SourceComponent>& input ) const;
-    double temperature(const std::pair<std::array<int, 3>, SourceComponent>& input) const;
-    bool hasHrate(const std::pair<std::array<int, 3>, SourceComponent>& input) const;
-    bool hasTemperature(const std::pair<std::array<int, 3>, SourceComponent>& input) const;
+    double rate(const std::array<int, 3>& ijk, SourceComponent input ) const;
+    std::optional<double> hrate(const std::array<int, 3>& ijk, SourceComponent input ) const;
+    std::optional<double> temperature(const std::array<int, 3>& ijk, SourceComponent input) const;
     bool hasSource(const std::array<int, 3>& input) const;
 
     void updateSource(const DeckRecord& record);
-
-    //! \brief Add a source term for a grid cell.
-    void addSourceCell(const SourceCell& cell)
-    {
-        m_cells.push_back(cell);
-    }
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)
@@ -105,7 +95,7 @@ public:
     }
 
 private:
-    std::vector<SourceCell> m_cells;
+    std::map<std::array<int, 3>, std::vector<SourceCell>> m_cells;
 };
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/Source.hpp
+++ b/opm/input/eclipse/Schedule/Source.hpp
@@ -96,6 +96,9 @@ public:
 
 private:
     std::map<std::array<int, 3>, std::vector<SourceCell>> m_cells;
+
+    std::vector<SourceCell>::iterator findSourceCell(std::vector<SourceCell>& source_vec, SourceComponent input);
+    std::vector<SourceCell>::const_iterator findSourceCell(const std::vector<SourceCell>& source_vec, SourceComponent input) const;
 };
 
 } // namespace Opm

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -6243,12 +6243,12 @@ SOURCE
     {
         size_t currentStep = 0;
         const auto& source = schedule[currentStep].source();
-        BOOST_CHECK_EQUAL(source.size(), 2);
-        double rate11 = source.rate({{0,0,0},Opm::SourceComponent::GAS});
+        BOOST_CHECK_EQUAL(source.size(), 1);  // num cells
+        double rate11 = source.rate({0,0,0},Opm::SourceComponent::GAS);
         BOOST_CHECK_EQUAL(rate11,
                         schedule.getUnits().to_si("Mass/Time", 0.01));
 
-        double rate12 = source.rate({{0,0,0},Opm::SourceComponent::WATER});
+        double rate12 = source.rate({0,0,0},Opm::SourceComponent::WATER);
         BOOST_CHECK_EQUAL(rate12,
                       schedule.getUnits().to_si("Mass/Time", 0.01));
     }
@@ -6256,15 +6256,15 @@ SOURCE
     {
         size_t currentStep = 1;
         const auto& source = schedule[currentStep].source();
-        BOOST_CHECK_EQUAL(source.size(), 3);
-        double rate21 = source.rate({{0,0,0},Opm::SourceComponent::GAS});
+        BOOST_CHECK_EQUAL(source.size(), 2);  // num cells
+        double rate21 = source.rate({0,0,0},Opm::SourceComponent::GAS);
         BOOST_CHECK_EQUAL(rate21,
                         schedule.getUnits().to_si("Mass/Time", 0.02));
-        double rate22 = source.rate({{0,0,0},Opm::SourceComponent::WATER});
+        double rate22 = source.rate({0,0,0},Opm::SourceComponent::WATER);
         BOOST_CHECK_EQUAL(rate22,
                         schedule.getUnits().to_si("Mass/Time", 0.01));
 
-        double rate23 = source.rate({{0,0,1},Opm::SourceComponent::WATER});
+        double rate23 = source.rate({0,0,1},Opm::SourceComponent::WATER);
         BOOST_CHECK_EQUAL(rate23,
                       schedule.getUnits().to_si("Mass/Time", 0.01));
     }

--- a/tests/parser/SourceTests.cpp
+++ b/tests/parser/SourceTests.cpp
@@ -82,39 +82,41 @@ SOURCE
     for (const auto& record : kw[0]) {
         prop.updateSource(record);
     }
-    BOOST_CHECK_EQUAL(prop.size(), 2U);
-    const auto& c1 = *prop.begin();
-    BOOST_CHECK_EQUAL(c1.ijk[0], 0);
-    BOOST_CHECK_EQUAL(c1.ijk[1], 0);
-    BOOST_CHECK_EQUAL(c1.ijk[2], 0);
-    BOOST_CHECK(c1.component == Opm::SourceComponent::GAS);
-    BOOST_CHECK_EQUAL(c1.rate,
+
+    BOOST_CHECK_EQUAL(prop.size(), 1U);  // num cells
+    const auto& c1 = prop.begin();
+    BOOST_CHECK_EQUAL(c1->second.size(), 2U);  // num entries for one cell
+    BOOST_CHECK_EQUAL(c1->first[0], 0);
+    BOOST_CHECK_EQUAL(c1->first[1], 0);
+    BOOST_CHECK_EQUAL(c1->first[2], 0);
+    BOOST_CHECK(c1->second[0].component == Opm::SourceComponent::GAS);
+    BOOST_CHECK_EQUAL(c1->second[0].rate,
                       deck.getActiveUnitSystem().to_si("Mass/Time", 0.01));
 
     BOOST_CHECK(prop.hasSource({0,0,0}));
-    double rate2 = prop.rate({{0,0,0},Opm::SourceComponent::WATER});
+    double rate2 = prop.rate({0,0,0}, Opm::SourceComponent::WATER);
     BOOST_CHECK_EQUAL(rate2,
                       deck.getActiveUnitSystem().to_si("Mass/Time", 0.01));
-
 
     for (const auto& record : kw[1]) {
         prop.updateSource(record);
     }
 
-    BOOST_CHECK_EQUAL(prop.size(), 3U);
-    const auto& c21 = *prop.begin();
-    BOOST_CHECK_EQUAL(c21.ijk[0], 0);
-    BOOST_CHECK_EQUAL(c21.ijk[1], 0);
-    BOOST_CHECK_EQUAL(c21.ijk[2], 0);
-    BOOST_CHECK(c21.component == Opm::SourceComponent::GAS);
-    BOOST_CHECK_EQUAL(c21.rate,
+    BOOST_CHECK_EQUAL(prop.size(), 2U);  // num cells
+    const auto& c21 = prop.begin();
+    BOOST_CHECK_EQUAL(c1->second.size(), 2U);  // num entries for one cell
+    BOOST_CHECK_EQUAL(c21->first[0], 0);
+    BOOST_CHECK_EQUAL(c21->first[1], 0);
+    BOOST_CHECK_EQUAL(c21->first[2], 0);
+    BOOST_CHECK(c21->second[0].component == Opm::SourceComponent::GAS);
+    BOOST_CHECK_EQUAL(c21->second[0].rate,
                       deck.getActiveUnitSystem().to_si("Mass/Time", 0.00));
 
-    double rate22 = prop.rate({{0,0,0},Opm::SourceComponent::WATER});
+    double rate22 = prop.rate({0,0,0}, Opm::SourceComponent::WATER);
     BOOST_CHECK_EQUAL(rate22,
                       deck.getActiveUnitSystem().to_si("Mass/Time", 0.01));
 
-    double rate23 = prop.rate({{0,0,1},Opm::SourceComponent::WATER});
+    double rate23 = prop.rate({0,0,1}, Opm::SourceComponent::WATER);
     BOOST_CHECK_EQUAL(rate23,
                       deck.getActiveUnitSystem().to_si("Mass/Time", 0.02));
     
@@ -177,21 +179,23 @@ SOURCE
         prop.updateSource(record);
     }
 
-    BOOST_CHECK_EQUAL(prop.size(), 1U);
-    const auto& c1 = *prop.begin();
-    BOOST_CHECK(c1.component == Opm::SourceComponent::GAS);
-    BOOST_CHECK_EQUAL(c1.rate,
+    BOOST_CHECK_EQUAL(prop.size(), 1U);  // num cells
+    const auto& c1 = prop.begin();
+    BOOST_CHECK_EQUAL(c1->second.size(), 1U);  // num entries per cell
+    BOOST_CHECK(c1->second[0].component == Opm::SourceComponent::GAS);
+    BOOST_CHECK_EQUAL(c1->second[0].rate,
                       deck.getActiveUnitSystem().to_si("Mass/Time", 0.01));
 
-    BOOST_CHECK_EQUAL(c1.hrate.value(),
+    BOOST_CHECK_EQUAL(c1->second[0].hrate.value(),
                       deck.getActiveUnitSystem().to_si("Energy/Time", 1.0));
 
-    double rate = prop.rate({{0,0,0},Opm::SourceComponent::GAS});
+    double rate = prop.rate({0,0,0}, Opm::SourceComponent::GAS);
     BOOST_CHECK_EQUAL(rate,
                       deck.getActiveUnitSystem().to_si("Mass/Time", 0.01));
 
-    double hrate = prop.hrate({{0,0,0}, Opm::SourceComponent::GAS});
-    BOOST_CHECK_EQUAL(hrate,
+    auto hrate = prop.hrate({0,0,0}, Opm::SourceComponent::GAS);
+    BOOST_CHECK(hrate);
+    BOOST_CHECK_EQUAL(hrate.value(),
                       deck.getActiveUnitSystem().to_si("Energy/Time", 1.0));
 
 
@@ -199,35 +203,36 @@ SOURCE
         prop.updateSource(record);
     }
 
-    BOOST_CHECK_EQUAL(prop.size(), 2U);
-    const auto& c21 = *prop.begin();
-    BOOST_CHECK(c21.component == Opm::SourceComponent::GAS);
-    BOOST_CHECK_EQUAL(c21.rate,
+    BOOST_CHECK_EQUAL(prop.size(), 1U);  // num cells
+    const auto& c21 = prop.begin();
+    BOOST_CHECK_EQUAL(c21->second.size(), 2U);  // num entries per cell
+    BOOST_CHECK(c21->second[0].component == Opm::SourceComponent::GAS);
+    BOOST_CHECK_EQUAL(c21->second[0].rate,
                       deck.getActiveUnitSystem().to_si("Mass/Time", 0.01));
 
-    BOOST_CHECK_EQUAL(c21.hrate.value(),
+    BOOST_CHECK_EQUAL(c21->second[0].hrate.value(),
                       deck.getActiveUnitSystem().to_si("Energy/Time", 1.0));
 
-    double rate21 = prop.rate({{0,0,0},Opm::SourceComponent::GAS});
-    BOOST_CHECK_EQUAL(rate21, c21.rate);
-    double rate22 = prop.rate({{0,0,0},Opm::SourceComponent::WATER});
+    double rate21 = prop.rate({0,0,0}, Opm::SourceComponent::GAS);
+    BOOST_CHECK_EQUAL(rate21, c21->second[0].rate);
+    double rate22 = prop.rate({0,0,0}, Opm::SourceComponent::WATER);
     BOOST_CHECK_EQUAL(rate22,
                       deck.getActiveUnitSystem().to_si("Mass/Time", 0.02));
-    BOOST_CHECK(prop.hasHrate({{0,0,0}, Opm::SourceComponent::WATER}));
-    double hrate2 = prop.hrate({{0,0,0}, Opm::SourceComponent::WATER});
-    BOOST_CHECK_EQUAL(hrate2, deck.getActiveUnitSystem().to_si("Energy/Time", 2.0)); 
+    auto hrate2 = prop.hrate({0,0,0}, Opm::SourceComponent::WATER);
+    BOOST_CHECK(hrate2);
+    BOOST_CHECK_EQUAL(hrate2.value(), deck.getActiveUnitSystem().to_si("Energy/Time", 2.0)); 
 
     for (const auto& record : kw[2]) {
         prop.updateSource(record);
     }
 
-    BOOST_CHECK_EQUAL(prop.size(), 2U);
-    BOOST_CHECK(!prop.hasHrate({{0,0,0}, Opm::SourceComponent::GAS}));
-    BOOST_CHECK(!prop.hasHrate({{0,0,0}, Opm::SourceComponent::WATER}));
-    BOOST_CHECK(prop.hasTemperature({{0,0,0}, Opm::SourceComponent::GAS}));
-    BOOST_CHECK(prop.hasTemperature({{0,0,0}, Opm::SourceComponent::WATER}));
-    double temp1 = prop.temperature({{0,0,0}, Opm::SourceComponent::GAS});
-    BOOST_CHECK_EQUAL(temp1, 50 + 273.15);
-    double temp2 = prop.temperature({{0,0,0}, Opm::SourceComponent::WATER});
-    BOOST_CHECK_EQUAL(temp2, 273.15 + 100);   
+    BOOST_CHECK_EQUAL(prop.size(), 1U);  // num cells
+    BOOST_CHECK(!prop.hrate({0,0,0}, Opm::SourceComponent::GAS));
+    BOOST_CHECK(!prop.hrate({0,0,0}, Opm::SourceComponent::WATER));
+    auto temp1 = prop.temperature({0,0,0}, Opm::SourceComponent::GAS);
+    BOOST_CHECK(temp1);
+    BOOST_CHECK_EQUAL(temp1.value(), 50 + 273.15);
+    auto temp2 = prop.temperature({0,0,0}, Opm::SourceComponent::WATER);
+    BOOST_CHECK(temp2);
+    BOOST_CHECK_EQUAL(temp2.value(), 273.15 + 100);   
 }


### PR DESCRIPTION
With many entries in SOURCE, which can be the case when coupling other simulators to Flow, looking up a vector was very slow. Changing the structure to std::map makes looking up ijk indices much faster.

Removed the functions "hasHrate" and "hasTemperature" since "hrate" and "temperature" functions now return std::optional which can be used for checking instead.

Companion PR: https://github.com/OPM/opm-simulators/pull/6140