### PR TITLE
Form Initial Report Configuration Object

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -2642,6 +2642,10 @@ namespace {
         return this->m_static.m_python_handle;
     }
 
+    const std::optional<RPTConfig>& Schedule::initialReportConfiguration() const
+    {
+        return this->m_static.rpt_config;
+    }
 
     const GasLiftOpt& Schedule::glo(std::size_t report_step) const {
         return this->snapshots[report_step].glo();

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -392,6 +392,13 @@ namespace Opm {
         bool operator==(const Schedule& data) const;
         std::shared_ptr<const Python> python() const;
 
+        /// Retrieve initial report configuration object
+        ///
+        /// Populated by RPTSOL keyword in the SOLUTION section.
+        ///
+        /// \return Initial configuration object.  Nullopt if there is no
+        /// RPTSOL information in the SOLUTION section.
+        const std::optional<RPTConfig>& initialReportConfiguration() const;
 
         const ScheduleState& back() const;
         const ScheduleState& operator[](std::size_t index) const;

--- a/opm/input/eclipse/Schedule/ScheduleStatic.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleStatic.cpp
@@ -92,6 +92,18 @@ namespace {
         return ovp;
     }
 
+    std::optional<Opm::RPTConfig>
+    rptConfigSolutionSection(const Opm::SOLUTIONSection& section)
+    {
+        const auto input = section.getKeywordList<Opm::ParserKeywords::RPTSOL>();
+
+        if (input.empty()) {
+            return {};
+        }
+
+        return { Opm::RPTConfig { *input.back() } };
+    }
+
 } // Anonymous namespace
 
 Opm::ScheduleStatic::ScheduleStatic(std::shared_ptr<const Python> python_handle,
@@ -115,6 +127,7 @@ Opm::ScheduleStatic::ScheduleStatic(std::shared_ptr<const Python> python_handle,
     , gaslift_opt_active { deck.hasKeyword<ParserKeywords::LIFTOPT>() }
     , oilVap          { vappars_solution_section(SOLUTIONSection { deck }, runspec) }
     , slave_mode      { slave_mode_ }
+    , rpt_config      { rptConfigSolutionSection(SOLUTIONSection { deck }) }
 {}
 
 Opm::ScheduleStatic Opm::ScheduleStatic::serializationTestObject()
@@ -133,6 +146,7 @@ Opm::ScheduleStatic Opm::ScheduleStatic::serializationTestObject()
     st.gaslift_opt_active = true;
     st.oilVap.emplace(OilVaporizationProperties::serializationTestObject());
     st.slave_mode = true;
+    st.rpt_config.emplace(RPTConfig::serializationTestObject());
 
     return st;
 }
@@ -151,5 +165,6 @@ bool Opm::ScheduleStatic::operator==(const ScheduleStatic& other) const
         && (this->gaslift_opt_active == other.gaslift_opt_active)
         && (this->oilVap == other.oilVap)
         && (this->slave_mode == other.slave_mode)
+        && (this->rpt_config == other.rpt_config)
         ;
 }

--- a/opm/input/eclipse/Schedule/ScheduleStatic.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleStatic.hpp
@@ -23,6 +23,7 @@
 
 #include <opm/input/eclipse/Schedule/MessageLimits.hpp>
 #include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
+#include <opm/input/eclipse/Schedule/RPTConfig.hpp>
 #include <opm/input/eclipse/Schedule/RSTConfig.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleRestartInfo.hpp>
 
@@ -98,6 +99,11 @@ struct ScheduleStatic
     /// simulation run (reservoir coupling facility).
     bool slave_mode{false};
 
+    /// SOLUTION section's PRT file report configuration (RPTSOL keyword).
+    ///
+    /// Nullopt if there is no RPTSOL keyword in the SOLUTION section.
+    std::optional<RPTConfig> rpt_config{};
+
     /// Default constructor.
     ///
     /// Creates an object that's mostly usable as a target in a
@@ -165,6 +171,7 @@ struct ScheduleStatic
         serializer(this->gaslift_opt_active);
         serializer(this->oilVap);
         serializer(this->slave_mode);
+        serializer(this->rpt_config);
     }
 
     /// Create a serialisation test object.


### PR DESCRIPTION
This PR creates an initial `RPTConfig` object from RPTSOL information in the SOLUTION section.  Previously, we would discard all such information other than very specific fluid-in-place mnemonics that were internalised into the `FIPConfig` object stored in the `EclipseState`'s `IOConfig` sub-object.  We make the information available to client code through a new dedicated member function
```
Schedule::initialReportConfiguration()
```
that returns `nullopt` if there is no RPTSOL information in the SOLUTION section.

This is an alternative to #4628 in support of OPM/opm-simulators#6329.