### PR TITLE
Don't Log Errors Immediately for DELAYED_EXIT1

### DIFF
--- a/opm/input/eclipse/Parser/ParseContext.cpp
+++ b/opm/input/eclipse/Parser/ParseContext.cpp
@@ -191,7 +191,6 @@ namespace Opm {
         }
 
         if (action == InputErrorAction::DELAYED_EXIT1) {
-            OpmLog::error(msg);
             errors.addError(errorKey, msg);
             return;
         }


### PR DESCRIPTION
Following the introduction (6d7d82dd8, #4362) and use (OPM/opm-simulators@0238f4533, OPM/opm-simulators#5765) of member function `ErrorGuard::formattedErrors()`, the diagnostic messages for `DELAYED_EXIT1` will be printed to both the console and the PRT file at the end of the parsing process.  There is no longer a need to print these immediately at the point of the `ParseContext::handleError()` call.