### PR TITLE
Remove unneeded maxOilSat from BlackOilFluidSystem::ParamCache.

### DIFF
--- a/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
@@ -86,9 +86,8 @@ public:
         using Evaluation = EvaluationT;
 
     public:
-        explicit ParameterCache(Scalar maxOilSat = 1.0, unsigned regionIdx = 0)
-            : maxOilSat_(maxOilSat)
-            , regionIdx_(regionIdx)
+        explicit ParameterCache(unsigned regionIdx = 0)
+            : regionIdx_(regionIdx)
         {
         }
 
@@ -103,7 +102,6 @@ public:
         void assignPersistentData(const OtherCache& other)
         {
             regionIdx_ = other.regionIndex();
-            maxOilSat_ = other.maxOilSat();
         }
 
         /*!
@@ -126,14 +124,7 @@ public:
         void setRegionIndex(unsigned val)
         { regionIdx_ = val; }
 
-        const Evaluation& maxOilSat() const
-        { return maxOilSat_; }
-
-        void setMaxOilSat(const Evaluation& val)
-        { maxOilSat_ = val; }
-
     private:
-        Evaluation maxOilSat_;
         unsigned regionIdx_;
     };
 

--- a/tests/material/test_eclblackoilfluidsystem.cpp
+++ b/tests/material/test_eclblackoilfluidsystem.cpp
@@ -644,10 +644,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(BlackOil, Evaluation, Types)
 
     // create a parameter cache
     using ParamCache = typename FluidSystem::template ParameterCache<Scalar>;
-    ParamCache paramCache(/*maxOilSat=*/0.5, /*regionIdx=*/1);
+    ParamCache paramCache(/*regionIdx=*/1);
     BOOST_CHECK_EQUAL(paramCache.regionIndex(), 1);
 
-    BOOST_CHECK_SMALL(Opm::abs(paramCache.maxOilSat() - 0.5), 1e-10);
     BOOST_CHECK_SMALL(Opm::abs(FluidSystem::reservoirTemperature() - (273.15 + 15.555)), 1e-10);
     BOOST_CHECK(FluidSystem::enableDissolvedGas());
     BOOST_CHECK(FluidSystem::enableVaporizedOil());

--- a/tests/material/test_eclblackoilfluidsystemnonstatic.cpp
+++ b/tests/material/test_eclblackoilfluidsystemnonstatic.cpp
@@ -648,7 +648,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(BlackOil, Evaluation, Types)
 
     const size_t numberOfRegions = FluidSystem::numRegions();
     for (size_t regionIndexToUse = 0; regionIndexToUse < numberOfRegions; ++regionIndexToUse) {
-        ParamCache paramCache(/*maxOilSat=*/0.5, regionIndexToUse);
+        ParamCache paramCache(regionIndexToUse);
 
         // create a parameter cache
         BOOST_CHECK_EQUAL(FluidSystem::reservoirTemperature(), fluidSystem.reservoirTemperature());


### PR DESCRIPTION
Not used, should be removed.