### PR TITLE
returning zero guide rate instead of throw due to invalid denominator.

### DIFF
--- a/opm/input/eclipse/Schedule/Group/GuideRate.cpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.cpp
@@ -277,7 +277,7 @@ void Opm::GuideRate::group_compute(const std::string& wgname,
         }
 
         if (is_formula) {
-            const auto guide_rate = this->eval_form(config.model(), wgname, oil_pot, gas_pot, wat_pot);
+            const auto guide_rate = this->eval_form(config.model(), "group " + wgname, oil_pot, gas_pot, wat_pot);
             this->assign_grvalue(wgname, config.model(), { sim_time, guide_rate, config.model().target() });
         }
     }
@@ -345,18 +345,18 @@ void Opm::GuideRate::well_compute(const std::string& wgname,
         }
 
         const auto& model = config.model();
-        const auto guide_rate = this->eval_form(model, wgname, oil_pot, gas_pot, wat_pot);
+        const auto guide_rate = this->eval_form(model, "well " + wgname, oil_pot, gas_pot, wat_pot);
         this->assign_grvalue(wgname, model, { sim_time, guide_rate, model.target() });
     }
 }
 
 double Opm::GuideRate::eval_form(const GuideRateModel& model,
-                                 const std::string&    wgname,
+                                 const std::string&    wgId,
                                  const double          oil_pot,
                                  const double          gas_pot,
                                  const double          wat_pot) const
 {
-    return model.eval(wgname, oil_pot, gas_pot, wat_pot);
+    return model.eval(wgId, oil_pot, gas_pot, wat_pot);
 }
 
 void Opm::GuideRate::assign_grvalue(const std::string&    wgname,

--- a/opm/input/eclipse/Schedule/Group/GuideRate.cpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.cpp
@@ -277,7 +277,7 @@ void Opm::GuideRate::group_compute(const std::string& wgname,
         }
 
         if (is_formula) {
-            const auto guide_rate = this->eval_form(config.model(), oil_pot, gas_pot, wat_pot);
+            const auto guide_rate = this->eval_form(config.model(), wgname, oil_pot, gas_pot, wat_pot);
             this->assign_grvalue(wgname, config.model(), { sim_time, guide_rate, config.model().target() });
         }
     }
@@ -345,17 +345,18 @@ void Opm::GuideRate::well_compute(const std::string& wgname,
         }
 
         const auto& model = config.model();
-        const auto guide_rate = this->eval_form(model, oil_pot, gas_pot, wat_pot);
+        const auto guide_rate = this->eval_form(model, wgname, oil_pot, gas_pot, wat_pot);
         this->assign_grvalue(wgname, model, { sim_time, guide_rate, model.target() });
     }
 }
 
 double Opm::GuideRate::eval_form(const GuideRateModel& model,
+                                 const std::string&    wgname,
                                  const double          oil_pot,
                                  const double          gas_pot,
                                  const double          wat_pot) const
 {
-    return model.eval(oil_pot, gas_pot, wat_pot);
+    return model.eval(wgname, oil_pot, gas_pot, wat_pot);
 }
 
 void Opm::GuideRate::assign_grvalue(const std::string&    wgname,

--- a/opm/input/eclipse/Schedule/Group/GuideRate.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.hpp
@@ -203,7 +203,7 @@ private:
                        const double       wat_pot);
 
     double eval_form(const GuideRateModel& model,
-                     const std::string&    wgname,
+                     const std::string&    wgId,
                      const double          oil_pot,
                      const double          gas_pot,
                      const double          wat_pot) const;

--- a/opm/input/eclipse/Schedule/Group/GuideRate.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.hpp
@@ -203,6 +203,7 @@ private:
                        const double       wat_pot);
 
     double eval_form(const GuideRateModel& model,
+                     const std::string&    wgname,
                      const double          oil_pot,
                      const double          gas_pot,
                      const double          wat_pot) const;

--- a/opm/input/eclipse/Schedule/Group/GuideRateModel.cpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRateModel.cpp
@@ -146,7 +146,7 @@ double GuideRateModel::pot(Target target, double oil_pot, double gas_pot, double
 }
 
 
-double GuideRateModel::eval(const std::string& wgname, double oil_pot, double gas_pot, double wat_pot) const {
+double GuideRateModel::eval(const std::string& wgId, double oil_pot, double gas_pot, double wat_pot) const {
     if (this->default_model)
         throw std::invalid_argument("The default GuideRateModel can not be evaluated - must enter GUIDERAT information explicitly.");
 
@@ -191,12 +191,12 @@ double GuideRateModel::eval(const std::string& wgname, double oil_pot, double ga
 
     const double denom = this->B + this->C*std::pow(R1, this->D) + this->E*std::pow(R2, this->F);
     if (denom <= 0) {
-        OpmLog::warning("GUIDERATE_ZERO_DEONM",
-            fmt::format("GuideRateModel::eval: Denominator {}  <= 0, which is not allowed. "
-                                " returning zero guide rate for well/group {}", denom, wgname) );
+        OpmLog::warning("GUIDERATE_ZERO_DENOM",
+               fmt::format("GUIDERAT formula denominator ({0:.6e}) is non-positive for {1}. "
+                           "Guide rate set to zero.", denom, wgId));
 
-        const auto debug_msg = fmt::format("GuideRateModel::eval: invalid denominator {} with :\n"
-               "val: {}, R1: {}, R2: {}, A: {}, B: {}, C: {}, D: {}, E: {}, F: {}",
+        const auto debug_msg = fmt::format("GuideRateModel::eval: invalid denominator {0:.6e} with :\n"
+               "val: {1:.6e}, R1: {2:.6e}, R2: {3:.6e}, A: {4}, B: {5}, C: {6}, D: {7}, E: {8}, F: {9}",
             denom, val, R1, R2, this->A, this->B, this->C, this->D, this->E, this->F);
         OpmLog::debug(debug_msg);
 

--- a/opm/input/eclipse/Schedule/Group/GuideRateModel.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRateModel.hpp
@@ -68,7 +68,7 @@ public:
 
     static GuideRateModel serializationTestObject();
 
-    double eval(const std::string& wgname, double oil_pot, double gas_pot, double wat_pot) const;
+    double eval(const std::string& wgId, double oil_pot, double gas_pot, double wat_pot) const;
     bool updateLINCOM(const UDAValue& alpha, const UDAValue& beta, const UDAValue& gamma) const;
     double update_delay() const;
     bool allow_increase() const;

--- a/opm/input/eclipse/Schedule/Group/GuideRateModel.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRateModel.hpp
@@ -68,7 +68,7 @@ public:
 
     static GuideRateModel serializationTestObject();
 
-    double eval(double oil_pot, double gas_pot, double wat_pot) const;
+    double eval(const std::string& wgname, double oil_pot, double gas_pot, double wat_pot) const;
     bool updateLINCOM(const UDAValue& alpha, const UDAValue& beta, const UDAValue& gamma) const;
     double update_delay() const;
     bool allow_increase() const;

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -329,10 +329,10 @@ GCONPROD
 BOOST_AUTO_TEST_CASE(TESTGuideRateModel) {
     Opm::GuideRateModel grc_default;
     BOOST_CHECK_THROW(Opm::GuideRateModel(0.0,GuideRateModel::Target::OIL, -5,0,0,0,0,0,true,1,true), std::invalid_argument);
-    BOOST_CHECK_THROW(grc_default.eval(1,0.50,0.50), std::invalid_argument);
+    BOOST_CHECK_THROW(grc_default.eval("WELLA", 1,0.50,0.50), std::invalid_argument);
 
     Opm::GuideRateModel grc_delay(10, GuideRateModel::Target::OIL, 1,1,0,0,0,0,true,1,true);
-    BOOST_CHECK_NO_THROW(grc_delay.eval(1.0, 0.5, 0.5));
+    BOOST_CHECK_NO_THROW(grc_delay.eval("WELLA", 1.0, 0.5, 0.5));
 }
 
 BOOST_AUTO_TEST_CASE(TESTGuideRateLINCOM) {


### PR DESCRIPTION

We see this problem for a field case, it stops the simulation. 