### PR TITLE
refactoring GroupLimitAction, adding exceed action for oil for GCONPROD keyword

### DIFF
--- a/opm/input/eclipse/Schedule/Group/Group.cpp
+++ b/opm/input/eclipse/Schedule/Group/Group.cpp
@@ -142,6 +142,7 @@ namespace {
         production.group_limit_action.allRates = Opm::Group::ExceedActionFromInt(rst_group.exceed_action);
         // For now, we do not know where the other actions are stored in IGRP, so we set them all
         // to the allRates value.
+        production.group_limit_action.oil = production.group_limit_action.allRates;
         production.group_limit_action.water = production.group_limit_action.allRates;
         production.group_limit_action.gas = production.group_limit_action.allRates;
         production.group_limit_action.liquid = production.group_limit_action.allRates;

--- a/opm/input/eclipse/Schedule/Group/Group.hpp
+++ b/opm/input/eclipse/Schedule/Group/Group.hpp
@@ -174,6 +174,7 @@ public:
 
     struct GroupLimitAction
     {
+        // \Note: we do not use allRates in the simulation, while keeping it for now for RESTART output purpose
         ExceedAction allRates{ExceedAction::NONE};
         ExceedAction oil{ExceedAction::NONE};
         ExceedAction water{ExceedAction::NONE};

--- a/opm/input/eclipse/Schedule/Group/Group.hpp
+++ b/opm/input/eclipse/Schedule/Group/Group.hpp
@@ -175,6 +175,7 @@ public:
     struct GroupLimitAction
     {
         ExceedAction allRates{ExceedAction::NONE};
+        ExceedAction oil{ExceedAction::NONE};
         ExceedAction water{ExceedAction::NONE};
         ExceedAction gas{ExceedAction::NONE};
         ExceedAction liquid{ExceedAction::NONE};
@@ -183,6 +184,7 @@ public:
         void serializeOp(Serializer& serializer)
         {
             serializer(allRates);
+            serializer(oil);
             serializer(water);
             serializer(gas);
             serializer(liquid);
@@ -191,6 +193,7 @@ public:
         bool operator==(const GroupLimitAction& other) const
         {
             return (this->allRates == other.allRates)
+                && (this->oil == other.oil)
                 && (this->water == other.water)
                 && (this->gas == other.gas)
                 && (this->liquid == other.liquid);

--- a/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
@@ -179,7 +179,6 @@ void handleGCONPROD(HandlerContext& handlerContext)
         }
 
         const Group::ProductionCMode controlMode = Group::ProductionCModeFromString(record.getItem("CONTROL_MODE").getTrimmedString(0));
-
         Group::GroupLimitAction groupLimitAction;
         groupLimitAction.allRates = Group::ExceedActionFromString(record.getItem("EXCEED_PROC").getTrimmedString(0));
         // \Note: we do not use the allRates anymore. Instead, we have explicit definition of actions for all the possible rate limits
@@ -317,8 +316,6 @@ void handleGCONPROD(HandlerContext& handlerContext)
 
                 if (!apply_default_resv_target)
                     production.production_controls |= static_cast<int>(Group::ProductionCMode::RESV);
-
-                // TODO: similar to RESV, we might need to add for other limits which will be treated with RATE exceeding procedure
 
                 if (new_group.updateProduction(production)) {
                     auto new_config = handlerContext.state().guide_rate();

--- a/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
@@ -179,20 +179,45 @@ void handleGCONPROD(HandlerContext& handlerContext)
         }
 
         const Group::ProductionCMode controlMode = Group::ProductionCModeFromString(record.getItem("CONTROL_MODE").getTrimmedString(0));
+        // \Note: we do not enforce the allRates anymore. Instead, we have explicit definition of actions for all the possible rate limits
+        const Group::ExceedAction allRates = Group::ExceedActionFromString(record.getItem("EXCEED_PROC").getTrimmedString(0));
+
         Group::GroupLimitAction groupLimitAction;
-        groupLimitAction.allRates = Group::ExceedActionFromString(record.getItem("EXCEED_PROC").getTrimmedString(0));
+
+        groupLimitAction.oil = allRates;
 
         groupLimitAction.water = record.getItem("WATER_EXCEED_PROCEDURE").defaultApplied(0)
-        ? groupLimitAction.allRates
+        ? allRates
         : Group::ExceedActionFromString(record.getItem("WATER_EXCEED_PROCEDURE").getTrimmedString(0));
         
         groupLimitAction.gas = record.getItem("GAS_EXCEED_PROCEDURE").defaultApplied(0)
-        ? groupLimitAction.allRates
+        ? allRates
         : Group::ExceedActionFromString(record.getItem("GAS_EXCEED_PROCEDURE").getTrimmedString(0));
 
         groupLimitAction.liquid = record.getItem("LIQUID_EXCEED_PROCEDURE").defaultApplied(0)
-        ? groupLimitAction.allRates
+        ? allRates
         : Group::ExceedActionFromString(record.getItem("LIQUID_EXCEED_PROCEDURE").getTrimmedString(0));
+
+        // we overwrite the actions based on the control mode,
+        // TODO: while how to handle `FLD` remains undecided
+        switch (controlMode) {
+            case Group::ProductionCMode::ORAT:
+                groupLimitAction.oil = Group::ExceedAction::RATE;
+                break;
+            case Group::ProductionCMode::WRAT:
+                groupLimitAction.water = Group::ExceedAction::RATE;
+                break;
+            case Group::ProductionCMode::GRAT:
+                groupLimitAction.gas = Group::ExceedAction::RATE;
+                break;
+            case Group::ProductionCMode::LRAT:
+                groupLimitAction.liquid = Group::ExceedAction::RATE;
+                break;
+            case Group::ProductionCMode::FLD:
+                //TODO: we do not know yet
+            default:
+                break; // do nothing
+        }
 
         const bool respond_to_parent = DeckItem::to_bool(record.getItem("RESPOND_TO_PARENT").getTrimmedString(0));
 
@@ -268,7 +293,7 @@ void handleGCONPROD(HandlerContext& handlerContext)
                 // GCONPROD
                 // 'G1' 'ORAT' 1000 100 200 300 RATE =>  constraints 100,200,300 should be honored
                 if (production.cmode == Group::ProductionCMode::ORAT ||
-                    (groupLimitAction.allRates != Group::ExceedAction::NONE &&
+                    (groupLimitAction.oil != Group::ExceedAction::NONE &&
                     !apply_default_oil_target)) {
                     production.production_controls |= static_cast<int>(Group::ProductionCMode::ORAT);
                 }
@@ -290,6 +315,8 @@ void handleGCONPROD(HandlerContext& handlerContext)
 
                 if (!apply_default_resv_target)
                     production.production_controls |= static_cast<int>(Group::ProductionCMode::RESV);
+
+                // TODO: similar to RESV, we might need to add for other limits which will be treated with RATE exceeding procedure
 
                 if (new_group.updateProduction(production)) {
                     auto new_config = handlerContext.state().guide_rate();

--- a/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
@@ -179,10 +179,12 @@ void handleGCONPROD(HandlerContext& handlerContext)
         }
 
         const Group::ProductionCMode controlMode = Group::ProductionCModeFromString(record.getItem("CONTROL_MODE").getTrimmedString(0));
-        // \Note: we do not enforce the allRates anymore. Instead, we have explicit definition of actions for all the possible rate limits
-        const Group::ExceedAction allRates = Group::ExceedActionFromString(record.getItem("EXCEED_PROC").getTrimmedString(0));
 
         Group::GroupLimitAction groupLimitAction;
+        groupLimitAction.allRates = Group::ExceedActionFromString(record.getItem("EXCEED_PROC").getTrimmedString(0));
+        // \Note: we do not use the allRates anymore. Instead, we have explicit definition of actions for all the possible rate limits
+        // \Note: the allRates is here for backward compatibility for the RESTART file output
+        const auto& allRates = groupLimitAction.allRates;
 
         groupLimitAction.oil = allRates;
 
@@ -214,7 +216,7 @@ void handleGCONPROD(HandlerContext& handlerContext)
                 groupLimitAction.liquid = Group::ExceedAction::RATE;
                 break;
             case Group::ProductionCMode::FLD:
-                //TODO: we do not know yet
+                //TODO: we do not know yet and we do nothing for now
             default:
                 break; // do nothing
         }


### PR DESCRIPTION
then it is possible to enforce specific action for oil rate alone, mostly to enforce RATE actions for the setting mode in GCONPROD.

allRates can be removed if there is no need for output, which remains to be checked. 