### PR TITLE
Show that EQUALS ACTNUM fails if there are cells with PORO 0

### DIFF
--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -1184,7 +1184,7 @@ static Opm::Deck createActnumBoxDeck2() {
             "ZCORN \n"
             "  8000*1 / \n"
             "PORO \n"
-            "  1000*0.15 /\n"
+            " 0 999*0.15 /\n"
             "EQUALS\n"
             " ACTNUM 0 1 10 1 10 1 1 /\n" // disable top layer
             "/ \n"
@@ -1209,7 +1209,7 @@ static Opm::Deck createActnumBoxDeck2() {
             "1000*0 /\n"
             "EDIT\n"
             "PORV\n"
-            "1000*1 /\n";
+            "0 1000*1 /\n";
 
     Opm::Parser parser;
     return parser.parseString( deckData);

--- a/tests/test_Serialization.cpp
+++ b/tests/test_Serialization.cpp
@@ -174,7 +174,34 @@ namespace {
         return std::make_tuple(out, pos1, pos2);
     }
 }
-
+BOOST_AUTO_TEST_CASE(tuple1)
+{
+    using T = std::tuple<int,double,double>;
+    auto obj = T(0,9,1);
+    int a = 3, b = 4;
+    Opm::Serialization::MemPacker packer;
+    Opm::Serializer ser(packer);
+    ser.pack(a, obj, b);
+    BOOST_CHECK(ser.position() == 192/8+4);
+    T out{};
+    int c{}, d{};
+    ser.unpack(c, out, d);
+    BOOST_CHECK(ser.position() == 192/8+4);
+    
+}
+BOOST_AUTO_TEST_CASE(tuple2)
+{
+    using T = std::tuple<int,double,double>;
+    auto obj = T(0,9,1);
+    Opm::Serialization::MemPacker packer;
+    Opm::Serializer ser(packer);
+    ser.pack(obj);
+    BOOST_CHECK(ser.position() == 128/8+4);
+    T out{};
+    ser.unpack(out);
+    BOOST_CHECK(ser.position() == 128/8+4);
+    
+}
 #define TEST_FOR_TYPE_NAMED_OBJ(TYPE, NAME, OBJ) \
 BOOST_AUTO_TEST_CASE(NAME) \
 { \


### PR DESCRIPTION
Just to show the problem