### PR TITLE
Ignoring TNavigator spesific arrays in summary file

### DIFF
--- a/opm/io/eclipse/ESmry.cpp
+++ b/opm/io/eclipse/ESmry.cpp
@@ -1023,7 +1023,8 @@ ESmry::getListOfArrays(const std::string& filename, bool formatted)
 
             fseek(ptr, 8, SEEK_CUR);
 
-            if ((strcmp(arrName, "SEQHDR  ") == 0) || (strcmp(arrName, "MINISTEP") == 0))
+            if ((strcmp(arrName, "SEQHDR  ") == 0) || (strcmp(arrName, "MINISTEP") == 0)
+                  || (strcmp(arrName, "TNAVHEAD") == 0) || (strcmp(arrName, "TNAVTIME") == 0) )
                 arrType = Opm::EclIO::INTE;
             else if (strcmp(arrName, "PARAMS  ") == 0)
                 arrType = Opm::EclIO::REAL;
@@ -1032,11 +1033,13 @@ ESmry::getListOfArrays(const std::string& filename, bool formatted)
             }
         }
 
-        uint64_t filePos = static_cast<uint64_t>(ftell(ptr));
 
-        std::tuple <std::string, uint64_t> t1;
-        t1 = std::make_tuple(Opm::EclIO::trimr(arrName), filePos);
-        resultVect.push_back(t1);
+        if ( std::find(ignore_keyword_list.begin(), ignore_keyword_list.end(), std::string(arrName)) == ignore_keyword_list.end()){
+            uint64_t filePos = static_cast<uint64_t>(ftell(ptr));
+            std::tuple <std::string, uint64_t> t1;
+            t1 = std::make_tuple(Opm::EclIO::trimr(arrName), filePos);
+            resultVect.push_back(t1);
+        }
 
         if (num > 0) {
             if (formatted) {

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -107,6 +107,8 @@ private:
     std::vector<int> seqIndex;
     std::vector<int> mini_steps;
 
+    std::vector<std::string> ignore_keyword_list = {"TNAVHEAD", "TNAVTIME"};
+
     void ijk_from_global_index(int glob, int &i, int &j, int &k) const;
 
     std::vector<SummaryNode> summaryNodes;


### PR DESCRIPTION
WIth this PR we are now able to open summary files (SMSPEC and UNSMRY) from simulator TNavigator using Opm::EclIO::ESmry.