### PR TITLE
Gpu support material law manager

### DIFF
--- a/opm/common/utility/VectorWithDefaultAllocator.hpp
+++ b/opm/common/utility/VectorWithDefaultAllocator.hpp
@@ -18,6 +18,8 @@
 
 #ifndef OPM_COMMON_VECTOR_WITH_DEFAULT_ALLOCATOR_HPP
 #define OPM_COMMON_VECTOR_WITH_DEFAULT_ALLOCATOR_HPP
+
+#include <vector>
 namespace Opm
 {
 // NVCC being weird about std::vector, so we need this workaround.

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -471,7 +471,6 @@ setGasOilHysteresisParams(const Scalar& sgmax,
     MaterialLaw::setGasOilHysteresisParams(sgmax, shmax, somin, params);
 }
 
-#if !HAVE_CUDA
 template<
     class Traits,
     template<class> class Storage,
@@ -482,6 +481,7 @@ EclEpsScalingPoints<typename Traits::Scalar>&
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 oilWaterScaledEpsPointsDrainage(unsigned elemIdx)
 {
+    #if !HAVE_CUDA
     auto& materialParams = materialLawParams_[elemIdx];
     switch (materialParams.approach()) {
     case EclMultiplexerApproach::Stone1: {
@@ -506,8 +506,10 @@ oilWaterScaledEpsPointsDrainage(unsigned elemIdx)
     default:
         throw std::logic_error("Enum value for material approach unknown!");
     }
+    #else
+        OPM_THROW(NotImplementedError, "CUDA support is not available");
+    #endif
 }
-#endif
 
 template<
     class Traits,

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -37,14 +37,29 @@
 
 namespace Opm {
 
-template<class TraitsT>
-EclMaterialLawManager<TraitsT>::EclMaterialLawManager() = default;
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::EclMaterialLawManager() = default;
 
-template<class TraitsT>
-EclMaterialLawManager<TraitsT>::~EclMaterialLawManager() = default;
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::~EclMaterialLawManager() = default;
 
-template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+void EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 initFromState(const EclipseState& eclState)
 {
     // get the number of saturation regions and the number of cells in the deck
@@ -134,8 +149,13 @@ initFromState(const EclipseState& eclState)
     }
 }
 
-template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+void EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
                       const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner,
                       const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
@@ -146,8 +166,13 @@ initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
 
 // TODO: Better (proper?) handling of mixed wettability systems - see ecl kw OPTIONS switch 74
 // Note: Without OPTIONS[74] the negative part of the Pcow curve is not scaled
-template<class TraitsT>
-std::pair<typename TraitsT::Scalar, bool> EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+std::pair<typename Traits::Scalar, bool> EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 applySwatinit(unsigned elemIdx,
               Scalar pcow,
               Scalar Sw)
@@ -220,9 +245,14 @@ applySwatinit(unsigned elemIdx,
     return {Sw, newSwatInit};
 }
 
-template<class TraitsT>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<TraitsT>::applyRestartSwatInit(const unsigned elemIdx,
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::applyRestartSwatInit(const unsigned elemIdx,
                                                      const Scalar   maxPcow)
 {
     // Maximum capillary pressure adjusted from SWATINIT data.
@@ -238,9 +268,14 @@ EclMaterialLawManager<TraitsT>::applyRestartSwatInit(const unsigned elemIdx,
               EclTwoPhaseSystemType::OilWater);
 }
 
-template<class TraitsT>
-const typename EclMaterialLawManager<TraitsT>::MaterialLawParams&
-EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+const typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::MaterialLawParams&
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 connectionMaterialLawParams(unsigned satRegionIdx, unsigned elemIdx) const
 {
     MaterialLawParams& mlp = const_cast<MaterialLawParams&>(materialLawParams_[elemIdx]);
@@ -328,8 +363,13 @@ connectionMaterialLawParams(unsigned satRegionIdx, unsigned elemIdx) const
     return mlp;
 }
 
-template<class TraitsT>
-int EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+int EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 getKrnumSatIdx(unsigned elemIdx, FaceDir::DirEnum facedir) const
 {
     using Dir = FaceDir::DirEnum;
@@ -355,8 +395,13 @@ getKrnumSatIdx(unsigned elemIdx, FaceDir::DirEnum facedir) const
     }
 }
 
-template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+void EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 oilWaterHysteresisParams(Scalar& soMax,
                          Scalar& swMax,
                          Scalar& swMin,
@@ -369,8 +414,13 @@ oilWaterHysteresisParams(Scalar& soMax,
     MaterialLaw::oilWaterHysteresisParams(soMax, swMax, swMin, params);
 }
 
-template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+void EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 setOilWaterHysteresisParams(const Scalar& soMax,
                             const Scalar& swMax,
                             const Scalar& swMin,
@@ -383,8 +433,13 @@ setOilWaterHysteresisParams(const Scalar& soMax,
     MaterialLaw::setOilWaterHysteresisParams(soMax, swMax, swMin, params);
 }
 
-template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+void EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 gasOilHysteresisParams(Scalar& sgmax,
                        Scalar& shmax,
                        Scalar& somin,
@@ -397,8 +452,13 @@ gasOilHysteresisParams(Scalar& sgmax,
     MaterialLaw::gasOilHysteresisParams(sgmax, shmax, somin, params);
 }
 
-template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+void EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 setGasOilHysteresisParams(const Scalar& sgmax,
                           const Scalar& shmax,
                           const Scalar& somin,
@@ -411,9 +471,14 @@ setGasOilHysteresisParams(const Scalar& sgmax,
     MaterialLaw::setGasOilHysteresisParams(sgmax, shmax, somin, params);
 }
 
-template<class TraitsT>
-EclEpsScalingPoints<typename TraitsT::Scalar>&
-EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+EclEpsScalingPoints<typename Traits::Scalar>&
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 oilWaterScaledEpsPointsDrainage(unsigned elemIdx)
 {
     auto& materialParams = materialLawParams_[elemIdx];
@@ -442,8 +507,13 @@ oilWaterScaledEpsPointsDrainage(unsigned elemIdx)
     }
 }
 
-template<class TraitsT>
-const typename EclMaterialLawManager<TraitsT>::MaterialLawParams& EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+const typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::MaterialLawParams& EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 materialLawParamsFunc_(unsigned elemIdx, FaceDir::DirEnum facedir) const
 {
     using Dir = FaceDir::DirEnum;
@@ -467,8 +537,13 @@ materialLawParamsFunc_(unsigned elemIdx, FaceDir::DirEnum facedir) const
     }
 }
 
-template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+void EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 readGlobalEpsOptions_(const EclipseState& eclState)
 {
     oilWaterEclEpsConfig_ = std::make_shared<EclEpsConfig>();
@@ -477,16 +552,26 @@ readGlobalEpsOptions_(const EclipseState& eclState)
     enableEndPointScaling_ = eclState.getTableManager().hasTables("ENKRVD");
 }
 
-template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+void EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 readGlobalHysteresisOptions_(const EclipseState& state)
 {
     hysteresisConfig_ = std::make_shared<EclHysteresisConfig>();
     hysteresisConfig_->initFromState(state.runspec());
 }
 
-template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+void EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 readGlobalThreePhaseOptions_(const Runspec& runspec)
 {
     bool gasEnabled = runspec.phases().active(Phase::GAS);

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -37,7 +37,7 @@
 
 namespace Opm {
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -45,7 +45,7 @@ template <
 >
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::EclMaterialLawManager() = default;
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -53,7 +53,7 @@ template <
 >
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::~EclMaterialLawManager() = default;
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -149,7 +149,7 @@ initFromState(const EclipseState& eclState)
     }
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -157,7 +157,7 @@ template <
 >
 void EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
-                      const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner,
+                      const std::function<Storage<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner,
                       const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
     InitParams initParams {*this, eclState, numCompressedElems};
@@ -166,7 +166,7 @@ initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
 
 // TODO: Better (proper?) handling of mixed wettability systems - see ecl kw OPTIONS switch 74
 // Note: Without OPTIONS[74] the negative part of the Pcow curve is not scaled
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -245,7 +245,7 @@ applySwatinit(unsigned elemIdx,
     return {Sw, newSwatInit};
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -268,7 +268,7 @@ EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::applyRestartSwatIn
               EclTwoPhaseSystemType::OilWater);
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -363,7 +363,7 @@ connectionMaterialLawParams(unsigned satRegionIdx, unsigned elemIdx) const
     return mlp;
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -373,7 +373,7 @@ int EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::
 getKrnumSatIdx(unsigned elemIdx, FaceDir::DirEnum facedir) const
 {
     using Dir = FaceDir::DirEnum;
-    const std::vector<int>* array = nullptr;
+    const Storage<int>* array = nullptr;
     switch(facedir) {
     case Dir::XPlus:
       array = &krnumXArray_;
@@ -395,7 +395,7 @@ getKrnumSatIdx(unsigned elemIdx, FaceDir::DirEnum facedir) const
     }
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -414,7 +414,7 @@ oilWaterHysteresisParams(Scalar& soMax,
     MaterialLaw::oilWaterHysteresisParams(soMax, swMax, swMin, params);
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -433,7 +433,7 @@ setOilWaterHysteresisParams(const Scalar& soMax,
     MaterialLaw::setOilWaterHysteresisParams(soMax, swMax, swMin, params);
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -452,7 +452,7 @@ gasOilHysteresisParams(Scalar& sgmax,
     MaterialLaw::gasOilHysteresisParams(sgmax, shmax, somin, params);
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -471,7 +471,7 @@ setGasOilHysteresisParams(const Scalar& sgmax,
     MaterialLaw::setGasOilHysteresisParams(sgmax, shmax, somin, params);
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -507,7 +507,7 @@ oilWaterScaledEpsPointsDrainage(unsigned elemIdx)
     }
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -537,7 +537,7 @@ materialLawParamsFunc_(unsigned elemIdx, FaceDir::DirEnum facedir) const
     }
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -552,7 +552,7 @@ readGlobalEpsOptions_(const EclipseState& eclState)
     enableEndPointScaling_ = eclState.getTableManager().hasTables("ENKRVD");
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -565,7 +565,7 @@ readGlobalHysteresisOptions_(const EclipseState& state)
     hysteresisConfig_->initFromState(state.runspec());
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -471,6 +471,7 @@ setGasOilHysteresisParams(const Scalar& sgmax,
     MaterialLaw::setGasOilHysteresisParams(sgmax, shmax, somin, params);
 }
 
+#if !HAVE_CUDA
 template<
     class Traits,
     template<class> class Storage,
@@ -506,6 +507,7 @@ oilWaterScaledEpsPointsDrainage(unsigned elemIdx)
         throw std::logic_error("Enum value for material approach unknown!");
     }
 }
+#endif
 
 template<
     class Traits,

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -123,25 +123,25 @@ public:
     // the three-phase material law used by the simulation
     using MaterialLaw = EclMultiplexerMaterial<Traits, GasOilTwoPhaseLaw, OilWaterTwoPhaseLaw, GasWaterTwoPhaseLaw>;
     using MaterialLawParams = typename MaterialLaw::Params;
-    using DirectionalMaterialLawParamsPtr = std::unique_ptr<DirectionalMaterialLawParams<MaterialLawParams>>;
+    using DirectionalMaterialLawParamsPtr = UniquePtr<DirectionalMaterialLawParams<MaterialLawParams>>;
 
     EclMaterialLawManager();
     ~EclMaterialLawManager();
 
 private:
     // internal typedefs
-    using GasOilEffectiveParamVector = std::vector<std::shared_ptr<GasOilEffectiveTwoPhaseParams>>;
-    using OilWaterEffectiveParamVector = std::vector<std::shared_ptr<OilWaterEffectiveTwoPhaseParams>>;
-    using GasWaterEffectiveParamVector = std::vector<std::shared_ptr<GasWaterEffectiveTwoPhaseParams>>;
+    using GasOilEffectiveParamVector = Storage<SharedPtr<GasOilEffectiveTwoPhaseParams>>;
+    using OilWaterEffectiveParamVector = Storage<SharedPtr<OilWaterEffectiveTwoPhaseParams>>;
+    using GasWaterEffectiveParamVector = Storage<SharedPtr<GasWaterEffectiveTwoPhaseParams>>;
 
-    using GasOilScalingPointsVector = std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar>>>;
-    using OilWaterScalingPointsVector = std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar>>>;
-    using GasWaterScalingPointsVector = std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar>>>;
-    using OilWaterScalingInfoVector = std::vector<EclEpsScalingPointsInfo<Scalar>>;
-    using GasOilParamVector = std::vector<std::shared_ptr<GasOilTwoPhaseHystParams>>;
-    using OilWaterParamVector = std::vector<std::shared_ptr<OilWaterTwoPhaseHystParams>>;
-    using GasWaterParamVector = std::vector<std::shared_ptr<GasWaterTwoPhaseHystParams>>;
-    using MaterialLawParamsVector = std::vector<std::shared_ptr<MaterialLawParams>>;
+    using GasOilScalingPointsVector = Storage<SharedPtr<EclEpsScalingPoints<Scalar>>>;
+    using OilWaterScalingPointsVector = Storage<SharedPtr<EclEpsScalingPoints<Scalar>>>;
+    using GasWaterScalingPointsVector = Storage<SharedPtr<EclEpsScalingPoints<Scalar>>>;
+    using OilWaterScalingInfoVector = Storage<EclEpsScalingPointsInfo<Scalar>>;
+    using GasOilParamVector = Storage<SharedPtr<GasOilTwoPhaseHystParams>>;
+    using OilWaterParamVector = Storage<SharedPtr<OilWaterTwoPhaseHystParams>>;
+    using GasWaterParamVector = Storage<SharedPtr<GasWaterTwoPhaseHystParams>>;
+    using MaterialLawParamsVector = Storage<SharedPtr<MaterialLawParams>>;
 
     // helper classes
 
@@ -153,29 +153,29 @@ private:
         //        field properties of cells on the leaf grid view for CpGrid with local grid refinement.
         //        Function argument 'lookupIdxOnLevelZeroAssigner' is added to lookup, for each
         //        leaf gridview cell with index 'elemIdx', its 'lookupIdx' (index of the parent/equivalent cell on level zero).
-        void run(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner,
+        void run(const std::function<Storage<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner,
                  const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
     private:
         class HystParams;
         // \brief Function argument 'fieldPropIntOnLeadAssigner' needed to lookup
         //        field properties of cells on the leaf grid view for CpGrid with local grid refinement.
-        void copySatnumArrays_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>&
+        void copySatnumArrays_(const std::function<Storage<int>(const FieldPropsManager&, const std::string&, bool)>&
                                fieldPropIntOnLeafAssigner);
         // \brief Function argument 'fieldPropIntOnLeadAssigner' needed to lookup
         //        field properties of cells on the leaf grid view for CpGrid with local grid refinement.
-        void copyIntArray_(std::vector<int>& dest, const std::string& keyword,
-                           const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>&
+        void copyIntArray_(Storage<int>& dest, const std::string& keyword,
+                           const std::function<Storage<int>(const FieldPropsManager&, const std::string&, bool)>&
                            fieldPropIntOnLeafAssigner);
-        unsigned imbRegion_(std::vector<int>& array, unsigned elemIdx);
+        unsigned imbRegion_(Storage<int>& array, unsigned elemIdx);
         void initArrays_(
-                         std::vector<std::vector<int>*>& satnumArray,
-                         std::vector<std::vector<int>*>& imbnumArray,
-                         std::vector<std::vector<MaterialLawParams>*>& mlpArray);
+                         Storage<Storage<int>*>& satnumArray,
+                         Storage<Storage<int>*>& imbnumArray,
+                         Storage<Storage<MaterialLawParams>*>& mlpArray);
         void initMaterialLawParamVectors_();
         void initOilWaterScaledEpsInfo_();
         // \brief Function argument 'fieldProptOnLeadAssigner' needed to lookup
         //        field properties of cells on the leaf grid view for CpGrid with local grid refinement.
-        void initSatnumRegionArray_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>&
+        void initSatnumRegionArray_(const std::function<Storage<int>(const FieldPropsManager&, const std::string&, bool)>&
                                     fieldPropIntOnLeafAssigner);
         void initThreePhaseParams_(
                                    HystParams &hystParams,
@@ -185,18 +185,18 @@ private:
         void readEffectiveParameters_();
         void readUnscaledEpsPointsVectors_();
         template <class Container>
-        void readUnscaledEpsPoints_(Container& dest, std::shared_ptr<EclEpsConfig> config, EclTwoPhaseSystemType system_type);
-        unsigned satRegion_(std::vector<int>& array, unsigned elemIdx);
-        unsigned satOrImbRegion_(std::vector<int>& array, std::vector<int>& default_vec, unsigned elemIdx);
+        void readUnscaledEpsPoints_(Container& dest, SharedPtr<EclEpsConfig> config, EclTwoPhaseSystemType system_type);
+        unsigned satRegion_(Storage<int>& array, unsigned elemIdx);
+        unsigned satOrImbRegion_(Storage<int>& array, Storage<int>& default_vec, unsigned elemIdx);
 
         // This class' implementation is defined in "EclMaterialLawManagerHystParams.cpp"
         class HystParams {
         public:
             explicit HystParams(EclMaterialLawManager<TraitsT, Storage, SharedPtr, UniquePtr>::InitParams& init_params);
             void finalize();
-            std::shared_ptr<GasOilTwoPhaseHystParams> getGasOilParams();
-            std::shared_ptr<OilWaterTwoPhaseHystParams> getOilWaterParams();
-            std::shared_ptr<GasWaterTwoPhaseHystParams> getGasWaterParams();
+            SharedPtr<GasOilTwoPhaseHystParams> getGasOilParams();
+            SharedPtr<OilWaterTwoPhaseHystParams> getOilWaterParams();
+            SharedPtr<GasWaterTwoPhaseHystParams> getGasWaterParams();
             void setConfig(unsigned satRegionIdx);
             // Function argument 'lookupIdxOnLevelZeroAssigner' is added to lookup, for each
             // leaf gridview cell with index 'elemIdx', its 'lookupIdx' (index of the parent/equivalent cell on level zero).
@@ -232,9 +232,9 @@ private:
             EclMaterialLawManager<TraitsT, Storage, SharedPtr, UniquePtr>::InitParams& init_params_;
             EclMaterialLawManager<TraitsT, Storage, SharedPtr, UniquePtr>& parent_;
             const EclipseState& eclState_;
-            std::shared_ptr<GasOilTwoPhaseHystParams> gasOilParams_;
-            std::shared_ptr<OilWaterTwoPhaseHystParams> oilWaterParams_;
-            std::shared_ptr<GasWaterTwoPhaseHystParams> gasWaterParams_;
+            SharedPtr<GasOilTwoPhaseHystParams> gasOilParams_;
+            SharedPtr<OilWaterTwoPhaseHystParams> oilWaterParams_;
+            SharedPtr<GasWaterTwoPhaseHystParams> gasWaterParams_;
         };
 
         // This class' implementation is defined in "EclMaterialLawManagerReadEffectiveParams.cpp"
@@ -243,7 +243,7 @@ private:
             explicit ReadEffectiveParams(EclMaterialLawManager<TraitsT, Storage, SharedPtr, UniquePtr>::InitParams& init_params);
             void read();
         private:
-            std::vector<double> normalizeKrValues_(const double tolcrit, const TableColumn& krValues) const;
+            Storage<double> normalizeKrValues_(const double tolcrit, const TableColumn& krValues) const;
             void readGasOilParameters_(GasOilEffectiveParamVector& dest, unsigned satRegionIdx);
             template <class TableType>
             void readGasOilFamily2_(
@@ -274,8 +274,8 @@ private:
         const EclipseState& eclState_;
         size_t numCompressedElems_;
 
-        std::unique_ptr<EclEpsGridProperties> epsImbGridProperties_; //imbibition
-        std::unique_ptr<EclEpsGridProperties> epsGridProperties_;    // drainage
+        UniquePtr<EclEpsGridProperties> epsImbGridProperties_; //imbibition
+        UniquePtr<EclEpsGridProperties> epsGridProperties_;    // drainage
 
     };  // end of "class InitParams"
 
@@ -287,7 +287,7 @@ public:
     //        Function argument 'lookupIdxOnLevelZeroAssigner' is added to lookup, for each
     //        leaf gridview cell with index 'elemIdx', its 'lookupIdx' (index of the parent/equivalent cell on level zero).
     void initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
-                               const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>&
+                               const std::function<Storage<int>(const FieldPropsManager&, const std::string&, bool)>&
                                fieldPropIntOnLeafAssigner,
                                const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
 
@@ -453,15 +453,15 @@ private:
     void readGlobalThreePhaseOptions_(const Runspec& runspec);
 
     bool enableEndPointScaling_;
-    std::shared_ptr<EclHysteresisConfig> hysteresisConfig_;
-    std::vector<std::shared_ptr<WagHysteresisConfig::WagHysteresisConfigRecord>> wagHystersisConfig_;
+    SharedPtr<EclHysteresisConfig> hysteresisConfig_;
+    Storage<SharedPtr<WagHysteresisConfig::WagHysteresisConfigRecord>> wagHystersisConfig_;
 
 
-    std::shared_ptr<EclEpsConfig> oilWaterEclEpsConfig_;
-    std::vector<EclEpsScalingPointsInfo<Scalar>> unscaledEpsInfo_;
+    SharedPtr<EclEpsConfig> oilWaterEclEpsConfig_;
+    Storage<EclEpsScalingPointsInfo<Scalar>> unscaledEpsInfo_;
     OilWaterScalingInfoVector oilWaterScaledEpsInfoDrainage_;
 
-    std::shared_ptr<EclEpsConfig> gasWaterEclEpsConfig_;
+    SharedPtr<EclEpsConfig> gasWaterEclEpsConfig_;
 
     GasOilScalingPointsVector gasOilUnscaledPointsVector_;
     OilWaterScalingPointsVector oilWaterUnscaledPointsVector_;
@@ -475,30 +475,30 @@ private:
     // this attribute only makes sense for twophase simulations!
     enum EclTwoPhaseApproach twoPhaseApproach_ = EclTwoPhaseApproach::GasOil;
 
-    std::vector<MaterialLawParams> materialLawParams_;
+    Storage<MaterialLawParams> materialLawParams_;
     DirectionalMaterialLawParamsPtr dirMaterialLawParams_;
 
-    std::vector<int> satnumRegionArray_;
-    std::vector<int> krnumXArray_;
-    std::vector<int> krnumYArray_;
-    std::vector<int> krnumZArray_;
-    std::vector<int> imbnumXArray_;
-    std::vector<int> imbnumYArray_;
-    std::vector<int> imbnumZArray_;
-    std::vector<int> imbnumRegionArray_;
-    std::vector<Scalar> stoneEtas_;
+    Storage<int> satnumRegionArray_;
+    Storage<int> krnumXArray_;
+    Storage<int> krnumYArray_;
+    Storage<int> krnumZArray_;
+    Storage<int> imbnumXArray_;
+    Storage<int> imbnumYArray_;
+    Storage<int> imbnumZArray_;
+    Storage<int> imbnumRegionArray_;
+    Storage<Scalar> stoneEtas_;
 
     bool enablePpcwmax_;
-    std::vector<Scalar> maxAllowPc_;
-    std::vector<bool> modifySwl_;
+    Storage<Scalar> maxAllowPc_;
+    Storage<bool> modifySwl_;
 
     bool hasGas;
     bool hasOil;
     bool hasWater;
 
-    std::shared_ptr<EclEpsConfig> gasOilConfig_;
-    std::shared_ptr<EclEpsConfig> oilWaterConfig_;
-    std::shared_ptr<EclEpsConfig> gasWaterConfig_;
+    SharedPtr<EclEpsConfig> gasOilConfig_;
+    SharedPtr<EclEpsConfig> oilWaterConfig_;
+    SharedPtr<EclEpsConfig> gasWaterConfig_;
 };
 } // namespace Opm
 

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -31,6 +31,11 @@
 #ifndef OPM_ECL_MATERIAL_LAW_MANAGER_HPP
 #define OPM_ECL_MATERIAL_LAW_MANAGER_HPP
 
+
+#include "EclTwoPhaseMaterial.hpp" // For GPU version we will directly access this material layer
+
+#include <opm/common/utility/VectorWithDefaultAllocator.hpp>
+
 #include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
 #include <opm/input/eclipse/EclipseState/WagHysteresisConfig.hpp>
 
@@ -69,7 +74,12 @@ class TableColumn;
  * \brief Provides an simple way to create and manage the material law objects
  *        for a complete ECL deck.
  */
-template <class TraitsT>
+template<
+    class TraitsT,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
 class EclMaterialLawManager
 {
 private:
@@ -138,7 +148,7 @@ private:
     // This class' implementation is defined in "EclMaterialLawManagerInitParams.cpp"
     class InitParams {
     public:
-        InitParams(EclMaterialLawManager<TraitsT>& parent, const EclipseState& eclState, size_t numCompressedElems);
+        InitParams(EclMaterialLawManager<TraitsT, Storage, SharedPtr, UniquePtr>& parent, const EclipseState& eclState, size_t numCompressedElems);
         // \brief Function argument 'fieldPropIntOnLeadAssigner' needed to lookup
         //        field properties of cells on the leaf grid view for CpGrid with local grid refinement.
         //        Function argument 'lookupIdxOnLevelZeroAssigner' is added to lookup, for each
@@ -182,7 +192,7 @@ private:
         // This class' implementation is defined in "EclMaterialLawManagerHystParams.cpp"
         class HystParams {
         public:
-            explicit HystParams(EclMaterialLawManager<TraitsT>::InitParams& init_params);
+            explicit HystParams(EclMaterialLawManager<TraitsT, Storage, SharedPtr, UniquePtr>::InitParams& init_params);
             void finalize();
             std::shared_ptr<GasOilTwoPhaseHystParams> getGasOilParams();
             std::shared_ptr<OilWaterTwoPhaseHystParams> getOilWaterParams();
@@ -219,8 +229,8 @@ private:
             readScaledEpsPointsImbibition_(unsigned elemIdx, EclTwoPhaseSystemType type,
                                            const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
 
-            EclMaterialLawManager<TraitsT>::InitParams& init_params_;
-            EclMaterialLawManager<TraitsT>& parent_;
+            EclMaterialLawManager<TraitsT, Storage, SharedPtr, UniquePtr>::InitParams& init_params_;
+            EclMaterialLawManager<TraitsT, Storage, SharedPtr, UniquePtr>& parent_;
             const EclipseState& eclState_;
             std::shared_ptr<GasOilTwoPhaseHystParams> gasOilParams_;
             std::shared_ptr<OilWaterTwoPhaseHystParams> oilWaterParams_;
@@ -230,7 +240,7 @@ private:
         // This class' implementation is defined in "EclMaterialLawManagerReadEffectiveParams.cpp"
         class ReadEffectiveParams {
         public:
-            explicit ReadEffectiveParams(EclMaterialLawManager<TraitsT>::InitParams& init_params);
+            explicit ReadEffectiveParams(EclMaterialLawManager<TraitsT, Storage, SharedPtr, UniquePtr>::InitParams& init_params);
             void read();
         private:
             std::vector<double> normalizeKrValues_(const double tolcrit, const TableColumn& krValues) const;
@@ -255,12 +265,12 @@ private:
             void readGasWaterParameters_(GasWaterEffectiveParamVector& dest, unsigned satRegionIdx);
             void readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionIdx);
 
-            EclMaterialLawManager<TraitsT>::InitParams& init_params_;
-            EclMaterialLawManager<TraitsT>& parent_;
+            EclMaterialLawManager<TraitsT, Storage, SharedPtr, UniquePtr>::InitParams& init_params_;
+            EclMaterialLawManager<TraitsT, Storage, SharedPtr, UniquePtr>& parent_;
             const EclipseState& eclState_;
         }; // end of "class ReadEffectiveParams"
 
-        EclMaterialLawManager<TraitsT>& parent_;
+        EclMaterialLawManager<TraitsT, Storage, SharedPtr, UniquePtr>& parent_;
         const EclipseState& eclState_;
         size_t numCompressedElems_;
 

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -462,10 +462,16 @@ public:
 
     #if !HAVE_CUDA
     EclEpsScalingPoints<Scalar>& oilWaterScaledEpsPointsDrainage(unsigned elemIdx);
+    #endif // !HAVE_CUDA
 
     const EclEpsScalingPointsInfo<Scalar>& oilWaterScaledEpsInfoDrainage(size_t elemIdx) const
-    { return oilWaterScaledEpsInfoDrainage_[elemIdx]; }
-    #endif // !HAVE_CUDA
+    {
+        #if !HAVE_CUDA
+        return oilWaterScaledEpsInfoDrainage_[elemIdx];
+        #else
+        OPM_THROW(std::runtime_error, "CUDA support is not available");
+        #endif // !HAVE_CUDA
+    }
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
@@ -28,9 +28,9 @@ namespace Opm {
 /* constructors*/
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 HystParams(EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams& init_params) :
@@ -46,9 +46,9 @@ HystParams(EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitPar
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
@@ -64,11 +64,11 @@ finalize()
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
-std::shared_ptr<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::GasOilTwoPhaseHystParams>
+SharedPtr<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::GasOilTwoPhaseHystParams>
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 getGasOilParams()
 {
@@ -77,11 +77,11 @@ getGasOilParams()
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
-std::shared_ptr<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::OilWaterTwoPhaseHystParams>
+SharedPtr<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::OilWaterTwoPhaseHystParams>
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 getOilWaterParams()
 {
@@ -90,11 +90,11 @@ getOilWaterParams()
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
-std::shared_ptr<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::GasWaterTwoPhaseHystParams>
+SharedPtr<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::GasWaterTwoPhaseHystParams>
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 getGasWaterParams()
 {
@@ -103,9 +103,9 @@ getGasWaterParams()
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
@@ -125,9 +125,9 @@ setConfig(unsigned satRegionIdx)
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
@@ -149,9 +149,9 @@ setDrainageParamsGasWater(unsigned elemIdx, unsigned satRegionIdx,
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
@@ -173,9 +173,9 @@ setDrainageParamsOilGas(unsigned elemIdx, unsigned satRegionIdx,
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
@@ -206,9 +206,9 @@ setDrainageParamsOilWater(unsigned elemIdx, unsigned satRegionIdx,
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
@@ -233,9 +233,9 @@ setImbibitionParamsGasWater(unsigned elemIdx, unsigned imbRegionIdx,
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
@@ -260,9 +260,9 @@ setImbibitionParamsOilGas(unsigned elemIdx, unsigned imbRegionIdx,
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
@@ -289,9 +289,9 @@ setImbibitionParamsOilWater(unsigned elemIdx, unsigned imbRegionIdx,
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 bool
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
@@ -302,9 +302,9 @@ hasGasOil_()
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 bool
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
@@ -315,9 +315,9 @@ hasGasWater_()
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 bool
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
@@ -328,9 +328,9 @@ hasOilWater_()
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 std::tuple<
   EclEpsScalingPointsInfo<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::Scalar>,
@@ -359,9 +359,9 @@ readScaledEpsPoints_(const EclEpsGridProperties& epsGridProperties, unsigned ele
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 std::tuple<
   EclEpsScalingPointsInfo<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::Scalar>,
@@ -377,9 +377,9 @@ readScaledEpsPointsDrainage_(unsigned elemIdx, EclTwoPhaseSystemType type,
 
 template<
     class Traits,
-    template<class> class Storage = VectorWithDefaultAllocator,
-    template<typename> typename SharedPtr = std::shared_ptr,
-    template<typename, typename...> typename UniquePtr = std::unique_ptr
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
 >
 std::tuple<
   EclEpsScalingPointsInfo<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::Scalar>,

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
@@ -25,6 +25,8 @@
 
 namespace Opm {
 
+#if !HAVE_CUDA
+
 /* constructors*/
 template<
     class Traits,
@@ -398,6 +400,8 @@ template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,0,1,2>>::In
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,0,1,2>>::InitParams::HystParams;
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,2,0,1>>::InitParams::HystParams;
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,2,0,1>>::InitParams::HystParams;
+
+#endif // !HAVE_CUDA
 
 
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
@@ -26,9 +26,14 @@
 namespace Opm {
 
 /* constructors*/
-template <class Traits>
-EclMaterialLawManager<Traits>::InitParams::HystParams::
-HystParams(EclMaterialLawManager<Traits>::InitParams& init_params) :
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
+HystParams(EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams& init_params) :
     init_params_{init_params}, parent_{init_params_.parent_},
     eclState_{init_params_.eclState_}
 {
@@ -39,9 +44,14 @@ HystParams(EclMaterialLawManager<Traits>::InitParams& init_params) :
 
 /* public methods, alphabetically sorted */
 
-template <class Traits>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 finalize()
 {
     if (hasGasOil_())
@@ -52,33 +62,53 @@ finalize()
         this->gasWaterParams_->finalize();
 }
 
-template <class Traits>
-std::shared_ptr<typename EclMaterialLawManager<Traits>::GasOilTwoPhaseHystParams>
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
+std::shared_ptr<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::GasOilTwoPhaseHystParams>
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 getGasOilParams()
 {
     return gasOilParams_;
 }
 
-template <class Traits>
-std::shared_ptr<typename EclMaterialLawManager<Traits>::OilWaterTwoPhaseHystParams>
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
+std::shared_ptr<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::OilWaterTwoPhaseHystParams>
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 getOilWaterParams()
 {
     return oilWaterParams_;
 }
 
-template <class Traits>
-std::shared_ptr<typename EclMaterialLawManager<Traits>::GasWaterTwoPhaseHystParams>
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
+std::shared_ptr<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::GasWaterTwoPhaseHystParams>
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 getGasWaterParams()
 {
     return gasWaterParams_;
 }
 
-template <class Traits>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 setConfig(unsigned satRegionIdx)
 {
     this->gasOilParams_->setConfig(this->parent_.hysteresisConfig_);
@@ -93,9 +123,14 @@ setConfig(unsigned satRegionIdx)
 
 } // namespace Opm
 
-template <class Traits>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 setDrainageParamsGasWater(unsigned elemIdx, unsigned satRegionIdx,
                           const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
@@ -112,9 +147,14 @@ setDrainageParamsGasWater(unsigned elemIdx, unsigned satRegionIdx,
     }
 }
 
-template <class Traits>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 setDrainageParamsOilGas(unsigned elemIdx, unsigned satRegionIdx,
                         const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
@@ -131,9 +171,14 @@ setDrainageParamsOilGas(unsigned elemIdx, unsigned satRegionIdx,
     }
 }
 
-template <class Traits>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 setDrainageParamsOilWater(unsigned elemIdx, unsigned satRegionIdx,
                           const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
@@ -159,9 +204,14 @@ setDrainageParamsOilWater(unsigned elemIdx, unsigned satRegionIdx,
     }
 }
 
-template <class Traits>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 setImbibitionParamsGasWater(unsigned elemIdx, unsigned imbRegionIdx,
                             const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
@@ -181,9 +231,14 @@ setImbibitionParamsGasWater(unsigned elemIdx, unsigned imbRegionIdx,
     }
 }
 
-template <class Traits>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 setImbibitionParamsOilGas(unsigned elemIdx, unsigned imbRegionIdx,
                           const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
@@ -203,9 +258,14 @@ setImbibitionParamsOilGas(unsigned elemIdx, unsigned imbRegionIdx,
     }
 }
 
-template <class Traits>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 setImbibitionParamsOilWater(unsigned elemIdx, unsigned imbRegionIdx,
                             const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
@@ -227,36 +287,56 @@ setImbibitionParamsOilWater(unsigned elemIdx, unsigned imbRegionIdx,
 
 /* private methods, alphabetically sorted */
 
-template <class Traits>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
 bool
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 hasGasOil_()
 {
     return this->parent_.hasGas && this->parent_.hasOil;
 }
 
-template <class Traits>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
 bool
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 hasGasWater_()
 {
     return this->parent_.hasGas && this->parent_.hasWater && !this->parent_.hasOil;
 }
 
-template <class Traits>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
+>
 bool
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 hasOilWater_()
 {
     return this->parent_.hasOil && this->parent_.hasWater;
 }
 
-template <class Traits>
-std::tuple<
-  EclEpsScalingPointsInfo<typename EclMaterialLawManager<Traits>::Scalar>,
-  EclEpsScalingPoints<typename EclMaterialLawManager<Traits>::Scalar>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
 >
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+std::tuple<
+  EclEpsScalingPointsInfo<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::Scalar>,
+  EclEpsScalingPoints<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::Scalar>
+>
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 readScaledEpsPoints_(const EclEpsGridProperties& epsGridProperties, unsigned elemIdx, EclTwoPhaseSystemType type,
                      const std::function<unsigned(unsigned)>& fieldPropIdxOnLevelZero)
 {
@@ -277,12 +357,17 @@ readScaledEpsPoints_(const EclEpsGridProperties& epsGridProperties, unsigned ele
     return {destInfo, destPoint};
 }
 
-template <class Traits>
-std::tuple<
-  EclEpsScalingPointsInfo<typename EclMaterialLawManager<Traits>::Scalar>,
-  EclEpsScalingPoints<typename EclMaterialLawManager<Traits>::Scalar>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
 >
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+std::tuple<
+  EclEpsScalingPointsInfo<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::Scalar>,
+  EclEpsScalingPoints<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::Scalar>
+>
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 readScaledEpsPointsDrainage_(unsigned elemIdx, EclTwoPhaseSystemType type,
                              const std::function<unsigned(unsigned)>& fieldPropIdxOnLevelZero)
 {
@@ -290,12 +375,17 @@ readScaledEpsPointsDrainage_(unsigned elemIdx, EclTwoPhaseSystemType type,
     return readScaledEpsPoints_(*epsGridProperties, elemIdx, type, fieldPropIdxOnLevelZero);
 }
 
-template <class Traits>
-std::tuple<
-  EclEpsScalingPointsInfo<typename EclMaterialLawManager<Traits>::Scalar>,
-  EclEpsScalingPoints<typename EclMaterialLawManager<Traits>::Scalar>
+template<
+    class Traits,
+    template<class> class Storage = VectorWithDefaultAllocator,
+    template<typename> typename SharedPtr = std::shared_ptr,
+    template<typename, typename...> typename UniquePtr = std::unique_ptr
 >
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+std::tuple<
+  EclEpsScalingPointsInfo<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::Scalar>,
+  EclEpsScalingPoints<typename EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::Scalar>
+>
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::HystParams::
 readScaledEpsPointsImbibition_(unsigned elemIdx, EclTwoPhaseSystemType type,
                                const std::function<unsigned(unsigned)>& fieldPropIdxOnLevelZero)
 {

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
@@ -31,9 +31,14 @@ namespace Opm {
 
 /* constructors*/
 
-template <class Traits>
-EclMaterialLawManager<Traits>::InitParams::
-InitParams(EclMaterialLawManager<Traits>& parent, const EclipseState& eclState, size_t numCompressedElems) :
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
+InitParams(EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>& parent, const EclipseState& eclState, size_t numCompressedElems) :
     parent_{parent},
     eclState_{eclState},
     numCompressedElems_{numCompressedElems}
@@ -50,9 +55,14 @@ InitParams(EclMaterialLawManager<Traits>& parent, const EclipseState& eclState, 
 
 /* public methods */
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 run(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>&
     fieldPropIntOnLeafAssigner,
     const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
@@ -94,9 +104,14 @@ run(const std::function<std::vector<int>(const FieldPropsManager&, const std::st
 
 /* private methods alphabetically sorted*/
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 copySatnumArrays_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
 {
     copyIntArray_(this->parent_.krnumXArray_, "KRNUMX", fieldPropIntOnLeafAssigner);
@@ -113,9 +128,14 @@ copySatnumArrays_(const std::function<std::vector<int>(const FieldPropsManager&,
     assert(!this->parent_.enableHysteresis() || this->numCompressedElems_ == this->parent_.imbnumRegionArray_.size());
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 copyIntArray_(std::vector<int>& dest, const std::string& keyword,
               const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
 {
@@ -124,18 +144,28 @@ copyIntArray_(std::vector<int>& dest, const std::string& keyword,
     }
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 unsigned
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 imbRegion_(std::vector<int>& array, unsigned elemIdx)
 {
     std::vector<int>& default_vec = this->parent_.imbnumRegionArray_;
     return satOrImbRegion_(array, default_vec, elemIdx);
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 initArrays_(
         std::vector<std::vector<int>*>& satnumArray,
         std::vector<std::vector<int>*>& imbnumArray,
@@ -161,9 +191,14 @@ initArrays_(
     }
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 initMaterialLawParamVectors_()
 {
     this->parent_.materialLawParams_.resize(this->numCompressedElems_);
@@ -173,18 +208,28 @@ initMaterialLawParamVectors_()
     }
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 initOilWaterScaledEpsInfo_()
 {
     // This vector will be updated in the hystParams.setDrainageOilWater() in the run() method
     this->parent_.oilWaterScaledEpsInfoDrainage_.resize(this->numCompressedElems_);
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 initSatnumRegionArray_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
 {
     // copy the SATNUM grid property. in some cases this is not necessary, but it
@@ -199,9 +244,14 @@ initSatnumRegionArray_(const std::function<std::vector<int>(const FieldPropsMana
     }
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 initThreePhaseParams_(HystParams &hystParams,
                       MaterialLawParams& materialParams,
                       unsigned satRegionIdx,
@@ -264,9 +314,14 @@ initThreePhaseParams_(HystParams &hystParams,
     } // end switch()
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 readEffectiveParameters_()
 {
     ReadEffectiveParams effectiveReader {*this};
@@ -274,9 +329,14 @@ readEffectiveParameters_()
     effectiveReader.read();
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 readUnscaledEpsPointsVectors_()
 {
     if (this->parent_.hasGas && this->parent_.hasOil) {
@@ -302,10 +362,15 @@ readUnscaledEpsPointsVectors_()
     }
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 template <class Container>
 void
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 readUnscaledEpsPoints_(Container& dest, std::shared_ptr<EclEpsConfig> config, EclTwoPhaseSystemType system_type)
 {
     const size_t numSatRegions = this->eclState_.runspec().tabdims().getNumSatTables();
@@ -316,18 +381,28 @@ readUnscaledEpsPoints_(Container& dest, std::shared_ptr<EclEpsConfig> config, Ec
     }
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 unsigned
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 satRegion_(std::vector<int>& array, unsigned elemIdx)
 {
     std::vector<int>& default_vec = this->parent_.satnumRegionArray_;
     return satOrImbRegion_(array, default_vec, elemIdx);
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 unsigned
-EclMaterialLawManager<Traits>::InitParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 satOrImbRegion_(std::vector<int>& array, std::vector<int>& default_vec, unsigned elemIdx)
 {
     int value;

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
@@ -31,7 +31,7 @@ namespace Opm {
 
 /* constructors*/
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -55,7 +55,7 @@ InitParams(EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>& parent,
 
 /* public methods */
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -63,7 +63,7 @@ template <
 >
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
-run(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>&
+run(const std::function<Storage<int>(const FieldPropsManager&, const std::string&, bool)>&
     fieldPropIntOnLeafAssigner,
     const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
@@ -73,9 +73,9 @@ run(const std::function<std::vector<int>(const FieldPropsManager&, const std::st
     copySatnumArrays_(fieldPropIntOnLeafAssigner);
     initOilWaterScaledEpsInfo_();
     initMaterialLawParamVectors_();
-    std::vector<std::vector<int>*> satnumArray;
-    std::vector<std::vector<int>*> imbnumArray;
-    std::vector<std::vector<MaterialLawParams>*> mlpArray;
+    Storage<Storage<int>*> satnumArray;
+    Storage<Storage<int>*> imbnumArray;
+    Storage<Storage<MaterialLawParams>*> mlpArray;
     initArrays_(satnumArray, imbnumArray, mlpArray);
     const auto num_arrays = mlpArray.size();
     for (unsigned i = 0; i < num_arrays; i++) {
@@ -104,7 +104,7 @@ run(const std::function<std::vector<int>(const FieldPropsManager&, const std::st
 
 /* private methods alphabetically sorted*/
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -112,7 +112,7 @@ template <
 >
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
-copySatnumArrays_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
+copySatnumArrays_(const std::function<Storage<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
 {
     copyIntArray_(this->parent_.krnumXArray_, "KRNUMX", fieldPropIntOnLeafAssigner);
     copyIntArray_(this->parent_.krnumYArray_, "KRNUMY", fieldPropIntOnLeafAssigner);
@@ -128,7 +128,7 @@ copySatnumArrays_(const std::function<std::vector<int>(const FieldPropsManager&,
     assert(!this->parent_.enableHysteresis() || this->numCompressedElems_ == this->parent_.imbnumRegionArray_.size());
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -136,15 +136,15 @@ template <
 >
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
-copyIntArray_(std::vector<int>& dest, const std::string& keyword,
-              const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
+copyIntArray_(Storage<int>& dest, const std::string& keyword,
+              const std::function<Storage<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
 {
     if (this->eclState_.fieldProps().has_int(keyword)) {
         dest = fieldPropIntOnLeafAssigner(this->eclState_.fieldProps(), keyword, /*needsTranslation*/true);
     }
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -152,13 +152,13 @@ template <
 >
 unsigned
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
-imbRegion_(std::vector<int>& array, unsigned elemIdx)
+imbRegion_(Storage<int>& array, unsigned elemIdx)
 {
-    std::vector<int>& default_vec = this->parent_.imbnumRegionArray_;
+    Storage<int>& default_vec = this->parent_.imbnumRegionArray_;
     return satOrImbRegion_(array, default_vec, elemIdx);
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -167,9 +167,9 @@ template <
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
 initArrays_(
-        std::vector<std::vector<int>*>& satnumArray,
-        std::vector<std::vector<int>*>& imbnumArray,
-        std::vector<std::vector<MaterialLawParams>*>& mlpArray)
+        Storage<Storage<int>*>& satnumArray,
+        Storage<Storage<int>*>& imbnumArray,
+        Storage<Storage<MaterialLawParams>*>& mlpArray)
 {
     satnumArray.push_back(&this->parent_.satnumRegionArray_);
     imbnumArray.push_back(&this->parent_.imbnumRegionArray_);
@@ -191,7 +191,7 @@ initArrays_(
     }
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -208,7 +208,7 @@ initMaterialLawParamVectors_()
     }
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -222,7 +222,7 @@ initOilWaterScaledEpsInfo_()
     this->parent_.oilWaterScaledEpsInfoDrainage_.resize(this->numCompressedElems_);
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -230,7 +230,7 @@ template <
 >
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
-initSatnumRegionArray_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
+initSatnumRegionArray_(const std::function<Storage<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
 {
     // copy the SATNUM grid property. in some cases this is not necessary, but it
     // should not require much memory anyway...
@@ -244,7 +244,7 @@ initSatnumRegionArray_(const std::function<std::vector<int>(const FieldPropsMana
     }
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -314,7 +314,7 @@ initThreePhaseParams_(HystParams &hystParams,
     } // end switch()
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -329,7 +329,7 @@ readEffectiveParameters_()
     effectiveReader.read();
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -362,7 +362,7 @@ readUnscaledEpsPointsVectors_()
     }
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -371,17 +371,17 @@ template <
 template <class Container>
 void
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
-readUnscaledEpsPoints_(Container& dest, std::shared_ptr<EclEpsConfig> config, EclTwoPhaseSystemType system_type)
+readUnscaledEpsPoints_(Container& dest, SharedPtr<EclEpsConfig> config, EclTwoPhaseSystemType system_type)
 {
     const size_t numSatRegions = this->eclState_.runspec().tabdims().getNumSatTables();
     dest.resize(numSatRegions);
     for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++satRegionIdx) {
-        dest[satRegionIdx] = std::make_shared<EclEpsScalingPoints<Scalar> >();
+        dest[satRegionIdx] = SharedPtr<EclEpsScalingPoints<Scalar> >();
         dest[satRegionIdx]->init(this->parent_.unscaledEpsInfo_[satRegionIdx], *config, system_type);
     }
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -389,13 +389,13 @@ template <
 >
 unsigned
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
-satRegion_(std::vector<int>& array, unsigned elemIdx)
+satRegion_(Storage<int>& array, unsigned elemIdx)
 {
-    std::vector<int>& default_vec = this->parent_.satnumRegionArray_;
+    Storage<int>& default_vec = this->parent_.satnumRegionArray_;
     return satOrImbRegion_(array, default_vec, elemIdx);
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -403,7 +403,7 @@ template <
 >
 unsigned
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::
-satOrImbRegion_(std::vector<int>& array, std::vector<int>& default_vec, unsigned elemIdx)
+satOrImbRegion_(Storage<int>& array, Storage<int>& default_vec, unsigned elemIdx)
 {
     int value;
     if (array.size() > 0) {

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
@@ -37,7 +37,7 @@
 namespace Opm {
 
 /* constructors*/
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -51,7 +51,7 @@ ReadEffectiveParams(EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>
 }
 
 /* public methods */
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -78,13 +78,13 @@ read() {
 /* private methods, alphabetically sorted*/
 
 // Relative permeability values not strictly greater than 'tolcrit' treated as zero.
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
     template<typename, typename...> typename UniquePtr
 >
-std::vector<double>
+Storage<double>
 EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::ReadEffectiveParams::
 normalizeKrValues_(const double tolcrit, const TableColumn& krValues) const
 {
@@ -98,7 +98,7 @@ normalizeKrValues_(const double tolcrit, const TableColumn& krValues) const
     return kr;
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -135,7 +135,7 @@ readGasOilParameters_(GasOilEffectiveParamVector& dest, unsigned satRegionIdx)
             readGasOilSlgof_(effParams, Swco, tolcrit, slgofTables.template getTable<SlgofTable>(satRegionIdx));
         else if ( !tableManager.getSgofletTable().empty() ) {
             const auto& letSgofTab = tableManager.getSgofletTable()[satRegionIdx];
-            const std::vector<Scalar> dum; // dummy arg to comform with existing interface
+            const Storage<Scalar> dum; // dummy arg to comform with existing interface
 
             effParams.setApproach(SatCurveMultiplexerApproach::LET);
             auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::LET>();
@@ -143,7 +143,7 @@ readGasOilParameters_(GasOilEffectiveParamVector& dest, unsigned satRegionIdx)
             // S=(So-Sogcr)/(1-Sogcr-Sgcr-Swco),  krog = Krt*S^L/[S^L+E*(1.0-S)^T]
             const Scalar s_min_w = letSgofTab.s2_critical;
             const Scalar s_max_w = 1.0-letSgofTab.s1_critical-Swco;
-            const std::vector<Scalar>& letCoeffsOil = {s_min_w, s_max_w,
+            const Storage<Scalar>& letCoeffsOil = {s_min_w, s_max_w,
                                                         static_cast<Scalar>(letSgofTab.l2_relperm),
                                                         static_cast<Scalar>(letSgofTab.e2_relperm),
                                                         static_cast<Scalar>(letSgofTab.t2_relperm),
@@ -153,7 +153,7 @@ readGasOilParameters_(GasOilEffectiveParamVector& dest, unsigned satRegionIdx)
             // S=(1-So-Sgcr-Swco)/(1-Sogcr-Sgcr-Swco), krg = Krt*S^L/[S^L+E*(1.0-S)^T]
             const Scalar s_min_nw = letSgofTab.s1_critical+Swco;
             const Scalar s_max_nw = 1.0-letSgofTab.s2_critical;
-            const std::vector<Scalar>& letCoeffsGas = {s_min_nw, s_max_nw,
+            const Storage<Scalar>& letCoeffsGas = {s_min_nw, s_max_nw,
                                                         static_cast<Scalar>(letSgofTab.l1_relperm),
                                                         static_cast<Scalar>(letSgofTab.e1_relperm),
                                                         static_cast<Scalar>(letSgofTab.t1_relperm),
@@ -161,7 +161,7 @@ readGasOilParameters_(GasOilEffectiveParamVector& dest, unsigned satRegionIdx)
             realParams.setKrnSamples(letCoeffsGas, dum);
 
             // S=(So-Sorg)/(1-Sorg-Sgl-Swco), Pc = Pct + (pcir_pc-Pct)*(1-S)^L/[(1-S)^L+E*S^T]
-            const std::vector<Scalar>& letCoeffsPc = {static_cast<Scalar>(letSgofTab.s2_residual),
+            const Storage<Scalar>& letCoeffsPc = {static_cast<Scalar>(letSgofTab.s2_residual),
                                                         static_cast<Scalar>(letSgofTab.s1_residual+Swco),
                                                         static_cast<Scalar>(letSgofTab.l_pc),
                                                         static_cast<Scalar>(letSgofTab.e_pc),
@@ -200,7 +200,7 @@ readGasOilParameters_(GasOilEffectiveParamVector& dest, unsigned satRegionIdx)
     }
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -217,8 +217,8 @@ readGasOilFamily2_(GasOilEffectiveTwoPhaseParams& effParams,
                         const std::string& columnName)
 {
     // convert the saturations of the SGFN keyword from gas to oil saturations
-    std::vector<double> SoSamples(sgfnTable.numRows());
-    std::vector<double> SoColumn = sofTable.getColumn("SO").vectorCopy();
+    Storage<double> SoSamples(sgfnTable.numRows());
+    Storage<double> SoColumn = sofTable.getColumn("SO").vectorCopy();
     for (size_t sampleIdx = 0; sampleIdx < sgfnTable.numRows(); ++ sampleIdx) {
         SoSamples[sampleIdx] = (1.0 - Swco) - sgfnTable.get("SG", sampleIdx);
     }
@@ -232,7 +232,7 @@ readGasOilFamily2_(GasOilEffectiveTwoPhaseParams& effParams,
     realParams.finalize();
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -246,7 +246,7 @@ readGasOilSgof_(GasOilEffectiveTwoPhaseParams& effParams,
                         const SgofTable& sgofTable)
 {
     // convert the saturations of the SGOF keyword from gas to oil saturations
-    std::vector<double> SoSamples(sgofTable.numRows());
+    Storage<double> SoSamples(sgofTable.numRows());
     for (size_t sampleIdx = 0; sampleIdx < sgofTable.numRows(); ++ sampleIdx) {
         SoSamples[sampleIdx] = (1.0 - Swco) - sgofTable.get("SG", sampleIdx);
     }
@@ -260,7 +260,7 @@ readGasOilSgof_(GasOilEffectiveTwoPhaseParams& effParams,
     realParams.finalize();
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -274,7 +274,7 @@ readGasOilSlgof_(GasOilEffectiveTwoPhaseParams& effParams,
                         const SlgofTable& slgofTable)
 {
     // convert the saturations of the SLGOF keyword from "liquid" to oil saturations
-    std::vector<double> SoSamples(slgofTable.numRows());
+    Storage<double> SoSamples(slgofTable.numRows());
     for (size_t sampleIdx = 0; sampleIdx < slgofTable.numRows(); ++ sampleIdx) {
         SoSamples[sampleIdx] = slgofTable.get("SL", sampleIdx) - Swco;
     }
@@ -288,7 +288,7 @@ readGasOilSlgof_(GasOilEffectiveTwoPhaseParams& effParams,
     realParams.finalize();
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -324,7 +324,7 @@ readGasWaterParameters_(GasWaterEffectiveParamVector& dest, unsigned satRegionId
         auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
         if (!sgwfnTables.empty()){
             const SgwfnTable& sgwfnTable = tableManager.getSgwfnTables().template getTable<SgwfnTable>( satRegionIdx );
-            std::vector<double> SwSamples(sgwfnTable.numRows());
+            Storage<double> SwSamples(sgwfnTable.numRows());
             for (size_t sampleIdx = 0; sampleIdx < sgwfnTable.numRows(); ++ sampleIdx)
                 SwSamples[sampleIdx] = 1 - sgwfnTable.get("SG", sampleIdx);
             realParams.setKrwSamples(SwSamples, normalizeKrValues_(tolcrit, sgwfnTable.getColumn("KRGW")));
@@ -335,10 +335,10 @@ readGasWaterParameters_(GasWaterEffectiveParamVector& dest, unsigned satRegionId
             const SgfnTable& sgfnTable = tableManager.getSgfnTables().template getTable<SgfnTable>( satRegionIdx );
             const SwfnTable& swfnTable = tableManager.getSwfnTables().template getTable<SwfnTable>( satRegionIdx );
 
-            std::vector<double> SwColumn = swfnTable.getColumn("SW").vectorCopy();
+            Storage<double> SwColumn = swfnTable.getColumn("SW").vectorCopy();
 
             realParams.setKrwSamples(SwColumn, normalizeKrValues_(tolcrit, swfnTable.getColumn("KRW")));
-            std::vector<double> SwSamples(sgfnTable.numRows());
+            Storage<double> SwSamples(sgfnTable.numRows());
             for (size_t sampleIdx = 0; sampleIdx < sgfnTable.numRows(); ++ sampleIdx)
                 SwSamples[sampleIdx] = 1 - sgfnTable.get("SG", sampleIdx);
             realParams.setKrnSamples(SwSamples, normalizeKrValues_(tolcrit, sgfnTable.getColumn("KRG")));
@@ -358,10 +358,10 @@ readGasWaterParameters_(GasWaterEffectiveParamVector& dest, unsigned satRegionId
         effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
         auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
 
-        std::vector<double> SwColumn = wsfTable.getColumn("SW").vectorCopy();
+        Storage<double> SwColumn = wsfTable.getColumn("SW").vectorCopy();
 
         realParams.setKrwSamples(SwColumn, normalizeKrValues_(tolcrit, wsfTable.getColumn("KRW")));
-        std::vector<double> SwSamples(gsfTable.numRows());
+        Storage<double> SwSamples(gsfTable.numRows());
         for (size_t sampleIdx = 0; sampleIdx < gsfTable.numRows(); ++ sampleIdx)
             SwSamples[sampleIdx] = 1 - gsfTable.get("SG", sampleIdx);
         realParams.setKrnSamples(SwSamples, normalizeKrValues_(tolcrit, gsfTable.getColumn("KRG")));
@@ -376,7 +376,7 @@ readGasWaterParameters_(GasWaterEffectiveParamVector& dest, unsigned satRegionId
     }
 }
 
-template <
+template<
     class Traits,
     template<class> class Storage,
     template<typename> typename SharedPtr,
@@ -403,7 +403,7 @@ readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionId
     {
         if (tableManager.hasTables("SWOF")) {
             const auto& swofTable = tableManager.getSwofTables().template getTable<SwofTable>(satRegionIdx);
-            const std::vector<double> SwColumn = swofTable.getColumn("SW").vectorCopy();
+            const Storage<double> SwColumn = swofTable.getColumn("SW").vectorCopy();
 
             effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
             auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
@@ -415,7 +415,7 @@ readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionId
         }
         else if ( !tableManager.getSwofletTable().empty() ) {
             const auto& letTab = tableManager.getSwofletTable()[satRegionIdx];
-            const std::vector<Scalar> dum; // dummy arg to conform with existing interface
+            const Storage<Scalar> dum; // dummy arg to conform with existing interface
 
             effParams.setApproach(SatCurveMultiplexerApproach::LET);
             auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::LET>();
@@ -423,7 +423,7 @@ readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionId
             // S=(Sw-Swcr)/(1-Sowcr-Swcr),  krw = Krt*S^L/[S^L+E*(1.0-S)^T]
             const Scalar s_min_w = letTab.s1_critical;
             const Scalar s_max_w = 1.0-letTab.s2_critical;
-            const std::vector<Scalar>& letCoeffsWat = {s_min_w, s_max_w,
+            const Storage<Scalar>& letCoeffsWat = {s_min_w, s_max_w,
                                                         static_cast<Scalar>(letTab.l1_relperm),
                                                         static_cast<Scalar>(letTab.e1_relperm),
                                                         static_cast<Scalar>(letTab.t1_relperm),
@@ -433,7 +433,7 @@ readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionId
             // S=(So-Sowcr)/(1-Sowcr-Swcr), krow = Krt*S^L/[S^L+E*(1.0-S)^T]
             const Scalar s_min_nw = letTab.s2_critical;
             const Scalar s_max_nw = 1.0-letTab.s1_critical;
-            const std::vector<Scalar>& letCoeffsOil = {s_min_nw, s_max_nw,
+            const Storage<Scalar>& letCoeffsOil = {s_min_nw, s_max_nw,
                                                         static_cast<Scalar>(letTab.l2_relperm),
                                                         static_cast<Scalar>(letTab.e2_relperm),
                                                         static_cast<Scalar>(letTab.t2_relperm),
@@ -441,7 +441,7 @@ readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionId
             realParams.setKrnSamples(letCoeffsOil, dum);
 
             // S=(Sw-Swco)/(1-Swco-Sorw), Pc = Pct + (Pcir-Pct)*(1-S)^L/[(1-S)^L+E*S^T]
-            const std::vector<Scalar>& letCoeffsPc = {static_cast<Scalar>(letTab.s1_residual),
+            const Storage<Scalar>& letCoeffsPc = {static_cast<Scalar>(letTab.s1_residual),
                                                         static_cast<Scalar>(letTab.s2_residual),
                                                         static_cast<Scalar>(letTab.l_pc),
                                                         static_cast<Scalar>(letTab.e_pc),
@@ -458,7 +458,7 @@ readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionId
     case SatFuncControls::KeywordFamily::Family_II:
     {
         const auto& swfnTable = tableManager.getSwfnTables().template getTable<SwfnTable>(satRegionIdx);
-        const std::vector<double> SwColumn = swfnTable.getColumn("SW").vectorCopy();
+        const Storage<double> SwColumn = swfnTable.getColumn("SW").vectorCopy();
 
         effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
         auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
@@ -469,7 +469,7 @@ readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionId
         if (!this->parent_.hasGas) {
             const auto& sof2Table = tableManager.getSof2Tables().template getTable<Sof2Table>(satRegionIdx);
             // convert the saturations of the SOF2 keyword from oil to water saturations
-            std::vector<double> SwSamples(sof2Table.numRows());
+            Storage<double> SwSamples(sof2Table.numRows());
             for (size_t sampleIdx = 0; sampleIdx < sof2Table.numRows(); ++ sampleIdx)
                 SwSamples[sampleIdx] = 1 - sof2Table.get("SO", sampleIdx);
 
@@ -477,7 +477,7 @@ readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionId
         } else {
             const auto& sof3Table = tableManager.getSof3Tables().template getTable<Sof3Table>(satRegionIdx);
             // convert the saturations of the SOF3 keyword from oil to water saturations
-            std::vector<double> SwSamples(sof3Table.numRows());
+            Storage<double> SwSamples(sof3Table.numRows());
             for (size_t sampleIdx = 0; sampleIdx < sof3Table.numRows(); ++ sampleIdx)
                 SwSamples[sampleIdx] = 1 - sof3Table.get("SO", sampleIdx);
 

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
@@ -37,18 +37,28 @@
 namespace Opm {
 
 /* constructors*/
-template <class Traits>
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
-ReadEffectiveParams(EclMaterialLawManager<Traits>::InitParams& init_params) :
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::ReadEffectiveParams::
+ReadEffectiveParams(EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams& init_params) :
     init_params_{init_params}, parent_{init_params_.parent_},
     eclState_{init_params_.eclState_}
 {
 }
 
 /* public methods */
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::ReadEffectiveParams::
 read() {
     auto& gasOilVector = this->parent_.gasOilEffectiveParamVector_;
     auto& oilWaterVector = this->parent_.oilWaterEffectiveParamVector_;
@@ -68,9 +78,14 @@ read() {
 /* private methods, alphabetically sorted*/
 
 // Relative permeability values not strictly greater than 'tolcrit' treated as zero.
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 std::vector<double>
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::ReadEffectiveParams::
 normalizeKrValues_(const double tolcrit, const TableColumn& krValues) const
 {
     auto kr = krValues.vectorCopy();
@@ -83,9 +98,14 @@ normalizeKrValues_(const double tolcrit, const TableColumn& krValues) const
     return kr;
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::ReadEffectiveParams::
 readGasOilParameters_(GasOilEffectiveParamVector& dest, unsigned satRegionIdx)
 {
     if (!this->parent_.hasGas || !this->parent_.hasOil)
@@ -180,10 +200,15 @@ readGasOilParameters_(GasOilEffectiveParamVector& dest, unsigned satRegionIdx)
     }
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 template <class TableType>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::ReadEffectiveParams::
 readGasOilFamily2_(GasOilEffectiveTwoPhaseParams& effParams,
                         const Scalar Swco,
                         const double tolcrit,
@@ -207,9 +232,14 @@ readGasOilFamily2_(GasOilEffectiveTwoPhaseParams& effParams,
     realParams.finalize();
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::ReadEffectiveParams::
 readGasOilSgof_(GasOilEffectiveTwoPhaseParams& effParams,
                         const Scalar Swco,
                         const double tolcrit,
@@ -230,9 +260,14 @@ readGasOilSgof_(GasOilEffectiveTwoPhaseParams& effParams,
     realParams.finalize();
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::ReadEffectiveParams::
 readGasOilSlgof_(GasOilEffectiveTwoPhaseParams& effParams,
                         const Scalar Swco,
                         const double tolcrit,
@@ -253,9 +288,14 @@ readGasOilSlgof_(GasOilEffectiveTwoPhaseParams& effParams,
     realParams.finalize();
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::ReadEffectiveParams::
 readGasWaterParameters_(GasWaterEffectiveParamVector& dest, unsigned satRegionIdx)
 {
     if (!this->parent_.hasGas || !this->parent_.hasWater || this->parent_.hasOil)
@@ -336,9 +376,14 @@ readGasWaterParameters_(GasWaterEffectiveParamVector& dest, unsigned satRegionId
     }
 }
 
-template <class Traits>
+template <
+    class Traits,
+    template<class> class Storage,
+    template<typename> typename SharedPtr,
+    template<typename, typename...> typename UniquePtr
+>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+EclMaterialLawManager<Traits, Storage, SharedPtr, UniquePtr>::InitParams::ReadEffectiveParams::
 readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionIdx)
 {
     if (!this->parent_.hasOil || !this->parent_.hasWater)

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -251,35 +251,52 @@ public:
     }
 
     static Scalar trappedGasSaturation(const Params& params, bool maximumTrapping){
+        #if !HAVE_CUDA
+        // For now we have not implemented hysteresis for CUDA, and SnTrapped is only implemented by EclHysteresisTwoPhaseLawParams
         if(params.approach() == EclTwoPhaseApproach::GasOil)
             return params.gasOilParams().SnTrapped(maximumTrapping);
         if(params.approach() == EclTwoPhaseApproach::GasWater)
             return params.gasWaterParams().SnTrapped(maximumTrapping);
         return 0.0; // oil-water case
+        #else
+        return 0.0; // oil-water case
+        #endif
     }
 
     static Scalar strandedGasSaturation(const Params& params, Scalar Sg, Scalar Kg){
+        #if !HAVE_CUDA
         if(params.approach() == EclTwoPhaseApproach::GasOil)
             return params.gasOilParams().SnStranded(Sg, Kg);
         if(params.approach() == EclTwoPhaseApproach::GasWater)
             return params.gasWaterParams().SnStranded(Sg, Kg);
         return 0.0; // oil-water case
+        #else
+        return 0.0; // oil-water case
+        #endif
     }
 
     static Scalar trappedOilSaturation(const Params& params, bool maximumTrapping){
+        #if !HAVE_CUDA
         if(params.approach() == EclTwoPhaseApproach::GasOil)
             return params.gasOilParams().SwTrapped();
         if(params.approach() == EclTwoPhaseApproach::OilWater)
             return params.oilWaterParams().SnTrapped(maximumTrapping);
         return 0.0; // gas-water case
+        #else
+        return 0.0; // gas-water case
+        #endif
     }
 
     static Scalar trappedWaterSaturation(const Params& params){
+        #if !HAVE_CUDA
         if(params.approach() == EclTwoPhaseApproach::GasWater)
             return params.gasWaterParams().SwTrapped();
         if(params.approach() == EclTwoPhaseApproach::OilWater)
             return params.oilWaterParams().SwTrapped();
         return 0.0; // gas-oil case
+        #else
+        return 0.0; // gas-oil case
+        #endif
     }
 
 


### PR DESCRIPTION
Still lots to do, adding as draft to make my work visible.

Plan is to amend material law manager in the least possible invasive way to support GPU execution. The GPU execution will to begin with not support end-point scaling or hysteresis.