### PR TITLE
Tidy Up WListManager::newList Implementation

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WList.cpp
+++ b/opm/input/eclipse/Schedule/Well/WList.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <opm/input/eclipse/Schedule/Well/WList.hpp>
+
 #include <algorithm>
 
 namespace Opm {
@@ -25,41 +26,46 @@ namespace Opm {
 WList::WList(const storage& wlist, const std::string& wlname)
     : well_list(wlist)
     , name(wlname)
+{}
+
+std::size_t WList::size() const
 {
-}
-
-
-std::size_t WList::size() const {
     return this->well_list.size();
 }
 
-
-std::string WList::getName() const {
-    return this->name;
+void WList::clear()
+{
+    this->well_list.clear();
 }
 
-bool WList::has(const std::string& well) const {
-    return (std::count(this->well_list.begin(), this->well_list.end(), well) > 0);
+bool WList::has(const std::string& well) const
+{
+    return std::find(this->well_list.begin(), this->well_list.end(), well)
+        != this->well_list.end();
 }
 
-void WList::add(const std::string& well) {
-    //add well if it is not already in the well list
-    if (std::count(this->well_list.begin(), this->well_list.end(), well) == 0)
+void WList::add(const std::string& well)
+{
+    // Add well if it is not already in the well list.
+    if (! this->has(well)) {
         this->well_list.push_back(well);
+    }
 }
 
-void WList::del(const std::string& well) {
+void WList::del(const std::string& well)
+{
     auto end_keep = std::remove(this->well_list.begin(), this->well_list.end(), well);
     this->well_list.erase(end_keep, this->well_list.end());
 }
 
-
-std::vector<std::string> WList::wells() const {
+const std::vector<std::string>& WList::wells() const
+{
     return this->well_list;
 }
 
-bool WList::operator==(const WList& data) const {
+bool WList::operator==(const WList& data) const
+{
     return this->well_list == data.well_list;
 }
 
-}
+} // namespace Opm

--- a/opm/input/eclipse/Schedule/Well/WList.hpp
+++ b/opm/input/eclipse/Schedule/Well/WList.hpp
@@ -20,25 +20,30 @@
 #define WLIST_HPP
 
 #include <cstddef>
+#include <string>
 #include <unordered_set>
 #include <vector>
-#include <string>
 
 namespace Opm {
 
-class WList {
+class WList
+{
 public:
     using storage = std::vector<std::string>;
 
     WList() = default;
     WList(const storage& wlist, const std::string& wlname);
+
     std::size_t size() const;
+
+    void clear();
+
     void add(const std::string& well);
     void del(const std::string& well);
     bool has(const std::string& well) const;
-    std::string getName() const;
+    const std::string& getName() const { return this->name; }
 
-    std::vector<std::string> wells() const;
+    const std::vector<std::string>& wells() const;
     bool operator==(const WList& data) const;
 
     template<class Serializer>
@@ -51,9 +56,8 @@ public:
 private:
     storage well_list;
     std::string name;
-
 };
 
-}
+} // namespace Opm
 
-#endif
+#endif // WLIST_HPP

--- a/opm/input/eclipse/Schedule/Well/WListManager.hpp
+++ b/opm/input/eclipse/Schedule/Well/WListManager.hpp
@@ -19,19 +19,21 @@
 #ifndef WLISTMANAGER_HPP
 #define WLISTMANAGER_HPP
 
+#include <opm/input/eclipse/Schedule/Well/WList.hpp>
+
 #include <cstddef>
 #include <map>
-#include <vector>
 #include <string>
-#include <opm/input/eclipse/Schedule/Well/WList.hpp>
+#include <vector>
+
+namespace Opm::RestartIO {
+    struct RstState;
+} // namespace Opm::RestartIO
 
 namespace Opm {
 
-namespace RestartIO {
-struct RstState;
-}
-
-class WListManager {
+class WListManager
+{
 public:
     WListManager() = default;
     explicit WListManager(const RestartIO::RstState& rst_state);
@@ -64,7 +66,42 @@ private:
     std::map<std::string, WList> wlists;
     std::map<std::string, std::vector<std::string>> well_wlist_names;
     std::map<std::string, std::size_t> no_wlists_well;
+
+    /// Reset contents of existing well list.
+    ///
+    /// Implements the 'NEW' operation with a non-empty list of wells for
+    /// the case of an existing well list.  On exit, the existing well list
+    /// object will hold only those wells that are include in the 'NEW'
+    /// operation.
+    ///
+    /// \param[in] wlistName Well list name.
+    ///
+    /// \param[in] newWells List of wells to include in the new well list
+    /// object.
+    void resetExistingWList(const std::string& wlistName,
+                            const std::vector<std::string>& newWells);
+
+    /// Clear contents of existing well list.
+    ///
+    /// Implements the 'NEW' operation for a empty list of wells in the case
+    /// of an existing well list.
+    ///
+    /// \param[in] wlistName Well list name.
+    void clearExistingWList(const std::string& wlistName);
+
+    /// Create a new well list.
+    ///
+    /// Implements the 'NEW' operation with a non-empty list of wells for
+    /// the case of a non-existent well list.
+    ///
+    /// \param[in] wlistName Well list name.
+    ///
+    /// \param[in] newWells List of wells to include in the new well list
+    /// object.
+    void createNewWList(const std::string& wlistName,
+                        const std::vector<std::string>& newWells);
 };
 
-}
-#endif
+} // namespace Opm
+
+#endif // WLISTMANAGER_HPP


### PR DESCRIPTION
In particular split the function into three helpers to deal with the individual cases,

  - New list where none exist (`createNewWList()`)
  - New empty list with existing name (`clearExistingWList()`)
  - New non-empty list with existing name (`resetExistingWList()`)

There are further opportunities to simplify this class, but this handles the most immediate readability issues and enables making `WList::wells()` return a reference to its internal vector instead of a copy of the same.