### PR TITLE
Remove conversions and accessors for empty ConditionalStorage.

### DIFF
--- a/opm/material/checkFluidSystem.hpp
+++ b/opm/material/checkFluidSystem.hpp
@@ -260,8 +260,15 @@ void checkFluidState(const BaseFluidState& fs)
         std::ignore = fs.saturation(/*phaseIdx=*/0);
         std::ignore = fs.fugacity(/*phaseIdx=*/0, /*compIdx=*/0);
         std::ignore = fs.fugacityCoefficient(/*phaseIdx=*/0, /*compIdx=*/0);
-        std::ignore = fs.enthalpy(/*phaseIdx=*/0);
-        std::ignore = fs.internalEnergy(/*phaseIdx=*/0);
+        // Note that we will no longer require that a fluid system
+        // supports enthalpy and internalEnergy compile time.
+        // The commented-out checks below only confirmed that there
+        // was a function that could be compiled, not that it actually
+        // made sense (usually empty but throwing functions).
+        // It is better to make such things compile errors rather than
+        // runtime errors.
+        // std::ignore = fs.enthalpy(/*phaseIdx=*/0);
+        // std::ignore = fs.internalEnergy(/*phaseIdx=*/0);
         std::ignore = fs.viscosity(/*phaseIdx=*/0);
     };
 }

--- a/opm/material/common/ConditionalStorage.hpp
+++ b/opm/material/common/ConditionalStorage.hpp
@@ -138,20 +138,6 @@ public:
         return *this;
     }
 
-    const T& operator*() const
-    { throw std::logic_error("data member deactivated"); }
-    T& operator*()
-    { throw std::logic_error("data member deactivated"); }
-
-    const T* operator->() const
-    { throw std::logic_error("data member deactivated"); }
-    T* operator->()
-    { throw std::logic_error("data member deactivated"); }
-
-    operator const T&() const
-    { throw std::logic_error("data member deactivated"); }
-    operator T&()
-    { throw std::logic_error("data member deactivated"); }
 };
 
 } // namespace Opm

--- a/tests/test_ConditionalStorage.cpp
+++ b/tests/test_ConditionalStorage.cpp
@@ -103,21 +103,11 @@ int main()
         // the assignment operator for the "wrapper" object should always work
         baz = foo;
 
-        try {
-            *bar;
-
-            // this is supposed to throw an std::logic_error
-            std::abort();
-        }
-        catch (std::logic_error &) {}
-
-        try {
-            std::ignore = foo->size();
-
-            // this is supposed to throw an std::logic_error
-            std::abort();
-        }
-        catch (std::logic_error &) {}
+        // Tests for the following expressions have been removed.
+        // They used to result in exceptions, but now become compile
+        // errors instead.
+        //  *bar;
+        //  foo->size();
     }
 
     {


### PR DESCRIPTION
Instead of throwing, this will now be a compile error.

This will require downstream changes.

Manual: Makes some types of run-time errors into compile-time errors, making it easier to avoid certain types of programming mistakes.