### PR TITLE
Include File Extension in RSM File Input Source

### DIFF
--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -708,11 +708,19 @@ void Opm::EclipseIO::Impl::writeRestartFile(const Action::State& action_state,
 
 void Opm::EclipseIO::Impl::writeRunSummary() const
 {
-    const auto outputFile = std::filesystem::path {
-        this->outputDir_
-    } / this->baseName_;
+    const auto formatted = this->es_.get().cfg().io().getFMTOUT();
 
-    EclIO::ESmry { outputFile.generic_string() }.write_rsm_file();
+    const auto ext = '.'
+        + (formatted ? std::string{"F"} : std::string{})
+        + "SMSPEC";
+
+    const auto rset = EclIO::OutputStream::ResultSet {
+        this->outputDir_, this->baseName_
+    };
+
+    const auto smspec = EclIO::OutputStream::outputFileName(rset, ext);
+
+    EclIO::ESmry { smspec }.write_rsm_file();
 }
 
 void Opm::EclipseIO::Impl::writeRftFile(const double       secs_elapsed,


### PR DESCRIPTION
This PR switches to using the `outputFileName()` helper function to generate the name of the 'SMSPEC' file used as the source when creating RSM file output.  This means that we now handle certain very special cases that we did not handle before.  More importantly however, since we now include the proper filename extension, class `ESmry` now has enough information to determine whether or not the input is formatted (`.FSMSPEC`) or unformatted (`.SMSPEC`).  Previously the `ESmry` class would be forced to guess that the input is unformatted and while this is the common case, this would lead to RSM file generation failure when the run uses formatted output.

Thanks to GitHub user 'gnrteixeira' for identifying this problem in Issue OPM/opm-simulators#6340.

---

While here, also switch to using `outputFileName()` to generate the proper output filename for the run's `EGRID` file.  This is mostly to handle the aforementioned special cases and does not normally not affect any real cases.

---

This PR resolves OPM/opm-simulators#6340.