### PR TITLE
Fix div_unit

### DIFF
--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -464,25 +464,25 @@ measure div_unit( measure numer, measure denom ) {
         denom == measure::liquid_surface_rate )
         return measure::water_cut;
 
-    if( numer == measure::liquid_surface_rate &&
+    if( numer == measure::liquid_surface_volume &&
         denom == measure::time )
-        return measure::liquid_surface_volume;
+        return measure::liquid_surface_rate;
 
-    if( numer == measure::gas_surface_rate &&
+    if( numer == measure::gas_surface_volume &&
         denom == measure::time )
-        return measure::gas_surface_volume;
+        return measure::gas_surface_rate;
 
-    if( numer == measure::mass_rate &&
+    if( numer == measure::mass &&
         denom == measure::time )
-        return measure::mass;
+        return measure::mass_rate;
 
     if( numer == measure::mass_rate &&
         denom == measure::liquid_surface_rate )
         return measure::polymer_density;
 
-    if( numer == measure::energy_rate &&
+    if( numer == measure::energy &&
         denom == measure::time )
-        return measure::energy;
+        return measure::energy_rate;
 
     return measure::identity;
 }

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -451,37 +451,37 @@ constexpr const bool producer = false;
  * unit conversion. This removes a lot of boilerplate. ad-hoc solution to poor
  * unit support in general.
  */
-measure div_unit( measure denom, measure div ) {
-    if( denom == measure::gas_surface_rate &&
-        div   == measure::liquid_surface_rate )
+measure div_unit( measure numer, measure denom ) {
+    if( numer == measure::gas_surface_rate &&
+        denom == measure::liquid_surface_rate )
         return measure::gas_oil_ratio;
 
-    if( denom == measure::liquid_surface_rate &&
-        div   == measure::gas_surface_rate )
+    if( numer == measure::liquid_surface_rate &&
+        denom == measure::gas_surface_rate )
         return measure::oil_gas_ratio;
 
-    if( denom == measure::liquid_surface_rate &&
-        div   == measure::liquid_surface_rate )
+    if( numer == measure::liquid_surface_rate &&
+        denom == measure::liquid_surface_rate )
         return measure::water_cut;
 
-    if( denom == measure::liquid_surface_rate &&
-        div   == measure::time )
+    if( numer == measure::liquid_surface_rate &&
+        denom == measure::time )
         return measure::liquid_surface_volume;
 
-    if( denom == measure::gas_surface_rate &&
-        div   == measure::time )
+    if( numer == measure::gas_surface_rate &&
+        denom == measure::time )
         return measure::gas_surface_volume;
 
-    if( denom == measure::mass_rate &&
-        div   == measure::time )
+    if( numer == measure::mass_rate &&
+        denom == measure::time )
         return measure::mass;
 
-    if( denom == measure::mass_rate &&
-        div   == measure::liquid_surface_rate )
+    if( numer == measure::mass_rate &&
+        denom == measure::liquid_surface_rate )
         return measure::polymer_density;
 
-    if( denom == measure::energy_rate &&
-        div   == measure::time )
+    if( numer == measure::energy_rate &&
+        denom == measure::time )
         return measure::energy;
 
     return measure::identity;


### PR DESCRIPTION
Changed the names of arguments representing the numerator and denominator of the division.
I think div_unit() should convert volume/time to rate NOT rate/time to volume.