### PR TITLE
Varnish ScheduleStatic Implementation

### DIFF
--- a/opm/input/eclipse/Schedule/ScheduleStatic.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleStatic.cpp
@@ -19,106 +19,137 @@
 
 #include <opm/input/eclipse/Schedule/ScheduleStatic.hpp>
 
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+
+#include <opm/input/eclipse/Python/Python.hpp>
+
 #include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Deck/DeckItem.hpp>
+#include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/DeckSection.hpp>
 
 #include <opm/input/eclipse/Parser/ParserKeywords/L.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/V.hpp>
 
-#include <opm/input/eclipse/Python/Python.hpp>
+#include <memory>
+#include <optional>
+#include <utility>
 
 namespace {
 
-double sumthin_summary_section(const Opm::SUMMARYSection& section) {
-    const auto entries = section.getKeywordList<Opm::ParserKeywords::SUMTHIN>();
+    double sumthin_summary_section(const Opm::SUMMARYSection& section)
+    {
+        const auto entries = section.getKeywordList<Opm::ParserKeywords::SUMTHIN>();
 
-    // Care only about the last SUMTHIN entry in the SUMMARY
-    // section if keyword is present here at all.
-    return entries.empty()
-        ? -1.0 // (<= 0.0)
-        : entries.back()->getRecord(0).getItem(0).getSIDouble(0);
-}
-
-bool rptonly_summary_section(const Opm::SUMMARYSection& section) {
-    auto rptonly = false;
-
-    using On = Opm::ParserKeywords::RPTONLY;
-    using Off = Opm::ParserKeywords::RPTONLYO;
-
-    // Last on/off keyword entry "wins".
-    for (const auto& keyword : section) {
-        if (keyword.is<On>())
-            rptonly = true;
-        else if (keyword.is<Off>())
-            rptonly = false;
+        // Care only about the last SUMTHIN entry in the SUMMARY
+        // section if keyword is present here at all.
+        return entries.empty()
+            ? -1.0 // (<= 0.0)
+            : entries.back()->getRecord(0).getItem(0).getSIDouble(0);
     }
 
-    return rptonly;
-}
+    bool rptonly_summary_section(const Opm::SUMMARYSection& section)
+    {
+        auto rptonly = false;
 
-std::optional<Opm::OilVaporizationProperties>
-vappars_solution_section(const Opm::SOLUTIONSection& section, const int numpvt) {
-    if (section.hasKeyword("VAPPARS")) {
-        const auto& record = section.getKeyword("VAPPARS").getRecord(0);
-        Opm::OilVaporizationProperties ovp(numpvt);
-        double vap1 = record.getItem("OIL_VAP_PROPENSITY").get< double >(0);
-        double vap2 = record.getItem("OIL_DENSITY_PROPENSITY").get< double >(0);
+        using On = Opm::ParserKeywords::RPTONLY;
+        using Off = Opm::ParserKeywords::RPTONLYO;
+
+        // Last on/off keyword entry "wins".
+        for (const auto& keyword : section) {
+            if (keyword.is<On>()) {
+                rptonly = true;
+            }
+            else if (keyword.is<Off>()) {
+                rptonly = false;
+            }
+        }
+
+        return rptonly;
+    }
+
+    std::optional<Opm::OilVaporizationProperties>
+    vappars_solution_section(const Opm::SOLUTIONSection& section,
+                             const Opm::Runspec&         runspec)
+    {
+        using Kw = Opm::ParserKeywords::VAPPARS;
+
+        if (! section.hasKeyword<Kw>()) {
+            return {};
+        }
+
+        auto ovp = Opm::OilVaporizationProperties { runspec.tabdims().getNumPVTTables() };
+
+        const auto& record = section.getKeyword(Kw::keywordName).getRecord(0);
+
+        const auto vap1 = record.getItem<Kw::OIL_VAP_PROPENSITY>().get<double>(0);
+        const auto vap2 = record.getItem<Kw::OIL_DENSITY_PROPENSITY>().get<double>(0);
+
         Opm::OilVaporizationProperties::updateVAPPARS(ovp, vap1, vap2);
+
         return ovp;
     }
-    return std::nullopt;
-}
-}
 
-namespace Opm {
+} // Anonymous namespace
 
-ScheduleStatic::ScheduleStatic(std::shared_ptr<const Python> python_handle,
-                               const ScheduleRestartInfo& restart_info,
-                               const Deck& deck,
-                               const Runspec& runspec,
-                               const std::optional<int>& output_interval_,
-                               const ParseContext& parseContext,
-                               ErrorGuard& errors,
-                               bool slave_mode_) :
-    m_python_handle(python_handle),
-    m_input_path(deck.getInputPath()),
-    rst_info(restart_info),
-    m_deck_message_limits( deck ),
-    m_unit_system( deck.getActiveUnitSystem() ),
-    m_runspec( runspec ),
-    rst_config( SOLUTIONSection(deck), parseContext, runspec.compositional(), errors ),
-    output_interval(output_interval_),
-    sumthin(sumthin_summary_section(SUMMARYSection{ deck })),
-    rptonly(rptonly_summary_section(SUMMARYSection{ deck })),
-    gaslift_opt_active(deck.hasKeyword<ParserKeywords::LIFTOPT>()),
-    oilVap(vappars_solution_section(SOLUTIONSection{deck},
-                                    runspec.tabdims().getNumPVTTables())),
-    slave_mode{slave_mode_}
+Opm::ScheduleStatic::ScheduleStatic(std::shared_ptr<const Python> python_handle,
+                                    const ScheduleRestartInfo&    restart_info,
+                                    const Deck&                   deck,
+                                    const Runspec&                runspec,
+                                    const std::optional<int>&     output_interval_,
+                                    const ParseContext&           parseContext,
+                                    ErrorGuard&                   errors,
+                                    const bool                    slave_mode_)
+    : m_python_handle { std::move(python_handle) }
+    , m_input_path    { deck.getInputPath() }
+    , rst_info        { restart_info }
+    , m_deck_message_limits { deck }
+    , m_unit_system   { deck.getActiveUnitSystem() }
+    , m_runspec       { runspec }
+    , rst_config      { SOLUTIONSection(deck), parseContext, runspec.compositional(), errors }
+    , output_interval { output_interval_ }
+    , sumthin         { sumthin_summary_section(SUMMARYSection{ deck }) }
+    , rptonly         { rptonly_summary_section(SUMMARYSection{ deck }) }
+    , gaslift_opt_active { deck.hasKeyword<ParserKeywords::LIFTOPT>() }
+    , oilVap          { vappars_solution_section(SOLUTIONSection { deck }, runspec) }
+    , slave_mode      { slave_mode_ }
 {}
 
-ScheduleStatic ScheduleStatic::serializationTestObject()
+Opm::ScheduleStatic Opm::ScheduleStatic::serializationTestObject()
 {
-    auto python = std::make_shared<Python>(Python::Enable::OFF);
-    ScheduleStatic st(python);
+    ScheduleStatic st { std::make_shared<const Python>(Python::Enable::OFF) };
+
     st.m_deck_message_limits = MessageLimits::serializationTestObject();
     st.m_runspec = Runspec::serializationTestObject();
     st.m_unit_system = UnitSystem::newFIELD();
     st.m_input_path = "Some/funny/path";
     st.rst_config = RSTConfig::serializationTestObject();
     st.rst_info = ScheduleRestartInfo::serializationTestObject();
+    st.output_interval.emplace(123);
+    st.sumthin = 1.618;
+    st.rptonly = true;
+    st.gaslift_opt_active = true;
+    st.oilVap.emplace(OilVaporizationProperties::serializationTestObject());
+    st.slave_mode = true;
+
     return st;
 }
 
-bool ScheduleStatic::operator==(const ScheduleStatic& other) const
+bool Opm::ScheduleStatic::operator==(const ScheduleStatic& other) const
 {
-    return this->m_input_path == other.m_input_path &&
-           this->m_deck_message_limits == other.m_deck_message_limits &&
-           this->m_unit_system == other.m_unit_system &&
-           this->rst_config == other.rst_config &&
-           this->rst_info == other.rst_info &&
-           this->gaslift_opt_active == other.gaslift_opt_active &&
-           this->m_runspec == other.m_runspec;
-}
-
+    return (this->m_input_path == other.m_input_path)
+        && (this->rst_info == other.rst_info)
+        && (this->m_deck_message_limits == other.m_deck_message_limits)
+        && (this->m_unit_system == other.m_unit_system)
+        && (this->m_runspec == other.m_runspec)
+        && (this->rst_config == other.rst_config)
+        && (this->output_interval == other.output_interval)
+        && (this->sumthin == other.sumthin)
+        && (this->rptonly == other.rptonly)
+        && (this->gaslift_opt_active == other.gaslift_opt_active)
+        && (this->oilVap == other.oilVap)
+        && (this->slave_mode == other.slave_mode)
+        ;
 }

--- a/opm/input/eclipse/Schedule/ScheduleStatic.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleStatic.hpp
@@ -31,33 +31,111 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 
 namespace Opm {
 
-class Python;
+    class Python;
 
+} // namespace Opm
+
+namespace Opm {
+
+/// Initial state of Schedule object created from information in SOLUTION
+/// section
 struct ScheduleStatic
 {
-    std::shared_ptr<const Python> m_python_handle;
-    std::string m_input_path;
-    ScheduleRestartInfo rst_info;
-    MessageLimits m_deck_message_limits;
-    UnitSystem m_unit_system;
-    Runspec m_runspec;
-    RSTConfig rst_config;
-    std::optional<int> output_interval;
+    // Note to maintainers: When changing this list of data members, please
+    // update operator==(), serializationTestObject(), and serializeOp()
+    // accordingly.
+
+    /// Run's Python interpreter
+    std::shared_ptr<const Python> m_python_handle{};
+
+    /// On-disk location of run's model description (".DATA" file).
+    std::string m_input_path{};
+
+    /// How to handle SCHEDULE section in a restarted simulation run.
+    ScheduleRestartInfo rst_info{};
+
+    /// Limits on number of messages of each kind (MESSAGES keyword).
+    MessageLimits m_deck_message_limits{};
+
+    /// Run's input/output unit system conventions.
+    UnitSystem m_unit_system{};
+
+    /// Run's descriptive meta information (RUNSPEC section).
+    Runspec m_runspec{};
+
+    /// Initial restart file output requests.
+    ///
+    /// Keyword RPTRST in SOLUTION section.
+    RSTConfig rst_config{};
+
+    /// Not really used and therefore intentionally undocumented.
+    std::optional<int> output_interval{};
+
+    /// Sparse summary output interval (SUMTHIN keyword in SUMMARY section).
+    ///
+    /// Negative default value means to output summary information at every
+    /// time step.
     double sumthin{-1.0};
+
+    /// Whether or not to output summary information at report steps only
+    /// (RPTONLY keyword in SUMMARY section).
+    ///
+    /// Default value is to output summary information at every time step.
     bool rptonly{false};
+
+    /// Whether or not run activates the gas-lift optimisation facility.
     bool gaslift_opt_active{false};
-    std::optional<OilVaporizationProperties> oilVap;
+
+    /// Limits on gas re-solution and oil vaporisation rates (e.g., DRSTD in
+    /// SOLUTION section).
+    std::optional<OilVaporizationProperties> oilVap{};
+
+    /// Whether or not this run is externally controlled by another
+    /// simulation run (reservoir coupling facility).
     bool slave_mode{false};
 
+    /// Default constructor.
+    ///
+    /// Creates an object that's mostly usable as a target in a
+    /// deserialisation operation.
     ScheduleStatic() = default;
 
-    explicit ScheduleStatic(std::shared_ptr<const Python> python_handle) :
-        m_python_handle(python_handle)
+    /// Constructor.
+    ///
+    /// Creates an object with everything other than the run's Python
+    /// interpreter in its default state.  The object is mostly usable as a
+    /// target in a deserialisation operation.
+    ///
+    /// \param[in] python_handle Run's Python interpreter.
+    explicit ScheduleStatic(std::shared_ptr<const Python> python_handle)
+        : m_python_handle { std::move(python_handle) }
     {}
 
+    /// Constructor.
+    ///
+    /// \param[in] python_handle Run's Python interpreter.
+    ///
+    /// \param[in] restart_info How to handle SCHEDULE section in a
+    /// restarted simulation run.
+    ///
+    /// \param[in] deck Run's model description.  Mostly used for its
+    /// SOLUTION and SUMMARY section contents.
+    ///
+    /// \param[in] runspec Run's descriptive meta information
+    ///
+    /// \param[in] output_interval_ Not really used and therefore left
+    /// undocumented.
+    ///
+    /// \param[in] parseContext How to handle parse failures.
+    ///
+    /// \param[in,out] errors Collection of parse failures.
+    ///
+    /// \param[in] slave_mode Whether or not this run is externally
+    /// controlled by another simulation (reservoir coupling facility).
     ScheduleStatic(std::shared_ptr<const Python> python_handle,
                    const ScheduleRestartInfo& restart_info,
                    const Deck& deck,
@@ -67,22 +145,37 @@ struct ScheduleStatic
                    ErrorGuard& errors,
                    const bool slave_mode);
 
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
-        serializer(m_deck_message_limits);
-        serializer(this->rst_info);
-        serializer(m_runspec);
-        serializer(m_unit_system);
         serializer(this->m_input_path);
-        serializer(rst_info);
-        serializer(rst_config);
+        serializer(this->rst_info);
+        serializer(this->m_deck_message_limits);
+        serializer(this->m_unit_system);
+        serializer(this->m_runspec);
+        serializer(this->rst_config);
         serializer(this->output_interval);
+        serializer(this->sumthin);
+        serializer(this->rptonly);
         serializer(this->gaslift_opt_active);
+        serializer(this->oilVap);
+        serializer(this->slave_mode);
     }
 
+    /// Create a serialisation test object.
     static ScheduleStatic serializationTestObject();
 
+    /// Equality predicate.
+    ///
+    /// \param[in] other Object against which \code *this \endcode will be
+    /// tested for equality.
+    ///
+    /// \return Whether or not \code *this \endcode is the same as \p other.
     bool operator==(const ScheduleStatic& other) const;
 };
 


### PR DESCRIPTION
In particular

  - Add missing headers and re-sort include statements
  - Add braces to single-statement blocks
  - Add Doxygen-style documentation
  - Ensure all data members are accounted for in `operator==()`, `serializeOp()`, and `serializationTestObject()`.

This is in preparation of forming an initial report configuration object (`RPTConfig`) from the RPTSOL keyword in the SOLUTION section.