### PR TITLE
Use Pressure as tolerance limit for thp in NETBALAN

### DIFF
--- a/opm/input/eclipse/Schedule/Network/Balance.cpp
+++ b/opm/input/eclipse/Schedule/Network/Balance.cpp
@@ -61,6 +61,14 @@ namespace {
 
         return tol;
     }
+    double defaultTHPTolerance()
+    {
+        static const auto tol = Opm::UnitSystem::newMETRIC()
+            .to_si(Opm::UnitSystem::measure::pressure,
+                   Opm::ParserKeywords::NETBALAN::THP_CONVERGENCE_LIMIT::defaultValue);
+
+        return tol;
+    }
 }
 
 namespace Opm { namespace Network {
@@ -72,7 +80,7 @@ Balance::Balance()
     , calc_interval      (defaultCalcInterval())
     , ptol               (defaultNodePressureTolerance())
     , m_pressure_max_iter(NB::MAX_ITER::defaultValue)
-    , m_thp_tolerance    (NB::THP_CONVERGENCE_LIMIT::defaultValue)
+    , m_thp_tolerance    (defaultTHPTolerance())
     , m_thp_max_iter     (NB::MAX_ITER_THP::defaultValue)
 {}
 
@@ -85,7 +93,7 @@ Balance::Balance(const DeckKeyword& keyword)
     this->ptol = record.getItem<NB::PRESSURE_CONVERGENCE_LIMIT>().getSIDouble(0);
     this->m_pressure_max_iter = record.getItem<NB::MAX_ITER>().get<int>(0);
 
-    this->m_thp_tolerance = record.getItem<NB::THP_CONVERGENCE_LIMIT>().get<double>(0);
+    this->m_thp_tolerance = record.getItem<NB::THP_CONVERGENCE_LIMIT>().getSIDouble(0);
     this->m_thp_max_iter = record.getItem<NB::MAX_ITER_THP>().get<int>(0);
 
     if (const auto& targBE = record.getItem<NB::TARGET_BALANCE_ERROR>(); !targBE.defaultApplied(0)) {
@@ -104,18 +112,19 @@ Balance::Balance(const DeckKeyword& keyword)
 Balance::Balance(const bool network_active)
     : calc_mode      (CalcMode::TimeStepStart)
     , calc_interval  (defaultCalcInterval())
-    , m_thp_tolerance(NB::THP_CONVERGENCE_LIMIT::defaultValue)
-    , m_thp_max_iter (NB::MAX_ITER_THP::defaultValue)
 {
     if (network_active) {
-        this->ptol = UnitSystem::newMETRIC().to_si(UnitSystem::measure::pressure,
-                                                   NB::PRESSURE_CONVERGENCE_LIMIT::defaultValue);
-
+        this->ptol = defaultNodePressureTolerance();
         this->m_pressure_max_iter = NB::MAX_ITER::defaultValue;
+
+        this->m_thp_tolerance = defaultTHPTolerance();
+        this->m_thp_max_iter = NB::MAX_ITER_THP::defaultValue;
     }
     else {
         this->ptol = 0.0;
         this->m_pressure_max_iter = 0;
+        this->m_thp_tolerance = 0.0;
+        this->m_thp_max_iter = 0;
     }
 }
 

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/N/NETBALAN
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/N/NETBALAN
@@ -30,7 +30,8 @@
       "item": 4,
       "name": "THP_CONVERGENCE_LIMIT",
       "value_type": "DOUBLE",
-      "default": 0.01
+      "default": 0.01,
+      "dimension" : "Pressure"
     },
     {
       "item": 5,

--- a/opm/output/eclipse/CreateDoubHead.cpp
+++ b/opm/output/eclipse/CreateDoubHead.cpp
@@ -135,7 +135,7 @@ namespace {
 
         param.balancingInterval = units.from_si(M::time, netbalan.interval());
         param.convTolNodPres = units.from_si(M::pressure, netbalan.pressure_tolerance());
-        param.convTolTHPCalc = units.from_si(M::identity, netbalan.thp_tolerance());
+        param.convTolTHPCalc = units.from_si(M::pressure, netbalan.thp_tolerance());
 
         if (const auto& trgBE = netbalan.target_balance_error(); trgBE.has_value()) {
             param.targBranchBalError = units.from_si(M::pressure, trgBE.value());

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -5328,7 +5328,7 @@ END
     BOOST_CHECK_EQUAL( netbalan1.interval(), 86400 );
     BOOST_CHECK_EQUAL( netbalan1.pressure_tolerance(), 200000 );
     BOOST_CHECK_EQUAL( netbalan1.pressure_max_iter(), 3 );
-    BOOST_CHECK_EQUAL( netbalan1.thp_tolerance(), 4 );
+    BOOST_CHECK_EQUAL( netbalan1.thp_tolerance(), 4e5 );
     BOOST_CHECK_EQUAL( netbalan1.thp_max_iter(), 5 );
 }
 


### PR DESCRIPTION
While testing https://github.com/OPM/opm-simulators/pull/6175 I noticed that the tolerance was not scaled to SI units.