### PR TITLE
Add inverseFormationVolumeFactorAndViscosity() to blackoil fluidsystem.

### DIFF
--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -118,6 +118,7 @@ template <class ScalarT,
           unsigned numStoragePhases = FluidSystem::numPhases>
 class BlackOilFluidState
 {
+public:
     enum { waterPhaseIdx = FluidSystem::waterPhaseIdx };
     enum { gasPhaseIdx = FluidSystem::gasPhaseIdx };
     enum { oilPhaseIdx = FluidSystem::oilPhaseIdx };
@@ -126,7 +127,6 @@ class BlackOilFluidState
     enum { gasCompIdx = FluidSystem::gasCompIdx };
     enum { oilCompIdx = FluidSystem::oilCompIdx };
 
-public:
     using Scalar = ScalarT;
     enum { numPhases = FluidSystem::numPhases };
     enum { numComponents = FluidSystem::numComponents };

--- a/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
@@ -811,6 +811,20 @@ public:
         }
     }
 
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    STATIC_OR_DEVICE std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState,
+                                             unsigned phaseIdx,
+                                             unsigned regionIdx)
+    {
+        switch (phaseIdx) {
+        case oilPhaseIdx: return oilPvt_->inverseFormationVolumeFactorAndViscosity(fluidState, regionIdx);
+        case gasPhaseIdx: return gasPvt_->inverseFormationVolumeFactorAndViscosity(fluidState, regionIdx);
+        case waterPhaseIdx: return waterPvt_->inverseFormationVolumeFactorAndViscosity(fluidState, regionIdx);
+        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        }
+    }
+
     /*!
      * \brief Returns the formation volume factor \f$B_\alpha\f$ of a "saturated" fluid
      *        phase

--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -344,6 +344,17 @@ public:
     }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/)
+    {
+        throw std::logic_error("Needs fixing before merging!");
+        return {};
+    }
+
+    /*!
      * \brief Returns the formation volume factor [-] of brine saturated with CO2 at a given pressure.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.hpp
@@ -262,6 +262,17 @@ public:
     }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/)
+    {
+        throw std::logic_error("Needs fixing before merging!");
+        return {};
+    }
+
+    /*!
     * \brief Returns the formation volume factor [-] of brine saturated
     *        with H2 at a given pressure.
     */

--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -242,6 +242,17 @@ public:
     }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/)
+    {
+        throw std::logic_error("Needs fixing before merging!");
+        return {};
+    }
+
+    /*!
      * \brief Returns the formation volume factor [-] of water saturated gas at given pressure.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp
@@ -184,6 +184,17 @@ public:
     }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/)
+    {
+        throw std::logic_error("Needs fixing before merging!");
+        return {};
+    }
+
+    /*!
      * \brief Returns the saturation pressure of the water phase [Pa]
      *        depending on its mass fraction of the gas component
      *

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -174,6 +174,17 @@ public:
     { return saturatedInverseFormationVolumeFactor(regionIdx, temperature, pressure); }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/)
+    {
+        throw std::logic_error("Needs fixing before merging!");
+        return {};
+    }
+
+    /*!
      * \brief Returns the formation volume factor [-] of gas saturated oil.
      *
      * Note that constant compressibility oil is a special case of dead oil and dead oil

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -159,6 +159,17 @@ public:
     { return inverseOilB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/)
+    {
+        throw std::logic_error("Needs fixing before merging!");
+        return {};
+    }
+
+    /*!
      * \brief Returns the formation volume factor [-] of saturated oil.
      *
      * Note that by definition, dead oil is always gas saturated.

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -171,6 +171,17 @@ public:
     { return saturatedInverseFormationVolumeFactor(regionIdx, temperature, pressure); }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/)
+    {
+        throw std::logic_error("Needs fixing before merging!");
+        return {};
+    }
+
+    /*!
      * \brief Returns the formation volume factor [-] of oil saturated gas at given pressure.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.hpp
@@ -205,6 +205,17 @@ public:
     { return inverseGasB_[regionIdx].eval(pressure, Rvw, /*extrapolate=*/true); }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/)
+    {
+        throw std::logic_error("Needs fixing before merging!");
+        return {};
+    }
+
+    /*!
      * \brief Returns the formation volume factor [-] of water saturated gas at a given pressure.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -203,6 +203,14 @@ public:
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rv, Rvw)); }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx)
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.inverseFormationVolumeFactorAndViscosity(fluidState, regionIdx)); }
+
+    /*!
      * \brief Returns the formation volume factor [-] of oil saturated gas given a set of parameters.
      */
     template <class Evaluation = Scalar>

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -276,6 +276,17 @@ public:
     }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/)
+    {
+        throw std::logic_error("Needs fixing before merging!");
+        return {};
+    }
+
+    /*!
      * \brief Returns the formation volume factor [-] of oil-saturated gas.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/H2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/H2GasPvt.hpp
@@ -190,6 +190,17 @@ public:
     }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/)
+    {
+        throw std::logic_error("Needs fixing before merging!");
+        return {};
+    }
+
+    /*!
     * \brief Returns the formation volume factor [-] of oil saturated gas at given pressure.
     */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -215,6 +215,36 @@ public:
     }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx)
+    {
+        const LhsEval& p = decay<LhsEval>(fluidState.pressure(FluidState::oilPhaseIdx));
+        const LhsEval& Rs = decay<LhsEval>(fluidState.Rs());
+
+        const auto satSegIdx = this->saturatedGasDissolutionFactorTable_[regionIdx].findSegmentIndex(p, /*extrapolate=*/ true);
+        const auto& RsSat = this->saturatedGasDissolutionFactorTable_[regionIdx].eval(p, SegmentIndex{satSegIdx});
+        const bool useSaturatedTables = (fluidState.saturation(FluidState::gasPhaseIdx) > 0.0) && (Rs >= (1.0 - 1e-10) * RsSat);
+
+        if (useSaturatedTables) {
+            const LhsEval b = this->inverseSaturatedOilBTable_[regionIdx].eval(p, SegmentIndex{satSegIdx});
+            const LhsEval invBMu = this->inverseSaturatedOilBMuTable_[regionIdx].eval(p, SegmentIndex{satSegIdx});
+            const LhsEval mu = b / invBMu;
+            return { b, mu };
+        } else {
+            unsigned ii, jj1, jj2;
+            LhsEval alpha, beta1, beta2;
+            this->inverseOilBTable_[regionIdx].findPoints(ii, jj1, jj2, alpha, beta1, beta2, Rs, p, /*extrapolate =*/ true);
+            const LhsEval b = this->inverseOilBTable_[regionIdx].eval(ii, jj1, jj2, alpha, beta1, beta2);
+            const LhsEval invBMu = this->inverseOilBMuTable_[regionIdx].eval(ii, jj1, jj2, alpha, beta1, beta2);
+            const LhsEval mu = b / invBMu;
+            return { b, mu };
+        }
+    }
+
+    /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -192,6 +192,14 @@ public:
     { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rs)); }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx)
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.inverseFormationVolumeFactorAndViscosity(fluidState, regionIdx)); }
+
+    /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -267,6 +267,17 @@ public:
     }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/)
+    {
+        throw std::logic_error("Needs fixing before merging!");
+        return {};
+    }
+
+    /*!
      * \brief Returns the formation volume factor [-] of gas-saturated oil phase.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -186,6 +186,14 @@ public:
         OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rsw, saltconcentration));
     }
 
+    /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx)
+    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.inverseFormationVolumeFactorAndViscosity(fluidState, regionIdx)); }
+
         /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
      */

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -304,6 +304,17 @@ public:
     }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/)
+    {
+        throw std::logic_error("Needs fixing before merging!");
+        return {};
+    }
+
+    /*!
      * \brief Returns the saturation pressure of the water phase [Pa]
      *        depending on its mass fraction of the gas component
      *

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -217,6 +217,36 @@ public:
     { return inverseGasB_[regionIdx].eval(pressure, Rv, /*extrapolate=*/true); }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx)
+    {
+        const LhsEval& p = decay<LhsEval>(fluidState.pressure(FluidState::gasPhaseIdx));
+        const LhsEval& Rv = decay<LhsEval>(fluidState.Rv());
+
+        const auto satSegIdx = this->saturatedOilVaporizationFactorTable_[regionIdx].findSegmentIndex(p, /*extrapolate=*/ true);
+        const auto& RvSat = this->saturatedOilVaporizationFactorTable_[regionIdx].eval(p, SegmentIndex{satSegIdx});
+        const bool useSaturatedTables = (fluidState.saturation(FluidState::oilPhaseIdx) > 0.0) && (Rv >= (1.0 - 1e-10) * RvSat);
+
+        if (useSaturatedTables) {
+            const LhsEval b = this->inverseSaturatedGasB_[regionIdx].eval(p, SegmentIndex{satSegIdx});
+            const LhsEval invBMu = this->inverseSaturatedGasBMu_[regionIdx].eval(p, SegmentIndex{satSegIdx});
+            const LhsEval mu = b / invBMu;
+            return { b, mu };
+        } else {
+            unsigned ii, jj1, jj2;
+            LhsEval alpha, beta1, beta2;
+            this->inverseGasB_[regionIdx].findPoints(ii, jj1, jj2, alpha, beta1, beta2, p, Rv, /*extrapolate =*/ true);
+            const LhsEval b = this->inverseGasB_[regionIdx].eval(ii, jj1, jj2, alpha, beta1, beta2);
+            const LhsEval invBMu = this->inverseGasBMu_[regionIdx].eval(ii, jj1, jj2, alpha, beta1, beta2);
+            const LhsEval mu = b / invBMu;
+            return { b, mu };
+        }
+    }
+
+    /*!
      * \brief Returns the formation volume factor [-] of oil saturated gas at a given pressure.
      */
     template <class Evaluation>

--- a/opm/material/fluidsystems/blackoilpvt/WetHumidGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetHumidGasPvt.hpp
@@ -211,6 +211,17 @@ public:
     }
 
     /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/)
+    {
+        throw std::logic_error("Needs fixing before merging!");
+        return {};
+    }
+
+    /*!
      * \brief Returns the formation volume factor [-] of water saturated gas at a given pressure.
      */
     template <class Evaluation>


### PR DESCRIPTION
For now only implemented for the Norne-relevant pvt variants, but can easily be extended to cover all.

Improves "Props/update time" for Norne (M4 Pro, 10 cores) from 3.03s to 2.16s (subject to some variation) when combined with downstream PR.