### PR TITLE
Add New Keyword for Hydraulic Fracturing Seeds at Well Connections

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -327,6 +327,7 @@ if(ENABLE_ECL_INPUT)
     opm/input/eclipse/Schedule/Well/WellEconProductionLimits.cpp
     opm/input/eclipse/Schedule/Well/WellEnums.cpp
     opm/input/eclipse/Schedule/Well/WellFoamProperties.cpp
+    opm/input/eclipse/Schedule/Well/WellFractureSeeds.cpp
     opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
     opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
     opm/input/eclipse/Schedule/Well/WellMatcher.cpp
@@ -534,6 +535,7 @@ if(ENABLE_ECL_INPUT)
     tests/test_PAvgCalculator.cpp
     tests/test_PAvgDynamicSourceData.cpp
     tests/test_Serialization.cpp
+    tests/test_WellFractureSeeds.cpp
     tests/material/test_co2brinepvt.cpp
     tests/material/test_h2brinepvt.cpp
     tests/material/test_hysteresis.cpp
@@ -1388,6 +1390,7 @@ if(ENABLE_ECL_INPUT)
        opm/input/eclipse/Schedule/Well/WListManager.hpp
        opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp
        opm/input/eclipse/Schedule/Well/WellFoamProperties.hpp
+       opm/input/eclipse/Schedule/Well/WellFractureSeeds.hpp
        opm/input/eclipse/Schedule/Well/WellBrineProperties.hpp
        opm/input/eclipse/Schedule/Well/WellMICPProperties.hpp
        opm/input/eclipse/Schedule/Well/WellPolymerProperties.hpp

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -86,6 +86,7 @@ namespace Opm {
     class UDQActive;
     class UDQConfig;
     class Well;
+    class WellFractureSeeds;
     class WellTestConfig;
     class WListManager;
 
@@ -498,6 +499,11 @@ namespace Opm {
         map_member<int, VFPInjTable> vfpinj;
         map_member<std::string, Group> groups;
         map_member<std::string, Well> wells;
+
+        /// Well fracturing seed points and associate fracture plane normal
+        /// vectors.
+        map_member<std::string, WellFractureSeeds> wseed;
+
         // constant flux aquifers
         std::unordered_map<int, SingleAquiferFlux> aqufluxs;
         BCProp bcprop;
@@ -537,6 +543,7 @@ namespace Opm {
             serializer(vfpinj);
             serializer(groups);
             serializer(wells);
+            serializer(wseed);
             serializer(aqufluxs);
             serializer(bcprop);
             serializer(inj_streams);

--- a/opm/input/eclipse/Schedule/Well/WellFractureSeeds.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellFractureSeeds.cpp
@@ -1,0 +1,158 @@
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/Schedule/Well/WellFractureSeeds.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <numeric>
+#include <vector>
+
+bool Opm::WellFractureSeeds::updateSeed(const std::size_t   seedCellGlobal,
+                                        const NormalVector& seedNormal)
+{
+    const auto ix = this->seedIndex(seedCellGlobal);
+
+    if (ix == this->seedCell_.size()) {
+        return this->insertNewSeed(seedCellGlobal, seedNormal);
+    }
+    else {
+        return this->updateExistingSeed(ix, seedNormal);
+    }
+}
+
+void Opm::WellFractureSeeds::finalizeSeeds()
+{
+    this->establishLookup();
+}
+
+const Opm::WellFractureSeeds::NormalVector*
+Opm::WellFractureSeeds::getNormal(const SeedCell& c) const
+{
+    const auto ix = this->seedIndex(c.c);
+
+    if (ix == this->seedNormal_.size()) {
+        return nullptr;
+    }
+    else {
+        return &this->seedNormal_[ix];
+    }
+}
+
+bool Opm::WellFractureSeeds::operator==(const WellFractureSeeds& that) const
+{
+    return (this->wellName_ == that.wellName_)
+        && (this->seedCell_ == that.seedCell_)
+        && (this->seedNormal_ == that.seedNormal_)
+        && (this->lookup_ == that.lookup_)
+        ;
+}
+
+Opm::WellFractureSeeds Opm::WellFractureSeeds::serializationTestObject()
+{
+    auto s = WellFractureSeeds { "testwell" };
+
+    s.seedCell_.push_back(1729);
+    s.seedNormal_.push_back({ 1.1, -2.2, 3.3 });
+    s.lookup_.push_back(0);
+
+    return s;
+}
+
+// ===========================================================================
+// Private member functions of class WellFractureSeeds below separator
+// ===========================================================================
+
+void Opm::WellFractureSeeds::establishLookup()
+{
+    this->lookup_.assign(this->seedNormal_.size(), NormalVectorIx{});
+    std::iota(this->lookup_.begin(), this->lookup_.end(), NormalVectorIx{});
+
+    std::sort(this->lookup_.begin(), this->lookup_.end(),
+              [this](const auto i1, const auto i2)
+              { return this->seedCell_[i1] < this->seedCell_[i2]; });
+}
+
+Opm::WellFractureSeeds::NormalVectorIx
+Opm::WellFractureSeeds::seedIndex(const std::size_t seedCellGlobal) const
+{
+    assert (this->seedCell_.size() == this->seedNormal_.size());
+
+    if (this->lookup_.size() == this->seedNormal_.size()) {
+        return this->seedIndexBinarySearch(seedCellGlobal);
+    }
+    else {
+        return this->seedIndexLinearSearch(seedCellGlobal);
+    }
+}
+
+Opm::WellFractureSeeds::NormalVectorIx
+Opm::WellFractureSeeds::seedIndexBinarySearch(const std::size_t seedCellGlobal) const
+{
+    assert (this->lookup_.size() == this->seedCell_.size());
+
+    auto ixPos = std::lower_bound(this->lookup_.begin(),
+                                  this->lookup_.end(),
+                                  seedCellGlobal,
+                                  [this](const auto ix, const std::size_t search)
+                                  { return this->seedCell_[ix] < search; });
+
+    if ((ixPos == this->lookup_.end()) ||
+        (this->seedCell_[*ixPos] != seedCellGlobal))
+    {
+        return this->seedCell_.size();
+    }
+    else {
+        return *ixPos;
+    }
+}
+
+Opm::WellFractureSeeds::NormalVectorIx
+Opm::WellFractureSeeds::seedIndexLinearSearch(const std::size_t seedCellGlobal) const
+{
+    auto cellPos = std::find(this->seedCell_.begin(),
+                             this->seedCell_.end(),
+                             seedCellGlobal);
+
+    return (cellPos == this->seedCell_.end())
+        ? this->seedCell_.size()
+        : std::distance(this->seedCell_.begin(), cellPos);
+}
+
+bool Opm::WellFractureSeeds::insertNewSeed(const std::size_t   seedCellGlobal,
+                                           const NormalVector& seedNormal)
+{
+    this->seedCell_.push_back(seedCellGlobal);
+    this->seedNormal_.push_back(seedNormal);
+    this->lookup_.clear();
+
+    return true;
+}
+
+bool Opm::WellFractureSeeds::updateExistingSeed(const NormalVectorIx ix,
+                                                const NormalVector&  seedNormal)
+{
+    const auto isDifferent = this->seedNormal_[ix] != seedNormal;
+
+    this->seedNormal_[ix] = seedNormal;
+
+    return isDifferent;
+}

--- a/opm/input/eclipse/Schedule/Well/WellFractureSeeds.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellFractureSeeds.hpp
@@ -1,0 +1,248 @@
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_WELL_FRACTURE_SEED_HPP_INCLUDED
+#define OPM_WELL_FRACTURE_SEED_HPP_INCLUDED
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace Opm {
+
+/// Fracture seed points attached to a single well.
+class WellFractureSeeds
+{
+public:
+    /// Disambiguating type for requesting fracture plane normal vectors
+    /// based on insertion indices.
+    struct SeedIndex
+    {
+        /// Insertion/record index.
+        std::size_t i{};
+    };
+
+    /// Disambiguating type for requesting fracture plane normal vectors
+    /// based on Cartesian cell indices.
+    struct SeedCell
+    {
+        /// Cartesian cell index.
+        std::size_t c{};
+    };
+
+    /// Type alias for the normal vector at a single seed point.
+    using NormalVector = std::array<double, 3>;
+
+    /// Default constructor.
+    ///
+    /// Forms an object which is mostly usable as the destination of a
+    /// deserialisation operation.
+    WellFractureSeeds() = default;
+
+    /// Constructor.
+    ///
+    /// \param[in] wellName Named well to which this seed collection is
+    /// associated.
+    explicit WellFractureSeeds(const std::string& wellName)
+        : wellName_ { wellName }
+    {}
+
+    /// Named well to which this seed collection is associated.
+    ///
+    /// Exists mostly to meet interface requirements of class
+    /// ScheduleState::map_member<>.
+    const std::string& name() const
+    {
+        return this->wellName_;
+    }
+
+    /// Insert or update a fracture seed in current collection.
+    ///
+    /// \param[in] seedCellGlobal Linearised Cartesian cell index.  Should
+    /// typically correspond to a reservoir connection for the named well.
+    ///
+    /// \param[in] seedNormal Fracturing plane's normal vector.  Need not be
+    /// a unit normal as far as class WellFractureSeeds goes, but subsequent
+    /// uses may prefer unit normals.
+    ///
+    /// \return Whether or not a seed was inserted/updated.  Typically
+    /// 'true'.
+    bool updateSeed(const std::size_t   seedCellGlobal,
+                    const NormalVector& seedNormal);
+
+    /// Establish accelerator structure for LOG(n) normal vector lookup
+    /// based on Cartesian cell indices.
+    ///
+    /// This is an optimisation that requires more memory in the object, and
+    /// you should call this function only when all updateSeed() calls have
+    /// been made.  You do not need to call this function in order to use
+    /// the object, but it will reduce the cost of those kinds of lookup.
+    /// If you do not call this function, then normal vector lookup based on
+    /// Cartesian cell indices will use a linear search.
+    void finalizeSeeds();
+
+    /// Predicate for empty fracture seed collection.
+    ///
+    /// \return Whether or not the current collection is empty.
+    bool empty() const { return this->seedCell_.empty(); }
+
+    /// Number of fracture seeds in the current collection.
+    auto numSeeds() const { return this->seedCell_.size(); }
+
+    /// Look up fracturing plane normal vector based on Cartesian cell index.
+    ///
+    /// \param[in] c Cartesian cell index.
+    ///
+    /// \return Fracturing plane normal vector in cell \p c.  Not guaranteed
+    /// to be a unit normal vector.  Nullptr if no seed exists in cell \p c.
+    const NormalVector* getNormal(const SeedCell& c) const;
+
+    /// Retrieve fracturing plane normal vector based on insertion
+    /// order/record index.
+    ///
+    /// Should normally be used in conjunction with member function
+    /// seedCells() only.
+    ///
+    /// \param[in] i Insertion order.  Should be in the range [0
+    /// .. numSeeds()).
+    ///
+    /// \return Fracturing plane normal vector in seed cell inserted as the
+    /// \p i-th unique cell index.  Not guaranteed to be a unit normal vector.
+    const NormalVector& getNormal(const SeedIndex& i) const
+    {
+        return this->seedNormal_[i.i];
+    }
+
+    /// Retrieve this collection's fracture seed cells
+    ///
+    /// \return Sequence of Cartesian cell indices.  The normal vector of
+    /// the fracturing plane in cell \code seedCells()[i] \endcode is \code
+    /// getNormal(SeedIndex{i}) \endcode.
+    const std::vector<std::size_t>& seedCells() const
+    {
+        return this->seedCell_;
+    }
+
+    /// Equality predicate.
+    ///
+    /// \param[in] that Object against which \code *this \endcode will be
+    /// tested for equality.
+    ///
+    /// \return Whether or not \code *this \endcode is the same as \p that.
+    bool operator==(const WellFractureSeeds& that) const;
+
+    /// Create a serialisation test object.
+    static WellFractureSeeds serializationTestObject();
+
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
+    template <class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(this->wellName_);
+        serializer(this->seedCell_);
+        serializer(this->seedNormal_);
+        serializer(this->lookup_);
+    }
+
+private:
+    using NormalVectorIx = std::vector<NormalVector>::size_type;
+
+    /// Named well to which this fracture seed collection is associated.
+    ///
+    /// Mostly exists to meet the interface requirement of class
+    /// ScheduleState::map_member<>.
+    std::string wellName_{};
+
+    /// Cartesian indices in insertion order of this collection fracture
+    /// seed cells.
+    std::vector<std::size_t> seedCell_{};
+
+    /// Fracturing plane normal vectors for all seed cells.
+    std::vector<NormalVector> seedNormal_{};
+
+    /// Binary search lookup structure.
+    ///
+    /// Indices into seedCell_ and seedNormal_ ordered by seedCell_ values.
+    std::vector<NormalVectorIx> lookup_{};
+
+    /// Back end for finalizeSeeds().
+    ///
+    /// Builds the lookup_ array to enable using binary search for Cartesian
+    /// cells.
+    void establishLookup();
+
+    /// Compute insertion order index for Cartesian cell index.
+    ///
+    /// Switches between linear and binary search based on availability of
+    /// lookup_ data.
+    ///
+    /// \param[in] seedCellGlobal Linearised Cartesian cell index.
+    ///
+    /// \return Insertion order index for \p seedCellGlobal.  Returns
+    /// numSeeds() if \p seedCellGlobal does not exist in seedCell_.
+    NormalVectorIx seedIndex(const std::size_t seedCellGlobal) const;
+
+    /// Compute insertion order index for Cartesian cell index using binary
+    /// search.
+    ///
+    /// \param[in] seedCellGlobal Linearised Cartesian cell index.
+    ///
+    /// \return Insertion order index for \p seedCellGlobal.  Returns
+    /// numSeeds() if \p seedCellGlobal does not exist in seedCell_.
+    NormalVectorIx seedIndexBinarySearch(const std::size_t seedCellGlobal) const;
+
+    /// Compute insertion order index for Cartesian cell index using linear
+    /// search.
+    ///
+    /// \param[in] seedCellGlobal Linearised Cartesian cell index.
+    ///
+    /// \return Insertion order index for \p seedCellGlobal.  Returns
+    /// numSeeds() if \p seedCellGlobal does not exist in seedCell_.
+    NormalVectorIx seedIndexLinearSearch(const std::size_t seedCellGlobal) const;
+
+    /// Insert a new seed cell and associate normal vector into collection.
+    ///
+    /// Invalidates lookup_ data.
+    ///
+    /// \param[in] Linearised Cartesian cell index
+    ///
+    /// \param[in] seedNormal Fracturing plane's normal vector.
+    ///
+    /// \return Whether or not a seed was inserted/updated.  Typically
+    /// 'true'.
+    bool insertNewSeed(const std::size_t seedCellGlobal, const NormalVector& seedNormal);
+
+    /// Update normal vector direction of an existing seed cell.
+    ///
+    /// \param[in] ix Insertion order index for an existing seed cell.
+    /// Typically computed by seedIndex().
+    ///
+    /// \param[in] seedNormal Fracturing plane's normal vector.
+    ///
+    /// \return Whether or not the normal vector for seed \p ix was updated.
+    bool updateExistingSeed(const NormalVectorIx ix, const NormalVector& seedNormal);
+};
+
+} // namespace Opm
+
+#endif // OPM_WELL_FRACTURE_SEED_HPP_INCLUDED

--- a/opm/input/eclipse/share/keywords/900_OPM/W/WSEED
+++ b/opm/input/eclipse/share/keywords/900_OPM/W/WSEED
@@ -1,0 +1,47 @@
+{
+  "name": "WSEED",
+  "sections": [
+    "SCHEDULE"
+  ],
+  "requires": ["MECH"],
+  "items": [
+    {
+      "item": 1,
+      "name": "WELL",
+      "value_type": "STRING"
+    },
+    {
+      "item": 2,
+      "name": "I",
+      "value_type": "INT"
+    },
+    {
+      "item": 3,
+      "name": "J",
+      "value_type": "INT"
+    },
+    {
+      "item": 4,
+      "name": "K",
+      "value_type": "INT"
+    },
+    {
+      "item": 5,
+      "name": "NORMAL_X",
+      "value_type": "DOUBLE",
+      "dimension": "Length"
+    },
+    {
+      "item": 6,
+      "name": "NORMAL_Y",
+      "value_type": "DOUBLE",
+      "dimension": "Length"
+    },
+    {
+      "item": 7,
+      "name": "NORMAL_Z",
+      "value_type": "DOUBLE",
+      "dimension": "Length"
+    }
+  ]
+}

--- a/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1198,4 +1198,6 @@ set( keywords
      900_OPM/W/WINJFCNC
      900_OPM/W/WMICP
      900_OPM/W/WPMITAB
-     900_OPM/W/WSKPTAB)
+     900_OPM/W/WSEED
+     900_OPM/W/WSKPTAB
+   )

--- a/tests/parser/ScheduleSerializeTest.cpp
+++ b/tests/parser/ScheduleSerializeTest.cpp
@@ -72,6 +72,7 @@
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellFoamProperties.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellFractureSeeds.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMICPProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellPolymerProperties.hpp>
@@ -317,7 +318,9 @@ DATES             -- 7
 /
 )";
 
-static Schedule make_schedule(const std::string& deck_string)
+namespace {
+
+Schedule make_schedule(const std::string& deck_string)
 {
     const auto deck = Parser{}.parseString(deck_string);
     EclipseGrid grid(10,10,10);
@@ -329,6 +332,8 @@ static Schedule make_schedule(const std::string& deck_string)
         runspec, std::make_shared<Python>()
     };
 }
+
+} // Anonymous namespace
 
 BOOST_AUTO_TEST_CASE(SerializeWTest)
 {

--- a/tests/test_Serialization.cpp
+++ b/tests/test_Serialization.cpp
@@ -144,6 +144,7 @@
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellFoamProperties.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellFractureSeeds.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMICPProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellPolymerProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>
@@ -345,6 +346,7 @@ TEST_FOR_TYPE(WellBrineProperties)
 TEST_FOR_TYPE(WellConnections)
 TEST_FOR_TYPE(WellEconProductionLimits)
 TEST_FOR_TYPE(WellFoamProperties)
+TEST_FOR_TYPE(WellFractureSeeds)
 TEST_FOR_TYPE_NAMED(Well::WellGuideRate, WellGuideRate)
 TEST_FOR_TYPE_NAMED(Well::WellInjectionProperties, WellInjectionProperties)
 TEST_FOR_TYPE(WellPolymerProperties)

--- a/tests/test_WellFractureSeeds.cpp
+++ b/tests/test_WellFractureSeeds.cpp
@@ -1,0 +1,676 @@
+/*
+  Copyright 2025 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE Well_Fracture_Seeds
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/input/eclipse/Schedule/Well/WellFractureSeeds.hpp>
+
+#include <array>
+#include <cstddef>
+#include <utility>
+
+using NormalVector = Opm::WellFractureSeeds::NormalVector;
+
+BOOST_AUTO_TEST_SUITE(Insert_Unique)
+
+BOOST_AUTO_TEST_CASE(Single_Seed)
+{
+    auto seeds = Opm::WellFractureSeeds { "W1" };
+
+    BOOST_CHECK_EQUAL(seeds.name(), "W1");
+    BOOST_CHECK_MESSAGE(seeds.empty(), "Default constructed WellFractureSeeds object must be empty");
+
+    BOOST_CHECK_MESSAGE(seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }),
+                        "Inserting into empty collection must succeed");
+
+    BOOST_CHECK_EQUAL(seeds.numSeeds(), std::size_t{1});
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = seeds.seedCells();
+        const auto expect = std::vector { std::size_t{1729} };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+
+    seeds.finalizeSeeds();
+
+    BOOST_CHECK_EQUAL(seeds.name(), "W1");
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = seeds.seedCells();
+        const auto expect = std::vector { std::size_t{1729} };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Copy_Constructor)
+{
+    auto seeds = Opm::WellFractureSeeds { "W1" };
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+
+    const auto s2 = seeds;
+
+    BOOST_CHECK_MESSAGE(seeds == s2, "Copy constructed seeds object must be equal");
+
+    BOOST_CHECK_EQUAL(s2.numSeeds(), std::size_t{1});
+
+    {
+        const auto* n = s2.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = s2.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = s2.seedCells();
+        const auto expect = std::vector { std::size_t{1729} };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Move_Constructor)
+{
+    auto seeds = Opm::WellFractureSeeds { "W1" };
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+
+    const auto s2 = std::move(seeds);
+
+    BOOST_CHECK_EQUAL(s2.numSeeds(), std::size_t{1});
+
+    {
+        const auto* n = s2.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = s2.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = s2.seedCells();
+        const auto expect = std::vector { std::size_t{1729} };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Assignment_Operator)
+{
+    auto seeds = Opm::WellFractureSeeds { "W1" };
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+
+    auto s2 = Opm::WellFractureSeeds { "W2" };
+    s2.updateSeed(2718, NormalVector { 0.0, -1.0, 0.0 });
+
+    s2 = seeds;
+
+    BOOST_CHECK_MESSAGE(seeds == s2, "Directly assigned seeds object must be equal");
+
+    BOOST_CHECK_EQUAL(s2.numSeeds(), std::size_t{1});
+
+    {
+        const auto* n = s2.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = s2.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = s2.seedCells();
+        const auto expect = std::vector { std::size_t{1729} };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Move_Assignment_Operator)
+{
+    auto seeds = Opm::WellFractureSeeds { "W1" };
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+
+    auto s2 = Opm::WellFractureSeeds { "W2" };
+    s2.updateSeed(2718, NormalVector { 0.0, -1.0, 0.0 });
+
+    s2 = std::move(seeds);
+
+    BOOST_CHECK_EQUAL(s2.numSeeds(), std::size_t{1});
+
+    {
+        const auto* n = s2.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = s2.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = s2.seedCells();
+        const auto expect = std::vector { std::size_t{1729} };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Request_Missing_Seed)
+{
+    auto seeds = Opm::WellFractureSeeds { "W1" };
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+
+    BOOST_CHECK_EQUAL(seeds.numSeeds(), std::size_t{1});
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 271828 });
+        BOOST_CHECK_MESSAGE(n == nullptr, "Normal vector in non-existing seed cell must be null");
+    }
+
+    seeds.finalizeSeeds();
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 314159 });
+        BOOST_CHECK_MESSAGE(n == nullptr, "Normal vector in non-existing seed cell must be null");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Seeds)
+{
+    auto seeds = Opm::WellFractureSeeds { "W1" };
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+    seeds.updateSeed(1122, NormalVector { 0.0, 1.0, 0.0 });
+    seeds.updateSeed(3344, NormalVector { 0.0, 0.0, 1.0 });
+
+    BOOST_CHECK_EQUAL(seeds.numSeeds(), std::size_t{3});
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1122 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 3344 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 1.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 1 });
+
+        BOOST_CHECK_CLOSE(n[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 2 });
+
+        BOOST_CHECK_CLOSE(n[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 1.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = seeds.seedCells();
+        const auto expect = std::vector {
+            std::size_t{1729},
+            std::size_t{1122},
+            std::size_t{3344},
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+
+    seeds.finalizeSeeds();
+
+    BOOST_CHECK_EQUAL(seeds.name(), "W1");
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1122 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 3344 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 1.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 1 });
+
+        BOOST_CHECK_CLOSE(n[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 2 });
+
+        BOOST_CHECK_CLOSE(n[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 1.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = seeds.seedCells();
+        const auto expect = std::vector {
+            std::size_t{1729},
+            std::size_t{1122},
+            std::size_t{3344},
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Insert_Unique
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Insert_Duplicate)
+
+BOOST_AUTO_TEST_CASE(Different_Normal_Vectors)
+{
+    auto seeds = Opm::WellFractureSeeds { "W1" };
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+
+    BOOST_CHECK_MESSAGE(seeds.updateSeed(1729, NormalVector { 0.0, -1.0, 0.0 }),
+                        "Updating seed with different "
+                        "normal vector must succeed");
+
+    BOOST_CHECK_EQUAL(seeds.numSeeds(), std::size_t{1});
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0],  0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], -1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2],  0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0],  0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], -1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2],  0.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = seeds.seedCells();
+        const auto expect = std::vector { std::size_t{1729} };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+
+    seeds.finalizeSeeds();
+
+    BOOST_CHECK_EQUAL(seeds.name(), "W1");
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0],  0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], -1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2],  0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0],  0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], -1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2],  0.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = seeds.seedCells();
+        const auto expect = std::vector { std::size_t{1729} };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Same_Normal_Vector)
+{
+    auto seeds = Opm::WellFractureSeeds { "W1" };
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+
+    BOOST_CHECK_MESSAGE(! seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 }),
+                        "Updating seed with same "
+                        "normal vector must NOT succeed");
+
+    BOOST_CHECK_EQUAL(seeds.numSeeds(), std::size_t{1});
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = seeds.seedCells();
+        const auto expect = std::vector { std::size_t{1729} };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+
+    seeds.finalizeSeeds();
+
+    BOOST_CHECK_EQUAL(seeds.name(), "W1");
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = seeds.seedCells();
+        const auto expect = std::vector { std::size_t{1729} };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Seeds_Different_Normals)
+{
+    auto seeds = Opm::WellFractureSeeds { "W1" };
+    seeds.updateSeed(1729, NormalVector { 1.0, 0.0, 0.0 });
+    seeds.updateSeed(1122, NormalVector { 0.0, 1.0, 0.0 });
+    seeds.updateSeed(3344, NormalVector { 0.0, 0.0, 1.0 });
+    seeds.updateSeed(1729, NormalVector { 0.0, 0.0, 1.1 });
+
+    BOOST_CHECK_EQUAL(seeds.numSeeds(), std::size_t{3});
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 1.1, 1.0e-8);
+    }
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1122 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 3344 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 1.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 1.1, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 1 });
+
+        BOOST_CHECK_CLOSE(n[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 2 });
+
+        BOOST_CHECK_CLOSE(n[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 1.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = seeds.seedCells();
+        const auto expect = std::vector {
+            std::size_t{1729},
+            std::size_t{1122},
+            std::size_t{3344},
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+
+    seeds.finalizeSeeds();
+
+    BOOST_CHECK_EQUAL(seeds.name(), "W1");
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1729 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 1.1, 1.0e-8);
+    }
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 1122 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto* n = seeds.getNormal(Opm::WellFractureSeeds::SeedCell { 3344 });
+        BOOST_CHECK_MESSAGE(n != nullptr, "Normal vector in existing seed cell must not be null");
+
+        BOOST_CHECK_CLOSE((*n)[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE((*n)[2], 1.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 0 });
+
+        BOOST_CHECK_CLOSE(n[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 1.1, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 1 });
+
+        BOOST_CHECK_CLOSE(n[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 1.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 0.0, 1.0e-8);
+    }
+
+    {
+        const auto& n = seeds.getNormal(Opm::WellFractureSeeds::SeedIndex { 2 });
+
+        BOOST_CHECK_CLOSE(n[0], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[1], 0.0, 1.0e-8);
+        BOOST_CHECK_CLOSE(n[2], 1.0, 1.0e-8);
+    }
+
+    {
+        const auto& c = seeds.seedCells();
+        const auto expect = std::vector {
+            std::size_t{1729},
+            std::size_t{1122},
+            std::size_t{3344},
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Insert_Duplicate


### PR DESCRIPTION
This PR introduces a new, OPM specific, SCHEDULE section keyword
```
WSEED
```
for use in defining seed points for hydraulic fracturing.  This keyword is limited to use in the context of runs that enable geomechanical processing through the `MECH` keyword in the RUNSPEC section.  When enabled, the `WSEED` keyword has the following general structure
```
WSEED
  WellName  I J K  nx ny nz /
  WellName  I J K  nx ny nz /
-- ...
  WellName  I J K  nx ny nz /
/
```
in which `WellName` is a well name, a well name template, a well list, or a well list template.  I,J,K are coordinates of existing reservoir connections (COMPDAT keyword) and nx,ny,nz are components of a vector normal to fracturing plane.  They need not be a unit vector.  All keyword items are required.

We collect all seeds for a single well into a new container structure,
```
WellFractureSeeds
```
and add a `map_member<>` to the `ScheduleState`, `wseed`, keyed by the `WellName`, to hold all seed points.