### PR TITLE
Add compile-time dispatched capillaryPressures().

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
@@ -48,6 +48,21 @@ enum class EclMultiplexerApproach {
     OnePhase
 };
 
+template <EclMultiplexerApproach ApproachArg>
+struct EclMultiplexerDispatch
+{
+    static constexpr auto approach = ApproachArg;
+};
+
+// Helper struct to tell if a parameter pack starts with EclMultiplexerDispatch.
+template <typename ...Args>
+struct FrontIsEclMultiplexerDispatch : public std::false_type {};
+template <EclMultiplexerApproach Value, typename ...Args>
+struct FrontIsEclMultiplexerDispatch<EclMultiplexerDispatch<Value>, Args...> : public std::true_type {};
+template <typename ...Args>
+constexpr bool FrontIsEclMultiplexerDispatchV = FrontIsEclMultiplexerDispatch<Args...>::value;
+
+
 /*!
  * \brief Multiplexer implementation for the parameters required by the
  *        multiplexed three-phase material law.

--- a/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
@@ -29,6 +29,7 @@
 
 #include "EclStone1MaterialParams.hpp"
 
+#include <opm/common/TimingMacros.hpp>
 #include <opm/material/common/Valgrind.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 


### PR DESCRIPTION
This is a prototype that (together with a matching PR in opm-simulators) shows how we can get compile-time dispatch instead of run-time dispatch in the saturation function system, where we have "multiplexer" classes that currently do a run-time dispatch for every evaluation.

I think the syntax is not too scary, and it keeps all existing functionality, i.e. we can still get or partial complete run-time dispatch. The idea is to pass one class per dispatch you want to be compile time as a parameter pack. If you match (can use the front of the pack to make a dispatch) you do that dispatch and pass the rest of the pack further down the chain. That is not actually done here yet, but line 184 for example should then instead of
```
            Stone1Material::capillaryPressures(values,
```
be
```
            Stone1Material::capillaryPressures<Args...>(values,
```
That way, the LET-or-PiecewiseLinear multiplexer further down can get a compile time dispatch as well, etc.

The main potential cost is in compile time and memory usage for the executable. This has not been investigated yet, but it is possible that we must do some creative work to avoid the combinatorial explosion here.