### PR TITLE
Return group/well potentials from GuideRate object

### DIFF
--- a/opm/input/eclipse/Schedule/Group/GuideRate.cpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.cpp
@@ -27,6 +27,7 @@
 #include <opm/input/eclipse/Units/Units.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -130,6 +131,13 @@ double Opm::GuideRate::get(const std::string& name, const Phase& phase) const
         throw std::logic_error {message};
     }
     return iter->second;
+}
+
+const Opm::GuideRate::RateVector& Opm::GuideRate::getPotentials(const std::string& name) const
+{
+    // Assume caller has checked that the name exists.
+    assert(this->hasPotentials(name));
+    return this->potentials.at(name);
 }
 
 double Opm::GuideRate::getSI(const std::string&          well,

--- a/opm/input/eclipse/Schedule/Group/GuideRate.cpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.cpp
@@ -135,9 +135,10 @@ double Opm::GuideRate::get(const std::string& name, const Phase& phase) const
 
 const Opm::GuideRate::RateVector& Opm::GuideRate::getPotentials(const std::string& name) const
 {
-    // Assume caller has checked that the name exists.
-    assert(this->hasPotentials(name));
-    return this->potentials.at(name);
+    if (!this->hasPotentials(name)) {
+        auto message = fmt::format("Potentials for '{}' do not exist.", name);
+        throw std::logic_error {message};
+    }
 }
 
 double Opm::GuideRate::getSI(const std::string&          well,

--- a/opm/input/eclipse/Schedule/Group/GuideRate.cpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.cpp
@@ -139,6 +139,7 @@ const Opm::GuideRate::RateVector& Opm::GuideRate::getPotentials(const std::strin
         auto message = fmt::format("Potentials for '{}' do not exist.", name);
         throw std::logic_error {message};
     }
+    return this->potentials.at(name);
 }
 
 double Opm::GuideRate::getSI(const std::string&          well,

--- a/opm/input/eclipse/Schedule/Group/GuideRate.cpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.cpp
@@ -135,11 +135,12 @@ double Opm::GuideRate::get(const std::string& name, const Phase& phase) const
 
 const Opm::GuideRate::RateVector& Opm::GuideRate::getPotentials(const std::string& name) const
 {
-    if (!this->hasPotentials(name)) {
+    if (const auto candidate = this->potentials.find(name); candidate == this->potentials.end()) {
         auto message = fmt::format("Potentials for '{}' do not exist.", name);
         throw std::logic_error {message};
+    } else {
+        return candidate->second;
     }
-    return this->potentials.at(name);
 }
 
 double Opm::GuideRate::getSI(const std::string&          well,

--- a/opm/input/eclipse/Schedule/Group/GuideRate.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.hpp
@@ -135,6 +135,7 @@ public:
     double get(const std::string& group, const Group::GuideRateProdTarget target, const RateVector& rates) const;
     double get(const std::string& name, const GuideRateModel::Target model_target, const RateVector& rates) const;
     double get(const std::string& group, const Phase& phase) const;
+    const RateVector& getPotentials(const std::string& name) const;
 
     double getSI(const std::string& well, const WellGuideRateTarget target, const RateVector& rates) const;
     double getSI(const std::string& group, const Group::GuideRateProdTarget target, const RateVector& rates) const;

--- a/opm/output/data/GuideRateValue.hpp
+++ b/opm/output/data/GuideRateValue.hpp
@@ -148,17 +148,6 @@ namespace Opm { namespace data {
             return val;
         }
 
-    private:
-        enum { Size = static_cast<std::size_t>(Item::NumItems) };
-
-        std::bitset<Size>        mask_{};
-        std::array<double, Size> value_{};
-
-        constexpr std::size_t index(const Item p) const noexcept
-        {
-            return static_cast<std::size_t>(p);
-        }
-
         std::string itemName(const Item p) const
         {
             switch (p) {
@@ -173,6 +162,17 @@ namespace Opm { namespace data {
 
             return "Unknown (" + std::to_string(this->index(p)) + ')';
         }
+    private:
+        enum { Size = static_cast<std::size_t>(Item::NumItems) };
+
+        std::bitset<Size>        mask_{};
+        std::array<double, Size> value_{};
+
+        constexpr std::size_t index(const Item p) const noexcept
+        {
+            return static_cast<std::size_t>(p);
+        }
+
     };
 
 }} // namespace Opm::data


### PR DESCRIPTION
Add a helper method to return group/well potentials. This is to be used by the reservoir coupling code in opm-simulators, see https://github.com/OPM/opm-simulators/pull/6170