### PR TITLE
Make itemName() of GuideRateValue public

### DIFF
--- a/opm/output/data/GuideRateValue.hpp
+++ b/opm/output/data/GuideRateValue.hpp
@@ -148,17 +148,6 @@ namespace Opm { namespace data {
             return val;
         }
 
-    private:
-        enum { Size = static_cast<std::size_t>(Item::NumItems) };
-
-        std::bitset<Size>        mask_{};
-        std::array<double, Size> value_{};
-
-        constexpr std::size_t index(const Item p) const noexcept
-        {
-            return static_cast<std::size_t>(p);
-        }
-
         std::string itemName(const Item p) const
         {
             switch (p) {
@@ -173,6 +162,17 @@ namespace Opm { namespace data {
 
             return "Unknown (" + std::to_string(this->index(p)) + ')';
         }
+    private:
+        enum { Size = static_cast<std::size_t>(Item::NumItems) };
+
+        std::bitset<Size>        mask_{};
+        std::array<double, Size> value_{};
+
+        constexpr std::size_t index(const Item p) const noexcept
+        {
+            return static_cast<std::size_t>(p);
+        }
+
     };
 
 }} // namespace Opm::data


### PR DESCRIPTION
Then it can be reused by opm-simulators code for debugging guide rates, see https://github.com/OPM/opm-simulators/pull/6170 (in particular [line 263](https://github.com/OPM/opm-simulators/pull/6170/files#diff-7a6796a825c71437c9a9a884020c7351480e1d1971b07eaf09422fea04dad077R263) in `GuideRateHandler.cpp`). This is also meant as a possible replacement for https://github.com/OPM/opm-common/pull/4567, see https://github.com/OPM/opm-simulators/pull/6170#issuecomment-2965669118 for more information. 