### PR TITLE
Rename BlackOilDefaultIndexTraits -> BlackOilDefaultFluidSystemIndices

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -961,7 +961,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/Constants.hpp
       opm/material/fluidsystems/NullParameterCache.hpp
       opm/material/fluidsystems/BaseFluidSystem.hpp
-      opm/material/fluidsystems/BlackOilDefaultIndexTraits.hpp
+      opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp
       opm/material/fluidsystems/ParameterCacheBase.hpp
       opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
       opm/material/fluidsystems/BrineCO2FluidSystem.hpp

--- a/opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp
+++ b/opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp
@@ -22,10 +22,10 @@
 */
 /*!
  * \file
- * \copydoc Opm::BlackOilDefaultIndexTraits
+ * \copydoc Opm::BlackOilDefaultFluidSystemIndices
  */
-#ifndef OPM_BLACK_OIL_DEFAULT_INDEX_TRAITS_HPP
-#define OPM_BLACK_OIL_DEFAULT_INDEX_TRAITS_HPP
+#ifndef OPM_BLACK_OIL_DEFAULT_FLUID_SYSTEM_INDICES_HPP
+#define OPM_BLACK_OIL_DEFAULT_FLUID_SYSTEM_INDICES_HPP
 
 namespace Opm {
 
@@ -33,7 +33,7 @@ namespace Opm {
  * \brief The class which specifies the default phase and component indices for the
  *        black-oil fluid system.
  */
-class BlackOilDefaultIndexTraits
+class BlackOilDefaultFluidSystemIndices
 {
 public:
     //! Index of the water phase

--- a/opm/material/fluidsystems/BlackOilFluidSystem.cpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.cpp
@@ -225,37 +225,37 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
 #endif
 
 #define INSTANTIATE_TYPE(T) \
-    template<> unsigned char BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::numActivePhases_ = 0; \
-    template<> std::array<bool, BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::numPhases> \
-        BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::phaseIsActive_ = {false, false, false}; \
-    template<> std::array<short, BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::numPhases> \
-        BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::activeToCanonicalPhaseIdx_ = {0, 1, 2}; \
-    template<> std::array<short, BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::numPhases> \
-        BlackOilFluidSystem<T , BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::canonicalToActivePhaseIdx_ = {0, 1, 2}; \
-    template<> T BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::surfaceTemperature = 0.0; \
-    template<> T BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::surfacePressure = 0.0; \
-    template<> T BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::reservoirTemperature_ = 0.0; \
-    template<> bool BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::enableDissolvedGas_ = true; \
-    template<> bool BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::enableDissolvedGasInWater_ = false; \
-    template<> bool BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::enableVaporizedOil_ = false; \
-    template<> bool BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::enableVaporizedWater_ = false; \
-    template<> bool BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::enableDiffusion_ = false; \
+    template<> unsigned char BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::numActivePhases_ = 0; \
+    template<> std::array<bool, BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::numPhases> \
+        BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::phaseIsActive_ = {false, false, false}; \
+    template<> std::array<short, BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::numPhases> \
+        BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::activeToCanonicalPhaseIdx_ = {0, 1, 2}; \
+    template<> std::array<short, BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::numPhases> \
+        BlackOilFluidSystem<T , BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::canonicalToActivePhaseIdx_ = {0, 1, 2}; \
+    template<> T BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::surfaceTemperature = 0.0; \
+    template<> T BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::surfacePressure = 0.0; \
+    template<> T BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::reservoirTemperature_ = 0.0; \
+    template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::enableDissolvedGas_ = true; \
+    template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::enableDissolvedGasInWater_ = false; \
+    template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::enableVaporizedOil_ = false; \
+    template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::enableVaporizedWater_ = false; \
+    template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::enableDiffusion_ = false; \
     template<> std::shared_ptr<OilPvtMultiplexer<T>> \
-        BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::oilPvt_ = {}; \
+        BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::oilPvt_ = {}; \
     template<> std::shared_ptr<GasPvtMultiplexer<T>> \
-        BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::gasPvt_ = {}; \
+        BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::gasPvt_ = {}; \
     template<> std::shared_ptr<WaterPvtMultiplexer<T>> \
-        BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::waterPvt_ = {}; \
+        BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::waterPvt_ = {}; \
     template<> std::vector<std::array<T, 3>> \
-        BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::referenceDensity_ = {}; \
+        BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::referenceDensity_ = {}; \
     template<> std::vector<std::array<T, 3>> \
-        BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::molarMass_ = {}; \
+        BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::molarMass_ = {}; \
     template<> std::vector<std::array<T, 9>> \
-        BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::diffusionCoefficients_ = {}; \
-    template<> bool BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::isInitialized_ = false; \
-    template<> bool BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::useSaturatedTables_ = false; \
-    template<> bool BlackOilFluidSystem<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>::enthalpy_eq_energy_ = false; \
-    template class BlackOilFluidSystem<T,BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>;
+        BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::diffusionCoefficients_ = {}; \
+    template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::isInitialized_ = false; \
+    template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::useSaturatedTables_ = false; \
+    template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>::enthalpy_eq_energy_ = false; \
+    template class BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>;
     // IMPORTANT: The class must be instantiated after the template template specializations
     //    or else the static variable above will appear as undefined in the generated object file.
 

--- a/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
@@ -25,7 +25,7 @@
  * \copydoc Opm::BlackOilFluidSystem
  */
 
-#include "BlackOilDefaultIndexTraits.hpp"
+#include <opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp>
 #include "blackoilpvt/OilPvtMultiplexer.hpp"
 #include "blackoilpvt/GasPvtMultiplexer.hpp"
 #include "blackoilpvt/WaterPvtMultiplexer.hpp"
@@ -66,8 +66,8 @@ class Schedule;
  *
  * \tparam Scalar The type used for scalar floating point values
  */
-template <class Scalar, class IndexTraits = BlackOilDefaultIndexTraits, 
-    template<typename> typename Storage = VectorWithDefaultAllocator, 
+template <class Scalar, class IndexTraits = BlackOilDefaultFluidSystemIndices,
+    template<typename> typename Storage = VectorWithDefaultAllocator,
     template<typename> typename SmartPointer = std::shared_ptr>
 class FLUIDSYSTEM_CLASSNAME : public BaseFluidSystem<Scalar, FLUIDSYSTEM_CLASSNAME<Scalar, IndexTraits, Storage, SmartPointer> >
 {
@@ -1907,7 +1907,7 @@ resizeArrays_(std::size_t numRegions)
 }
 
 #ifdef COMPILING_STATIC_FLUID_SYSTEM
-template <typename T> using BOFS = FLUIDSYSTEM_CLASSNAME<T, BlackOilDefaultIndexTraits, VectorWithDefaultAllocator, std::shared_ptr>;
+template <typename T> using BOFS = FLUIDSYSTEM_CLASSNAME<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator, std::shared_ptr>;
 
 #define DECLARE_INSTANCE(T)                                                           \
 template<> unsigned char BOFS<T>::numActivePhases_;                                   \

--- a/opm/material/fluidsystems/BlackOilFunctions.hpp
+++ b/opm/material/fluidsystems/BlackOilFunctions.hpp
@@ -27,7 +27,6 @@
 #ifndef OPM_MATERIAL_FLUIDSYSTEMS_BLACKOILFUNCTIONS_HEADER_INCLUDED
 #define OPM_MATERIAL_FLUIDSYSTEMS_BLACKOILFUNCTIONS_HEADER_INCLUDED
 
-#include "BlackOilDefaultIndexTraits.hpp"
 #include "blackoilpvt/GasPvtMultiplexer.hpp"
 #include "blackoilpvt/OilPvtMultiplexer.hpp"
 #include "blackoilpvt/WaterPvtMultiplexer.hpp"

--- a/opm/material/thermal/EclThermalLawManager.cpp
+++ b/opm/material/thermal/EclThermalLawManager.cpp
@@ -29,7 +29,7 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 
-#include <opm/material/fluidsystems/BlackOilDefaultIndexTraits.hpp>
+#include <opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 
 #include <cassert>
@@ -274,7 +274,7 @@ initNullCond_()
     thermalConductionLawParams_[0].finalize();
 }
 
-using FS = BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>;
+using FS = BlackOilFluidSystem<double, BlackOilDefaultFluidSystemIndices>;
 template class EclThermalLawManager<double,FS>;
 
 } // namespace Opm


### PR DESCRIPTION
Motivation is to more clearly name the various classes providing indices.

Downstream PR also required.