### PR TITLE
RstState: add check for undefined DRSDT in load_oil_vaporization

### DIFF
--- a/opm/io/eclipse/rst/state.cpp
+++ b/opm/io/eclipse/rst/state.cpp
@@ -355,6 +355,11 @@ RstState::RstState(std::shared_ptr<EclIO::RestartFileView> rstView,
 void RstState::load_oil_vaporization(const std::vector<int>& intehead,
                                      const std::vector<double>& doubhead)
 {
+    if (!(doubhead[VI::doubhead::dRsDt] < 1.0e+20)) {
+        // DRSDT is not defined in the restart file, so we don't need to update the oilvap object.
+        return;
+    }
+
     const std::size_t numPvtRegions = this->oilvap.numPvtRegions();
     const auto tconv = this->unit_system.to_si(::Opm::UnitSystem::measure::time, 1.0);
     std::vector<double> maximums(numPvtRegions, doubhead[VI::doubhead::dRsDt]/tconv);


### PR DESCRIPTION
When using restart, the DRSDT ended up being active for a simulation that did not use DRSDT in the first place. This matters for functions like `recycleFirstIterationStorage()` but I am not sure if it had any real consequences as of now.

Fixing this is required for https://github.com/OPM/opm-simulators/pull/6357 to work.

I added a check which checks if the DRSDT value was defined in the state and skips updating the oilvap object if this is the case, which resolves this problem.