### PR TITLE
Emit Usable Diagnostic for Unuspported Restart Report Number

### DIFF
--- a/opm/input/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -224,6 +224,14 @@ namespace Opm {
             .getItem<ParserKeywords::RESTART::REPORTNUMBER>()
             .get<int>(0);
 
+        if (step < 1) {
+            throw OpmInputError {
+                "OPM does not support restarting a "
+                "simulation before report number 1",
+                rst_kw.location()
+            };
+        }
+
         const auto input_path = std::filesystem::path {
             deck.getInputPath()
         };

--- a/tests/parser/InitConfigTest.cpp
+++ b/tests/parser/InitConfigTest.cpp
@@ -160,6 +160,22 @@ SKIPREST
 )" };
     }
 
+    std::string deckStr3_seq0()
+    {
+        return { R"(RUNSPEC
+DIMENS
+ 10 10 10 /
+START             -- 0
+19 JUN 2007 /
+GRID
+SOLUTION
+RESTART
+BASE 0 / -- From report step 0 => not supported
+SCHEDULE
+SKIPREST
+)" };
+    }
+
     std::string deckStr4()
     {
         return { R"(RUNSPEC
@@ -285,6 +301,11 @@ BOOST_AUTO_TEST_CASE(InitConfigTest)
     {
         const Deck deck3 = createDeck(deckStr3());
         BOOST_CHECK_THROW(InitConfig{deck3}, OpmInputError);
+    }
+
+    {
+        const Deck deck3_seq0 = createDeck(deckStr3_seq0());
+        BOOST_CHECK_THROW(InitConfig{deck3_seq0}, OpmInputError);
     }
 
     {


### PR DESCRIPTION
OPM Flow does not support restarting a simulation run from report step zero.  Previously, this would manifest in a very inscrutable diagnostic message of the form
```
Array ZGRP not found in sequence 0
```
which, while accurate, does not tell the user what the problem is.

This PR verifies that the restart step supplied as item 2 of the RESTART keyword is at least one (1).  If not, we now generate a diagnostic message of the form
```
Error: Problem with keyword RESTART
In CASE.DATA line 1729
OPM does not support restarting a simulation before report number 1
```
and stop processing the input file.