### PR TITLE
Support Identifying Requisite UDQ Schedule Objects

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp
@@ -74,6 +74,13 @@ public:
     bool operator==(const UDQASTNode& data) const;
     void required_summary(std::unordered_set<std::string>& summary_keys) const;
 
+    /// Populate collection of requisite objects needed to evaluate this node.
+    ///
+    /// \param[in,out] objects Specific Schedule objects named in containing
+    /// UDQ definition.  On exit also contains the specific objects needed
+    /// by this node and, recursively, its children.
+    void requiredObjects(UDQ::RequisiteEvaluationObjects& objects) const;
+
     template <class Serializer>
     void serializeOp(Serializer& serializer)
     {
@@ -135,6 +142,50 @@ private:
                                   const UDQContext& context) const;
 
     void func_tokens(std::set<UDQTokenType>& tokens) const;
+
+    /// Populate collection of requisite objects needed to evaluate this
+    /// node.
+    ///
+    /// \param[in,out] objects Specific Schedule objects named in containing
+    /// UDQ definition.  On exit also contains the specific objects needed
+    /// by this node.
+    void populateRequiredObjects(UDQ::RequisiteEvaluationObjects& objects) const;
+
+    /// Populate collection of requisite group level objects needed to
+    /// evaluate this node.
+    ///
+    /// \param[in,out] objects Specific Schedule objects named in containing
+    /// UDQ definition.  On exit also contains the specific group level
+    /// objects needed by this node.  Includes group names or group name
+    /// roots.
+    void populateRequiredGroupObjects(UDQ::RequisiteEvaluationObjects& objects) const;
+
+    /// Populate collection of requisite region level objects needed to
+    /// evaluate this node.
+    ///
+    /// \param[in,out] objects Specific Schedule objects named in containing
+    /// UDQ definition.  On exit also contains the specific region level
+    /// objects needed by this node.  Includes region set names and,
+    /// potentially, specific region numbers.
+    void populateRequiredRegionObjects(UDQ::RequisiteEvaluationObjects& objects) const;
+
+    /// Populate collection of requisite segment level objects needed to
+    /// evaluate this node.
+    ///
+    /// \param[in,out] objects Specific Schedule objects named in containing
+    /// UDQ definition.  On exit also contains the specific segment level
+    /// objects needed by this node.  Includes well names and, potentially,
+    /// specific segment numbers.
+    void populateRequiredSegmentObjects(UDQ::RequisiteEvaluationObjects& objects) const;
+
+    /// Populate collection of requisite well level objects needed to
+    /// evaluate this node.
+    ///
+    /// \param[in,out] objects Specific Schedule objects named in containing
+    /// UDQ definition.  On exit also contains the specific well level
+    /// objects needed by this node.  Includes well names, well name
+    /// templates, well lists, or well lists templates.
+    void populateRequiredWellObjects(UDQ::RequisiteEvaluationObjects& objects) const;
 };
 
 UDQASTNode operator*(const UDQASTNode&lhs, double rhs);

--- a/opm/input/eclipse/Schedule/UDQ/UDQDefine.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQDefine.cpp
@@ -314,6 +314,17 @@ UDQDefine UDQDefine::serializationTestObject()
     return result;
 }
 
+UDQ::RequisiteEvaluationObjects UDQDefine::requiredObjects() const
+{
+    auto objects = UDQ::RequisiteEvaluationObjects{};
+
+    if (this->ast != nullptr) {
+        this->ast->requiredObjects(objects);
+    }
+
+    return objects;
+}
+
 void UDQDefine::required_summary(std::unordered_set<std::string>& summary_keys) const
 {
     this->ast->required_summary(summary_keys);

--- a/opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp
@@ -77,6 +77,13 @@ public:
 
     static UDQDefine serializationTestObject();
 
+    /// All specific objects required for the defining expression.
+    ///
+    /// Could, for instance, be a collection of specific well names in a
+    /// field level UDQ, or a set of group name patterns for a group level
+    /// UDQ.
+    UDQ::RequisiteEvaluationObjects requiredObjects() const;
+
     UDQSet eval(const UDQContext& context) const;
     const std::string& keyword() const;
     const std::string& input_string() const { return this->input_string_; }

--- a/opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp
@@ -20,6 +20,9 @@
 #ifndef UDQ_ENUMS_HPP
 #define UDQ_ENUMS_HPP
 
+#include <cstddef>
+#include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -197,6 +200,37 @@ enum class UDAKeyword
 };
 
 namespace UDQ {
+
+    /// Collection of specific Schedule objects named in a UDQ definition.
+    struct RequisiteEvaluationObjects
+    {
+        /// Collection of named objects--typically wells or groups.
+        using NamedObjects = std::set<std::string>;
+
+        /// Collection of named and enumerated objects.
+        ///
+        /// Typically segment numbers pertaining to particular MS wells or
+        /// specific region IDs and their associate region sets.
+        using EnumeratedObjects = std::map<std::string, std::set<std::size_t>>;
+
+        /// Wells named in a UDQ definition.
+        ///
+        /// Individual well names, well name templates, well lists, or well
+        /// list templates.
+        NamedObjects wells{};
+
+        /// Groups named in a UDQ definition.
+        ///
+        /// Individual group names or group name roots.
+        NamedObjects groups{};
+
+        /// Multi-segmented wells and specific segment numbers named in UDQ
+        /// definition.
+        EnumeratedObjects msWells{};
+
+        /// Specific region sets and region IDs named in UDQ definition.
+        EnumeratedObjects regions{};
+    };
 
     UDQVarType targetType(const std::string& keyword, const std::vector<std::string>& selector);
     UDQVarType targetType(const std::string& keyword);


### PR DESCRIPTION
This PR adds a simple structure for holding Schedule objects that are needed to evaluate the defining expression of a UDQ.  The immediate use case is to enable issuing diagnostic messages for UDQ DEFINE statements that name objects&ndash;e.g., wells or groups&ndash;which do not exist at the point of definition.

We give the `UDQDefine` class the ability to generate this kind of collection by recursively populating the collection through its child `ASTNode`.