### PR TITLE
Document Internal EclipseIO::Impl Class

### DIFF
--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -46,85 +46,122 @@ class WellTestState;
 
 } // namespace Opm
 
-namespace Opm { namespace Action {
+namespace Opm::Action {
     class State;
-}} // namespace Opm::Action
+} // namespace Opm::Action
 
-namespace Opm { namespace out {
+namespace Opm::out {
     class Summary;
-}} // namespace Opm::out
+} // namespace Opm::out
 
 namespace Opm {
-/// \brief A class to write reservoir and well states of a blackoil
-///        simulation to disk.
+
+/// File I/O management for reservoir description and dynamic results.
 class EclipseIO
 {
 public:
-    /// \brief Sets common attributes required to write compatible result
-    /// files.
+    /// Constructor.
+    ///
+    /// \param[in] es Run's static parameters such as region definitions.
+    /// The EclipseIO object retains a reference to this object, whence the
+    /// lifetime of \p es should exceed that of the EclipseIO object.
+    ///
+    /// \param[in] grid Run's active cells.  The EclipseIO object takes
+    /// ownership of this grid object.
+    ///
+    /// \param[in] schedule Run's dynamic objects.  The EclipseIO object
+    /// retains a reference to this object, whence the lifetime of \p
+    /// schedule should exceed that of the EclipseIO object.
+    ///
+    /// \param[in] summary_config Run's collection of summary vectors
+    /// requested in the SUMMARY section of the model description.  Used to
+    /// initialise an internal \c SummaryConfig object that will
+    /// additionally contain all vectors needed to evaluate the defining
+    /// expressions of any user-defined quantities in the run.
+    ///
+    /// \param[in] basename Name of main input data file, stripped of
+    /// extensions and directory names.
+    ///
+    /// \param[in] writeEsmry Whether or not to additionally create a
+    /// "transposed" .ESMRY output file during the simulation run.  ESMRY
+    /// files typically load faster into post-processing tools such as
+    /// qsummary and ResInsight than traditional SMSPEC/UNSMRY files,
+    /// especially if the user only needs to view a small number of vectors.
+    /// On the other hand, ESMRY files typically require more memory while
+    /// writing.
     EclipseIO(const EclipseState&  es,
               EclipseGrid          grid,
               const Schedule&      schedule,
               const SummaryConfig& summary_config,
-              const std::string&   basename = "",
-              const bool writeEsmry = false);
+              const std::string&   basename = std::string{},
+              const bool           writeEsmry = false);
 
+    /// Deleted copy constructor.
+    ///
+    /// There must be exactly one object of this type in any given
+    /// simulation run.
     EclipseIO(const EclipseIO&) = delete;
 
+    /// Deleted assignment operator.
+    ///
+    /// There must be exactly one object of this type in any given
+    /// simulation run.
+    EclipseIO& operator=(const EclipseIO&) = delete;
+
+    /// Destructor.
+    ///
+    /// Needed for PIMPL idiom.
     ~EclipseIO();
 
-    /// \brief Output static properties in EGRID and INIT file.
+    /// Output static properties to EGRID and INIT files.
     ///
-    /// Write the static ECLIPSE data (grid, PVT curves, etc) to disk, and
-    /// set up additional initial properties.  For the current code the
-    /// algorithm for selecting which vectors are written to the INIT file
-    /// is as follows:
+    /// Write static property data (grid, PVT curves, etc) to disk.
+    /// Per-cell static property arrays are selected as follows:
     ///
-    ///    1. 3D properties which can be simply calculated in the output
-    ///       layer are unconditionally written to disk, that currently
-    ///       includes the DX, DY, DZ and DEPTH keyword.
+    ///    1. 3D properties which can be calculated in the output layer are
+    ///       unconditionally written to the INIT file.  This collection
+    ///       currently includes the DX, DY, DZ, and DEPTH properties.
     ///
-    ///    2. All integer propeerties from the deck are written
-    ///       unconditionally, that typically includes the MULTNUM, PVTNUM,
-    ///       SATNUM and so on.  Observe that the keywords PVTNUM, SATNUM,
-    ///       EQLNUM and FIPNUM are automatically created in the output
-    ///       layer, so they will be on disk even if they are not explicitly
-    ///       included in the deck.
+    ///    2. All integer properties from the input deck are unconditionally
+    ///       output to the INIT file.  This collection will include at
+    ///       least the FIPNUM, MULTNUM, PVTNUM, and SATNUM region
+    ///       definition arrays since these can be created in the output
+    ///       layer if needed.
     ///
-    ///    3. The PORV keyword will *always* be present in the INIT file,
-    ///       and that keyword will have nx*ny*nz elements; all other 3D
-    ///       properties will only have nactive elements.
+    ///    3. The PORV array will *always* be present in the INIT file.
+    ///       Furthermore, that array will be sized according to the number
+    ///       of Cartesian input cells--i.e., Nx * Ny * Nz.  All other 3D
+    ///       properties, whether floating-point or integer, will be sized
+    ///       according to the run's number of active cells.
     ///
-    ///    4. For floating point 3D keywords from the deck - like PORO and
-    ///       PERMX there is a *hardcoded* list in the writeINIFile()
-    ///       implementation of which keywords to output - if they are
-    ///       available.
+    ///    4. Certain floating-point 3D property arrays from the input deck,
+    ///       such as PORO, PERM* and scaled saturation function end points,
+    ///       are specifically known to the INIT file writing logic.  If
+    ///       available in the run, these will be output to the INIT file.
     ///
-    ///    5. The container simProps contains additional 3D floating point
-    ///       properties which have been calculated by the simulator, this
-    ///       typically includes the transmissibilities TRANX, TRANY and
-    ///       TRANZ but could in principle be anye floating point
-    ///       property.
+    ///    5. SimProps contains additional 3D floating-point properties from
+    ///       the simulator.  Common property arrays here include the TRAN*
+    ///       arrays of interface transmissibilities, but could in principle
+    ///       be any floating-point property.
     ///
-    ///       If you want the FOE keyword in the summary output the
-    ///       simProps container must contain the initial OIP field.
+    /// \param[in] simProps Initial per-cell properties such as
+    /// transmissibilities.  Will be output to the INIT file.
     ///
-    /// In addition:
-    ///   - The NNC argument is distributed between the EGRID and INIT files.
+    /// \param[in] int_data Additional integer arrays defined by simulator.
+    /// May contain things like the MPI partition arrays.  Will be output to
+    /// the INIT file.
+    ///
+    /// \param[in] nnc Run's non-neighbouring connections.  Includes those
+    /// connections that are derived from corner-point grid processing and
+    /// those connections that are explicitly entered using keywords like
+    /// NNC, EDITNNC, or EDITNNCR.  The cell pairs will be output to the
+    /// EGRID file while the associate transmissibility will be output to
+    /// the INIT file.
     void writeInitial(data::Solution simProps = data::Solution(),
                       std::map<std::string, std::vector<int>> int_data = {},
                       const std::vector<NNCdata>& nnc = {});
 
-    /// \brief Overwrite the initial OIP values.
-    ///
-    /// These are also written when we call writeInitial if the simProps
-    /// contains them.  If not, these are assumed to zero and the simulator
-    /// can update them with this methods.
-    ///
-    /// \param[in] simProps The properties containing at least OIP.
-    void overwriteInitialOIP(const data::Solution& simProps);
-
-    /// \brief Write a reservoir state and summary information to disk.
+    /// Write reservoir state and summary information to disk.
     ///
     /// Calling this method is only meaningful after the first time step has
     /// been completed.
@@ -140,6 +177,46 @@ public:
     /// can load and restart from files with double precision keywords, but
     /// this is non-standard, and other third party applications might choke
     /// on those.
+    ///
+    /// \param[in] action_state Run's current action system state.  Expected
+    /// to hold current values for the number of times each action has run
+    /// and the time of each action's last run.
+    ///
+    /// \param[in] wtest_state Run's current WTEST information.  Expected to
+    /// hold information about those wells that have been closed due to
+    /// various runtime conditions.
+    ///
+    /// \param[in] st Summary values from most recent call to
+    /// Summary::eval().  Source object from which to retrieve the values
+    /// that go into the output buffer.
+    ///
+    /// \param[in] udq_state Run's current UDQ values.
+    ///
+    /// \param[in] report_step One-based report step index for which to
+    /// create output.  This is the number that gets incorporated into the
+    /// file extension of "separate" restart and summary output files (e.g.,
+    /// .X000n and .S000n).  Report_step=0 represents time zero.
+    ///
+    /// \param[in] isSubstep Whether or not we're being called in the middle
+    /// of a report step.  We typically output summary file information only
+    /// for sub-steps.
+    ///
+    /// \param[in] seconds_elapsed Elapsed physical (i.e., simulated) time
+    /// in seconds since start of simulation.
+    ///
+    /// \param[in] value Collection of per-cell, per-well, per-connection,
+    /// per-segment, per-group, and per-aquifer dynamic results pertaining
+    /// to this time point.
+    ///
+    /// \param[in] write_double Whether or not to output simulation results
+    /// as double precision floating-point numbers.  Compatibility
+    /// considerations may dictate outputting arrays as single precision
+    /// ("float") only.
+    ///
+    /// \param[in] time_step Current time step index.  Passing something
+    /// different than nullopt will generate restart file output even for
+    /// time steps that are not report steps.  This is a poor-man's
+    /// approximation of the BASIC=6 setting of the RPTRST keyword.
     void writeTimeStep(const Action::State& action_state,
                        const WellTestState& wtest_state,
                        const SummaryState&  st,
@@ -151,9 +228,10 @@ public:
                        const bool           write_double = false,
                        std::optional<int>   time_step = std::nullopt);
 
-    /// Will load solution data and wellstate from the restart file.  This
-    /// method will consult the IOConfig object to get filename and report
-    /// step to restart from.
+    /// Load per-cell solution data and wellstate from restart file.
+    ///
+    /// Name of restart file and report step from which to restart inferred
+    /// from internal IOConfig and InitConfig objects.
     ///
     /// The map keys should be a map of keyword names and their
     /// corresponding dimension object.  In other words, loading the state
@@ -168,9 +246,6 @@ public:
     /// RS and RV.  If you request keys which are not found in the restart
     /// file an exception will be raised.  This also happens if the size of
     /// a vector does not match the expected size.
-    ///
-    /// The function will consult the InitConfig object in the EclipseState
-    /// object to determine which file and report step to load.
     ///
     /// The extra_keys argument can be used to request additional kewyords
     /// from the restart value.  The extra vectors will be stored in the
@@ -181,13 +256,36 @@ public:
     /// it is missing.  Otherwise, if the bool is false missing, keywords
     /// will be ignored and there will not be an empty vector in the return
     /// value.
+    ///
+    /// \param[in,out] action_state Run's action system state.  On input, a
+    /// valid object.  On exit, populated from restart file information.
+    ///
+    /// \param[in,out] summary_state Run's container of summary vector
+    /// values.  On input, a valid object.  On exit, populated from restart
+    /// file information.  Mostly relevant to cumulative quantities such as
+    /// FOPT.
+    ///
+    /// \param[in] solution_keys Descriptors of requisite and optional
+    /// per-cell dynamic values to load from restart file.
+    ///
+    /// \param[in] extra_keys Descriptors of additional dynamic values to
+    /// load from restart file.  Optional.
+    ///
+    /// \return Collection of per-cell, per-well, per-connection,
+    /// per-segment, per-group, and per-aquifer dynamic results at
+    /// simulation restart time.
     RestartValue loadRestart(Action::State&                 action_state,
                              SummaryState&                  summary_state,
                              const std::vector<RestartKey>& solution_keys,
                              const std::vector<RestartKey>& extra_keys = {}) const;
 
-    /// Will load solution data from the restart file.  This
-    /// method will consult the IOConfig object to get filename.
+    /// Load per-cell solution data from restart file at specific time.
+    ///
+    /// Common use case is to load the initial volumes-in-place from time
+    /// zero.
+    ///
+    /// Name of restart file inferred from internal IOConfig and InitConfig
+    /// objects.
     ///
     /// The map keys should be a map of keyword names and their
     /// corresponding dimension object.  In other words, loading the state
@@ -203,21 +301,40 @@ public:
     /// file an exception will be raised.  This also happens if the size of
     /// a vector does not match the expected size.
     ///
-    /// The function will consult the InitConfig object in the EclipseState
-    /// object to determine which file and report step to load.
+    /// \param[in] solution_keys Descriptors of requisite and optional
+    /// per-cell dynamic values to load from restart file.
     ///
+    /// \param[in] report_step One-based report step index for which load
+    /// restart file information.
+    ///
+    /// \return Collection of per-cell results at \p report_step.
     data::Solution loadRestartSolution(const std::vector<RestartKey>& solution_keys,
                                        const int                      report_step) const;
 
+    /// Access internal summary vector calculation engine.
+    ///
+    /// Mainly provided in order to allow callers to invoke Summary::eval().
+    ///
+    /// \return Read-only reference to internal summary vector calculation
+    /// engine.
     const out::Summary& summary() const;
+
+    /// Access finalised summary configuration object.
+    ///
+    /// Provided to enable callers to learn all summary vectors needed to
+    /// evaluate defining expressions of user-defined quantities.
+    ///
+    /// \return Read-only reference to internal summary configuration object.
     const SummaryConfig& finalSummaryConfig() const;
 
 private:
+    /// Implementation class.
     class Impl;
+
+    /// Pointer to implementation object.
     std::unique_ptr<Impl> impl;
 };
 
 } // namespace Opm
-
 
 #endif // OPM_ECLIPSE_WRITER_HPP


### PR DESCRIPTION
In particular, add Doxygen-style comments to member functions and data members.  While here, document function parameters and return values of the main `EclipseIO` class in a similar style.

While here, also remove the declaration of the member function
```
EclipseIO::overwriteInitialOIP
```
This function was introduced in PR OPM/opm-output#198, but was rather shortlived.  The implementation, though not the declaration, was removed in PR OPM/opm-output#235.