### PR TITLE
Set all group actions when restarting.

### DIFF
--- a/opm/input/eclipse/Schedule/Group/Group.cpp
+++ b/opm/input/eclipse/Schedule/Group/Group.cpp
@@ -140,6 +140,11 @@ namespace {
 
         production.cmode = Opm::Group::ProductionCModeFromInt(rst_group.prod_cmode);
         production.group_limit_action.allRates = Opm::Group::ExceedActionFromInt(rst_group.exceed_action);
+        // For now, we do not know where the other actions are stored in IGRP, so we set them all
+        // to the allRates value.
+        production.group_limit_action.water = production.group_limit_action.allRates;
+        production.group_limit_action.gas = production.group_limit_action.allRates;
+        production.group_limit_action.liquid = production.group_limit_action.allRates;
         production.guide_rate_def = Opm::Group::GuideRateProdTargetFromInt(rst_group.prod_guide_rate_def);
 
         production.production_controls = 0;


### PR DESCRIPTION
This makes the production.group_limit_action object valid after a restart, which is required by https://github.com/OPM/opm-simulators/pull/6331

Note that to support accurate restart with different group actions for different phases (GCONPROD items 11-13) we need to write the data to the proper locations in the IGRP array, which I do not know: @tskille that will be up to you, if prioritized.