### PR TITLE
Interpret GCONPROD FLD controls as inheriting control from parent(s).

### DIFF
--- a/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
@@ -199,27 +199,6 @@ void handleGCONPROD(HandlerContext& handlerContext)
         ? allRates
         : Group::ExceedActionFromString(record.getItem("LIQUID_EXCEED_PROCEDURE").getTrimmedString(0));
 
-        // we overwrite the actions based on the control mode,
-        // TODO: while how to handle `FLD` remains undecided
-        switch (controlMode) {
-            case Group::ProductionCMode::ORAT:
-                groupLimitAction.oil = Group::ExceedAction::RATE;
-                break;
-            case Group::ProductionCMode::WRAT:
-                groupLimitAction.water = Group::ExceedAction::RATE;
-                break;
-            case Group::ProductionCMode::GRAT:
-                groupLimitAction.gas = Group::ExceedAction::RATE;
-                break;
-            case Group::ProductionCMode::LRAT:
-                groupLimitAction.liquid = Group::ExceedAction::RATE;
-                break;
-            case Group::ProductionCMode::FLD:
-                //TODO: we do not know yet and we do nothing for now
-            default:
-                break; // do nothing
-        }
-
         const bool respond_to_parent = DeckItem::to_bool(record.getItem("RESPOND_TO_PARENT").getTrimmedString(0));
 
         const auto oil_target = record.getItem("OIL_TARGET").get<UDAValue>(0);
@@ -316,6 +295,24 @@ void handleGCONPROD(HandlerContext& handlerContext)
                 production.resv_target = resv_target;
                 production.available_group_control = availableForGroupControl;
                 production.group_limit_action = groupLimitAction;
+
+                // we overwrite the actions based on the control mode,
+                switch (production.cmode) {
+                case Group::ProductionCMode::ORAT:
+                    production.group_limit_action.oil = Group::ExceedAction::RATE;
+                    break;
+                case Group::ProductionCMode::WRAT:
+                    production.group_limit_action.water = Group::ExceedAction::RATE;
+                    break;
+                case Group::ProductionCMode::GRAT:
+                    production.group_limit_action.gas = Group::ExceedAction::RATE;
+                    break;
+                case Group::ProductionCMode::LRAT:
+                    production.group_limit_action.liquid = Group::ExceedAction::RATE;
+                    break;
+                default:
+                    break; // do nothing
+                }
 
                 production.production_controls = 0;
                 // GCONPROD


### PR DESCRIPTION
This handles GCONPROD item 2 correctly for cases like the following:
```
GCONPROD
 'PLAT-A' 'ORAT' 20000.0  30000.0   1* 40000.0  'RATE' /
 'M5S'    'FLD'  500.0    30000.0   1* 40000.0  'WELL'  'YES' 1 'OIL' /
/
```
Here, the M5S group will now be treating ORAT as its control, which in turn will change the procedure for breaking the oil limit from WELL to RATE.

There are a few things that could still be considered: for the following case
```
GCONPROD
 'PLAT-A' 'LRAT' 20000.0  30000.0   1* 40000.0  'RATE' /
 'M5S'    'FLD'  500.0    30000.0   1* 40000.0  'WELL'  'YES' 1 'OIL' /
 'PLAT-A' 'ORAT' 20000.0  30000.0   1* 40000.0  'RATE' /
/
```
it is not clear if it should give identical results as the first one (since the last line overrides the first), or if the FLD control for M5S should become LRAT, since that is the control at the point in the file we encounter it.

Second, dynamic changes to the group control (due to limits reached) may in some cases lead to an inappropriate change of the procedure to match the new control, whereas it should probably stay as specified in the deck.

I think the current PR is a good step forward though, the two points above I consider corner cases.