### PR TITLE
Diagnose Missing Wells/Groups in UDQ DEFINE Statements

### DIFF
--- a/opm/input/eclipse/Parser/ParseContext.cpp
+++ b/opm/input/eclipse/Parser/ParseContext.cpp
@@ -128,6 +128,8 @@ namespace Opm {
 
         this->addKey(UDQ_PARSE_ERROR, InputErrorAction::THROW_EXCEPTION);
         this->addKey(UDQ_TYPE_ERROR, InputErrorAction::THROW_EXCEPTION);
+        this->addKey(UDQ_DEFINE_CANNOT_EVAL, InputErrorAction::DELAYED_EXIT1);
+
         this->addKey(SCHEDULE_GROUP_ERROR, InputErrorAction::THROW_EXCEPTION);
         this->addKey(SCHEDULE_IGNORED_GUIDE_RATE, InputErrorAction::WARN);
         this->addKey(SCHEDULE_WELL_IN_FIELD_GROUP, InputErrorAction::WARN);
@@ -402,6 +404,8 @@ namespace Opm {
 
     const std::string ParseContext::UDQ_PARSE_ERROR = "UDQ_PARSE_ERROR";
     const std::string ParseContext::UDQ_TYPE_ERROR = "UDQ_TYPE_ERROR";
+    const std::string ParseContext::UDQ_DEFINE_CANNOT_EVAL = "UDQ_DEFINE_CANNOT_EVAL";
+
     const std::string ParseContext::SCHEDULE_GROUP_ERROR = "SCHEDULE_GROUP_ERROR";
     const std::string ParseContext::SCHEDULE_IGNORED_GUIDE_RATE = "SCHEDULE_IGNORED_GUIDE_RATE";
     const std::string ParseContext::SCHEDULE_WELL_IN_FIELD_GROUP = "SCHEDULE_WELL_IN_FIELD_GROUP";

--- a/opm/input/eclipse/Parser/ParseContext.hpp
+++ b/opm/input/eclipse/Parser/ParseContext.hpp
@@ -261,6 +261,10 @@ class KeywordLocation;
         const static std::string UDQ_PARSE_ERROR;
         const static std::string UDQ_TYPE_ERROR;
 
+        /// Cannot evaluate the defining expression of a UDQ at the point of
+        /// definition due to missing objects, e.g., wells or groups.
+        const static std::string UDQ_DEFINE_CANNOT_EVAL;
+
         /*
           If the third item in the THPRES keyword is defaulted the
           threshold pressure is inferred from the initial pressure -

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -281,11 +281,12 @@ namespace Opm {
             || (this->m_definitions.find(keyword) != this->m_definitions.end());
     }
 
-    void UDQConfig::add_record(SegmentMatcherFactory                 create_segment_matcher,
-                               const DeckRecord&                     record,
-                               const KeywordLocation&                location,
-                               const std::size_t                     report_step,
-                               const std::optional<DynamicSelector>& dynamic_selector)
+    std::optional<std::string>
+    UDQConfig::add_record(SegmentMatcherFactory                 create_segment_matcher,
+                          const DeckRecord&                     record,
+                          const KeywordLocation&                location,
+                          const std::size_t                     report_step,
+                          const std::optional<DynamicSelector>& dynamic_selector)
     {
         using KW = ParserKeywords::UDQ;
 
@@ -309,12 +310,16 @@ namespace Opm {
         }
         else if (action == UDQAction::DEFINE) {
             this->add_define(quantity, location, data, report_step);
+
+            return { quantity };
         }
         else {
             throw std::runtime_error {
                 "Unknown UDQ Operation " + std::to_string(static_cast<int>(action))
             };
         }
+
+        return {};
     }
 
     void UDQConfig::add_unit(const std::string& keyword, const std::string& quoted_unit)

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
@@ -245,11 +245,12 @@ namespace Opm {
         /// \param[in] dynamic_selector Named entities in a dynamic context,
         /// such as the wells matching an ACTIONX condition.  Nullopt if no
         /// such dynamic entities apply to this UDQ record.
-        void add_record(SegmentMatcherFactory                 create_segment_matcher,
-                        const DeckRecord&                     record,
-                        const KeywordLocation&                location,
-                        std::size_t                           report_step,
-                        const std::optional<DynamicSelector>& dynamic_selector = std::nullopt);
+        std::optional<std::string>
+        add_record(SegmentMatcherFactory                 create_segment_matcher,
+                   const DeckRecord&                     record,
+                   const KeywordLocation&                location,
+                   std::size_t                           report_step,
+                   const std::optional<DynamicSelector>& dynamic_selector = std::nullopt);
 
         /// Incorporate a unit string for a UDQ
         ///


### PR DESCRIPTION
This PR adds logic to check if all wells/groups needed in a UDQ DEFINE statement are present at the point of definition.  In particular, wells must have been introduced through WELSPECS prior to the UDQ keyword if any specific well name is used in the defining expression.  Similarly, well lists must have been introduced and populated through WLIST before using the well list name in the UDQ. Finally, groups must be introduced through WELSPECS or GRUPTREE before using any specific group names in the defining expression.

If this requirement is not met, the parsing process will halt at the end of reading the full SCHEDULE section in order that all such problems may be diagnosed in a single run.  Some example output is shown below.

To this end, make `UDQConfig::add_record()` return an `optional<string>` containing the UDQ name if the record's action is DEFINE, and `nullopt` otherwise.  Then the UDQ keyword handler intercepts all new DEFINE statements and uses `UDQDefine::requiredObjects()` (#4612) to identify any requisite wells or groups.  If any of these are missing (#4618), we issue a diagnostic tagged with the new `ParseContext` key
```
ParseContext::UDQ_DEFINE_CANNOT_EVAL
```
whose default action is `DELAYED_EXIT1`.  The default action may be overridden in the usual way, through environment variables, but doing so will typically lead to calculating incorrect values for the user defined quantity.

---

#### Example Output From Missing Well Objects ####

The message below is printed to `OpmLog::error()` which will typically render the text in red colour on the console.
```
Error: Unrecoverable errors while loading input:

Problem with UDQ
In CASE.DATA line 251
DEFINE cannot be evaluated:
  Missing object in defining expression for FUBHPGI
    -> No existing well matches the name XD-1H
```