### PR TITLE
remove in-class initialization of Impl

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ActionResult.hpp
+++ b/opm/input/eclipse/Schedule/Action/ActionResult.hpp
@@ -384,7 +384,7 @@ private:
     class Impl;
 
     /// Pointer to implementation.
-    std::unique_ptr<Impl> pImpl_{};
+    std::unique_ptr<Impl> pImpl_; // No in-class initializer to workaround nvcc issue
 };
 
 } // Namespace Opm::Action


### PR DESCRIPTION
this is a workaround to fix build of downstream gpu test with old nvcc, in particular for default cuda version in ubuntu 24.04)