### PR TITLE
Support More General Region Set Names

### DIFF
--- a/opm/input/eclipse/share/keywords/000_Eclipse100/R/REGION2REGION_PROBE
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/R/REGION2REGION_PROBE
@@ -3,7 +3,7 @@
   "sections": [
     "SUMMARY"
   ],
-  "deck_name_regex": "(R[OG]FT[GL]?|RWFT)(_?[A-Z0-9_]{3})?",
+  "deck_name_regex": "(R[OG]FT[GL]?|RWFT)(_?[A-Z0-9_]{1,3})?",
   "items": [
     {
       "name": "REGION1",

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/R/REGION_PROBE
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/R/REGION_PROBE
@@ -106,7 +106,7 @@
   ],
     "CommentTracer": "???",
     "deck_name_regex": "RU.+|RTIPF.+|RTIPS.+|RTFTF.+|RTFTS.+|RTFTT.+|RTIPT.+|RTIPF.+|RTIPS.+|RTIP[1-9][0-9]*.+|RTFTT.+|RTFTF.+|RTFTS.+|RTFT[1-9][0-9]*.+|RTADS.+|RTDCY.+",
-    "deck_name_regex_suffix": "_{0,2}[A-Z0-9]{3}",
+    "deck_name_regex_suffix": "_{0,2}[A-Z0-9_]{1,3}",
     "data": {
         "value_type": "INT"
     }

--- a/opm/input/eclipse/share/keywords/900_OPM/R/REGION_PROBE_OPM
+++ b/opm/input/eclipse/share/keywords/900_OPM/R/REGION_PROBE_OPM
@@ -40,7 +40,7 @@
     "RWIPG",
     "RWIPL"
   ],
-  "deck_name_regex_suffix": "_{0,2}[A-Z0-9]{3}",
+  "deck_name_regex_suffix": "_{0,2}[A-Z0-9_]{1,3}",
   "data": {
     "value_type": "INT"
   }

--- a/opm/io/eclipse/SummaryNode.cpp
+++ b/opm/io/eclipse/SummaryNode.cpp
@@ -247,7 +247,7 @@ std::string
 Opm::EclIO::SummaryNode::normalise_region_keyword(const std::string& keyword)
 {
     static const auto region_kw = std::regex {
-        R"((R[A-Z]{2,4})(_{0,2}[A-Z0-9]{3})?)"
+        R"((R[A-Z]{2,4})(_{0,2}[A-Z0-9_]{1,3})?)"
     };
 
     auto keywordPieces = std::smatch {};

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -88,7 +88,19 @@ FIPNUM
    50*8  50*18
    50*9  50*19
    50*10 50*20
-/ 
+/
+
+FIP_A
+  500*1
+  500*2
+/
+
+EQUALS
+  FIP_BC 4 4* 1 5 /
+  FIP_BC 3 4* 6 7 /
+  FIP_BC 2 4* 8 8 /
+  FIP_BC 1 4* 9 10 /
+/
 
 SOLUTION
 TBLKFSEA
@@ -311,6 +323,10 @@ ROP
 /
 ROPR
 /
+ROPR__A
+ 2 /
+ROPR__BC
+ 1 4 /
 RGPR
 /
 RWPR


### PR DESCRIPTION
This commit introduces support for putting underscore characters into the name of a user defined region set (`FIP*` keywords). Specifically, this enables using region set names like

    FIP_A, FIP_BC, FIP_F00

and associate region level summary vectors like

    ROIIP_A, RWCT__BC, RPR___F0

These were previously rejected at the input level.