### PR TITLE
Prevent tautological-compare warnings for format.h with gcc 14.2.0

### DIFF
--- a/cmake/Modules/DownloadFmt.cmake
+++ b/cmake/Modules/DownloadFmt.cmake
@@ -12,6 +12,6 @@ endif()
 # in our depends list for downstream modules and the installation list.
 # Instead, we just download and use header only mode.
 add_compile_definitions(FMT_HEADER_ONLY)
-include_directories(${fmt_SOURCE_DIR}/include)
+include_directories(SYSTEM ${fmt_SOURCE_DIR}/include)
 set(fmt_POPULATED ${fmt_POPULATED} PARENT_SCOPE)
 set(fmt_SOURCE_DIR ${fmt_SOURCE_DIR} PARENT_SCOPE)


### PR DESCRIPTION
With gcc 14.2.0 (Ubuntu 24.10), I get a lot of warnings like this
```
/home/hakon/test/opm/opm/opm-simulators/build/_deps/fmt-src/include/fmt/ranges.h:215:59: warning: self-comparison always evaluates to true [-Wtautological-compare]
  215 |                                integer_sequence<bool, (Is == Is)...>);
      |                                                        ~~~^~~~~
```
when compiling. By adding the `SYSTEM` option to `include_directories()` for the format library, cmake will skip the warnings for the format library headers. See also: https://github.com/fmtlib/fmt/issues/3830