### PR TITLE
TabulatedComponent: fix memory leak

### DIFF
--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -161,19 +161,19 @@ public:
 
         // fill the temperature-pressure arrays
         for (unsigned iT = 0; iT < data_.nTemp_; ++ iT) {
-            Scalar temperature = iT * (data_.tempMax_ - data_.tempMin_) / (data_.nTemp_ - 1) + data_.tempMin_;
+            const Scalar temperature = iT * (data_.tempMax_ - data_.tempMin_) / (data_.nTemp_ - 1) + data_.tempMin_;
 
             try { data_.vaporPressure_[iT] = RawComponent::vaporPressure(temperature); }
             catch (const std::exception&) { data_.vaporPressure_[iT] = NaN; }
 
-            Scalar pgMax = maxGasPressure_(iT);
-            Scalar pgMin = minGasPressure_(iT);
+            const Scalar pgMax = maxGasPressure_(iT);
+            const Scalar pgMin = minGasPressure_(iT);
 
             // fill the temperature, pressure gas arrays
             for (unsigned iP = 0; iP < data_.nPress_; ++ iP) {
-                Scalar pressure = iP * (pgMax - pgMin) / (data_.nPress_ - 1) + pgMin;
+                const Scalar pressure = iP * (pgMax - pgMin) / (data_.nPress_ - 1) + pgMin;
 
-                unsigned i = iT + iP * data_.nTemp_;
+                const unsigned i = iT + iP * data_.nTemp_;
 
                 try { data_.gasEnthalpy_[i] = RawComponent::gasEnthalpy(temperature, pressure); }
                 catch (const std::exception&) { data_.gasEnthalpy_[i] = NaN; }
@@ -191,12 +191,12 @@ public:
                 catch (const std::exception&) { data_.gasThermalConductivity_[i] = NaN; }
             };
 
-            Scalar plMin = minLiquidPressure_(iT);
-            Scalar plMax = maxLiquidPressure_(iT);
+            const Scalar plMin = minLiquidPressure_(iT);
+            const Scalar plMax = maxLiquidPressure_(iT);
             for (unsigned iP = 0; iP < data_.nPress_; ++ iP) {
                 Scalar pressure = iP * (plMax - plMin) / (data_.nPress_ - 1) + plMin;
 
-                unsigned i = iT + iP*data_.nTemp_;
+                const unsigned i = iT + iP*data_.nTemp_;
 
                 try { data_.liquidEnthalpy_[i] = RawComponent::liquidEnthalpy(temperature, pressure); }
                 catch (const std::exception&) { data_.liquidEnthalpy_[i] = NaN; }
@@ -217,7 +217,7 @@ public:
 
         // fill the temperature-density arrays
         for (unsigned iT = 0; iT < data_.nTemp_; ++ iT) {
-            Scalar temperature = iT * (data_.tempMax_ - data_.tempMin_) / (data_.nTemp_ - 1) + data_.tempMin_;
+            const Scalar temperature = iT * (data_.tempMax_ - data_.tempMin_) / (data_.nTemp_ - 1) + data_.tempMin_;
 
             // calculate the minimum and maximum values for the gas
             // densities
@@ -229,13 +229,13 @@ public:
 
             // fill the temperature, density gas arrays
             for (unsigned iRho = 0; iRho < data_.nDensity_; ++ iRho) {
-                Scalar density =
+                const Scalar density =
                     Scalar(iRho) / (data_.nDensity_ - 1) *
                     (data_.maxGasDensity__[iT] - data_.minGasDensity__[iT])
                     +
                     data_.minGasDensity__[iT];
 
-                unsigned i = iT + iRho * data_.nTemp_;
+                const unsigned i = iT + iRho * data_.nTemp_;
 
                 try { data_.gasPressure_[i] = RawComponent::gasPressure(temperature, density); }
                 catch (const std::exception&) { data_.gasPressure_[i] = NaN; };
@@ -251,13 +251,13 @@ public:
 
             // fill the temperature, density liquid arrays
             for (unsigned iRho = 0; iRho < data_.nDensity_; ++ iRho) {
-                Scalar density =
+                const Scalar density =
                     Scalar(iRho) / (data_.nDensity_ - 1) *
                     (data_.maxLiquidDensity__[iT] - data_.minLiquidDensity__[iT])
                     +
                     data_.minLiquidDensity__[iT];
 
-                unsigned i = iT + iRho * data_.nTemp_;
+                const unsigned i = iT + iRho * data_.nTemp_;
 
                 try { data_.liquidPressure_[i] = RawComponent::liquidPressure(temperature, density); }
                 catch (const std::exception&) { data_.liquidPressure_[i] = NaN; };
@@ -584,7 +584,7 @@ private:
         if (alphaT < 0 || alphaT >= data_.nTemp_ - 1)
             return std::numeric_limits<Scalar>::quiet_NaN();
 
-        size_t iT = static_cast<size_t>(scalarValue(alphaT));
+        const size_t iT = static_cast<size_t>(scalarValue(alphaT));
         alphaT -= iT;
 
         return
@@ -603,17 +603,17 @@ private:
         if (alphaT < 0 || alphaT >= data_.nTemp_ - 1)
             return std::numeric_limits<Scalar>::quiet_NaN();
 
-        size_t iT = static_cast<size_t>(scalarValue(alphaT));
+        const size_t iT = static_cast<size_t>(scalarValue(alphaT));
         alphaT -= iT;
 
         Evaluation alphaP1 = pressLiquidIdx_(p, iT);
         Evaluation alphaP2 = pressLiquidIdx_(p, iT + 1);
 
-        size_t iP1 =
+        const size_t iP1 =
             static_cast<size_t>(
                 std::max<int>(0, std::min(static_cast<int>(data_.nPress_) - 2,
                                           static_cast<int>(scalarValue(alphaP1)))));
-        size_t iP2 =
+        const size_t iP2 =
             static_cast<size_t>(
                 std::max(0, std::min(static_cast<int>(data_.nPress_) - 2,
                                      static_cast<int>(scalarValue(alphaP2)))));
@@ -638,7 +638,7 @@ private:
         if (alphaT < 0 || alphaT >= data_.nTemp_ - 1)
             return std::numeric_limits<Scalar>::quiet_NaN();
 
-        size_t iT =
+        const size_t iT =
             static_cast<size_t>(
                 std::max(0, std::min(static_cast<int>(data_.nTemp_) - 2,
                                      static_cast<int>(scalarValue(alphaT)))));
@@ -646,11 +646,11 @@ private:
 
         Evaluation alphaP1 = pressGasIdx_(p, iT);
         Evaluation alphaP2 = pressGasIdx_(p, iT + 1);
-        size_t iP1 =
+        const size_t iP1 =
             static_cast<size_t>(
                 std::max(0, std::min(static_cast<int>(data_.nPress_) - 2,
                                      static_cast<int>(scalarValue(alphaP1)))));
-        size_t iP2 =
+        const size_t iP2 =
             static_cast<size_t>(
                 std::max(0, std::min(static_cast<int>(data_.nPress_) - 2,
                                      static_cast<int>(scalarValue(alphaP2)))));
@@ -672,18 +672,19 @@ private:
                                           const Evaluation& rho)
     {
         Evaluation alphaT = tempIdx_(T);
-        unsigned iT = std::max(0,
-                               std::min(static_cast<int>(data_.nTemp_ - 2),
-                                        static_cast<int>(alphaT)));
+        const unsigned iT =
+            std::max(0,
+                     std::min(static_cast<int>(data_.nTemp_ - 2),
+                              static_cast<int>(alphaT)));
         alphaT -= iT;
 
         Evaluation alphaP1 = densityGasIdx_(rho, iT);
         Evaluation alphaP2 = densityGasIdx_(rho, iT + 1);
-        unsigned iP1 =
+        const unsigned iP1 =
             std::max(0,
                      std::min(static_cast<int>(data_.nDensity_ - 2),
                               static_cast<int>(alphaP1)));
-        unsigned iP2 =
+        const unsigned iP2 =
             std::max(0,
                      std::min(static_cast<int>(data_.nDensity_ - 2),
                               static_cast<int>(alphaP2)));
@@ -705,13 +706,13 @@ private:
                                              const Evaluation& rho)
     {
         Evaluation alphaT = tempIdx_(T);
-        unsigned iT = std::max<int>(0, std::min<int>(data_.nTemp_ - 2, static_cast<int>(alphaT)));
+        const unsigned iT = std::max<int>(0, std::min<int>(data_.nTemp_ - 2, static_cast<int>(alphaT)));
         alphaT -= iT;
 
         Evaluation alphaP1 = densityLiquidIdx_(rho, iT);
         Evaluation alphaP2 = densityLiquidIdx_(rho, iT + 1);
-        unsigned iP1 = std::max<int>(0, std::min<int>(data_.nDensity_ - 2, static_cast<int>(alphaP1)));
-        unsigned iP2 = std::max<int>(0, std::min<int>(data_.nDensity_ - 2, static_cast<int>(alphaP2)));
+        const unsigned iP1 = std::max<int>(0, std::min<int>(data_.nDensity_ - 2, static_cast<int>(alphaP1)));
+        const unsigned iP2 = std::max<int>(0, std::min<int>(data_.nDensity_ - 2, static_cast<int>(alphaP2)));
         alphaP1 -= iP1;
         alphaP2 -= iP2;
 
@@ -734,8 +735,8 @@ private:
     template <class Evaluation>
     static Evaluation pressLiquidIdx_(const Evaluation& pressure, size_t tempIdx)
     {
-        Scalar plMin = minLiquidPressure_(tempIdx);
-        Scalar plMax = maxLiquidPressure_(tempIdx);
+        const Scalar plMin = minLiquidPressure_(tempIdx);
+        const Scalar plMax = maxLiquidPressure_(tempIdx);
 
         return (data_.nPress_ - 1) * (pressure - plMin) / (plMax - plMin);
     }
@@ -744,8 +745,8 @@ private:
     template <class Evaluation>
     static Evaluation pressGasIdx_(const Evaluation& pressure, size_t tempIdx)
     {
-        Scalar pgMin = minGasPressure_(tempIdx);
-        Scalar pgMax = maxGasPressure_(tempIdx);
+        const Scalar pgMin = minGasPressure_(tempIdx);
+        const Scalar pgMax = maxGasPressure_(tempIdx);
 
         return (data_.nPress_ - 1) * (pressure - pgMin) / (pgMax - pgMin);
     }
@@ -754,8 +755,8 @@ private:
     template <class Evaluation>
     static Evaluation densityLiquidIdx_(const Evaluation& density, size_t tempIdx)
     {
-        Scalar densityMin = minLiquidDensity_(tempIdx);
-        Scalar densityMax = maxLiquidDensity_(tempIdx);
+        const Scalar densityMin = minLiquidDensity_(tempIdx);
+        const Scalar densityMax = maxLiquidDensity_(tempIdx);
         return (data_.nDensity_ - 1) * (density - densityMin) / (densityMax - densityMin);
     }
 
@@ -763,8 +764,8 @@ private:
     template <class Evaluation>
     static Evaluation densityGasIdx_(const Evaluation& density, size_t tempIdx)
     {
-        Scalar densityMin = minGasDensity_(tempIdx);
-        Scalar densityMax = maxGasDensity_(tempIdx);
+        const Scalar densityMin = minGasDensity_(tempIdx);
+        const Scalar densityMax = maxGasDensity_(tempIdx);
         return (data_.nDensity_ - 1) * (density - densityMin) / (densityMax - densityMin);
     }
 

--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -322,7 +322,7 @@ public:
     template <class Evaluation>
     static Evaluation vaporPressure(const Evaluation& temperature)
     {
-        const Evaluation& result = interpolateT_(data_.vaporPressure_.data(), temperature);
+        const Evaluation& result = interpolateT_(data_.vaporPressure_, temperature);
         if (std::isnan(scalarValue(result)))
             return RawComponent::vaporPressure(temperature);
         return result;
@@ -337,7 +337,7 @@ public:
     template <class Evaluation>
     static Evaluation gasEnthalpy(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateGasTP_(data_.gasEnthalpy_.data(),
+        const Evaluation& result = interpolateGasTP_(data_.gasEnthalpy_,
                                                      temperature,
                                                      pressure);
         if (std::isnan(scalarValue(result)))
@@ -354,7 +354,7 @@ public:
     template <class Evaluation>
     static Evaluation liquidEnthalpy(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateLiquidTP_(data_.liquidEnthalpy_.data(),
+        const Evaluation& result = interpolateLiquidTP_(data_.liquidEnthalpy_,
                                                         temperature,
                                                         pressure);
         if (std::isnan(scalarValue(result)))
@@ -371,7 +371,7 @@ public:
     template <class Evaluation>
     static Evaluation gasHeatCapacity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateGasTP_(data_.gasHeatCapacity_.data(),
+        const Evaluation& result = interpolateGasTP_(data_.gasHeatCapacity_,
                                                      temperature,
                                                      pressure);
         if (std::isnan(scalarValue(result)))
@@ -388,7 +388,7 @@ public:
     template <class Evaluation>
     static Evaluation liquidHeatCapacity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateLiquidTP_(data_.liquidHeatCapacity_.data(),
+        const Evaluation& result = interpolateLiquidTP_(data_.liquidHeatCapacity_,
                                                         temperature,
                                                         pressure);
         if (std::isnan(scalarValue(result)))
@@ -425,7 +425,7 @@ public:
     template <class Evaluation>
     static Evaluation gasPressure(const Evaluation& temperature, Scalar density)
     {
-        const Evaluation& result = interpolateGasTRho_(data_.gasPressure_.data(),
+        const Evaluation& result = interpolateGasTRho_(data_.gasPressure_,
                                                        temperature,
                                                        density);
         if (std::isnan(scalarValue(result)))
@@ -443,7 +443,7 @@ public:
     template <class Evaluation>
     static Evaluation liquidPressure(const Evaluation& temperature, Scalar density)
     {
-        const Evaluation& result = interpolateLiquidTRho_(data_.liquidPressure_.data(),
+        const Evaluation& result = interpolateLiquidTRho_(data_.liquidPressure_,
                                                           temperature,
                                                           density);
         if (std::isnan(scalarValue(result)))
@@ -481,7 +481,7 @@ public:
     template <class Evaluation>
     static Evaluation gasDensity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateGasTP_(data_.gasDensity_.data(),
+        const Evaluation& result = interpolateGasTP_(data_.gasDensity_,
                                                      temperature,
                                                      pressure);
         if (std::isnan(scalarValue(result)))
@@ -499,7 +499,7 @@ public:
     template <class Evaluation>
     static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateLiquidTP_(data_.liquidDensity_.data(),
+        const Evaluation& result = interpolateLiquidTP_(data_.liquidDensity_,
                                                         temperature,
                                                         pressure);
         if (std::isnan(scalarValue(result)))
@@ -516,7 +516,7 @@ public:
     template <class Evaluation>
     static Evaluation gasViscosity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateGasTP_(data_.gasViscosity_.data(),
+        const Evaluation& result = interpolateGasTP_(data_.gasViscosity_,
                                                      temperature,
                                                      pressure);
         if (std::isnan(scalarValue(result)))
@@ -533,7 +533,7 @@ public:
     template <class Evaluation>
     static Evaluation liquidViscosity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateLiquidTP_(data_.liquidViscosity_.data(),
+        const Evaluation& result = interpolateLiquidTP_(data_.liquidViscosity_,
                                                         temperature,
                                                         pressure);
         if (std::isnan(scalarValue(result)))
@@ -550,7 +550,7 @@ public:
     template <class Evaluation>
     static Evaluation gasThermalConductivity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateGasTP_(data_.gasThermalConductivity_.data(),
+        const Evaluation& result = interpolateGasTP_(data_.gasThermalConductivity_,
                                                      temperature,
                                                      pressure);
         if (std::isnan(scalarValue(result)))
@@ -567,7 +567,7 @@ public:
     template <class Evaluation>
     static Evaluation liquidThermalConductivity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateLiquidTP_(data_.liquidThermalConductivity_.data(),
+        const Evaluation& result = interpolateLiquidTP_(data_.liquidThermalConductivity_,
                                                         temperature,
                                                         pressure);
         if (std::isnan(scalarValue(result)))
@@ -578,7 +578,7 @@ public:
 private:
     // returns an interpolated value depending on temperature
     template <class Evaluation>
-    static Evaluation interpolateT_(const Scalar* values, const Evaluation& T)
+    static Evaluation interpolateT_(const std::vector<Scalar>& values, const Evaluation& T)
     {
         Evaluation alphaT = tempIdx_(T);
         if (alphaT < 0 || alphaT >= data_.nTemp_ - 1)
@@ -595,7 +595,9 @@ private:
     // returns an interpolated value for liquid depending on
     // temperature and pressure
     template <class Evaluation>
-    static Evaluation interpolateLiquidTP_(const Scalar* values, const Evaluation& T, const Evaluation& p)
+    static Evaluation interpolateLiquidTP_(const std::vector<Scalar>& values,
+                                           const Evaluation& T,
+                                           const Evaluation& p)
     {
         Evaluation alphaT = tempIdx_(T);
         if (alphaT < 0 || alphaT >= data_.nTemp_ - 1)
@@ -628,7 +630,9 @@ private:
     // returns an interpolated value for gas depending on
     // temperature and pressure
     template <class Evaluation>
-    static Evaluation interpolateGasTP_(const Scalar* values, const Evaluation& T, const Evaluation& p)
+    static Evaluation interpolateGasTP_(const std::vector<Scalar>& values,
+                                        const Evaluation& T,
+                                        const Evaluation& p)
     {
         Evaluation alphaT = tempIdx_(T);
         if (alphaT < 0 || alphaT >= data_.nTemp_ - 1)
@@ -663,7 +667,9 @@ private:
     // returns an interpolated value for gas depending on
     // temperature and density
     template <class Evaluation>
-    static Evaluation interpolateGasTRho_(const Scalar* values, const Evaluation& T, const Evaluation& rho)
+    static Evaluation interpolateGasTRho_(const std::vector<Scalar>& values,
+                                          const Evaluation& T,
+                                          const Evaluation& rho)
     {
         Evaluation alphaT = tempIdx_(T);
         unsigned iT = std::max(0,
@@ -694,7 +700,9 @@ private:
     // returns an interpolated value for liquid depending on
     // temperature and density
     template <class Evaluation>
-    static Evaluation interpolateLiquidTRho_(const Scalar* values, const Evaluation& T, const Evaluation& rho)
+    static Evaluation interpolateLiquidTRho_(const std::vector<Scalar>& values,
+                                             const Evaluation& T,
+                                             const Evaluation& rho)
     {
         Evaluation alphaT = tempIdx_(T);
         unsigned iT = std::max<int>(0, std::min<int>(data_.nTemp_ - 2, static_cast<int>(alphaT)));

--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -222,10 +222,12 @@ public:
             // calculate the minimum and maximum values for the gas
             // densities
             data_.minGasDensity__[iT] = RawComponent::gasDensity(temperature, minGasPressure_(iT));
-            if (iT < data_.nTemp_ - 1)
+            if (iT < data_.nTemp_ - 1) {
                 data_.maxGasDensity__[iT] = RawComponent::gasDensity(temperature, maxGasPressure_(iT + 1));
-            else
+            }
+            else {
                 data_.maxGasDensity__[iT] = RawComponent::gasDensity(temperature, maxGasPressure_(iT));
+            }
 
             // fill the temperature, density gas arrays
             for (unsigned iRho = 0; iRho < data_.nDensity_; ++ iRho) {
@@ -244,10 +246,12 @@ public:
             // calculate the minimum and maximum values for the liquid
             // densities
             data_.minLiquidDensity__[iT] = RawComponent::liquidDensity(temperature, minLiquidPressure_(iT));
-            if (iT < data_.nTemp_ - 1)
+            if (iT < data_.nTemp_ - 1) {
                 data_.maxLiquidDensity__[iT] = RawComponent::liquidDensity(temperature, maxLiquidPressure_(iT + 1));
-            else
+            }
+            else {
                 data_.maxLiquidDensity__[iT] = RawComponent::liquidDensity(temperature, maxLiquidPressure_(iT));
+            }
 
             // fill the temperature, density liquid arrays
             for (unsigned iRho = 0; iRho < data_.nDensity_; ++ iRho) {
@@ -261,7 +265,7 @@ public:
 
                 try { data_.liquidPressure_[i] = RawComponent::liquidPressure(temperature, density); }
                 catch (const std::exception&) { data_.liquidPressure_[i] = NaN; };
-            };
+            }
         }
     }
 
@@ -323,8 +327,9 @@ public:
     static Evaluation vaporPressure(const Evaluation& temperature)
     {
         const Evaluation& result = interpolateT_(data_.vaporPressure_, temperature);
-        if (std::isnan(scalarValue(result)))
+        if (std::isnan(scalarValue(result))) {
             return RawComponent::vaporPressure(temperature);
+        }
         return result;
     }
 
@@ -340,8 +345,9 @@ public:
         const Evaluation& result = interpolateGasTP_(data_.gasEnthalpy_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(scalarValue(result)))
+        if (std::isnan(scalarValue(result))) {
             return RawComponent::gasEnthalpy(temperature, pressure);
+        }
         return result;
     }
 
@@ -357,8 +363,9 @@ public:
         const Evaluation& result = interpolateLiquidTP_(data_.liquidEnthalpy_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(scalarValue(result)))
+        if (std::isnan(scalarValue(result))) {
             return RawComponent::liquidEnthalpy(temperature, pressure);
+        }
         return result;
     }
 
@@ -374,8 +381,9 @@ public:
         const Evaluation& result = interpolateGasTP_(data_.gasHeatCapacity_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(scalarValue(result)))
+        if (std::isnan(scalarValue(result))) {
             return RawComponent::gasHeatCapacity(temperature, pressure);
+        }
         return result;
     }
 
@@ -391,8 +399,9 @@ public:
         const Evaluation& result = interpolateLiquidTP_(data_.liquidHeatCapacity_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(scalarValue(result)))
+        if (std::isnan(scalarValue(result))) {
             return RawComponent::liquidHeatCapacity(temperature, pressure);
+        }
         return result;
     }
 
@@ -428,9 +437,10 @@ public:
         const Evaluation& result = interpolateGasTRho_(data_.gasPressure_,
                                                        temperature,
                                                        density);
-        if (std::isnan(scalarValue(result)))
+        if (std::isnan(scalarValue(result))) {
             return RawComponent::gasPressure(temperature,
                                              density);
+        }
         return result;
     }
 
@@ -446,9 +456,10 @@ public:
         const Evaluation& result = interpolateLiquidTRho_(data_.liquidPressure_,
                                                           temperature,
                                                           density);
-        if (std::isnan(scalarValue(result)))
+        if (std::isnan(scalarValue(result))) {
             return RawComponent::liquidPressure(temperature,
                                                 density);
+        }
         return result;
     }
 
@@ -484,8 +495,9 @@ public:
         const Evaluation& result = interpolateGasTP_(data_.gasDensity_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(scalarValue(result)))
+        if (std::isnan(scalarValue(result))) {
             return RawComponent::gasDensity(temperature, pressure);
+        }
         return result;
     }
 
@@ -502,8 +514,9 @@ public:
         const Evaluation& result = interpolateLiquidTP_(data_.liquidDensity_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(scalarValue(result)))
+        if (std::isnan(scalarValue(result))) {
             return RawComponent::liquidDensity(temperature, pressure);
+        }
         return result;
     }
 
@@ -519,8 +532,9 @@ public:
         const Evaluation& result = interpolateGasTP_(data_.gasViscosity_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(scalarValue(result)))
+        if (std::isnan(scalarValue(result))) {
             return RawComponent::gasViscosity(temperature, pressure);
+        }
         return result;
     }
 
@@ -536,8 +550,9 @@ public:
         const Evaluation& result = interpolateLiquidTP_(data_.liquidViscosity_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(scalarValue(result)))
+        if (std::isnan(scalarValue(result))) {
             return RawComponent::liquidViscosity(temperature, pressure);
+        }
         return result;
     }
 
@@ -553,8 +568,9 @@ public:
         const Evaluation& result = interpolateGasTP_(data_.gasThermalConductivity_,
                                                      temperature,
                                                      pressure);
-        if (std::isnan(scalarValue(result)))
+        if (std::isnan(scalarValue(result))) {
             return RawComponent::gasThermalConductivity(temperature, pressure);
+        }
         return result;
     }
 
@@ -570,8 +586,9 @@ public:
         const Evaluation& result = interpolateLiquidTP_(data_.liquidThermalConductivity_,
                                                         temperature,
                                                         pressure);
-        if (std::isnan(scalarValue(result)))
+        if (std::isnan(scalarValue(result))) {
             return RawComponent::liquidThermalConductivity(temperature, pressure);
+        }
         return result;
     }
 
@@ -581,8 +598,9 @@ private:
     static Evaluation interpolateT_(const std::vector<Scalar>& values, const Evaluation& T)
     {
         Evaluation alphaT = tempIdx_(T);
-        if (alphaT < 0 || alphaT >= data_.nTemp_ - 1)
+        if (alphaT < 0 || alphaT >= data_.nTemp_ - 1) {
             return std::numeric_limits<Scalar>::quiet_NaN();
+        }
 
         const size_t iT = static_cast<size_t>(scalarValue(alphaT));
         alphaT -= iT;
@@ -600,8 +618,9 @@ private:
                                            const Evaluation& p)
     {
         Evaluation alphaT = tempIdx_(T);
-        if (alphaT < 0 || alphaT >= data_.nTemp_ - 1)
+        if (alphaT < 0 || alphaT >= data_.nTemp_ - 1) {
             return std::numeric_limits<Scalar>::quiet_NaN();
+        }
 
         const size_t iT = static_cast<size_t>(scalarValue(alphaT));
         alphaT -= iT;
@@ -635,8 +654,9 @@ private:
                                         const Evaluation& p)
     {
         Evaluation alphaT = tempIdx_(T);
-        if (alphaT < 0 || alphaT >= data_.nTemp_ - 1)
+        if (alphaT < 0 || alphaT >= data_.nTemp_ - 1) {
             return std::numeric_limits<Scalar>::quiet_NaN();
+        }
 
         const size_t iT =
             static_cast<size_t>(
@@ -773,40 +793,48 @@ private:
     // temperature index
     static Scalar minLiquidPressure_(size_t tempIdx)
     {
-        if (!useVaporPressure)
+        if (!useVaporPressure) {
             return data_.pressMin_;
-        else
+        }
+        else {
             return std::max<Scalar>(data_.pressMin_, data_.vaporPressure_[tempIdx] / 1.1);
+        }
     }
 
     // returns the maximum tabulized liquid pressure at a given
     // temperature index
     static Scalar maxLiquidPressure_(size_t tempIdx)
     {
-        if (!useVaporPressure)
+        if (!useVaporPressure) {
             return data_.pressMax_;
-        else
+        }
+        else {
             return std::max<Scalar>(data_.pressMax_, data_.vaporPressure_[tempIdx] * 1.1);
+        }
     }
 
     // returns the minumum tabulized gas pressure at a given
     // temperature index
     static Scalar minGasPressure_(size_t tempIdx)
     {
-        if (!useVaporPressure)
+        if (!useVaporPressure) {
             return data_.pressMin_;
-        else
+        }
+        else {
             return std::min<Scalar>(data_.pressMin_, data_.vaporPressure_[tempIdx] / 1.1);
+        }
     }
 
     // returns the maximum tabulized gas pressure at a given
     // temperature index
     static Scalar maxGasPressure_(size_t tempIdx)
     {
-        if (!useVaporPressure)
+        if (!useVaporPressure) {
             return data_.pressMax_;
-        else
+        }
+        else {
             return std::min<Scalar>(data_.pressMax_, data_.vaporPressure_[tempIdx] * 1.1);
+        }
     }
 
 

--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -28,12 +28,13 @@
 #ifndef OPM_TABULATED_COMPONENT_HPP
 #define OPM_TABULATED_COMPONENT_HPP
 
+#include <opm/material/common/MathToolbox.hpp>
+
 #include <cmath>
 #include <limits>
 #include <cassert>
 #include <stdexcept>
-
-#include <opm/material/common/MathToolbox.hpp>
+#include <vector>
 
 namespace Opm {
 /*!
@@ -55,7 +56,7 @@ template <class ScalarT, class RawComponent, bool useVaporPressure=true>
 class TabulatedComponent
 {
 public:
-    typedef ScalarT Scalar;
+    using Scalar = ScalarT;
 
     static constexpr bool isTabulated = true;
 
@@ -81,27 +82,27 @@ public:
         nDensity_ = nPress_;
 
         // allocate the arrays
-        vaporPressure_ = new Scalar[nTemp_];
-        minGasDensity__ = new Scalar[nTemp_];
-        maxGasDensity__ = new Scalar[nTemp_];
-        minLiquidDensity__ = new Scalar[nTemp_];
-        maxLiquidDensity__ = new Scalar[nTemp_];
+        vaporPressure_.resize(nTemp_);
+        minGasDensity__.resize(nTemp_);
+        maxGasDensity__.resize(nTemp_);
+        minLiquidDensity__.resize(nTemp_);
+        maxLiquidDensity__.resize(nTemp_);
 
-        gasEnthalpy_ = new Scalar[nTemp_*nPress_];
-        liquidEnthalpy_ = new Scalar[nTemp_*nPress_];
-        gasHeatCapacity_ = new Scalar[nTemp_*nPress_];
-        liquidHeatCapacity_ = new Scalar[nTemp_*nPress_];
-        gasDensity_ = new Scalar[nTemp_*nPress_];
-        liquidDensity_ = new Scalar[nTemp_*nPress_];
-        gasViscosity_ = new Scalar[nTemp_*nPress_];
-        liquidViscosity_ = new Scalar[nTemp_*nPress_];
-        gasThermalConductivity_ = new Scalar[nTemp_*nPress_];
-        liquidThermalConductivity_ = new Scalar[nTemp_*nPress_];
-        gasPressure_ = new Scalar[nTemp_*nDensity_];
-        liquidPressure_ = new Scalar[nTemp_*nDensity_];
+        gasEnthalpy_.resize(nTemp_*nPress_);
+        liquidEnthalpy_.resize(nTemp_*nPress_);
+        gasHeatCapacity_.resize(nTemp_*nPress_);
+        liquidHeatCapacity_.resize(nTemp_*nPress_);
+        gasDensity_.resize(nTemp_*nPress_);
+        liquidDensity_.resize(nTemp_*nPress_);
+        gasViscosity_.resize(nTemp_*nPress_);
+        liquidViscosity_.resize(nTemp_*nPress_);
+        gasThermalConductivity_.resize(nTemp_*nPress_);
+        liquidThermalConductivity_.resize(nTemp_*nPress_);
+        gasPressure_.resize(nTemp_*nDensity_);
+        liquidPressure_.resize(nTemp_*nDensity_);
 
         assert(std::numeric_limits<Scalar>::has_quiet_NaN);
-        Scalar NaN = std::numeric_limits<Scalar>::quiet_NaN();
+        constexpr Scalar NaN = std::numeric_limits<Scalar>::quiet_NaN();
 
         // fill the temperature-pressure arrays
         for (unsigned iT = 0; iT < nTemp_; ++ iT) {
@@ -266,7 +267,7 @@ public:
     template <class Evaluation>
     static Evaluation vaporPressure(const Evaluation& temperature)
     {
-        const Evaluation& result = interpolateT_(vaporPressure_, temperature);
+        const Evaluation& result = interpolateT_(vaporPressure_.data(), temperature);
         if (std::isnan(scalarValue(result)))
             return RawComponent::vaporPressure(temperature);
         return result;
@@ -281,7 +282,7 @@ public:
     template <class Evaluation>
     static Evaluation gasEnthalpy(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateGasTP_(gasEnthalpy_,
+        const Evaluation& result = interpolateGasTP_(gasEnthalpy_.data(),
                                                      temperature,
                                                      pressure);
         if (std::isnan(scalarValue(result)))
@@ -298,7 +299,7 @@ public:
     template <class Evaluation>
     static Evaluation liquidEnthalpy(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateLiquidTP_(liquidEnthalpy_,
+        const Evaluation& result = interpolateLiquidTP_(liquidEnthalpy_.data(),
                                                         temperature,
                                                         pressure);
         if (std::isnan(scalarValue(result)))
@@ -315,7 +316,7 @@ public:
     template <class Evaluation>
     static Evaluation gasHeatCapacity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateGasTP_(gasHeatCapacity_,
+        const Evaluation& result = interpolateGasTP_(gasHeatCapacity_.data(),
                                                      temperature,
                                                      pressure);
         if (std::isnan(scalarValue(result)))
@@ -332,7 +333,7 @@ public:
     template <class Evaluation>
     static Evaluation liquidHeatCapacity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateLiquidTP_(liquidHeatCapacity_,
+        const Evaluation& result = interpolateLiquidTP_(liquidHeatCapacity_.data(),
                                                         temperature,
                                                         pressure);
         if (std::isnan(scalarValue(result)))
@@ -369,7 +370,7 @@ public:
     template <class Evaluation>
     static Evaluation gasPressure(const Evaluation& temperature, Scalar density)
     {
-        const Evaluation& result = interpolateGasTRho_(gasPressure_,
+        const Evaluation& result = interpolateGasTRho_(gasPressure_.data(),
                                                        temperature,
                                                        density);
         if (std::isnan(scalarValue(result)))
@@ -387,7 +388,7 @@ public:
     template <class Evaluation>
     static Evaluation liquidPressure(const Evaluation& temperature, Scalar density)
     {
-        const Evaluation& result = interpolateLiquidTRho_(liquidPressure_,
+        const Evaluation& result = interpolateLiquidTRho_(liquidPressure_.data(),
                                                           temperature,
                                                           density);
         if (std::isnan(scalarValue(result)))
@@ -425,7 +426,7 @@ public:
     template <class Evaluation>
     static Evaluation gasDensity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateGasTP_(gasDensity_,
+        const Evaluation& result = interpolateGasTP_(gasDensity_.data(),
                                                      temperature,
                                                      pressure);
         if (std::isnan(scalarValue(result)))
@@ -443,7 +444,7 @@ public:
     template <class Evaluation>
     static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateLiquidTP_(liquidDensity_,
+        const Evaluation& result = interpolateLiquidTP_(liquidDensity_.data(),
                                                         temperature,
                                                         pressure);
         if (std::isnan(scalarValue(result)))
@@ -460,7 +461,7 @@ public:
     template <class Evaluation>
     static Evaluation gasViscosity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateGasTP_(gasViscosity_,
+        const Evaluation& result = interpolateGasTP_(gasViscosity_.data(),
                                                      temperature,
                                                      pressure);
         if (std::isnan(scalarValue(result)))
@@ -477,7 +478,7 @@ public:
     template <class Evaluation>
     static Evaluation liquidViscosity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateLiquidTP_(liquidViscosity_,
+        const Evaluation& result = interpolateLiquidTP_(liquidViscosity_.data(),
                                                         temperature,
                                                         pressure);
         if (std::isnan(scalarValue(result)))
@@ -494,7 +495,7 @@ public:
     template <class Evaluation>
     static Evaluation gasThermalConductivity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateGasTP_(gasThermalConductivity_,
+        const Evaluation& result = interpolateGasTP_(gasThermalConductivity_.data(),
                                                      temperature,
                                                      pressure);
         if (std::isnan(scalarValue(result)))
@@ -511,7 +512,7 @@ public:
     template <class Evaluation>
     static Evaluation liquidThermalConductivity(const Evaluation& temperature, const Evaluation& pressure)
     {
-        const Evaluation& result = interpolateLiquidTP_(liquidThermalConductivity_,
+        const Evaluation& result = interpolateLiquidTP_(liquidThermalConductivity_.data(),
                                                         temperature,
                                                         pressure);
         if (std::isnan(scalarValue(result)))
@@ -766,35 +767,35 @@ private:
     { return maxGasDensity__[tempIdx]; }
 
     // 1D fields with the temperature as degree of freedom
-    static Scalar* vaporPressure_;
+    static std::vector<Scalar> vaporPressure_;
 
-    static Scalar* minLiquidDensity__;
-    static Scalar* maxLiquidDensity__;
+    static std::vector<Scalar> minLiquidDensity__;
+    static std::vector<Scalar> maxLiquidDensity__;
 
-    static Scalar* minGasDensity__;
-    static Scalar* maxGasDensity__;
+    static std::vector<Scalar> minGasDensity__;
+    static std::vector<Scalar> maxGasDensity__;
 
     // 2D fields with the temperature and pressure as degrees of
     // freedom
-    static Scalar* gasEnthalpy_;
-    static Scalar* liquidEnthalpy_;
+    static std::vector<Scalar> gasEnthalpy_;
+    static std::vector<Scalar> liquidEnthalpy_;
 
-    static Scalar* gasHeatCapacity_;
-    static Scalar* liquidHeatCapacity_;
+    static std::vector<Scalar> gasHeatCapacity_;
+    static std::vector<Scalar> liquidHeatCapacity_;
 
-    static Scalar* gasDensity_;
-    static Scalar* liquidDensity_;
+    static std::vector<Scalar> gasDensity_;
+    static std::vector<Scalar> liquidDensity_;
 
-    static Scalar* gasViscosity_;
-    static Scalar* liquidViscosity_;
+    static std::vector<Scalar> gasViscosity_;
+    static std::vector<Scalar> liquidViscosity_;
 
-    static Scalar* gasThermalConductivity_;
-    static Scalar* liquidThermalConductivity_;
+    static std::vector<Scalar> gasThermalConductivity_;
+    static std::vector<Scalar> liquidThermalConductivity_;
 
     // 2D fields with the temperature and density as degrees of
     // freedom
-    static Scalar* gasPressure_;
-    static Scalar* liquidPressure_;
+    static std::vector<Scalar> gasPressure_;
+    static std::vector<Scalar> liquidPressure_;
 
     // temperature, pressure and density ranges
     static Scalar tempMin_;
@@ -811,39 +812,39 @@ private:
 };
 
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::vaporPressure_;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::vaporPressure_;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::minLiquidDensity__;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::minLiquidDensity__;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::maxLiquidDensity__;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::maxLiquidDensity__;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::minGasDensity__;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::minGasDensity__;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::maxGasDensity__;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::maxGasDensity__;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::gasEnthalpy_;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::gasEnthalpy_;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::liquidEnthalpy_;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::liquidEnthalpy_;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::gasHeatCapacity_;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::gasHeatCapacity_;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::liquidHeatCapacity_;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::liquidHeatCapacity_;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::gasDensity_;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::gasDensity_;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::liquidDensity_;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::liquidDensity_;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::gasViscosity_;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::gasViscosity_;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::liquidViscosity_;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::liquidViscosity_;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::gasThermalConductivity_;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::gasThermalConductivity_;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::liquidThermalConductivity_;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::liquidThermalConductivity_;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::gasPressure_;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::gasPressure_;
 template <class Scalar, class RawComponent, bool useVaporPressure>
-Scalar* TabulatedComponent<Scalar, RawComponent, useVaporPressure>::liquidPressure_;
+std::vector<Scalar> TabulatedComponent<Scalar, RawComponent, useVaporPressure>::liquidPressure_;
 template <class Scalar, class RawComponent, bool useVaporPressure>
 Scalar TabulatedComponent<Scalar, RawComponent, useVaporPressure>::tempMin_;
 template <class Scalar, class RawComponent, bool useVaporPressure>

--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -163,8 +163,12 @@ public:
         for (unsigned iT = 0; iT < data_.nTemp_; ++ iT) {
             const Scalar temperature = iT * (data_.tempMax_ - data_.tempMin_) / (data_.nTemp_ - 1) + data_.tempMin_;
 
-            try { data_.vaporPressure_[iT] = RawComponent::vaporPressure(temperature); }
-            catch (const std::exception&) { data_.vaporPressure_[iT] = NaN; }
+            try {
+                data_.vaporPressure_[iT] = RawComponent::vaporPressure(temperature);
+            }
+            catch (const std::exception&) {
+                data_.vaporPressure_[iT] = NaN;
+            }
 
             const Scalar pgMax = maxGasPressure_(iT);
             const Scalar pgMin = minGasPressure_(iT);
@@ -175,20 +179,40 @@ public:
 
                 const unsigned i = iT + iP * data_.nTemp_;
 
-                try { data_.gasEnthalpy_[i] = RawComponent::gasEnthalpy(temperature, pressure); }
-                catch (const std::exception&) { data_.gasEnthalpy_[i] = NaN; }
+                try {
+                    data_.gasEnthalpy_[i] = RawComponent::gasEnthalpy(temperature, pressure);
+                }
+                catch (const std::exception&) {
+                    data_.gasEnthalpy_[i] = NaN;
+                }
 
-                try { data_.gasHeatCapacity_[i] = RawComponent::gasHeatCapacity(temperature, pressure); }
-                catch (const std::exception&) { data_.gasHeatCapacity_[i] = NaN; }
+                try {
+                    data_.gasHeatCapacity_[i] = RawComponent::gasHeatCapacity(temperature, pressure);
+                }
+                catch (const std::exception&) {
+                    data_.gasHeatCapacity_[i] = NaN;
+                }
 
-                try { data_.gasDensity_[i] = RawComponent::gasDensity(temperature, pressure); }
-                catch (const std::exception&) { data_.gasDensity_[i] = NaN; }
+                try {
+                    data_.gasDensity_[i] = RawComponent::gasDensity(temperature, pressure);
+                }
+                catch (const std::exception&) {
+                    data_.gasDensity_[i] = NaN;
+                }
 
-                try { data_.gasViscosity_[i] = RawComponent::gasViscosity(temperature, pressure); }
-                catch (const std::exception&) { data_.gasViscosity_[i] = NaN; }
+                try {
+                    data_.gasViscosity_[i] = RawComponent::gasViscosity(temperature, pressure);
+                }
+                catch (const std::exception&) {
+                    data_.gasViscosity_[i] = NaN;
+                }
 
-                try { data_.gasThermalConductivity_[i] = RawComponent::gasThermalConductivity(temperature, pressure); }
-                catch (const std::exception&) { data_.gasThermalConductivity_[i] = NaN; }
+                try {
+                    data_.gasThermalConductivity_[i] = RawComponent::gasThermalConductivity(temperature, pressure);
+                }
+                catch (const std::exception&) {
+                    data_.gasThermalConductivity_[i] = NaN;
+                }
             };
 
             const Scalar plMin = minLiquidPressure_(iT);
@@ -198,20 +222,40 @@ public:
 
                 const unsigned i = iT + iP*data_.nTemp_;
 
-                try { data_.liquidEnthalpy_[i] = RawComponent::liquidEnthalpy(temperature, pressure); }
-                catch (const std::exception&) { data_.liquidEnthalpy_[i] = NaN; }
+                try {
+                    data_.liquidEnthalpy_[i] = RawComponent::liquidEnthalpy(temperature, pressure);
+                }
+                catch (const std::exception&) {
+                    data_.liquidEnthalpy_[i] = NaN;
+                }
 
-                try { data_.liquidHeatCapacity_[i] = RawComponent::liquidHeatCapacity(temperature, pressure); }
-                catch (const std::exception&) { data_.liquidHeatCapacity_[i] = NaN; }
+                try {
+                    data_.liquidHeatCapacity_[i] = RawComponent::liquidHeatCapacity(temperature, pressure);
+                }
+                catch (const std::exception&) {
+                    data_.liquidHeatCapacity_[i] = NaN;
+                }
 
-                try { data_.liquidDensity_[i] = RawComponent::liquidDensity(temperature, pressure); }
-                catch (const std::exception&) { data_.liquidDensity_[i] = NaN; }
+                try {
+                    data_.liquidDensity_[i] = RawComponent::liquidDensity(temperature, pressure);
+                }
+                catch (const std::exception&) {
+                    data_.liquidDensity_[i] = NaN;
+                }
 
-                try { data_.liquidViscosity_[i] = RawComponent::liquidViscosity(temperature, pressure); }
-                catch (const std::exception&) { data_.liquidViscosity_[i] = NaN; }
+                try {
+                    data_.liquidViscosity_[i] = RawComponent::liquidViscosity(temperature, pressure);
+                }
+                catch (const std::exception&) {
+                    data_.liquidViscosity_[i] = NaN;
+                }
 
-                try { data_.liquidThermalConductivity_[i] = RawComponent::liquidThermalConductivity(temperature, pressure); }
-                catch (const std::exception&) { data_.liquidThermalConductivity_[i] = NaN; }
+                try {
+                    data_.liquidThermalConductivity_[i] = RawComponent::liquidThermalConductivity(temperature, pressure);
+                }
+                catch (const std::exception&) {
+                    data_.liquidThermalConductivity_[i] = NaN;
+                }
             }
         }
 
@@ -239,9 +283,13 @@ public:
 
                 const unsigned i = iT + iRho * data_.nTemp_;
 
-                try { data_.gasPressure_[i] = RawComponent::gasPressure(temperature, density); }
-                catch (const std::exception&) { data_.gasPressure_[i] = NaN; };
-            };
+                try {
+                    data_.gasPressure_[i] = RawComponent::gasPressure(temperature, density);
+                }
+                catch (const std::exception&) {
+                    data_.gasPressure_[i] = NaN;
+                }
+            }
 
             // calculate the minimum and maximum values for the liquid
             // densities
@@ -263,8 +311,12 @@ public:
 
                 const unsigned i = iT + iRho * data_.nTemp_;
 
-                try { data_.liquidPressure_[i] = RawComponent::liquidPressure(temperature, density); }
-                catch (const std::exception&) { data_.liquidPressure_[i] = NaN; };
+                try {
+                    data_.liquidPressure_[i] = RawComponent::liquidPressure(temperature, density);
+                }
+                catch (const std::exception&) {
+                    data_.liquidPressure_[i] = NaN;
+                }
             }
         }
     }
@@ -413,7 +465,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation gasInternalEnergy(const Evaluation& temperature, const Evaluation& pressure)
-    { return gasEnthalpy(temperature, pressure) - pressure/gasDensity(temperature, pressure); }
+    { return gasEnthalpy(temperature, pressure) - pressure / gasDensity(temperature, pressure); }
 
     /*!
      * \brief Specific internal energy of the liquid \f$\mathrm{[J/kg]}\f$.
@@ -423,7 +475,7 @@ public:
      */
     template <class Evaluation>
     static Evaluation liquidInternalEnergy(const Evaluation& temperature, const Evaluation& pressure)
-    { return liquidEnthalpy(temperature, pressure) - pressure/liquidDensity(temperature, pressure); }
+    { return liquidEnthalpy(temperature, pressure) - pressure / liquidDensity(temperature, pressure); }
 
     /*!
      * \brief The pressure of gas in \f$\mathrm{[Pa]}\f$ at a given density and temperature.
@@ -480,7 +532,6 @@ public:
      */
     static bool gasIsIdeal()
     { return RawComponent::gasIsIdeal(); }
-
 
     /*!
      * \brief The density of gas at a given pressure and temperature
@@ -743,7 +794,6 @@ private:
             values[(iT + 1) + (iP2 + 1) * data_.nTemp_] * (    alphaT) * (    alphaP2);
     }
 
-
     // returns the index of an entry in a temperature field
     template <class Evaluation>
     static Evaluation tempIdx_(const Evaluation& temperature)
@@ -836,7 +886,6 @@ private:
             return std::min<Scalar>(data_.pressMax_, data_.vaporPressure_[tempIdx] * 1.1);
         }
     }
-
 
     // returns the minimum tabulized liquid density at a given
     // temperature index

--- a/opm/material/components/TabulatedComponent.hpp
+++ b/opm/material/components/TabulatedComponent.hpp
@@ -31,6 +31,7 @@
 #include <opm/material/common/MathToolbox.hpp>
 
 #include <cmath>
+#include <cstddef>
 #include <limits>
 #include <cassert>
 #include <stdexcept>
@@ -653,7 +654,7 @@ private:
             return std::numeric_limits<Scalar>::quiet_NaN();
         }
 
-        const size_t iT = static_cast<size_t>(scalarValue(alphaT));
+        const std::size_t iT = static_cast<std::size_t>(scalarValue(alphaT));
         alphaT -= iT;
 
         return
@@ -673,18 +674,18 @@ private:
             return std::numeric_limits<Scalar>::quiet_NaN();
         }
 
-        const size_t iT = static_cast<size_t>(scalarValue(alphaT));
+        const std::size_t iT = static_cast<std::size_t>(scalarValue(alphaT));
         alphaT -= iT;
 
         Evaluation alphaP1 = pressLiquidIdx_(p, iT);
         Evaluation alphaP2 = pressLiquidIdx_(p, iT + 1);
 
-        const size_t iP1 =
-            static_cast<size_t>(
+        const std::size_t iP1 =
+            static_cast<std::size_t>(
                 std::max<int>(0, std::min(static_cast<int>(data_.nPress_) - 2,
                                           static_cast<int>(scalarValue(alphaP1)))));
-        const size_t iP2 =
-            static_cast<size_t>(
+        const std::size_t iP2 =
+            static_cast<std::size_t>(
                 std::max(0, std::min(static_cast<int>(data_.nPress_) - 2,
                                      static_cast<int>(scalarValue(alphaP2)))));
         alphaP1 -= iP1;
@@ -709,20 +710,20 @@ private:
             return std::numeric_limits<Scalar>::quiet_NaN();
         }
 
-        const size_t iT =
-            static_cast<size_t>(
+        const std::size_t iT =
+            static_cast<std::size_t>(
                 std::max(0, std::min(static_cast<int>(data_.nTemp_) - 2,
                                      static_cast<int>(scalarValue(alphaT)))));
         alphaT -= iT;
 
         Evaluation alphaP1 = pressGasIdx_(p, iT);
         Evaluation alphaP2 = pressGasIdx_(p, iT + 1);
-        const size_t iP1 =
-            static_cast<size_t>(
+        const std::size_t iP1 =
+            static_cast<std::size_t>(
                 std::max(0, std::min(static_cast<int>(data_.nPress_) - 2,
                                      static_cast<int>(scalarValue(alphaP1)))));
-        const size_t iP2 =
-            static_cast<size_t>(
+        const std::size_t iP2 =
+            static_cast<std::size_t>(
                 std::max(0, std::min(static_cast<int>(data_.nPress_) - 2,
                                      static_cast<int>(scalarValue(alphaP2)))));
         alphaP1 -= iP1;
@@ -803,7 +804,7 @@ private:
 
     // returns the index of an entry in a pressure field
     template <class Evaluation>
-    static Evaluation pressLiquidIdx_(const Evaluation& pressure, size_t tempIdx)
+    static Evaluation pressLiquidIdx_(const Evaluation& pressure, std::size_t tempIdx)
     {
         const Scalar plMin = minLiquidPressure_(tempIdx);
         const Scalar plMax = maxLiquidPressure_(tempIdx);
@@ -813,7 +814,7 @@ private:
 
     // returns the index of an entry in a temperature field
     template <class Evaluation>
-    static Evaluation pressGasIdx_(const Evaluation& pressure, size_t tempIdx)
+    static Evaluation pressGasIdx_(const Evaluation& pressure, std::size_t tempIdx)
     {
         const Scalar pgMin = minGasPressure_(tempIdx);
         const Scalar pgMax = maxGasPressure_(tempIdx);
@@ -823,7 +824,7 @@ private:
 
     // returns the index of an entry in a density field
     template <class Evaluation>
-    static Evaluation densityLiquidIdx_(const Evaluation& density, size_t tempIdx)
+    static Evaluation densityLiquidIdx_(const Evaluation& density, std::size_t tempIdx)
     {
         const Scalar densityMin = minLiquidDensity_(tempIdx);
         const Scalar densityMax = maxLiquidDensity_(tempIdx);
@@ -832,7 +833,7 @@ private:
 
     // returns the index of an entry in a density field
     template <class Evaluation>
-    static Evaluation densityGasIdx_(const Evaluation& density, size_t tempIdx)
+    static Evaluation densityGasIdx_(const Evaluation& density, std::size_t tempIdx)
     {
         const Scalar densityMin = minGasDensity_(tempIdx);
         const Scalar densityMax = maxGasDensity_(tempIdx);
@@ -841,7 +842,7 @@ private:
 
     // returns the minimum tabulized liquid pressure at a given
     // temperature index
-    static Scalar minLiquidPressure_(size_t tempIdx)
+    static Scalar minLiquidPressure_(std::size_t tempIdx)
     {
         if (!useVaporPressure) {
             return data_.pressMin_;
@@ -853,7 +854,7 @@ private:
 
     // returns the maximum tabulized liquid pressure at a given
     // temperature index
-    static Scalar maxLiquidPressure_(size_t tempIdx)
+    static Scalar maxLiquidPressure_(std::size_t tempIdx)
     {
         if (!useVaporPressure) {
             return data_.pressMax_;
@@ -865,7 +866,7 @@ private:
 
     // returns the minumum tabulized gas pressure at a given
     // temperature index
-    static Scalar minGasPressure_(size_t tempIdx)
+    static Scalar minGasPressure_(std::size_t tempIdx)
     {
         if (!useVaporPressure) {
             return data_.pressMin_;
@@ -877,7 +878,7 @@ private:
 
     // returns the maximum tabulized gas pressure at a given
     // temperature index
-    static Scalar maxGasPressure_(size_t tempIdx)
+    static Scalar maxGasPressure_(std::size_t tempIdx)
     {
         if (!useVaporPressure) {
             return data_.pressMax_;
@@ -889,22 +890,22 @@ private:
 
     // returns the minimum tabulized liquid density at a given
     // temperature index
-    static Scalar minLiquidDensity_(size_t tempIdx)
+    static Scalar minLiquidDensity_(std::size_t tempIdx)
     { return data_.minLiquidDensity__[tempIdx]; }
 
     // returns the maximum tabulized liquid density at a given
     // temperature index
-    static Scalar maxLiquidDensity_(size_t tempIdx)
+    static Scalar maxLiquidDensity_(std::size_t tempIdx)
     { return data_.maxLiquidDensity__[tempIdx]; }
 
     // returns the minumum tabulized gas density at a given
     // temperature index
-    static Scalar minGasDensity_(size_t tempIdx)
+    static Scalar minGasDensity_(std::size_t tempIdx)
     { return data_.minGasDensity__[tempIdx]; }
 
     // returns the maximum tabulized gas density at a given
     // temperature index
-    static Scalar maxGasDensity_(size_t tempIdx)
+    static Scalar maxGasDensity_(std::size_t tempIdx)
     { return data_.maxGasDensity__[tempIdx]; }
 
     static TabulatedComponentData<Scalar> data_;


### PR DESCRIPTION
And tidy up some other things while at it.

While the leak is minor, in that nobody is likely to call this more than once in a run, it clogs up valgrind error logs.