### PR TITLE
Janitoring: mark constructor explicit

### DIFF
--- a/opm/common/utility/VoigtArray.hpp
+++ b/opm/common/utility/VoigtArray.hpp
@@ -69,7 +69,7 @@ public:
     VoigtContainer() = default;
 
     template<class Array>
-    VoigtContainer(const Array& array);
+    explicit VoigtContainer(const Array& array);
 
     VoigtContainer(std::initializer_list<T> value)
     {


### PR DESCRIPTION
Quell newly introduced (or well, newly noticed) static analyzer warnings-