### PR TITLE
update how to determine too high roughness

### DIFF
--- a/opm/input/eclipse/Schedule/MSW/Segment.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Segment.cpp
@@ -106,12 +106,12 @@ namespace Opm {
         , m_y                (0.0)
     {
         if (is_valid_value(m_roughness) && is_valid_value(m_internal_diameter)) {
-            const double safe_roughness = m_internal_diameter * std::min(MAX_REL_ROUGHNESS, m_roughness/m_internal_diameter);
+            const double safe_roughness = m_internal_diameter * MAX_REL_ROUGHNESS;
             if (m_roughness > safe_roughness) {
                 OpmLog::warning(fmt::format("Well {} segment {}: Too high roughness {:.3e} is limited to {:.3e} to avoid singularity in friction factor calculation.",
                                             wname, m_segment_number, m_roughness, safe_roughness));
+                m_roughness = safe_roughness;
             }
-            m_roughness = safe_roughness;
         }
 
         const auto segment_type = segmentTypeFromInt(rst_segment.segment_type);

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -294,8 +294,10 @@ namespace Opm {
             }
 
             const double input_roughness = record.getItem("ROUGHNESS").getSIDouble(0);
-            const double roughness = diameter * std::min(Segment::MAX_REL_ROUGHNESS, input_roughness/diameter);
-            if (input_roughness > roughness) {
+            const double safe_roughness = Segment::MAX_REL_ROUGHNESS * diameter;
+            const bool too_high_roughness = input_roughness > safe_roughness;
+            const double roughness = too_high_roughness ? safe_roughness : input_roughness;
+            if (too_high_roughness) {
                 const auto& location = welsegsKeyword.location();
                 OpmLog::warning(fmt::format("Well {} WELSEGS segment {} to {}: Too high roughness {:.3e} is found at line {} in file {}, \n"
                                             "the value is limited to {:.3e} to avoid singularity in friction factor calculation.",

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -296,8 +296,10 @@ namespace Opm {
             const double input_roughness = record.getItem("ROUGHNESS").getSIDouble(0);
             const double roughness = diameter * std::min(Segment::MAX_REL_ROUGHNESS, input_roughness/diameter);
             if (input_roughness > roughness) {
-                OpmLog::warning(fmt::format("Well {} WELSEGS segment {} to {}: Too high roughness {:.3e} is limited to {:.3e} to avoid singularity in friction factor calculation.",
-                                            wname, segment1, segment2, input_roughness, roughness));
+                const auto& location = welsegsKeyword.location();
+                OpmLog::warning(fmt::format("Well {} WELSEGS segment {} to {}: Too high roughness {:.3e} is found at line {} in file {}, \n"
+                                            "the value is limited to {:.3e} to avoid singularity in friction factor calculation.",
+                                            wname, segment1, segment2, input_roughness, location.lineno, location.filename, roughness));
             }
 
             const auto node_X = record.getItem("LENGTH_X").getSIDouble(0);


### PR DESCRIPTION
With the master branch, we got some message like the following due to rounding error from `diameter*input_roughness/diameter`

```
Warning: Well G segment 76 to 76: Too high roughness 1.500e-05 is limited to 1.500e-05 to avoid singularity in friction factor calculation.
```

this PR refactor the calculation to avoid that. 

And also, the PR adds the line number and file name for the warning to help diagnostic . 
