### PR TITLE
Implement scaling for Pc hysteresis

### DIFF
--- a/opm/input/eclipse/EclipseState/Runspec.cpp
+++ b/opm/input/eclipse/EclipseState/Runspec.cpp
@@ -446,6 +446,16 @@ EclHysterConfig::EclHysterConfig(const Opm::Deck& deck)
         // Killough model: Regularisation for trapped critical saturation calculations
         if (pcHystMod == 0 || krHystMod == 2 || krHystMod == 3)
             modParamTrappedValue = ehystrKeyword.getRecord(0).getItem("mod_param_trapped").get<double>(0);
+
+        if (pcHystMod >= 0) {
+            const int pc_scaling_value = ehystrKeyword.getRecord(0).getItem("enable_pc_scaling").get<int>(0);
+            if (pc_scaling_value != 0 && pc_scaling_value != 1) {
+                throw std::runtime_error(
+                    "Only 0 and 1 allowed for the 'capillary pressure scaling parameter' "
+                    "(the 14 item of the 'EHYSTR' keyword).");
+            }
+            enablePcScaling = pc_scaling_value;
+        }
     }
 
 EclHysterConfig EclHysterConfig::serializationTestObject()
@@ -457,6 +467,7 @@ EclHysterConfig EclHysterConfig::serializationTestObject()
     result.modParamTrappedValue = 3;
     result.curvatureCapPrsValue = 4;
     result.activeWagHyst = true;
+    result.enablePcScaling = false;
 
     return result;
 }
@@ -479,6 +490,9 @@ double EclHysterConfig::curvatureCapPrs() const
 bool EclHysterConfig::activeWag() const
 { return activeWagHyst; }
 
+bool EclHysterConfig::doPcScaling() const
+{ return enablePcScaling; }
+
 bool EclHysterConfig::operator==(const EclHysterConfig& data) const
 {
     return (this->active() == data.active())
@@ -487,6 +501,7 @@ bool EclHysterConfig::operator==(const EclHysterConfig& data) const
         && (this->modParamTrapped() == data.modParamTrapped())
         && (this->curvatureCapPrs() == data.curvatureCapPrs())
         && (this->activeWag() == data.activeWag())
+        && (this->doPcScaling() == data.doPcScaling())
         ;
 }
 

--- a/opm/input/eclipse/EclipseState/Runspec.hpp
+++ b/opm/input/eclipse/EclipseState/Runspec.hpp
@@ -336,6 +336,11 @@ public:
      */
     bool activeWag() const;
 
+    /*!
+     * \brief Do Pc scaling for scanning curves.
+     */
+    bool doPcScaling() const;
+
     bool operator==(const EclHysterConfig& data) const;
 
     template<class Serializer>
@@ -347,6 +352,7 @@ public:
         serializer(modParamTrappedValue);
         serializer(curvatureCapPrsValue);
         serializer(activeWagHyst);
+        serializer(enablePcScaling);
     }
 
 private:
@@ -363,6 +369,9 @@ private:
 
     // enable WAG hysteresis
     bool activeWagHyst  { false };
+
+    // flag to enable Pc scaling
+    bool enablePcScaling { false };
 };
 
 class SatFuncControls {

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/E/EHYSTR
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/E/EHYSTR
@@ -94,6 +94,13 @@
       "value_type": "INT",
       "default": 0,
       "comment": "Not used"
+    },
+    {
+      "item": 14,
+      "name": "enable_pc_scaling",
+      "value_type": "INT",
+      "default": 0,
+      "comment": "Not used"
     }
   ]
 }

--- a/opm/material/fluidmatrixinteractions/EclHysteresisConfig.cpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisConfig.cpp
@@ -42,6 +42,7 @@ void EclHysteresisConfig::initFromState(const Runspec& runspec)
     modParamTrapped_ = runspec.hysterPar().modParamTrapped();
     curvatureCapPrs_ = runspec.hysterPar().curvatureCapPrs();
     enableWagHyst_ = runspec.hysterPar().activeWag();
+    enablePcScalingHyst_ = runspec.hysterPar().doPcScaling();
 
 }
 

--- a/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
@@ -128,6 +128,12 @@ public:
     bool enableWagHysteresis() const
     { return enableWagHyst_; }
 
+    /*!
+     * \brief Returns whether Pc scaling is enabled.
+     */
+    bool enablePcScalingHyst() const
+    { return enablePcScalingHyst_; }
+
 #if HAVE_ECL_INPUT
     /*!
      * \brief Reads all relevant material parameters form a cell of a parsed ECL deck.
@@ -149,6 +155,9 @@ private:
 
     // WAG hysteresis
     bool enableWagHyst_{false};
+
+    // Enable bug fix for capillary pressure scaling
+    bool enablePcScalingHyst_{false};
 };
 
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
@@ -181,8 +181,11 @@ public:
         }
         else {
             Scalar pciwght = params.pcWght(); // Align pci and pcd at Swir
-            const Evaluation SwScan = (Sw-params.pcSwMdc())/(Swma-params.pcSwMdc());
-            const Evaluation SwScaled = params.Swcri() + (1 - params.Sncri() - params.Swcri()) * SwScan;
+            Evaluation SwScaled = Sw; // Use without scaling. This is Killough 1976
+            if (params.config().enablePcScalingHyst()) {
+                const Evaluation SwScan = (Sw-params.pcSwMdc())/(Swma-params.pcSwMdc());
+                SwScaled = params.Swcri() + (1 - params.Sncri() - params.Swcri()) * SwScan;
+            }
             const Evaluation dPc = pciwght*EffectiveLaw::twoPhaseSatPcnw(params.imbibitionParams(), SwScaled) - EffectiveLaw::twoPhaseSatPcnw(params.drainageParams(), SwScaled);
             const Evaluation Pcd = EffectiveLaw::twoPhaseSatPcnw(params.drainageParams(), Sw);
             if (dPc == 0.0)


### PR DESCRIPTION
This PR adds an item 14 that allows users to enable scaling in the Pc scanning curves. See discussions in OPM/opm-simulators#6383 

For now, it is defaulted to false, but as the discussions show, this is a feature (or bug fix?) that we should use as the default.  