### PR TITLE
NetworkGraph: some janitoring

### DIFF
--- a/examples/networkgraph.cpp
+++ b/examples/networkgraph.cpp
@@ -39,10 +39,12 @@ public:
     {
         return m_name;
     }
+
     void set_outlet(std::shared_ptr<Node> outlet)
     {
         m_outlet = outlet;
     }
+
     std::shared_ptr<Node> get_outlet()
     {
         return m_outlet;
@@ -54,6 +56,7 @@ public:
     {
         m_vfp = vfp;
     }
+
     int get_vfp()
     {
         return m_vfp;
@@ -63,6 +66,7 @@ public:
     {
         m_fixed_pres = pres;
     }
+
     double get_fixed_pres()
     {
         return m_fixed_pres;
@@ -98,7 +102,6 @@ private:
     std::shared_ptr<Node> next_branch();
 };
 
-
 Node::Node(const std::string& name)
     : m_name(name)
 {
@@ -108,7 +111,6 @@ Node::Node(const std::string& name)
 std::shared_ptr<Node>
 Node::next_branch()
 {
-
     std::shared_ptr<Node> p1 = m_outlet;
 
     while (p1 != nullptr) {
@@ -126,7 +128,6 @@ Node::next_branch()
 bool
 Node::delete_from_inlet_list(const std::string& name)
 {
-
     int ind = -1;
 
     for (size_t n = 0; n < m_inlet_list.size(); n++)
@@ -152,11 +153,9 @@ Node::add_well(const std::string& name)
     return true;
 }
 
-
 void
 Node::print(std::stringstream& netw_str)
 {
-
     netw_str.seekg(0, std::ios::end);
     int init_length = netw_str.tellg();
 
@@ -196,7 +195,6 @@ Node::print(std::stringstream& netw_str)
     }
 }
 
-
 void
 Node::add_inlet_node(std::shared_ptr<Node> node)
 {
@@ -211,7 +209,6 @@ Node::add_inlet_node(std::shared_ptr<Node> node)
 
     m_inlet_list.push_back(node);
 }
-
 
 class NetWork
 {
@@ -270,13 +267,11 @@ private:
     std::vector<std::shared_ptr<Node>> m_top_node_list;
 };
 
-
 NetWork::NetWork(const std::string& filename)
 {
     std::filesystem::path inputFileName {filename};
 
     if (inputFileName.extension() == ".DATA") {
-
         parse_data_deck(inputFileName);
 
     } else if (inputFileName.extension() == ".UNRST") {
@@ -290,11 +285,9 @@ NetWork::NetWork(const std::string& filename)
     }
 }
 
-
 void
 NetWork::parse_data_deck(const std::filesystem::path& inputFileName)
 {
-
     Opm::ParseContext parseContext;
     parseContext.update(Opm::ParseContext::PARSE_UNKNOWN_KEYWORD, Opm::InputErrorAction::IGNORE);
     parseContext.update(Opm::ParseContext::PARSE_RANDOM_TEXT, Opm::InputErrorAction::IGNORE);
@@ -331,7 +324,6 @@ NetWork::parse_data_deck(const std::filesystem::path& inputFileName)
     }
 
     for (auto keyw : deck_schecule) {
-
         if (keyw.name() == "START") {
             m_node_input_list.push_back({});
             m_bran_input_list.push_back({});
@@ -402,7 +394,6 @@ NetWork::parse_data_deck(const std::filesystem::path& inputFileName)
 
         } else if ((keyw.name() == "BRANPROP") && (!skiprest)) {
             for (auto& rec : keyw) {
-
                 auto downtree = rec.getItem(0).get<std::string>(0);
                 auto uptree = rec.getItem(1).get<std::string>(0);
                 auto vfp = rec.getItem(2).get<int>(0);
@@ -438,7 +429,6 @@ NetWork::parse_data_deck(const std::filesystem::path& inputFileName)
 void
 NetWork::parse_unrst(const std::filesystem::path& inputFileName)
 {
-
     Opm::EclIO::ERst rst1(inputFileName);
 
     auto all_reports = rst1.listOfReportStepNumbers();
@@ -459,7 +449,6 @@ NetWork::parse_unrst(const std::filesystem::path& inputFileName)
 std::string
 NetWork::time_str(time_t t1)
 {
-
     std::vector<std::string> mndStr {
         "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
 
@@ -489,11 +478,9 @@ NetWork::time_str(time_t t1)
     return date_str.str();
 }
 
-
 void
 NetWork::print_network_input()
 {
-
     std::cout << "m_report_time_list: " << m_report_time_list.size() << "\n";
     std::cout << "m_well_input_list : " << m_well_input_list.size() << "\n";
 
@@ -525,7 +512,6 @@ NetWork::print_network_input()
     std::cout << "\n\n";
 }
 
-
 bool
 NetWork::node_exist(const std::string& name)
 {
@@ -535,7 +521,6 @@ NetWork::node_exist(const std::string& name)
 
     return false;
 }
-
 
 void
 NetWork::add_node(const std::string& name)
@@ -547,7 +532,6 @@ NetWork::add_node(const std::string& name)
         exit(1);
     }
 }
-
 
 void
 NetWork::add_branch(const std::string& downtree, const std::string& uptree, int vfp)
@@ -584,7 +568,6 @@ NetWork::add_branch(const std::string& downtree, const std::string& uptree, int 
 
     pDowntree->set_outlet(pUptree);
     pDowntree->set_vfp(vfp);
-
 
     pUptree->add_inlet_node(pDowntree);
 }
@@ -624,7 +607,6 @@ NetWork::delete_branch(const std::string& downtree, const std::string& uptree)
     if (!found_in_list)
         m_top_node_list.push_back(pDowntree);
 }
-
 
 void
 NetWork::build_network(int rstep)
@@ -694,7 +676,6 @@ NetWork::build_network(int rstep)
 void
 NetWork::print_network(int rstep)
 {
-
     std::cout << "\n\n";
 
     time_t t = m_report_time_list[rstep - 1];
@@ -702,7 +683,6 @@ NetWork::print_network(int rstep)
     std::cout << "Report step : " << time_str(t) << "\n\n";
 
     for (size_t n = 0; n < m_top_node_list.size(); n++) {
-
         m_top_node_list[n]->print(m_netw_str);
         m_netw_str << "\n\n";
     }
@@ -808,11 +788,9 @@ NetWork::time_from_rec(const Opm::DeckRecord& rec)
     return std::mktime(&date1);
 }
 
-
 time_t
 NetWork::time_from_rst(const std::string& rstfile, int rstep)
 {
-
     Opm::EclIO::ERst rst1(rstfile);
 
     auto inteh = rst1.getRestartData<int>("INTEHEAD", rstep);
@@ -841,18 +819,15 @@ NetWork::time_from_rst(const std::string& rstfile, int rstep)
 void
 NetWork::br_input_from_rst(const std::string& rstfile, std::vector<int> rstep_vect)
 {
-
     Opm::EclIO::ERst rst1(rstfile);
 
     for (int& rstep : rstep_vect) {
-
         m_rst_time = time_from_rst(rstfile, rstep);
         m_report_time_list.push_back(m_rst_time);
 
         auto intehead = rst1.getRestartData<int>("INTEHEAD", rstep);
 
         if (rst1.hasArray("ZNODE", rstep)) {
-
             std::vector<std::string> nodelist;
 
             auto noactnod = intehead[129]; // Number of active/defined nodes in the network
@@ -917,11 +892,9 @@ NetWork::br_input_from_rst(const std::string& rstfile, std::vector<int> rstep_ve
     }
 }
 
-
 static void
 printHelp()
 {
-
     std::cout << "\n This program visualizes a production network with terminal output."
               << " Input to this program should be a valid data deck (.DATA) \n or a unified"
               << " restart file (.UNRST).\n\n The program takes these options"
@@ -931,11 +904,9 @@ printHelp()
               << " -h Print help and exit.\n\n";
 }
 
-
 int
 main(int argc, char** argv)
 {
-
     int c = 0;
     bool list_report_steps = false;
     int rstep = -1;

--- a/examples/networkgraph.cpp
+++ b/examples/networkgraph.cpp
@@ -185,7 +185,7 @@ Node::print(std::stringstream& netw_str)
 
         netw_str << " : ";
 
-        for (auto& well : m_well_list)
+        for (const auto& well : m_well_list)
             netw_str << " " << well;
 
         if (next_br != nullptr) {
@@ -323,7 +323,7 @@ NetWork::parse_data_deck(const std::filesystem::path& inputFileName)
         exit(1);
     }
 
-    for (auto keyw : deck_schecule) {
+    for (const auto& keyw : deck_schecule) {
         if (keyw.name() == "START") {
             m_node_input_list.push_back({});
             m_bran_input_list.push_back({});
@@ -350,7 +350,7 @@ NetWork::parse_data_deck(const std::filesystem::path& inputFileName)
             }
 
         } else if (keyw.name() == "DATES") {
-            for (auto& rec : keyw) {
+            for (const auto& rec : keyw) {
                 last_time = time_from_rec(rec);
 
                 if (m_report_time_list.size() == 0) {
@@ -393,7 +393,7 @@ NetWork::parse_data_deck(const std::filesystem::path& inputFileName)
                 skiprest = true;
 
         } else if ((keyw.name() == "BRANPROP") && (!skiprest)) {
-            for (auto& rec : keyw) {
+            for (const auto& rec : keyw) {
                 auto downtree = rec.getItem(0).get<std::string>(0);
                 auto uptree = rec.getItem(1).get<std::string>(0);
                 auto vfp = rec.getItem(2).get<int>(0);
@@ -404,7 +404,7 @@ NetWork::parse_data_deck(const std::filesystem::path& inputFileName)
             }
 
         } else if ((keyw.name() == "NODEPROP") && (!skiprest)) {
-            for (auto& rec : keyw) {
+            for (const auto& rec : keyw) {
                 if (rec.getItem(1).hasValue(0)) {
                     auto node_name = rec.getItem(0).get<std::string>(0);
                     auto node_pres = rec.getItem(1).get<double>(0);
@@ -414,7 +414,7 @@ NetWork::parse_data_deck(const std::filesystem::path& inputFileName)
             }
 
         } else if ((keyw.name() == "WELSPECS") && (!skiprest)) {
-            for (auto& rec : keyw) {
+            for (const auto& rec : keyw) {
                 auto wname = rec.getItem(0).get<std::string>(0);
                 auto gname = rec.getItem(1).get<std::string>(0);
 
@@ -449,10 +449,11 @@ NetWork::parse_unrst(const std::filesystem::path& inputFileName)
 std::string
 NetWork::time_str(time_t t1)
 {
-    std::vector<std::string> mndStr {
-        "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
+    const std::vector<std::string> mndStr {
+        "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"
+    };
 
-    std::tm* date = std::localtime(&t1);
+    const std::tm* date = std::localtime(&t1);
 
     std::stringstream date_str;
 
@@ -622,7 +623,7 @@ NetWork::build_network(int rstep)
         for (int n = 0; n < rstep; n++)
             input_step_vect.push_back(n);
 
-    for (auto& n : input_step_vect) {
+    for (const auto n : input_step_vect) {
 
         for (size_t b = 0; b < m_bran_input_list[n].size(); b++) {
             auto downtree = std::get<0>(m_bran_input_list[n][b]);
@@ -644,7 +645,7 @@ NetWork::build_network(int rstep)
 
     std::map<std::string, std::string> well_map;
 
-    for (auto n : input_step_vect) {
+    for (const auto n : input_step_vect) {
         for (size_t b = 0; b < m_well_input_list[n].size(); b++) {
             auto wname = std::get<0>(m_well_input_list[n][b]);
             auto gname = std::get<1>(m_well_input_list[n][b]);
@@ -652,7 +653,7 @@ NetWork::build_network(int rstep)
         }
     }
 
-    for (auto m : well_map) {
+    for (const auto& m : well_map) {
         auto gname = m.second;
         auto wname = m.first;
 
@@ -661,7 +662,7 @@ NetWork::build_network(int rstep)
                 m_node_list[n]->add_well(wname);
     }
 
-    for (auto n : input_step_vect) {
+    for (const auto n : input_step_vect) {
         for (size_t b = 0; b < m_node_input_list[n].size(); b++) {
             auto node = std::get<0>(m_node_input_list[n][b]);
             auto pressure = std::get<1>(m_node_input_list[n][b]);
@@ -706,33 +707,35 @@ NetWork::print_network(int rstep)
 void
 NetWork::print_report_steps()
 {
-
-    if (!m_from_unrst)
+    if (!m_from_unrst) {
         std::cout << "\n\nStart date  " << time_str(m_start_date) << "\n";
+    }
 
     std::cout << "\nList of all report steps \n\n";
 
-    for (size_t n = 0; n < m_report_time_list.size(); n++)
+    for (size_t n = 0; n < m_report_time_list.size(); n++) {
         std::cout << "Report step " << n + 1 << "  | " << time_str(m_report_time_list[n]) << "\n";
+    }
 }
 
 time_t
 NetWork::time_from_rec(const Opm::DeckRecord& rec)
 {
-
-    std::map<std::string, int> mnd_map {{"JAN", 0},
-                                        {"FEB", 1},
-                                        {"MAR", 2},
-                                        {"APR", 3},
-                                        {"MAY", 4},
-                                        {"JUN", 5},
-                                        {"JUL", 6},
-                                        {"JLY", 6},
-                                        {"AUG", 7},
-                                        {"SEP", 8},
-                                        {"OCT", 9},
-                                        {"NOV", 10},
-                                        {"DEC", 11}};
+    const std::map<std::string, int> mnd_map {
+        {"JAN", 0},
+        {"FEB", 1},
+        {"MAR", 2},
+        {"APR", 3},
+        {"MAY", 4},
+        {"JUN", 5},
+        {"JUL", 6},
+        {"JLY", 6},
+        {"AUG", 7},
+        {"SEP", 8},
+        {"OCT", 9},
+        {"NOV", 10},
+        {"DEC", 11}
+    };
 
     auto day = rec.getItem(0).get<int>(0);
     auto mndStr = rec.getItem(1).get<std::string>(0);

--- a/examples/networkgraph.cpp
+++ b/examples/networkgraph.cpp
@@ -92,7 +92,6 @@ private:
     int m_vfp;
     int m_xpos = -1;
     double m_fixed_pres = -1.0;
-    int m_ind = -1;
 
     std::string m_name;
     std::shared_ptr<Node> m_outlet;

--- a/examples/networkgraph.cpp
+++ b/examples/networkgraph.cpp
@@ -42,36 +42,36 @@ public:
     void set_outlet(std::shared_ptr<Node> outlet)
     {
         m_outlet = outlet;
-    };
+    }
     std::shared_ptr<Node> get_outlet()
     {
         return m_outlet;
-    };
+    }
 
     void add_inlet_node(std::shared_ptr<Node> n);
 
     void set_vfp(int vfp)
     {
         m_vfp = vfp;
-    };
+    }
     int get_vfp()
     {
         return m_vfp;
-    };
+    }
 
     void set_fixed_pres(double pres)
     {
         m_fixed_pres = pres;
-    };
+    }
     double get_fixed_pres()
     {
         return m_fixed_pres;
-    };
+    }
 
     int get_xpos()
     {
         return m_xpos;
-    };
+    }
 
     void print(std::stringstream& netw_str);
 
@@ -82,7 +82,7 @@ public:
     void reset_outlet()
     {
         m_outlet = nullptr;
-    };
+    }
 
 private:
     int m_vfp;

--- a/examples/networkgraph.cpp
+++ b/examples/networkgraph.cpp
@@ -26,6 +26,7 @@
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
+#include <cstddef>
 #include <getopt.h>
 #include <iostream>
 #include <sstream>
@@ -175,7 +176,7 @@ Node::print(std::stringstream& netw_str)
         m_xpos = netw_str.str().find_first_of("+", init_length) - pos_lineshift;
     }
 
-    for (size_t m = 0; m < m_inlet_list.size(); m++) {
+    for (std::size_t m = 0; m < m_inlet_list.size(); m++) {
         m_inlet_list[m]->print(netw_str);
     }
 
@@ -331,7 +332,7 @@ NetWork::parse_data_deck(const std::filesystem::path& inputFileName)
             last_time = m_start_date;
         }
         else if (keyw.name() == "TSTEP") {
-            for (size_t n = 0; n < keyw[0].getItem(0).data_size(); n++) {
+            for (std::size_t n = 0; n < keyw[0].getItem(0).data_size(); n++) {
                 auto dt = keyw[0].getItem(0).get<double>(n);
                 last_time = last_time + static_cast<int>(dt * 24.0 * 3600.0);
 
@@ -486,8 +487,8 @@ NetWork::print_network_input()
 
     std::cout << "\nm_bran_input_list: " << m_bran_input_list.size() << "\n\n";
 
-    for (size_t r = 0; r < m_bran_input_list.size(); r++) {
-        for (size_t n = 0; n < m_bran_input_list[r].size(); n++) {
+    for (std::size_t r = 0; r < m_bran_input_list.size(); r++) {
+        for (std::size_t n = 0; n < m_bran_input_list[r].size(); n++) {
             auto downtree = std::get<0>(m_bran_input_list[r][n]);
             auto uptree = std::get<1>(m_bran_input_list[r][n]);
             auto vfp = std::get<2>(m_bran_input_list[r][n]);
@@ -499,8 +500,8 @@ NetWork::print_network_input()
 
     std::cout << "\n\nm_node_input_list: " << m_node_input_list.size() << "\n\n";
 
-    for (size_t r = 0; r < m_node_input_list.size(); r++) {
-        for (size_t n = 0; n < m_node_input_list[r].size(); n++) {
+    for (std::size_t r = 0; r < m_node_input_list.size(); r++) {
+        for (std::size_t n = 0; n < m_node_input_list[r].size(); n++) {
             auto node = std::get<0>(m_node_input_list[r][n]);
             auto pres = std::get<1>(m_node_input_list[r][n]);
 
@@ -543,7 +544,7 @@ NetWork::add_branch(const std::string& downtree, const std::string& uptree, int 
     std::shared_ptr<Node> pDowntree;
 
     // handle uptree node
-    for (size_t n = 0; n < m_node_list.size(); n++) {
+    for (std::size_t n = 0; n < m_node_list.size(); n++) {
         if (m_node_list[n]->name() == uptree) {
             pUptree = m_node_list[n];
         }
@@ -555,7 +556,7 @@ NetWork::add_branch(const std::string& downtree, const std::string& uptree, int 
     }
 
     // handle down tree node
-    for (size_t n = 0; n < m_node_list.size(); n++) {
+    for (std::size_t n = 0; n < m_node_list.size(); n++) {
         if (m_node_list[n]->name() == downtree) {
             pDowntree = m_node_list[n];
         }
@@ -619,7 +620,7 @@ NetWork::build_network(int rstep)
     }
 
     for (const auto n : input_step_vect) {
-        for (size_t b = 0; b < m_bran_input_list[n].size(); b++) {
+        for (std::size_t b = 0; b < m_bran_input_list[n].size(); b++) {
             auto downtree = std::get<0>(m_bran_input_list[n][b]);
             auto uptree = std::get<1>(m_bran_input_list[n][b]);
             auto vfp = std::get<2>(m_bran_input_list[n][b]);
@@ -635,7 +636,7 @@ NetWork::build_network(int rstep)
 
     m_top_node_list.clear();
 
-    for (size_t n = 0; n < m_node_list.size(); n++) {
+    for (std::size_t n = 0; n < m_node_list.size(); n++) {
         if (m_node_list[n]->get_outlet() == nullptr) {
             m_top_node_list.push_back(m_node_list[n]);
         }
@@ -644,7 +645,7 @@ NetWork::build_network(int rstep)
     std::map<std::string, std::string> well_map;
 
     for (const auto n : input_step_vect) {
-        for (size_t b = 0; b < m_well_input_list[n].size(); b++) {
+        for (std::size_t b = 0; b < m_well_input_list[n].size(); b++) {
             auto wname = std::get<0>(m_well_input_list[n][b]);
             auto gname = std::get<1>(m_well_input_list[n][b]);
             well_map[wname] = gname;
@@ -655,7 +656,7 @@ NetWork::build_network(int rstep)
         auto gname = m.second;
         auto wname = m.first;
 
-        for (size_t n = 0; n < m_node_list.size(); n++) {
+        for (std::size_t n = 0; n < m_node_list.size(); n++) {
             if (m_node_list[n]->name() == gname) {
                 m_node_list[n]->add_well(wname);
             }
@@ -663,11 +664,11 @@ NetWork::build_network(int rstep)
     }
 
     for (const auto n : input_step_vect) {
-        for (size_t b = 0; b < m_node_input_list[n].size(); b++) {
+        for (std::size_t b = 0; b < m_node_input_list[n].size(); b++) {
             auto node = std::get<0>(m_node_input_list[n][b]);
             auto pressure = std::get<1>(m_node_input_list[n][b]);
 
-            for (size_t m = 0; m < m_node_list.size(); m++) {
+            for (std::size_t m = 0; m < m_node_list.size(); m++) {
                 if (m_node_list[m]->name() == node) {
                     m_node_list[m]->set_fixed_pres(pressure);
                 }
@@ -685,7 +686,7 @@ NetWork::print_network(int rstep)
 
     std::cout << "Report step : " << time_str(t) << "\n\n";
 
-    for (size_t n = 0; n < m_top_node_list.size(); n++) {
+    for (std::size_t n = 0; n < m_top_node_list.size(); n++) {
         m_top_node_list[n]->print(m_netw_str);
         m_netw_str << "\n\n";
     }
@@ -694,7 +695,7 @@ NetWork::print_network(int rstep)
 
     std::cout << "\nFixed pressure nodes: \n\n";
 
-    for (size_t n = 0; n < m_node_list.size(); n++) {
+    for (std::size_t n = 0; n < m_node_list.size(); n++) {
         auto fixed_pres = m_node_list[n]->get_fixed_pres();
 
         if (fixed_pres > -1.0) {
@@ -715,7 +716,7 @@ NetWork::print_report_steps()
 
     std::cout << "\nList of all report steps \n\n";
 
-    for (size_t n = 0; n < m_report_time_list.size(); n++) {
+    for (std::size_t n = 0; n < m_report_time_list.size(); n++) {
         std::cout << "Report step " << n + 1 << "  | " << time_str(m_report_time_list[n]) << "\n";
     }
 }

--- a/examples/networkgraph.cpp
+++ b/examples/networkgraph.cpp
@@ -17,10 +17,6 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <getopt.h>
-#include <iostream>
-#include <sstream>
-
 #include <opm/io/eclipse/ERst.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
@@ -30,6 +26,9 @@
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
 
 class Node
 {

--- a/examples/networkgraph.cpp
+++ b/examples/networkgraph.cpp
@@ -246,7 +246,6 @@ private:
 
     void br_input_from_rst(const std::string& rstfile, std::vector<int> rstep_vect);
 
-    void print_network_input();
     void parse_data_deck(const std::filesystem::path& inputFileName);
     void parse_unrst(const std::filesystem::path& inputFileName);
 
@@ -477,40 +476,6 @@ NetWork::time_str(time_t t1)
     date_str << ":" << std::setw(2) << std::setfill('0') << date->tm_sec;
 
     return date_str.str();
-}
-
-void
-NetWork::print_network_input()
-{
-    std::cout << "m_report_time_list: " << m_report_time_list.size() << "\n";
-    std::cout << "m_well_input_list : " << m_well_input_list.size() << "\n";
-
-    std::cout << "\nm_bran_input_list: " << m_bran_input_list.size() << "\n\n";
-
-    for (std::size_t r = 0; r < m_bran_input_list.size(); r++) {
-        for (std::size_t n = 0; n < m_bran_input_list[r].size(); n++) {
-            auto downtree = std::get<0>(m_bran_input_list[r][n]);
-            auto uptree = std::get<1>(m_bran_input_list[r][n]);
-            auto vfp = std::get<2>(m_bran_input_list[r][n]);
-
-            std::cout << "r= " << r << ", n= " << n << " " << downtree;
-            std::cout << " " << uptree << " " << vfp << "\n";
-        }
-    }
-
-    std::cout << "\n\nm_node_input_list: " << m_node_input_list.size() << "\n\n";
-
-    for (std::size_t r = 0; r < m_node_input_list.size(); r++) {
-        for (std::size_t n = 0; n < m_node_input_list[r].size(); n++) {
-            auto node = std::get<0>(m_node_input_list[r][n]);
-            auto pres = std::get<1>(m_node_input_list[r][n]);
-
-            std::cout << "r= " << r << ", n= " << n << " " << node;
-            std::cout << " " << pres << "\n";
-        }
-    }
-
-    std::cout << "\n\n";
 }
 
 bool


### PR DESCRIPTION
Some standard janitoring chores.

whitespace, braces, constness, use of standard algorithms (to quell sca warnings), removal of unused members.

Not entirely sure about the last commit, it removes a method that is unused, that maybe was used during development, maybe is intended to be used later. If the latter I'll change the commit to comment it out instead.