### PR TITLE
removing unused Segment::m_perf_length member variable

### DIFF
--- a/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
@@ -346,7 +346,6 @@ namespace {
                     throw std::runtime_error("Not all the connections are attached with a segment. "
                                              "The information from COMPSEGS is not complete");
             }
-            new_segment_set.updatePerfLength( new_connection_set );
 
             return std::make_pair( WellConnections( std::move( new_connection_set ) ),
                                    WellSegments( std::move(new_segment_set)));
@@ -421,7 +420,6 @@ namespace {
         auto comp_pressure_drop = pressure_drop_from_int(rst_well.msw_pressure_drop_model);
 
         WellSegments segments( comp_pressure_drop, segments_list);
-        segments.updatePerfLength( connections );
 
         return std::make_pair( std::move(connections), std::move(segments));
     }

--- a/opm/input/eclipse/Schedule/MSW/Segment.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Segment.cpp
@@ -221,7 +221,6 @@ namespace Opm {
         result.m_data_ready = true;
         result.m_x = 12.0;
         result.m_y = 13.0;
-        result.m_perf_length = 14.0;
         result.m_icd = SICD::serializationTestObject();
         return result;
     }
@@ -252,11 +251,6 @@ namespace Opm {
     double Segment::depth() const
     {
         return m_depth;
-    }
-
-    double Segment::perfLength() const
-    {
-        return *this->m_perf_length;
     }
 
     double Segment::internalDiameter() const
@@ -333,7 +327,6 @@ namespace Opm {
             && this->m_roughness         == rhs.m_roughness
             && this->m_cross_area        == rhs.m_cross_area
             && this->m_volume            == rhs.m_volume
-            && this->m_perf_length       == rhs.m_perf_length
             && this->m_icd               == rhs.m_icd
             && this->m_data_ready        == rhs.m_data_ready
             && (this->m_x                == rhs.m_x)
@@ -411,11 +404,6 @@ namespace Opm {
     {
         auto new_valve = valve;
         this->updateValve__(new_valve, segment_length);
-    }
-
-    void Segment::updatePerfLength(double perf_length)
-    {
-        this->m_perf_length = perf_length;
     }
 
     const Valve& Segment::valve() const

--- a/opm/input/eclipse/Schedule/MSW/Segment.hpp
+++ b/opm/input/eclipse/Schedule/MSW/Segment.hpp
@@ -78,7 +78,6 @@ namespace Opm {
         int segmentNumber() const;
         int branchNumber() const;
         int outletSegment() const;
-        double perfLength() const;
         double totalLength() const;
         double node_X() const;
         double node_Y() const;
@@ -103,7 +102,6 @@ namespace Opm {
         const AutoICD& autoICD() const;
         const Valve& valve() const;
 
-        void updatePerfLength(double perf_length);
         void updateSpiralICD(const SICD& spiral_icd);
         void updateAutoICD(const AutoICD& aicd);
         void updateValve(const Valve& valve, const double segment_length);
@@ -146,7 +144,6 @@ namespace Opm {
             serializer(m_data_ready);
             serializer(m_x);
             serializer(m_y);
-            serializer(m_perf_length);
             serializer(m_icd);
         }
 
@@ -228,7 +225,6 @@ namespace Opm {
         // simulations, but needed for the SEG option in WRFTPLT.
         double m_y{};
 
-        std::optional<double> m_perf_length;
         std::variant<RegularSegment, SICD, AutoICD, Valve> m_icd;
 
         // There are three other properties for the segment pertaining to

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -806,12 +806,4 @@ WellSegments::MultiPhaseModel WellSegments::MultiPhaseModelFromString(const std:
     }
 }
 
-
-void WellSegments::updatePerfLength(const WellConnections& connections) {
-    for (auto& segment : this->m_segments) {
-        auto perf_length = connections.segment_perf_length( segment.segmentNumber() );
-        segment.updatePerfLength(perf_length);
-    }
-}
-
 }

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -93,7 +93,6 @@ namespace Opm {
 
         const Segment& operator[](size_t idx) const;
         void orderSegments();
-        void updatePerfLength(const WellConnections& connections);
 
         bool operator==( const WellSegments& ) const;
         bool operator!=( const WellSegments& ) const;


### PR DESCRIPTION
It was spotted that Segment::m_perf_length is not used anywhere. 

So the PR is to remove it. 