### PR TITLE
[cmake] Search for OpenMP from the package configuration file

### DIFF
--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -15,7 +15,11 @@ if(TARGET opmcommon)
     find_package(Python3 COMPONENTS Development.Embed REQUIRED)
   endif()
 
-  if(opm-common_COMPILE_LIBS MATCHES dunecommon)
+  if(opm-common_LIBS MATCHES dunecommon)
     find_package(dune-common REQUIRED)
+  endif()
+
+  if(opm-common_LIBS MATCHES OpenMP::OpenMP)
+    find_package(OpenMP REQUIRED)
   endif()
 endif()


### PR DESCRIPTION
Allows opm-common to be used by programs that do not use the OPM specific build system at all.

We add target OpenMP::OpenMP_CXX to the linker line. Hence we always need to search for it, at least if the module is use by non-OPM modules.

Otherwise you might get the same errror as for the (autopkgtests in Debian](https://salsa.debian.org/science-team/opm-common/-/jobs/7439843):
```
-- No module specific tests for module 'opm-common' ('OpmCommonMacros.cmake' not found)
-- Setting opm-common_INCLUDE_DIRS=/usr/include;/usr/include/cjson
-- Setting opm-common_LIBRARIES=$<TARGET_FILE:opmcommon>;fmt::fmt;OpenMP::OpenMP_CXX;Boost::system;Boost::unit_test_framework;/usr/lib/x86_64-linux-gnu/libcjson.so
...
 * Vc, C++ Vectorization library, <https://github.com/VcDevel/Vc>
   For use of SIMD instructions
-- Configuring done (5.0s)
CMake Error at src/CMakeLists.txt:1 (add_executable):
  Target "dune-autopkgtest" links to:
    OpenMP::OpenMP_CXX
  but the target was not found.  Possible reasons include:
    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```

While this only ocurs if you use opm-common as a dune module, it still would be great to have this in the release. We do have people that are using opm-grid at least.