### PR TITLE
Removing phase usage 

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -982,6 +982,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/fluidsystems/BaseFluidSystem.hpp
       opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp
       opm/material/fluidsystems/ParameterCacheBase.hpp
+      opm/material/fluidsystems/PhaseUsageInfo.hpp
       opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
       opm/material/fluidsystems/BrineCO2FluidSystem.hpp
       opm/material/fluidsystems/GasPhase.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -60,6 +60,7 @@ list (APPEND MAIN_SOURCE_FILES
       opm/material/densead/Evaluation.cpp
       opm/material/fluidmatrixinteractions/EclEpsScalingPoints.cpp
       opm/material/fluidsystems/BlackOilFluidSystem.cpp
+      opm/material/fluidsystems/PhaseUsageInfo.cpp
       opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.cpp
       opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.cpp
       opm/material/fluidsystems/blackoilpvt/Co2GasPvt.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -486,6 +486,7 @@ list (APPEND TEST_SOURCE_FILES
       tests/test_nonuniformtablelinear.cpp
       tests/test_OpmInputError_format.cpp
       tests/test_OpmLog.cpp
+      tests/test_PhaseUsageInfo.cpp
       tests/test_param.cpp
       tests/test_RootFinders.cpp
       tests/test_ScheduleGrid.cpp

--- a/opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp
+++ b/opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp
@@ -36,12 +36,18 @@ namespace Opm {
 class BlackOilDefaultFluidSystemIndices
 {
 public:
+    //! Total number of phases
+    static constexpr unsigned numPhases = 3;
+
     //! Index of the water phase
     static constexpr unsigned waterPhaseIdx = 0;
     //! Index of the oil phase
     static constexpr unsigned oilPhaseIdx = 1;
     //! Index of the gas phase
     static constexpr unsigned gasPhaseIdx = 2;
+
+    //! Total number of components
+    static constexpr unsigned numComponents = 3;
 
     //! Index of the oil component
     static constexpr int oilCompIdx = 0;

--- a/opm/material/fluidsystems/BlackOilFluidSystem.cpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.cpp
@@ -51,30 +51,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
     std::size_t num_regions = eclState.runspec().tabdims().getNumPVTTables();
     initBegin(num_regions);
 
-    numActivePhases_ = 0;
-    std::fill_n(&phaseIsActive_[0], numPhases, false);
-
-    if (eclState.runspec().phases().active(Phase::OIL)) {
-        phaseIsActive_[oilPhaseIdx] = true;
-        ++numActivePhases_;
-    }
-
-    if (eclState.runspec().phases().active(Phase::GAS)) {
-        phaseIsActive_[gasPhaseIdx] = true;
-        ++numActivePhases_;
-    }
-
-    if (eclState.runspec().phases().active(Phase::WATER)) {
-        phaseIsActive_[waterPhaseIdx] = true;
-        ++numActivePhases_;
-    }
-
-    // this fluidsystem only supports one, two or three phases
-    if (numActivePhases_ < 1 || numActivePhases_ > 3) {
-        OPM_THROW(std::runtime_error,
-                  fmt::format("Fluidsystem supports 1-3 phases, but {} is active\n",
-                              numActivePhases_));
-    }
+    phaseUsageInfo_.initFromState(eclState);
 
     // set the surface conditions using the STCOND keyword
     surfaceTemperature = eclState.getTableManager().stCond().temperature;
@@ -222,13 +199,8 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
 #endif
 
 #define INSTANTIATE_TYPE(T) \
-    template<> unsigned char BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::numActivePhases_ = 0; \
-    template<> std::array<bool, BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::numPhases> \
-        BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::phaseIsActive_ = {false, false, false}; \
-    template<> std::array<short, BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::numPhases> \
-        BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::activeToCanonicalPhaseIdx_ = {0, 1, 2}; \
-    template<> std::array<short, BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::numPhases> \
-        BlackOilFluidSystem<T , BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::canonicalToActivePhaseIdx_ = {0, 1, 2}; \
+    template<> PhaseUsageInfo<BlackOilDefaultFluidSystemIndices> \
+               BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::phaseUsageInfo_ = {};   \
     template<> T BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::surfaceTemperature = 0.0; \
     template<> T BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::surfacePressure = 0.0; \
     template<> T BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::reservoirTemperature_ = 0.0; \

--- a/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
@@ -45,6 +45,7 @@
 #include <opm/material/common/HasMemberGeneratorMacros.hpp>
 #include <opm/material/fluidsystems/NullParameterCache.hpp>
 #include <opm/material/fluidsystems/BlackOilFunctions.hpp>
+#include <opm/material/fluidsystems/PhaseUsageInfo.hpp>
 
 #include <array>
 #include <cstddef>
@@ -91,6 +92,7 @@ public:
     using WaterPvt = std::conditional_t<std::is_same_v<Storage<Scalar>, VectorWithDefaultAllocator<Scalar>>,
                                         WaterPvtMultiplexer<Scalar>,
                                         BrineCo2Pvt<Scalar, Storage>>;
+    using IndexTraitsType = IndexTraits;
 
     #ifdef COMPILING_STATIC_FLUID_SYSTEM
     //! \copydoc BaseFluidSystem::ParameterCache
@@ -162,8 +164,6 @@ public:
     explicit FLUIDSYSTEM_CLASSNAME(const FLUIDSYSTEM_CLASSNAME<Scalar, IndexTraits, StorageT>& other)
         : surfacePressure(other.surfacePressure)
         , surfaceTemperature(other.surfaceTemperature)
-        , numActivePhases_(other.numActivePhases_)
-        , phaseIsActive_(other.phaseIsActive_)
         , reservoirTemperature_(other.reservoirTemperature_)
         , gasPvt_(other.gasPvt_)
         , oilPvt_(other.oilPvt_)
@@ -176,8 +176,6 @@ public:
         , referenceDensity_(StorageT<typename decltype(referenceDensity_)::value_type>(other.referenceDensity_))
         , molarMass_(StorageT<typename decltype(molarMass_)::value_type>(other.molarMass_))
         , diffusionCoefficients_(StorageT<typename decltype(diffusionCoefficients_)::value_type>(other.diffusionCoefficients_))
-        , activeToCanonicalPhaseIdx_(other.activeToCanonicalPhaseIdx_)
-        , canonicalToActivePhaseIdx_(other.canonicalToActivePhaseIdx_)
         , isInitialized_(other.isInitialized_)
         , useSaturatedTables_(other.useSaturatedTables_)
         , enthalpy_eq_energy_(other.enthalpy_eq_energy_)
@@ -186,8 +184,6 @@ public:
 
     FLUIDSYSTEM_CLASSNAME(Scalar _surfacePressure_,
                           Scalar _surfaceTemperature_,
-                          unsigned _numActivePhases_,
-                          std::array<bool, 3> _phaseIsActive_,
                           Scalar _reservoirTemperature_,
                           const GasPvt& _gasPvt_,
                           const OilPvt& _oilPvt_,
@@ -197,18 +193,15 @@ public:
                           bool _enableVaporizedOil_,
                           bool _enableVaporizedWater_,
                           bool _enableDiffusion_,
+                          const PhaseUsageInfo<IndexTraits>& _phaseUsageInfo_,
                           Storage<std::array<Scalar, 3>>&& _referenceDensity_,
                           Storage<std::array<Scalar, 3>>&& _molarMass_,
                           Storage<std::array<Scalar, 3 * 3>>&& _diffusionCoefficients_,
-                          std::array<short, 3> _activeToCanonicalPhaseIdx_,
-                          std::array<short, 3> _canonicalToActivePhaseIdx_,
                           bool _isInitialized_,
                           bool _useSaturatedTables_,
                           bool _enthalpy_eq_energy_)
         : surfacePressure(_surfacePressure_)
         , surfaceTemperature(_surfaceTemperature_)
-        , numActivePhases_(_numActivePhases_)
-        , phaseIsActive_(_phaseIsActive_)
         , reservoirTemperature_(_reservoirTemperature_)
         , gasPvt_(_gasPvt_)
         , oilPvt_(_oilPvt_)
@@ -218,11 +211,10 @@ public:
         , enableVaporizedOil_(_enableVaporizedOil_)
         , enableVaporizedWater_(_enableVaporizedWater_)
         , enableDiffusion_(_enableDiffusion_)
+        , phaseUsageInfo_(_phaseUsageInfo_)
         , referenceDensity_(std::move(_referenceDensity_))
         , molarMass_(std::move(_molarMass_))
         , diffusionCoefficients_(std::move(_diffusionCoefficients_))
-        , activeToCanonicalPhaseIdx_(_activeToCanonicalPhaseIdx_)
-        , canonicalToActivePhaseIdx_(_canonicalToActivePhaseIdx_)
         , isInitialized_(_isInitialized_)
         , useSaturatedTables_(_useSaturatedTables_)
         , enthalpy_eq_energy_(_enthalpy_eq_energy_)
@@ -424,20 +416,20 @@ public:
     //! Index of the gas component
     static constexpr int gasCompIdx = IndexTraits::gasCompIdx;
 
-protected:
-    STATIC_OR_NOTHING unsigned char numActivePhases_;
-    STATIC_OR_NOTHING std::array<bool,numPhases> phaseIsActive_;
-
 public:
+
+    //! \brief Returns a const reference to PhaseUsageInfo
+    STATIC_OR_DEVICE const PhaseUsageInfo<IndexTraits>& phaseUsage() NOTHING_OR_CONST
+    { return phaseUsageInfo_; }
+
     //! \brief Returns the number of active fluid phases (i.e., usually three)
     STATIC_OR_DEVICE unsigned numActivePhases() NOTHING_OR_CONST
-    { return numActivePhases_; }
+    { return phaseUsageInfo_.numActivePhases(); }
 
     //! \brief Returns whether a fluid phase is active
     STATIC_OR_DEVICE bool phaseIsActive(unsigned phaseIdx) NOTHING_OR_CONST
     {
-        assert(phaseIdx < numPhases);
-        return phaseIsActive_[phaseIdx];
+        return phaseUsageInfo_.phaseIsActive(phaseIdx);
     }
 
     //! \brief returns the index of "primary" component of a phase (solvent)
@@ -1766,8 +1758,7 @@ private:
     STATIC_OR_NOTHING Storage<std::array<Scalar, /*numComponents=*/3> > molarMass_;
     STATIC_OR_NOTHING Storage<std::array<Scalar, /*numComponents=*/3 * /*numPhases=*/3> > diffusionCoefficients_;
 
-    STATIC_OR_NOTHING std::array<short, numPhases> activeToCanonicalPhaseIdx_;
-    STATIC_OR_NOTHING std::array<short, numPhases> canonicalToActivePhaseIdx_;
+    STATIC_OR_NOTHING PhaseUsageInfo<IndexTraits> phaseUsageInfo_;
 
     STATIC_OR_NOTHING bool isInitialized_;
     STATIC_OR_NOTHING bool useSaturatedTables_;
@@ -1778,8 +1769,6 @@ private:
     explicit FLUIDSYSTEM_CLASSNAME(const FLUIDSYSTEM_CLASSNAME_STATIC<Scalar, IndexTraits, StorageT>& other)
         : surfacePressure(other.surfacePressure)
         , surfaceTemperature(other.surfaceTemperature)
-        , numActivePhases_(other.numActivePhases_)
-        , phaseIsActive_(other.phaseIsActive_)
         , reservoirTemperature_(other.reservoirTemperature_)
         , gasPvt_(other.gasPvt_)
         , oilPvt_(other.oilPvt_)
@@ -1792,8 +1781,7 @@ private:
         , referenceDensity_(StorageT<typename decltype(referenceDensity_)::value_type>(other.referenceDensity_))
         , molarMass_(StorageT<typename decltype(molarMass_)::value_type>(other.molarMass_))
         , diffusionCoefficients_(StorageT<typename decltype(diffusionCoefficients_)::value_type>(other.diffusionCoefficients_))
-        , activeToCanonicalPhaseIdx_(other.activeToCanonicalPhaseIdx_)
-        , canonicalToActivePhaseIdx_(other.canonicalToActivePhaseIdx_)
+        , phaseUsageInfo_(other.phaseUsageInfo_)
         , isInitialized_(other.isInitialized_)
         , useSaturatedTables_(other.useSaturatedTables_)
         , enthalpy_eq_energy_(other.enthalpy_eq_energy_)
@@ -1826,8 +1814,7 @@ initBegin(std::size_t numPvtRegions)
     surfacePressure = 1.01325e5; // [Pa]
     setReservoirTemperature(surfaceTemperature);
 
-    numActivePhases_ = numPhases;
-    std::fill_n(&phaseIsActive_[0], numPhases, true);
+    phaseUsageInfo_.initBegin();
 
     resizeArrays_(numPvtRegions);
 }
@@ -1870,15 +1857,8 @@ NOTHING_OR_DEVICE void FLUIDSYSTEM_CLASSNAME<Scalar,IndexTraits, Storage>::initE
         molarMass_[regionIdx][oilCompIdx] = 175e-3; // kg/mol
     }
 
+    phaseUsageInfo_.initEnd();
 
-    int activePhaseIdx = 0;
-    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-        if(phaseIsActive(phaseIdx)){
-            canonicalToActivePhaseIdx_[phaseIdx] = activePhaseIdx;
-            activeToCanonicalPhaseIdx_[activePhaseIdx] = phaseIdx;
-            activePhaseIdx++;
-        }
-    }
     isInitialized_ = true;
 }
 
@@ -1959,17 +1939,14 @@ template <class Scalar, class IndexTraits, template<typename> typename Storage>
 NOTHING_OR_DEVICE short FLUIDSYSTEM_CLASSNAME<Scalar,IndexTraits, Storage>::
 activeToCanonicalPhaseIdx(unsigned activePhaseIdx) NOTHING_OR_CONST
 {
-    assert(activePhaseIdx<numActivePhases());
-    return activeToCanonicalPhaseIdx_[activePhaseIdx];
+    return phaseUsageInfo_.activeToCanonicalPhaseIdx(activePhaseIdx);
 }
 
 template <class Scalar, class IndexTraits, template<typename> typename Storage>
 NOTHING_OR_DEVICE short FLUIDSYSTEM_CLASSNAME<Scalar,IndexTraits, Storage>::
 canonicalToActivePhaseIdx(unsigned phaseIdx) NOTHING_OR_CONST
 {
-    assert(phaseIdx<numPhases);
-    assert(phaseIsActive(phaseIdx));
-    return canonicalToActivePhaseIdx_[phaseIdx];
+    return phaseUsageInfo_.canonicalToActivePhaseIdx(phaseIdx);
 }
 
 template <class Scalar, class IndexTraits, template<typename> typename Storage>
@@ -1983,11 +1960,8 @@ resizeArrays_(std::size_t numRegions)
 #ifdef COMPILING_STATIC_FLUID_SYSTEM
 template <typename T> using BOFS = FLUIDSYSTEM_CLASSNAME<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>;
 
-#define DECLARE_INSTANCE(T)                                                           \
-template<> unsigned char BOFS<T>::numActivePhases_;                                   \
-template<> std::array<bool, BOFS<T>::numPhases> BOFS<T>::phaseIsActive_;              \
-template<> std::array<short, BOFS<T>::numPhases> BOFS<T>::activeToCanonicalPhaseIdx_; \
-template<> std::array<short, BOFS<T>::numPhases> BOFS<T>::canonicalToActivePhaseIdx_; \
+#define DECLARE_INSTANCE(T) \
+template<> PhaseUsageInfo<BlackOilDefaultFluidSystemIndices> BOFS<T>::phaseUsageInfo_;\
 template<> T BOFS<T>::surfaceTemperature;                                             \
 template<> T BOFS<T>::surfacePressure;                                                \
 template<> T BOFS<T>::reservoirTemperature_;                                          \
@@ -2048,8 +2022,6 @@ copy_to_gpu(const FLUIDSYSTEM_CLASSNAME<Scalar, IndexTraits>& oldFluidSystem) {
     return FLUIDSYSTEM_CLASSNAME<Scalar, IndexTraits, GpuBuffer>(
         oldFluidSystem.surfacePressure,
         oldFluidSystem.surfaceTemperature,
-        oldFluidSystem.numActivePhases_,
-        oldFluidSystem.phaseIsActive_,
         oldFluidSystem.reservoirTemperature_,
         newGasPvt,
         newOilPvt,
@@ -2059,11 +2031,10 @@ copy_to_gpu(const FLUIDSYSTEM_CLASSNAME<Scalar, IndexTraits>& oldFluidSystem) {
         oldFluidSystem.enableVaporizedOil_,
         oldFluidSystem.enableVaporizedWater_,
         oldFluidSystem.enableDiffusion_,
+        oldFluidSystem.phaseUsageInfo_,
         std::move(newReferenceDensity),
         std::move(newMolarMass),
         std::move(newDiffusionCoefficients),
-        oldFluidSystem.activeToCanonicalPhaseIdx_,
-        oldFluidSystem.canonicalToActivePhaseIdx_,
         oldFluidSystem.isInitialized_,
         oldFluidSystem.useSaturatedTables_,
         oldFluidSystem.enthalpy_eq_energy_
@@ -2088,8 +2059,6 @@ make_view(FLUIDSYSTEM_CLASSNAME<Scalar, IndexTraits, GpuBuffer>& oldFluidSystem)
     return FLUIDSYSTEM_CLASSNAME<Scalar, IndexTraits, GpuView>(
         oldFluidSystem.surfacePressure,
         oldFluidSystem.surfaceTemperature,
-        oldFluidSystem.numActivePhases_,
-        oldFluidSystem.phaseIsActive_,
         oldFluidSystem.reservoirTemperature_,
         newGasPvt,
         newOilPvt,
@@ -2099,11 +2068,10 @@ make_view(FLUIDSYSTEM_CLASSNAME<Scalar, IndexTraits, GpuBuffer>& oldFluidSystem)
         oldFluidSystem.enableVaporizedOil_,
         oldFluidSystem.enableVaporizedWater_,
         oldFluidSystem.enableDiffusion_,
+        oldFluidSystem.phaseUsageInfo_,
         std::move(newReferenceDensity),
         std::move(newMolarMass),
         std::move(newDiffusionCoefficients),
-        oldFluidSystem.activeToCanonicalPhaseIdx_,
-        oldFluidSystem.canonicalToActivePhaseIdx_,
         oldFluidSystem.isInitialized_,
         oldFluidSystem.useSaturatedTables_,
         oldFluidSystem.enthalpy_eq_energy_

--- a/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
@@ -377,7 +377,7 @@ public:
      ****************************************/
 
     //! \copydoc BaseFluidSystem::numPhases
-    static constexpr unsigned numPhases = 3;
+    static constexpr unsigned numPhases = IndexTraits::numPhases;
 
     //! Index of the water phase
     static constexpr unsigned waterPhaseIdx = IndexTraits::waterPhaseIdx;
@@ -407,7 +407,7 @@ public:
      ****************************************/
 
     //! \copydoc BaseFluidSystem::numComponents
-    static constexpr unsigned numComponents = 3;
+    static constexpr unsigned numComponents = IndexTraits::numComponents;
 
     //! Index of the oil component
     static constexpr int oilCompIdx = IndexTraits::oilCompIdx;

--- a/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
@@ -265,7 +265,7 @@ public:
      *
      * After calling this method the reference densities, all dissolution and formation
      * volume factors, the oil bubble pressure, all viscosities and the water
-     * compressibility must be set. Before the fluid system can be used, initEnd() must
+     * compressibility must be set. Before the fluid system can be used, updateIndexMapping_() must
      * be called to finalize the initialization.
      */
     STATIC_OR_NOTHING void initBegin(std::size_t numPvtRegions);
@@ -1814,8 +1814,6 @@ initBegin(std::size_t numPvtRegions)
     surfacePressure = 1.01325e5; // [Pa]
     setReservoirTemperature(surfaceTemperature);
 
-    phaseUsageInfo_.initBegin();
-
     resizeArrays_(numPvtRegions);
 }
 
@@ -1856,8 +1854,6 @@ NOTHING_OR_DEVICE void FLUIDSYSTEM_CLASSNAME<Scalar,IndexTraits, Storage>::initE
         // finally, for oil phase, we take the molar mass from the spe9 paper
         molarMass_[regionIdx][oilCompIdx] = 175e-3; // kg/mol
     }
-
-    phaseUsageInfo_.initEnd();
 
     isInitialized_ = true;
 }

--- a/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
@@ -1814,6 +1814,8 @@ initBegin(std::size_t numPvtRegions)
     surfacePressure = 1.01325e5; // [Pa]
     setReservoirTemperature(surfaceTemperature);
 
+    phaseUsageInfo_.initFromPhases(Phases{true, true, true});
+
     resizeArrays_(numPvtRegions);
 }
 

--- a/opm/material/fluidsystems/PhaseUsageInfo.cpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.cpp
@@ -45,11 +45,8 @@ namespace Opm {
 
 template <typename IndexTraits>
 PhaseUsageInfo<IndexTraits>::PhaseUsageInfo()
-  : numActivePhases_(0)
 {
-    std::fill_n(&phaseIsActive_[0], numPhases, false);
-    std::fill_n(&this->canonicalToActivePhaseIdx_[0], numPhases, -1);
-    std::fill_n(&this->activeToCanonicalPhaseIdx_[0], numPhases, -1);
+    reset_();
 }
 
 template <typename IndexTraits>
@@ -62,6 +59,14 @@ void PhaseUsageInfo<IndexTraits>::updateIndexMapping_() {
             activePhaseIdx++;
         }
     }
+}
+
+template <typename IndexTraits>
+void PhaseUsageInfo<IndexTraits>::reset_() {
+    numActivePhases_ = 0;
+    std::fill_n(&phaseIsActive_[0], numPhases, false);
+    std::fill_n(&canonicalToActivePhaseIdx_[0], numPhases, -1);
+    std::fill_n(&activeToCanonicalPhaseIdx_[0], numPhases, -1);
 }
 
 #if HAVE_ECL_INPUT
@@ -78,6 +83,9 @@ void PhaseUsageInfo<IndexTraits>::initFromState(const EclipseState& eclState)
 
 template <typename IndexTraits>
 void PhaseUsageInfo<IndexTraits>::initFromPhases(const Phases& phases) {
+
+    this->reset_();
+
     if (phases.active(Phase::OIL)) {
         phaseIsActive_[oilPhaseIdx] = true;
         ++numActivePhases_;

--- a/opm/material/fluidsystems/PhaseUsageInfo.cpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.cpp
@@ -1,0 +1,122 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
+#include <opm/material/fluidsystems/PhaseUsageInfo.hpp>
+#include <opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp>
+
+#if HAVE_ECL_INPUT
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#endif
+
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/input/eclipse/EclipseState/Phase.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <stdexcept>
+
+#include <fmt/format.h>
+
+namespace Opm {
+
+template <class IndexTraits>
+void PhaseUsageInfo<IndexTraits>::setNumActivePhases(unsigned numActivePhases) {
+    assert(numActivePhases <= numPhases);
+    numActivePhases_ = numActivePhases;
+    // TODO: should we do something else here?
+}
+
+template <class IndexTraits>
+void PhaseUsageInfo<IndexTraits>::initBegin() {
+    numActivePhases_ = numPhases;
+    std::fill_n(&phaseIsActive_[0], numPhases, true);
+}
+
+template <class IndexTraits>
+void PhaseUsageInfo<IndexTraits>::initEnd() {
+    int activePhaseIdx = 0;
+    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        if(phaseIsActive_[phaseIdx]){
+            this->canonicalToActivePhaseIdx_[phaseIdx] = activePhaseIdx;
+            this->activeToCanonicalPhaseIdx_[activePhaseIdx] = phaseIdx;
+            activePhaseIdx++;
+        }
+    }
+}
+
+#if HAVE_ECL_INPUT
+template <class IndexTraits>
+void PhaseUsageInfo<IndexTraits>::initFromState(const EclipseState& eclState)
+{
+    const auto& phases = eclState.runspec().phases();
+    initFromPhases(phases);
+
+    has_micp = eclState.runspec().micp();
+    has_co2_or_h2store = eclState.runspec().co2Storage() || eclState.runspec().h2Storage();
+}
+#endif
+
+template <class IndexTraits>
+void PhaseUsageInfo<IndexTraits>::initFromPhases(const Phases& phases) {
+    //       initBegin();
+    numActivePhases_ = 0;
+    std::fill_n(&phaseIsActive_[0], numPhases, false);
+
+    if (phases.active(Phase::OIL)) {
+        phaseIsActive_[oilPhaseIdx] = true;
+        ++numActivePhases_;
+    }
+    if (phases.active(Phase::GAS)) {
+        phaseIsActive_[gasPhaseIdx] = true;
+        ++numActivePhases_;
+    }
+    if (phases.active(Phase::WATER)) {
+        phaseIsActive_[waterPhaseIdx] = true;
+        ++numActivePhases_;
+    }
+
+    // \Note: there is a test using default EclipseState, we allow numActivePhases_ == 0
+    // \Note: to let that test pass.
+    if (numActivePhases_ > 3) {
+         OPM_THROW(std::runtime_error,
+                   fmt::format("Fluidsystem and PhaseUsageInfo supports up to 3 phases, but {} is active\n",
+                               numActivePhases_));
+    }
+
+    has_solvent = phases.active(Phase::SOLVENT);
+    has_polymer = phases.active(Phase::POLYMER);
+    has_energy = phases.active(Phase::ENERGY);
+    has_polymermw = phases.active(Phase::POLYMW);
+    has_foam = phases.active(Phase::FOAM);
+    has_brine = phases.active(Phase::BRINE);
+    has_zFraction = phases.active(Phase::ZFRACTION);
+}
+
+// Explicit template instantiations for commonly used IndexTraits
+template class PhaseUsageInfo<BlackOilDefaultFluidSystemIndices>;
+
+} // namespace Opm

--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -34,6 +34,7 @@
 #endif
 
 #include <array>
+#include <cassert>
 
 namespace Opm
 {
@@ -41,18 +42,11 @@ namespace Opm
 template <class IndexTraits>
 class PhaseUsageInfo {
 public:
-    static constexpr int numPhases = 3;
+    static constexpr int numPhases = IndexTraits::numPhases;
 
     static constexpr int waterPhaseIdx = IndexTraits::waterPhaseIdx;
     static constexpr int oilPhaseIdx = IndexTraits::oilPhaseIdx;
     static constexpr int gasPhaseIdx = IndexTraits::gasPhaseIdx;
-
-    //! Index of the oil component
-    static constexpr int oilCompIdx = IndexTraits::oilCompIdx;
-    //! Index of the water component
-    static constexpr int waterCompIdx = IndexTraits::waterCompIdx;
-    //! Index of the gas component
-    static constexpr int gasCompIdx = IndexTraits::gasCompIdx;
 
     explicit PhaseUsageInfo(const Phases& phases) {
         initFromPhases(phases);

--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -160,12 +160,12 @@ private:
             ++numActivePhases_;
         }
 
-        // we only support one, two or three phases
-        if (numActivePhases_ < 1 || numActivePhases_ > 3) {
-            OPM_THROW(std::runtime_error,
-                      fmt::format("Fluidsystem and PhaseUsageInfo supports 1-3 phases, but {} is active\n",
-                                  numActivePhases_));
-        }
+        // // we only support one, two or three phases
+        // if (numActivePhases_ < 1 || numActivePhases_ > 3) {
+        //     OPM_THROW(std::runtime_error,
+        //               fmt::format("Fluidsystem and PhaseUsageInfo supports 1-3 phases, but {} is active\n",
+        //                           numActivePhases_));
+        // }
 
         has_solvent = phases.active(Phase::SOLVENT);
         has_polymer = phases.active(Phase::POLYMER);

--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -128,6 +128,8 @@ private:
     //  updating the mapping between active and canonical phase indices
     void updateIndexMapping_();
 
+    void reset_();
+
 };
 
 }

--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -39,7 +39,7 @@
 namespace Opm
 {
 
-template <class IndexTraits>
+template <typename IndexTraits>
 class PhaseUsageInfo {
 public:
     static constexpr int numPhases = IndexTraits::numPhases;
@@ -48,13 +48,7 @@ public:
     static constexpr int oilPhaseIdx = IndexTraits::oilPhaseIdx;
     static constexpr int gasPhaseIdx = IndexTraits::gasPhaseIdx;
 
-    explicit PhaseUsageInfo(const Phases& phases) {
-        initFromPhases(phases);
-    }
-
-    PhaseUsageInfo() = default;
-
-    void setNumActivePhases(unsigned numActivePhases);
+    PhaseUsageInfo();
 
     [[nodiscard]] unsigned numActivePhases() const {
         return numActivePhases_;
@@ -64,10 +58,6 @@ public:
         assert(phaseIdx < numPhases);
         return phaseIsActive_[phaseIdx];
     }
-
-    void initBegin();
-
-    void initEnd();
 
     [[nodiscard]] short canonicalToActivePhaseIdx(unsigned phaseIdx) const {
         assert(phaseIdx<numPhases);
@@ -79,6 +69,8 @@ public:
         assert(activePhaseIdx< numActivePhases_);
         return activeToCanonicalPhaseIdx_[activePhaseIdx];
     }
+
+    void initFromPhases(const Phases& phases);
 
 #if HAVE_ECL_INPUT
     void initFromState(const EclipseState& eclState);
@@ -122,9 +114,9 @@ public:
 
 private:
     unsigned char numActivePhases_ = 0;
-    std::array<bool, numPhases> phaseIsActive_ {{false, false, false}};
-    std::array<short, numPhases> activeToCanonicalPhaseIdx_ {{0, 1, 2}};
-    std::array<short, numPhases> canonicalToActivePhaseIdx_ {{0, 1, 2}};
+    std::array<bool, numPhases> phaseIsActive_;
+    std::array<short, numPhases> activeToCanonicalPhaseIdx_;
+    std::array<short, numPhases> canonicalToActivePhaseIdx_;
 
     bool has_solvent{};
     bool has_polymer{};
@@ -137,7 +129,9 @@ private:
     bool has_micp{};
     bool has_co2_or_h2store{};
 
-    void initFromPhases(const Phases& phases);
+    //  updating the mapping between active and canonical phase indices
+    void updateIndexMapping_();
+
 };
 
 }

--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -1,5 +1,32 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
 #ifndef OPM_PHASEUSAGEINFO_HPP
 #define OPM_PHASEUSAGEINFO_HPP
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
 
 #if HAVE_ECL_INPUT
 #include <opm/common/ErrorMacros.hpp>
@@ -7,8 +34,6 @@
 #endif
 
 #include <array>
-
-#include <fmt/format.h>
 
 namespace Opm
 {
@@ -35,11 +60,7 @@ public:
 
     PhaseUsageInfo() = default;
 
-    void setNumActivePhases(unsigned numActivePhases) {
-        assert(numActivePhases <= numPhases);
-        numActivePhases_ = numActivePhases;
-        // TODO: it is not complete
-    }
+    void setNumActivePhases(unsigned numActivePhases);
 
     [[nodiscard]] unsigned numActivePhases() const {
         return numActivePhases_;
@@ -50,21 +71,9 @@ public:
         return phaseIsActive_[phaseIdx];
     }
 
-    void initBegin() {
-        numActivePhases_ = numPhases;
-        std::fill_n(&phaseIsActive_[0], numPhases, true);
-    }
+    void initBegin();
 
-    void initEnd() {
-        int activePhaseIdx = 0;
-        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            if(phaseIsActive_[phaseIdx]){
-                this->canonicalToActivePhaseIdx_[phaseIdx] = activePhaseIdx;
-                this->activeToCanonicalPhaseIdx_[activePhaseIdx] = phaseIdx;
-                activePhaseIdx++;
-            }
-        }
-    }
+    void initEnd();
 
     [[nodiscard]] short canonicalToActivePhaseIdx(unsigned phaseIdx) const {
         assert(phaseIdx<numPhases);
@@ -78,15 +87,7 @@ public:
     }
 
 #if HAVE_ECL_INPUT
-    void initFromState(const EclipseState& eclState)
-    {
-        const auto& phases = eclState.runspec().phases();
-        initFromPhases(phases);
-
-        has_micp = eclState.runspec().micp();
-        has_co2_or_h2store = eclState.runspec().co2Storage() || eclState.runspec().h2Storage();
-//        initEnd();
-    }
+    void initFromState(const EclipseState& eclState);
 #endif
 
     bool hasSolvent() const noexcept {
@@ -142,40 +143,7 @@ private:
     bool has_micp{};
     bool has_co2_or_h2store{};
 
-    void initFromPhases(const Phases& phases) {
-        //       initBegin();
-        numActivePhases_ = 0;
-        std::fill_n(&phaseIsActive_[0], numPhases, false);
-
-        if (phases.active(Phase::OIL)) {
-            phaseIsActive_[oilPhaseIdx] = true;
-            ++numActivePhases_;
-        }
-        if (phases.active(Phase::GAS)) {
-            phaseIsActive_[gasPhaseIdx] = true;
-            ++numActivePhases_;
-        }
-        if (phases.active(Phase::WATER)) {
-            phaseIsActive_[waterPhaseIdx] = true;
-            ++numActivePhases_;
-        }
-
-        // // we only support one, two or three phases
-        // if (numActivePhases_ < 1 || numActivePhases_ > 3) {
-        //     OPM_THROW(std::runtime_error,
-        //               fmt::format("Fluidsystem and PhaseUsageInfo supports 1-3 phases, but {} is active\n",
-        //                           numActivePhases_));
-        // }
-
-        has_solvent = phases.active(Phase::SOLVENT);
-        has_polymer = phases.active(Phase::POLYMER);
-        has_energy = phases.active(Phase::ENERGY);
-        has_polymermw = phases.active(Phase::POLYMW);
-        has_foam = phases.active(Phase::FOAM);
-        has_brine = phases.active(Phase::BRINE);
-        has_zFraction = phases.active(Phase::ZFRACTION);
-    }
-
+    void initFromPhases(const Phases& phases);
 };
 
 }

--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -1,0 +1,168 @@
+#ifndef OPM_PHASEUSAGEINFO_HPP
+#define OPM_PHASEUSAGEINFO_HPP
+
+#if HAVE_ECL_INPUT
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#endif
+
+#include <array>
+
+#include <fmt/format.h>
+
+namespace Opm
+{
+
+template <class IndexTraits>
+class PhaseUsageInfo {
+public:
+    static constexpr int numPhases = 3;
+
+    static constexpr int waterPhaseIdx = IndexTraits::waterPhaseIdx;
+    static constexpr int oilPhaseIdx = IndexTraits::oilPhaseIdx;
+    static constexpr int gasPhaseIdx = IndexTraits::gasPhaseIdx;
+
+    //! Index of the oil component
+    static constexpr int oilCompIdx = IndexTraits::oilCompIdx;
+    //! Index of the water component
+    static constexpr int waterCompIdx = IndexTraits::waterCompIdx;
+    //! Index of the gas component
+    static constexpr int gasCompIdx = IndexTraits::gasCompIdx;
+
+    [[nodiscard]] unsigned numActivePhases() const {
+        return numActivePhases_;
+    }
+
+    [[nodiscard]] bool phaseIsActive(unsigned phaseIdx) const {
+        assert(phaseIdx < numPhases);
+        return phaseIsActive_[phaseIdx];
+    }
+
+    void initBegin() {
+        numActivePhases_ = numPhases;
+        std::fill_n(&phaseIsActive_[0], numPhases, true);
+    }
+
+    void initEnd() {
+        int activePhaseIdx = 0;
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            if(phaseIsActive_[phaseIdx]){
+                this->canonicalToActivePhaseIdx_[phaseIdx] = activePhaseIdx;
+                this->activeToCanonicalPhaseIdx_[activePhaseIdx] = phaseIdx;
+                activePhaseIdx++;
+            }
+        }
+    }
+
+    [[nodiscard]] short canonicalToActivePhaseIdx(unsigned phaseIdx) const {
+        assert(phaseIdx<numPhases);
+        if (!phaseIsActive(phaseIdx)) return -1;  // old phase_used return -1
+        return canonicalToActivePhaseIdx_[phaseIdx];
+    }
+
+    [[nodiscard]] short activeToCanonicalPhaseIdx(unsigned activePhaseIdx) const {
+        assert(activePhaseIdx< numActivePhases_);
+        return activeToCanonicalPhaseIdx_[activePhaseIdx];
+    }
+
+#if HAVE_ECL_INPUT
+    void initFromState(const EclipseState& eclState)
+    {
+        // TODO: check some existing code, whether it is necessary and sensible
+ //       initBegin();
+        numActivePhases_ = 0;
+        std::fill_n(&phaseIsActive_[0], numPhases, false);
+
+        if (eclState.runspec().phases().active(Phase::OIL)) {
+            phaseIsActive_[oilPhaseIdx] = true;
+            ++numActivePhases_;
+        }
+        if (eclState.runspec().phases().active(Phase::GAS)) {
+            phaseIsActive_[gasPhaseIdx] = true;
+            ++numActivePhases_;
+        }
+        if (eclState.runspec().phases().active(Phase::WATER)) {
+            phaseIsActive_[waterPhaseIdx] = true;
+            ++numActivePhases_;
+        }
+
+        // we only support one, two or three phases
+        if (numActivePhases_ < 1 || numActivePhases_ > 3) {
+            OPM_THROW(std::runtime_error,
+                      fmt::format("Fluidsystem and PhaseUsageInfo supports 1-3 phases, but {} is active\n",
+                                  numActivePhases_));
+        }
+
+        const auto& phases = eclState.runspec().phases();
+
+        has_solvent = phases.active(Phase::SOLVENT);
+        has_polymer = phases.active(Phase::POLYMER);
+        has_energy = phases.active(Phase::ENERGY);
+        has_polymermw = phases.active(Phase::POLYMW);
+        has_foam = phases.active(Phase::FOAM);
+        has_brine = phases.active(Phase::BRINE);
+        has_zFraction = phases.active(Phase::ZFRACTION);
+
+        has_micp = eclState.runspec().micp();
+        has_co2_or_h2store = eclState.runspec().co2Storage() || eclState.runspec().h2Storage();
+//        initEnd();
+    }
+#endif
+
+    bool hasSolvent() const noexcept {
+        return has_solvent;
+    }
+
+    bool hasPolymer() const noexcept {
+        return has_polymer;
+    }
+
+    bool hasEnergy() const noexcept {
+        return has_energy;
+    }
+
+    bool hasPolymerMW() const noexcept {
+        return has_polymermw;
+    }
+
+    bool hasFoam() const noexcept {
+        return has_foam;
+    }
+
+    bool hasBrine() const noexcept {
+        return has_brine;
+    }
+
+    bool hasZFraction() const noexcept {
+       return has_zFraction;
+    }
+
+    bool hasMICP() const noexcept {
+        return has_micp;
+    }
+
+    bool hasCO2orH2Store() const noexcept {
+        return has_co2_or_h2store;
+    }
+
+private:
+    unsigned char numActivePhases_ = 0;
+    std::array<bool, numPhases> phaseIsActive_ {{false, false, false}};
+    std::array<short, numPhases> activeToCanonicalPhaseIdx_ {{0, 1, 2}};
+    std::array<short, numPhases> canonicalToActivePhaseIdx_ {{0, 1, 2}};
+
+    bool has_solvent{};
+    bool has_polymer{};
+    bool has_energy{};
+    // polymer molecular weight
+    bool has_polymermw{};
+    bool has_foam{};
+    bool has_brine{};
+    bool has_zFraction{};
+    bool has_micp{};
+    bool has_co2_or_h2store{};
+};
+
+}
+
+#endif

--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -24,10 +24,6 @@
 #ifndef OPM_PHASEUSAGEINFO_HPP
 #define OPM_PHASEUSAGEINFO_HPP
 
-#if HAVE_CONFIG_H
-#include "config.h"
-#endif // HAVE_CONFIG_H
-
 #if HAVE_ECL_INPUT
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>

--- a/tests/test_PhaseUsageInfo.cpp
+++ b/tests/test_PhaseUsageInfo.cpp
@@ -1,0 +1,144 @@
+#define BOOST_TEST_MODULE PhaseUsageInfoTest
+#include <boost/test/included/unit_test.hpp>
+
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+OPM is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+            the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    OPM is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief This is a simple test that illustrates how to use the Opm:PhaseUsageInfo class.
+ */
+#include "config.h"
+
+#if HAVE_ECL_INPUT
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#endif
+
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+#include <opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp>
+#include <opm/material/fluidsystems/PhaseUsageInfo.hpp>
+
+namespace Opm
+{
+
+BOOST_AUTO_TEST_CASE(default_constructor)
+{
+    using PhaseUsage = PhaseUsageInfo<BlackOilDefaultFluidSystemIndices>;
+    PhaseUsage pu;
+    BOOST_CHECK(pu.numActivePhases() == 0);
+    for (unsigned i = 0; i < PhaseUsage::numPhases; ++i) {
+        BOOST_CHECK(!pu.phaseIsActive(i));
+        BOOST_CHECK(pu.canonicalToActivePhaseIdx(i) == -1);
+    }
+    BOOST_CHECK(!pu.hasSolvent());
+    BOOST_CHECK(!pu.hasPolymer());
+    BOOST_CHECK(!pu.hasEnergy());
+    BOOST_CHECK(!pu.hasPolymerMW());
+    BOOST_CHECK(!pu.hasFoam());
+    BOOST_CHECK(!pu.hasBrine());
+    BOOST_CHECK(!pu.hasZFraction());
+    BOOST_CHECK(!pu.hasMICP());
+    BOOST_CHECK(!pu.hasCO2orH2Store());
+
+    BOOST_TEST_MESSAGE("Default constructor test passed.");
+}
+
+BOOST_AUTO_TEST_CASE(constructor_with_phases)
+{
+    // water and oil active, gas inactive
+    const Phases phases {/*oil*/ true,
+        /*gas*/ false,
+        /*water*/ true,
+        /*solvent*/ false,
+        /*polymer*/ true,
+        /*energy*/ false,
+        /*polymw*/ false,
+        /*foam*/ false,
+        /*brine*/ true,
+        /*zfraction*/ false};
+
+    using PhaseUsage = PhaseUsageInfo<BlackOilDefaultFluidSystemIndices>;
+    PhaseUsage pu;
+    pu.initFromPhases(phases);
+    BOOST_CHECK(pu.numActivePhases() == 2);
+    BOOST_CHECK(pu.phaseIsActive(PhaseUsage::waterPhaseIdx));
+    BOOST_CHECK(pu.phaseIsActive(PhaseUsage::oilPhaseIdx));
+    BOOST_CHECK(!pu.phaseIsActive(PhaseUsage::gasPhaseIdx));
+
+    BOOST_CHECK(!pu.hasSolvent());
+    BOOST_CHECK(pu.hasPolymer());
+    BOOST_CHECK(!pu.hasEnergy());
+    BOOST_CHECK(!pu.hasPolymerMW());
+    BOOST_CHECK(!pu.hasFoam());
+    BOOST_CHECK(pu.hasBrine());
+    BOOST_CHECK(!pu.hasZFraction());
+    BOOST_CHECK(!pu.hasMICP());
+    BOOST_CHECK(!pu.hasCO2orH2Store());
+
+    BOOST_CHECK(pu.canonicalToActivePhaseIdx(PhaseUsage::waterPhaseIdx) == 0);
+    BOOST_CHECK(pu.canonicalToActivePhaseIdx(PhaseUsage::oilPhaseIdx) == 1);
+    BOOST_CHECK(pu.canonicalToActivePhaseIdx(PhaseUsage::gasPhaseIdx) == -1);
+
+    BOOST_CHECK(pu.activeToCanonicalPhaseIdx(0) == PhaseUsage::waterPhaseIdx);
+    BOOST_CHECK(pu.activeToCanonicalPhaseIdx(1) == PhaseUsage::oilPhaseIdx);
+
+    BOOST_TEST_MESSAGE("Constructor with phases test passed.");
+}
+
+
+#if HAVE_ECL_INPUT
+BOOST_AUTO_TEST_CASE(constructor_with_datafile)
+{
+    const std::string data_file {"equil_co2store_go.DATA"};
+    const EclipseState ecl_state {Parser{}.parseFile(data_file)};
+    using PhaseUsage = PhaseUsageInfo<BlackOilDefaultFluidSystemIndices>;
+
+    PhaseUsage pu;
+    pu.initFromState(ecl_state);
+
+    BOOST_CHECK(pu.numActivePhases() == 2);
+    BOOST_CHECK(!pu.phaseIsActive(PhaseUsage::waterPhaseIdx));
+    BOOST_CHECK(pu.phaseIsActive(PhaseUsage::oilPhaseIdx));
+    BOOST_CHECK(pu.phaseIsActive(PhaseUsage::gasPhaseIdx));
+
+    BOOST_CHECK(!pu.hasSolvent());
+    BOOST_CHECK(!pu.hasPolymer());
+    BOOST_CHECK(!pu.hasEnergy());
+    BOOST_CHECK(!pu.hasPolymerMW());
+    BOOST_CHECK(!pu.hasFoam());
+    BOOST_CHECK(!pu.hasBrine());
+    BOOST_CHECK(!pu.hasZFraction());
+    BOOST_CHECK(!pu.hasMICP());
+
+    BOOST_CHECK(pu.hasCO2orH2Store());
+
+    BOOST_CHECK(pu.canonicalToActivePhaseIdx(PhaseUsage::waterPhaseIdx) == -1);
+    BOOST_CHECK(pu.canonicalToActivePhaseIdx(PhaseUsage::oilPhaseIdx) == 0);
+    BOOST_CHECK(pu.canonicalToActivePhaseIdx(PhaseUsage::gasPhaseIdx) == 1);
+
+    BOOST_CHECK(pu.activeToCanonicalPhaseIdx(0) == PhaseUsage::oilPhaseIdx);
+    BOOST_CHECK(pu.activeToCanonicalPhaseIdx(1) == PhaseUsage::gasPhaseIdx);
+}
+#endif
+}

--- a/tests/test_PhaseUsageInfo.cpp
+++ b/tests/test_PhaseUsageInfo.cpp
@@ -1,33 +1,29 @@
-#define BOOST_TEST_MODULE PhaseUsageInfoTest
-#include <boost/test/included/unit_test.hpp>
-
-// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
-// vi: set et ts=4 sw=4 sts=4:
 /*
+  Copyright 2025 Equinor ASA.
+
   This file is part of the Open Porous Media project (OPM).
 
-OPM is free software: you can redistribute it and/or modify
-        it under the terms of the GNU General Public License as published by
-            the Free Software Foundation, either version 2 of the License, or
-    (at your option) any later version.
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-    OPM is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-
-  Consult the COPYING file in the top-level source directory of this
-  module for the precise wording of the license and the list of
-  copyright holders.
 */
 /*!
  * \file
  *
  * \brief This is a simple test that illustrates how to use the Opm:PhaseUsageInfo class.
  */
+
+#define BOOST_TEST_MODULE PhaseUsageInfoTest
+#include <boost/test/included/unit_test.hpp>
 #include "config.h"
 
 #if HAVE_ECL_INPUT
@@ -110,8 +106,37 @@ BOOST_AUTO_TEST_CASE(constructor_with_phases)
 #if HAVE_ECL_INPUT
 BOOST_AUTO_TEST_CASE(constructor_with_datafile)
 {
-    const std::string data_file {"equil_co2store_go.DATA"};
-    const EclipseState ecl_state {Parser{}.parseFile(data_file)};
+    const std::string deck_input = R"(
+RUNSPEC   ==
+
+OIL
+GAS
+CO2STORE
+
+DIMENS
+1 1 20
+/
+
+GRID ==
+
+DXV
+1.0
+/
+
+DYV
+1.0
+/
+
+DZV
+20*5.0
+/
+
+TOPS
+0.0
+/
+END
+)";
+    const EclipseState ecl_state {Parser{}.parseString(deck_input)};
     using PhaseUsage = PhaseUsageInfo<BlackOilDefaultFluidSystemIndices>;
 
     PhaseUsage pu;


### PR DESCRIPTION
Introducing PhaseUageInfo (named can be changed) which can be used in FluidSystem or passed around for the classes that do not have FluidSystem accessible. Purpose is to remove the usage of `PhaseUsage` and avoid to have a separate phase Index from it. 