### PR TITLE
Add Well/Group Existence Predicates to HandlerContext

### DIFF
--- a/opm/input/eclipse/Schedule/HandlerContext.cpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.cpp
@@ -30,6 +30,7 @@
 #include <opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
 
 #include "MSW/WelSegsSet.hpp"
 
@@ -149,6 +150,21 @@ void HandlerContext::invalidNamePattern(const std::string& namePattern) const
 const Action::WGNames& HandlerContext::action_wgnames() const
 {
     return schedule_.action_wgnames;
+}
+
+bool HandlerContext::hasWell(const std::string& pattern) const
+{
+    const auto& schedState = this->schedule_.back();
+
+    return WellMatcher {
+        &schedState.well_order(), // <- Note: Pointer to NameOrder
+        schedState.wlist_manager()
+    }.hasWell(pattern);
+}
+
+bool HandlerContext::hasGroup(const std::string& pattern) const
+{
+    return this->schedule_.back().group_order().anyGroupMatches(pattern);
 }
 
 std::vector<std::string>

--- a/opm/input/eclipse/Schedule/HandlerContext.hpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.hpp
@@ -151,6 +151,25 @@ public:
     //! \brief Obtain well group names from a pattern.
     std::vector<std::string> groupNames(const std::string& pattern) const;
 
+    //! \brief Whether or not any existing well matches a name pattern.
+    //!
+    //! If the pattern is a well list or a well list template, then the
+    //! predicate will check if any well lists matching the pattern exists
+    //! and, if so, whether the corresponding well list is non-empty.
+    //!
+    //! \param[in] pattern Well name, well name template, well list, or well
+    //! list template.
+    //!
+    //! \return Whether or not any existing well matches \p pattern.
+    bool hasWell(const std::string& pattern) const;
+
+    //! \brief Whether or not any existing group matches a name pattern.
+    //!
+    //! \param[in] pattern Group name or group name root.
+    //!
+    //! \return Whether or not any existing group matches \p pattern.
+    bool hasGroup(const std::string& pattern) const;
+
     //! \brief Obtain well names from a pattern.
     //! \details Throws if no wells match the pattern and pattern is not a WLIST.
     std::vector<std::string>

--- a/opm/input/eclipse/Schedule/Well/NameOrder.cpp
+++ b/opm/input/eclipse/Schedule/Well/NameOrder.cpp
@@ -131,6 +131,14 @@ bool GroupOrder::has(const std::string& gname) const
         != this->name_list_.end();
 }
 
+bool GroupOrder::anyGroupMatches(const std::string& pattern) const
+{
+    return std::any_of(this->name_list_.begin(),
+                       this->name_list_.end(),
+                       [&pattern](const auto& gname)
+                       { return shmatch(pattern, gname); });
+}
+
 std::vector<std::string> GroupOrder::names(const std::string& pattern) const
 {
     auto gnames = std::vector<std::string>{};

--- a/opm/input/eclipse/Schedule/Well/NameOrder.hpp
+++ b/opm/input/eclipse/Schedule/Well/NameOrder.hpp
@@ -112,6 +112,16 @@ public:
     /// \return Whether or not \p gname exists in the current collection.
     bool has(const std::string& gname) const;
 
+    /// Group name existence predicate.
+    ///
+    /// Pattern matching version.
+    ///
+    /// \param[in] pattern Group name or group name root.
+    ///
+    /// \return Whether or not any group in the current collection matches
+    /// the \p pattern.
+    bool anyGroupMatches(const std::string& pattern) const;
+
     /// Retrieve sequence of group names ordered appropriately for restart
     /// file output.
     ///

--- a/opm/input/eclipse/Schedule/Well/WList.hpp
+++ b/opm/input/eclipse/Schedule/Well/WList.hpp
@@ -36,6 +36,9 @@ public:
 
     std::size_t size() const;
 
+    /// Predicate for an empty list.
+    bool empty() const { return this->size() == 0; }
+
     void clear();
 
     void add(const std::string& well);

--- a/opm/input/eclipse/Schedule/Well/WListManager.cpp
+++ b/opm/input/eclipse/Schedule/Well/WListManager.cpp
@@ -54,6 +54,16 @@ namespace Opm {
         return (this->wlists.size());
     }
 
+    bool WListManager::hasWell(const std::string& pattern) const
+    {
+        return std::any_of(this->wlists.begin(), this->wlists.end(),
+                           [patt = pattern.substr(1)](const auto& wlist)
+                           {
+                               return shmatch(patt, wlist.first.substr(1))
+                                   && !wlist.second.empty();
+                           });
+    }
+
     bool WListManager::hasList(const std::string& name) const
     {
         return this->wlists.find(name) != this->wlists.end();

--- a/opm/input/eclipse/Schedule/Well/WListManager.hpp
+++ b/opm/input/eclipse/Schedule/Well/WListManager.hpp
@@ -40,6 +40,19 @@ public:
     static WListManager serializationTestObject();
 
     std::size_t WListSize() const;
+
+    /// Whether or not one or more wells matching a well list name or well
+    /// list template exists.
+    ///
+    /// This predicate checks whether or not a well list exists matching the
+    /// pattern *and* that that well list is non-empty.
+    ///
+    /// \param[in] pattern Well list name or well list template.
+    ///
+    /// \return Whether or not there are any current wells matching \p
+    /// pattern.
+    bool hasWell(const std::string& pattern) const;
+
     bool hasList(const std::string&) const;
     WList& getList(const std::string& name);
     const WList& getList(const std::string& name) const;

--- a/opm/input/eclipse/Schedule/Well/WellMatcher.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellMatcher.hpp
@@ -108,6 +108,21 @@ public:
     /// \return *this.
     WellMatcher& operator=(WellMatcher&& rhs);
 
+    /// Well existence predicate.
+    ///
+    /// Checks whether or not a well matching a name pattern exists in the
+    /// collection.  If the pattern represents one or more well lists, i.e.,
+    /// there is a leading asterisk as in "*PROD", then the predicate will
+    /// check if the well list exists and, if so, if the well list is
+    /// non-empty.
+    ///
+    /// \param[in] pattern Well name, well name template, well list, or well
+    /// list template.
+    ///
+    /// \return Whether or not a well matching the \p pattern exists in the
+    /// current collection.
+    bool hasWell(const std::string& pattern) const;
+
     /// Sort a list of well names according to the established order.
     ///
     /// Throws an exception if any name in the list is not known.


### PR DESCRIPTION
This enables slightly less expensive existence checks than calling `Schedule::wellNames()` and `Schedule::groupNames()` and checking if the resulting name list is empty.  The immediate use case is to enable issuing diagnostic messages for UDQ DEFINE statements that name objects which do not exist at the point of definition.  Cf. commit 8263aea9b9f06b79cde3842a0ff26a5eaa976545 (#4612)

To this end, add helper functions

* `WellMatcher::hasWell()`
* `GroupOrder::anyMatchingGroups()`

and implement the predicates in terms of these helper functions. The former is effectively the computational engine of `WellMatcher::wells()` without forming a vector of strings, and the latter is the internals of `GroupOrder::names()` with the same provision.

One small quirk of `WellMatcher::hasWell()` is that if the pattern is a well list or a well list template, then the predicate will
return `true` only if the well list exists **and** is non-empty.