### PR TITLE
Remove Unused PvtxTable Member Function

### DIFF
--- a/opm/input/eclipse/EclipseState/Tables/PvtxTable.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtxTable.cpp
@@ -142,27 +142,6 @@ namespace Opm {
         return m_outerColumn.size();
     }
 
-    double PvtxTable::evaluate(const std::string& column,
-                               const double       outerArg,
-                               const double       innerArg) const
-    {
-        const TableIndex outerIndex = m_outerColumn.lookup(outerArg);
-
-        const auto& underSaturatedTable1 = getUnderSaturatedTable(outerIndex.getIndex1());
-        const double weight1 = outerIndex.getWeight1();
-
-        double value = weight1 * underSaturatedTable1.evaluate(column, innerArg);
-
-        if (weight1 < 1) {
-            const auto& underSaturatedTable2 = getUnderSaturatedTable(outerIndex.getIndex2());
-            const double weight2 = outerIndex.getWeight2();
-
-            value += weight2 * underSaturatedTable2.evaluate(column, innerArg);
-        }
-
-        return value;
-    }
-
     double PvtxTable::getArgValue(const std::size_t index) const
     {
         if (! (index < m_outerColumn.size())) {

--- a/opm/input/eclipse/EclipseState/Tables/PvtxTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtxTable.hpp
@@ -172,22 +172,6 @@ namespace Opm {
         /// \param[in] tableNumber Node index in the range 0..size()-1.
         const SimpleTable& getUnderSaturatedTable(std::size_t tableNumber) const;
 
-        /// Interpolate property value at single point
-        ///
-        /// \param[in] column Property name.  Must be one of the named
-        /// dependent properties defined by a derived class.
-        ///
-        /// \param[in] outerArg Value of primary lookup key/variate.
-        /// Typically an Rs (PVTO) or a Pg (PVTG) value.
-        ///
-        /// \param[in] innerArg Value of secondary independent variate.
-        /// Typically an oil pressure (PVTO) or Rv (PVTG) value.
-        ///
-        /// \return Value of dependent variate \p column at the indenpendent
-        /// variate point (\p outerArg, \p innerArg), e.g., Bo(Rs,Po) or
-        /// Vg(Pg,Rv).
-        double evaluate(const std::string& column, double outerArg, double innerArg) const;
-
         /// Retrieve composition/pressure node value at input point.
         ///
         /// \param[in] index Node index in the range 0..size()-1.

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -958,9 +958,6 @@ PVTO
     BOOST_CHECK_EQUAL( BO.back( ) , 1.01 );
 
     BOOST_CHECK_CLOSE(1.15 , table0.evaluate( "BO" , 250*1e5 ) , 1e-6);
-
-    BOOST_CHECK_CLOSE( 1.15 , pvtoTable.evaluate( "BO" , 1e-3 , 250*1e5 ) , 1e-6 );
-    BOOST_CHECK_CLOSE( 1.15 , pvtoTable.evaluate( "BO" , 0.0 , 250*1e5 ) , 1e-6 );
 }
 
 BOOST_AUTO_TEST_CASE( SGOF ) {


### PR DESCRIPTION
Outside of a single unit test, the member function
```
PvtxTable::evaluate(x1, x2)
```
isn't actually used anywhere in the simulator.  Remove it to reduce the maintenance cost of the `PvtxTable` class.