### PR TITLE
Remove unused capillary pressure storage.

### DIFF
--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -244,12 +244,6 @@ public:
     { saturation_[canonicalToStoragePhaseIndex_(phaseIdx)] = S; }
 
     /*!
-     * \brief Set the capillary pressure of a fluid phase [-].
-     */
-    void setPc(unsigned phaseIdx, const Scalar& pc)
-    { pc_[canonicalToStoragePhaseIndex_(phaseIdx)] = pc; }
-
-    /*!
      * \brief Set the total saturation used for sequential methods
      */
     void setTotalSaturation(const Scalar& value)
@@ -350,12 +344,6 @@ public:
      */
     const Scalar& saturation(unsigned phaseIdx) const
     { return saturation_[canonicalToStoragePhaseIndex_(phaseIdx)]; }
-
-    /*!
-     * \brief Return the capillary pressure of a fluid phase [-]
-     */
-    const Scalar& pc(unsigned phaseIdx) const
-    { return pc_[canonicalToStoragePhaseIndex_(phaseIdx)]; }
 
     /*!
      * \brief Return the total saturation needed for sequential
@@ -677,7 +665,6 @@ private:
     ConditionalStorage<enableEnergy, std::array<Scalar, numStoragePhases> > enthalpy_{};
     Scalar totalSaturation_{};
     std::array<Scalar, numStoragePhases> pressure_{};
-    std::array<Scalar, numStoragePhases> pc_{};
     std::array<Scalar, numStoragePhases> saturation_{};
     std::array<Scalar, numStoragePhases> invB_{};
     std::array<Scalar, numStoragePhases> density_{};


### PR DESCRIPTION
Never used (read) by OPM Flow, was always redundant since all phase pressures are stored in this class anyway. Should save 12 doubles per cell for a 3-phase simulation, or 96 MB per million cells.

Requires a very small downstream update.

Manual: reduce memory consumption during simulation by 96 MB per million cells.