### PR TITLE
fixed: plug minor memory leak

### DIFF
--- a/external/resinsight/LibCore/cvfAssert.cpp
+++ b/external/resinsight/LibCore/cvfAssert.cpp
@@ -425,9 +425,9 @@ int AssertHandlerWinDialog::handleUsingCrtDbgReport(const char* fileName, int li
 //==================================================================================================
 
 #ifdef WIN32
-AssertHandler* Assert::sm_handler = new AssertHandlerWinDialog;
+std::unique_ptr<AssertHandler> Assert::sm_handler = std::make_unique<AssertHandlerWinDialog>();
 #else
-AssertHandler* Assert::sm_handler = new AssertHandlerConsole;
+std::unique_ptr<AssertHandler> Assert::sm_handler = std::make_unique<AssertHandlerConsole>();
 #endif
 
 //--------------------------------------------------------------------------------------------------
@@ -439,17 +439,16 @@ void Assert::setReportMode(ReportMode reportMode)
     if (reportMode == INTERACTIVE_DIALOG) return;
 #endif
 
-    delete sm_handler;
-    sm_handler = NULL;
+    sm_handler.reset();
 
     if (reportMode == CONSOLE)
     {
-        sm_handler = new AssertHandlerConsole;
+        sm_handler = std::make_unique<AssertHandlerConsole>();
     }
 #ifdef WIN32
     else if (reportMode == INTERACTIVE_DIALOG)
     {
-        sm_handler = new AssertHandlerWinDialog;
+        sm_handler = std::make_unique<AssertHandlerWinDialog>();
     }
 #endif
 }

--- a/external/resinsight/LibCore/cvfAssert.h
+++ b/external/resinsight/LibCore/cvfAssert.h
@@ -37,6 +37,8 @@
 
 #pragma once
 
+#include <memory>
+
 namespace external {
 namespace cvf {
 
@@ -69,7 +71,7 @@ public:
     static FailAction   reportFailedAssert(const char* fileName, int lineNumber, const char* expr, const char* msg);
 
 private:
-    static AssertHandler*   sm_handler;
+    static std::unique_ptr<AssertHandler>   sm_handler;
 };
 
 } // cvf


### PR DESCRIPTION
While this is very minor since it's just some small global data being reachable at end of application, it clogs up valgrind error logs and is an easy fix so..