### PR TITLE
Revamp Implementation Files for Opm::Group

### DIFF
--- a/opm/input/eclipse/EclipseState/Util/IOrderSet.hpp
+++ b/opm/input/eclipse/EclipseState/Util/IOrderSet.hpp
@@ -57,10 +57,22 @@ private:
 
 public:
     IOrderSet() = default;
-    IOrderSet(const index_type& index, const storage_type& data)
-        : m_index(index)
-        , m_data(data)
-   {}
+
+    /// Constructor.
+    ///
+    /// Populates container with an initial set of elements.
+    ///
+    /// \param[in] data Ordered view of element collection.
+    explicit IOrderSet(const std::vector<T>& data)
+        : m_index { data.begin(), data.end() }
+        , m_data  { data }
+    {
+        if (this->m_data.size() != this->m_index.size()) {
+            throw std::invalid_argument {
+                "Initial sequence has duplicate elements"
+            };
+        }
+    }
 
     std::size_t size() const {
         return this->m_index.size();

--- a/opm/input/eclipse/Schedule/Group/Group.cpp
+++ b/opm/input/eclipse/Schedule/Group/Group.cpp
@@ -92,17 +92,21 @@ namespace {
     {
         injection.injection_controls = 0;
 
-        if (active.rate)
-            injection.injection_controls += static_cast<int>(Opm::Group::InjectionCMode::RATE);
+        if (active.rate) {
+            injection.injection_controls |= static_cast<int>(Opm::Group::InjectionCMode::RATE);
+        }
 
-        if (active.resv)
-            injection.injection_controls += static_cast<int>(Opm::Group::InjectionCMode::RESV);
+        if (active.resv) {
+            injection.injection_controls |= static_cast<int>(Opm::Group::InjectionCMode::RESV);
+        }
 
-        if (active.rein)
-            injection.injection_controls += static_cast<int>(Opm::Group::InjectionCMode::REIN);
+        if (active.rein) {
+            injection.injection_controls |= static_cast<int>(Opm::Group::InjectionCMode::REIN);
+        }
 
-        if (active.vrep)
-            injection.injection_controls += static_cast<int>(Opm::Group::InjectionCMode::VREP);
+        if (active.vrep) {
+            injection.injection_controls |= static_cast<int>(Opm::Group::InjectionCMode::VREP);
+        }
     }
 
     bool has_active(const ProductionLimits& limits)
@@ -127,10 +131,12 @@ namespace {
     {
         auto production = Opm::Group::GroupProductionProperties { unit_system, rst_group.name };
 
-        auto update_if_defined = [](Opm::UDAValue& target, const double value) {
-                if (is_defined(value))
-                    target.update(value);
-            };
+        auto update_if_defined = [](Opm::UDAValue& target, const double value)
+        {
+            if (is_defined(value)) {
+                target.update(value);
+            }
+        };
 
         update_if_defined(production.oil_target, rst_group.oil_rate_limit);
         update_if_defined(production.gas_target, rst_group.gas_rate_limit);
@@ -139,6 +145,7 @@ namespace {
         update_if_defined(production.resv_target, rst_group.resv_rate_limit);
 
         production.cmode = Opm::Group::ProductionCModeFromInt(rst_group.prod_cmode);
+
         production.group_limit_action.allRates = Opm::Group::ExceedActionFromInt(rst_group.exceed_action);
         // For now, we do not know where the other actions are stored in IGRP, so we set them all
         // to the allRates value.
@@ -150,17 +157,21 @@ namespace {
 
         production.production_controls = 0;
 
-        if (active.oil)
-            production.production_controls += static_cast<int>(Opm::Group::ProductionCMode::ORAT);
+        if (active.oil) {
+            production.production_controls |= static_cast<int>(Opm::Group::ProductionCMode::ORAT);
+        }
 
-        if (active.gas)
-            production.production_controls += static_cast<int>(Opm::Group::ProductionCMode::GRAT);
+        if (active.gas) {
+            production.production_controls |= static_cast<int>(Opm::Group::ProductionCMode::GRAT);
+        }
 
-        if (active.wat)
-            production.production_controls += static_cast<int>(Opm::Group::ProductionCMode::WRAT);
+        if (active.wat) {
+            production.production_controls |= static_cast<int>(Opm::Group::ProductionCMode::WRAT);
+        }
 
-        if (active.liq)
-            production.production_controls += static_cast<int>(Opm::Group::ProductionCMode::LRAT);
+        if (active.liq) {
+            production.production_controls |= static_cast<int>(Opm::Group::ProductionCMode::LRAT);
+        }
 
         if (active.resv)
             production.production_controls += static_cast<int>(Opm::Group::ProductionCMode::RESV);
@@ -174,10 +185,12 @@ namespace {
     {
         auto injection = Opm::Group::GroupInjectionProperties { rst_group.name };
 
-        auto update_if_defined = [](Opm::UDAValue& target, const double value) {
-                if (is_defined(value))
-                    target.update(value);
-            };
+        auto update_if_defined = [](Opm::UDAValue& target, const double value)
+        {
+            if (is_defined(value)) {
+                target.update(value);
+            }
+        };
 
         update_if_defined(injection.surface_max_rate, rst_group.gas_surface_limit);
         update_if_defined(injection.resv_max_rate, rst_group.gas_reservoir_limit);
@@ -186,6 +199,7 @@ namespace {
 
         injection.phase = Opm::Phase::GAS;
         injection.cmode = Opm::Group::InjectionCModeFromInt(rst_group.ginj_cmode);
+
         injection.guide_rate_def = Opm::Group::GuideRateInjTargetFromInt(rst_group.inj_gas_guide_rate_def);
         injection.guide_rate = is_defined(rst_group.inj_gas_guide_rate) ? rst_group.inj_gas_guide_rate : 0.0;
 
@@ -200,10 +214,12 @@ namespace {
     {
         auto injection = Opm::Group::GroupInjectionProperties { rst_group.name };
 
-        auto update_if_defined = [](Opm::UDAValue& target, const double value) {
-                if (is_defined(value))
-                    target.update(value);
-            };
+        auto update_if_defined = [](Opm::UDAValue& target, const double value)
+        {
+            if (is_defined(value)) {
+                target.update(value);
+            }
+        };
 
         update_if_defined(injection.surface_max_rate, rst_group.water_surface_limit);
         update_if_defined(injection.resv_max_rate, rst_group.water_reservoir_limit);
@@ -212,6 +228,7 @@ namespace {
 
         injection.phase = Opm::Phase::WATER;
         injection.cmode = Opm::Group::InjectionCModeFromInt(rst_group.winj_cmode);
+
         injection.guide_rate_def = Opm::Group::GuideRateInjTargetFromInt(rst_group.inj_water_guide_rate_def);
         injection.guide_rate = is_defined(rst_group.inj_water_guide_rate) ? rst_group.inj_water_guide_rate : 0;
 
@@ -222,36 +239,38 @@ namespace {
 
         return injection;
     }
-}
+} // Anonymous namespace
 
 namespace Opm {
 
 Group::Group()
-    : Group("", 0, 0.0, UnitSystem())
-{
-}
+    : Group { "", 0, 0.0, UnitSystem() }
+{}
 
-
-
-
-
-Group::Group(const std::string& name, std::size_t insert_index_arg, double udq_undefined_arg, const UnitSystem& unit_system_arg) :
-    m_name(name),
-    m_insert_index(insert_index_arg),
-    udq_undefined(udq_undefined_arg),
-    unit_system(unit_system_arg),
-    group_type(GroupType::NONE),
-    gefac(1),
-    use_efficiency_in_network(true),
-    production_properties(unit_system, name)
+Group::Group(const std::string& name,
+             const std::size_t  insert_index_arg,
+             const double       udq_undefined_arg,
+             const UnitSystem&  unit_system_arg)
+    : m_name                   (name)
+    , m_insert_index           (insert_index_arg)
+    , udq_undefined            (udq_undefined_arg)
+    , unit_system              (unit_system_arg)
+    , group_type               (GroupType::NONE)
+    , gefac                    (1)
+    , use_efficiency_in_network(true)
+    , production_properties    (unit_system, name)
 {
     // All groups are initially created as children of the "FIELD" group.
-    if (name != "FIELD")
+    if (name != "FIELD") {
         this->parent_group = "FIELD";
+    }
 }
 
-Group::Group(const RestartIO::RstGroup& rst_group, std::size_t insert_index_arg, double udq_undefined_arg, const UnitSystem& unit_system_arg) :
-    Group(rst_group.name, insert_index_arg, udq_undefined_arg, unit_system_arg)
+Group::Group(const RestartIO::RstGroup& rst_group,
+             const std::size_t          insert_index_arg,
+             const double               udq_undefined_arg,
+             const UnitSystem&          unit_system_arg)
+    : Group { rst_group.name, insert_index_arg, udq_undefined_arg, unit_system_arg }
 {
     this->gefac = rst_group.efficiency_factor;
 
@@ -259,7 +278,7 @@ Group::Group(const RestartIO::RstGroup& rst_group, std::size_t insert_index_arg,
     const auto gas_inj_limits   = GasInjectionLimits  { rst_group };
     const auto water_inj_limits = WaterInjectionLimits{ rst_group };
 
-    if ((rst_group.prod_cmode != 0) || rst_group.exceed_action >0 || has_active(prod_limits)) {
+    if ((rst_group.prod_cmode != 0) || (rst_group.exceed_action > 0) || has_active(prod_limits)) {
         this->updateProduction(make_production_properties(rst_group, prod_limits, unit_system_arg));
     }
 
@@ -272,10 +291,10 @@ Group::Group(const RestartIO::RstGroup& rst_group, std::size_t insert_index_arg,
     }
 }
 
-
 Group Group::serializationTestObject()
 {
-    Group result;
+    Group result{};
+
     result.m_name = "test1";
     result.m_insert_index = 1;
     result.udq_undefined = 3.0;
@@ -284,8 +303,8 @@ Group Group::serializationTestObject()
     result.gefac = 4.0;
     result.use_efficiency_in_network = true;
     result.parent_group = "test2";
-    result.m_wells = {{"test3", "test4"}, {"test5", "test6"}};
-    result.m_groups = {{"test7", "test8"}, {"test9", "test10"}};
+    result.m_wells = IOrderSet { std::vector<std::string> {"test3", "test4"} };
+    result.m_groups = IOrderSet { std::vector<std::string> {"test5", "test6"} };
     result.injection_properties = {{Opm::Phase::OIL, GroupInjectionProperties::serializationTestObject()}};
     result.production_properties = GroupProductionProperties::serializationTestObject();
     result.m_topup_phase = Phase::OIL;
@@ -294,44 +313,54 @@ Group Group::serializationTestObject()
     return result;
 }
 
-std::size_t Group::insert_index() const {
+std::size_t Group::insert_index() const
+{
     return this->m_insert_index;
 }
 
-const std::string& Group::name() const {
+const std::string& Group::name() const
+{
     return this->m_name;
 }
 
-bool Group::is_field() const {
-    return (this->m_name == "FIELD");
+bool Group::is_field() const
+{
+    return this->m_name == "FIELD";
 }
 
-const Group::GroupProductionProperties& Group::productionProperties() const {
+const Group::GroupProductionProperties& Group::productionProperties() const
+{
     return this->production_properties;
 }
 
-const std::map<Phase, Group::GroupInjectionProperties>& Group::injectionProperties() const {
+const std::map<Phase, Group::GroupInjectionProperties>&
+Group::injectionProperties() const
+{
     return this->injection_properties;
 }
 
-const Group::GroupInjectionProperties& Group::injectionProperties(Phase phase) const {
+const Group::GroupInjectionProperties&
+Group::injectionProperties(const Phase phase) const
+{
     return this->injection_properties.at(phase);
 }
 
-namespace {
-namespace detail {
+namespace { namespace detail {
 
-bool has_control(int controls, Group::InjectionCMode cmode) {
-    return ((controls & static_cast<int>(cmode)) != 0);
-}
-
-bool has_control(int controls, Group::ProductionCMode cmode) {
-    return ((controls & static_cast<int>(cmode)) != 0);
-}
-}
+bool has_control(int controls, Group::InjectionCMode cmode)
+{
+    return (controls & static_cast<int>(cmode)) != 0;
 }
 
-bool Group::updateInjection(const GroupInjectionProperties& injection) {
+bool has_control(int controls, Group::ProductionCMode cmode)
+{
+    return (controls & static_cast<int>(cmode)) != 0;
+}
+
+}} // namespace <anonymous>::detail
+
+bool Group::updateInjection(const GroupInjectionProperties& injection)
+{
     bool update = false;
 
     if (!this->hasType(GroupType::INJECTION)) {
@@ -343,7 +372,8 @@ bool Group::updateInjection(const GroupInjectionProperties& injection) {
     if (iter == this->injection_properties.end()) {
         this->injection_properties.insert(std::make_pair(injection.phase, injection));
         update = true;
-    } else {
+    }
+    else {
         if (iter->second != injection) {
             iter->second = injection;
             update = true;
@@ -352,21 +382,27 @@ bool Group::updateInjection(const GroupInjectionProperties& injection) {
 
     if (detail::has_control(injection.injection_controls, Group::InjectionCMode::RESV) ||
         detail::has_control(injection.injection_controls, Group::InjectionCMode::REIN) ||
-        detail::has_control(injection.injection_controls, Group::InjectionCMode::VREP)) {
+        detail::has_control(injection.injection_controls, Group::InjectionCMode::VREP))
+    {
         auto topUp_phase = injection.phase;
         if (topUp_phase != this->m_topup_phase) {
             this->m_topup_phase = topUp_phase;
             update = true;
         }
-    } else {
-        if (this->m_topup_phase.has_value())
+    }
+    else {
+        if (this->m_topup_phase.has_value()) {
             update = true;
+        }
+
         this->m_topup_phase = {};
     }
+
     return update;
 }
 
-bool Group::updateProduction(const GroupProductionProperties& production) {
+bool Group::updateProduction(const GroupProductionProperties& production)
+{
     bool update = false;
 
     if (this->production_properties != production) {
@@ -383,25 +419,28 @@ bool Group::updateProduction(const GroupProductionProperties& production) {
 }
 
 Group::GroupInjectionProperties::GroupInjectionProperties(std::string group_name_arg)
-    : GroupInjectionProperties(std::move(group_name_arg), Phase::WATER, UnitSystem(UnitSystem::UnitType::UNIT_TYPE_METRIC))
+    : GroupInjectionProperties {
+          std::move(group_name_arg), Phase::WATER, UnitSystem(UnitSystem::UnitType::UNIT_TYPE_METRIC)
+      }
 {}
 
 Group::GroupInjectionProperties::GroupInjectionProperties(std::string group_name_arg,
                                                           const Phase phase_arg,
                                                           const UnitSystem& unit_system)
-    : name { std::move(group_name_arg) }
-    , phase { phase_arg }
-    , surface_max_rate { unit_system.getDimension((phase == Phase::WATER)
-                                                  ? UnitSystem::measure::liquid_surface_rate
-                                                  : UnitSystem::measure::gas_surface_rate) }
-    , resv_max_rate { unit_system.getDimension(UnitSystem::measure::rate) }
+    : name                  { std::move(group_name_arg) }
+    , phase                 { phase_arg }
+    , surface_max_rate      { unit_system.getDimension((phase == Phase::WATER)
+                                                       ? UnitSystem::measure::liquid_surface_rate
+                                                       : UnitSystem::measure::gas_surface_rate) }
+    , resv_max_rate         { unit_system.getDimension(UnitSystem::measure::rate) }
     , target_reinj_fraction { unit_system.getDimension(UnitSystem::measure::identity) }
-    , target_void_fraction { unit_system.getDimension(UnitSystem::measure::identity) }
+    , target_void_fraction  { unit_system.getDimension(UnitSystem::measure::identity) }
 {}
 
 Group::GroupInjectionProperties Group::GroupInjectionProperties::serializationTestObject()
 {
     Group::GroupInjectionProperties result{"G"};
+
     result.phase = Phase::OIL;
     result.cmode = InjectionCMode::REIN;
     result.surface_max_rate = UDAValue(1.0);
@@ -417,55 +456,53 @@ Group::GroupInjectionProperties Group::GroupInjectionProperties::serializationTe
     return result;
 }
 
-bool Group::GroupInjectionProperties::operator==(const GroupInjectionProperties& other) const {
-    return
-        this->name                    == other.name &&
-        this->phase                   == other.phase &&
-        this->cmode                   == other.cmode &&
-        this->surface_max_rate        == other.surface_max_rate &&
-        this->resv_max_rate           == other.resv_max_rate &&
-        this->target_reinj_fraction   == other.target_reinj_fraction &&
-        this->injection_controls      == other.injection_controls &&
-        this->target_void_fraction    == other.target_void_fraction &&
-        this->reinj_group             == other.reinj_group &&
-        this->guide_rate              == other.guide_rate &&
-        this->guide_rate_def          == other.guide_rate_def &&
-        this->available_group_control == other.available_group_control &&
-        this->voidage_group           == other.voidage_group;
+bool Group::GroupInjectionProperties::operator==(const GroupInjectionProperties& other) const
+{
+    return (this->name                    == other.name)
+        && (this->phase                   == other.phase)
+        && (this->cmode                   == other.cmode)
+        && (this->surface_max_rate        == other.surface_max_rate)
+        && (this->resv_max_rate           == other.resv_max_rate)
+        && (this->target_reinj_fraction   == other.target_reinj_fraction)
+        && (this->injection_controls      == other.injection_controls)
+        && (this->target_void_fraction    == other.target_void_fraction)
+        && (this->reinj_group             == other.reinj_group)
+        && (this->guide_rate              == other.guide_rate)
+        && (this->guide_rate_def          == other.guide_rate_def)
+        && (this->available_group_control == other.available_group_control)
+        && (this->voidage_group           == other.voidage_group)
+        ;
 }
 
-bool Group::GroupInjectionProperties::operator!=(const GroupInjectionProperties& other) const {
-    return !(*this == other);
+bool Group::GroupInjectionProperties::operator!=(const GroupInjectionProperties& other) const
+{
+    return ! (*this == other);
 }
 
-bool Group::GroupInjectionProperties::updateUDQActive(const UDQConfig& udq_config, UDQActive& active) const {
+bool Group::GroupInjectionProperties::updateUDQActive(const UDQConfig& udq_config, UDQActive& active) const
+{
     int update_count = 0;
 
-    update_count += active.update(udq_config, this->surface_max_rate, this->name, UDAControl::GCONINJE_SURFACE_MAX_RATE);
-    update_count += active.update(udq_config, this->resv_max_rate, this->name, UDAControl::GCONINJE_RESV_MAX_RATE);
+    update_count += active.update(udq_config, this->surface_max_rate,      this->name, UDAControl::GCONINJE_SURFACE_MAX_RATE);
+    update_count += active.update(udq_config, this->resv_max_rate,         this->name, UDAControl::GCONINJE_RESV_MAX_RATE);
     update_count += active.update(udq_config, this->target_reinj_fraction, this->name, UDAControl::GCONINJE_TARGET_REINJ_FRACTION);
-    update_count += active.update(udq_config, this->target_void_fraction, this->name, UDAControl::GCONINJE_TARGET_VOID_FRACTION);
+    update_count += active.update(udq_config, this->target_void_fraction,  this->name, UDAControl::GCONINJE_TARGET_VOID_FRACTION);
 
-    return (update_count > 0);
+    return update_count > 0;
 }
 
-bool Group::GroupInjectionProperties::uda_phase() const {
-    if (this->surface_max_rate.is<std::string>())
-        return true;
-
-    if (this->resv_max_rate.is<std::string>())
-        return true;
-
-    if (this->target_reinj_fraction.is<std::string>())
-        return true;
-
-    if (this->target_void_fraction.is<std::string>())
-        return true;
-
-    return false;
+bool Group::GroupInjectionProperties::uda_phase() const
+{
+    return this->surface_max_rate     .is<std::string>()
+        || this->resv_max_rate        .is<std::string>()
+        || this->target_reinj_fraction.is<std::string>()
+        || this->target_void_fraction .is<std::string>();
 }
 
-void Group::GroupInjectionProperties::update_uda(const UDQConfig& udq_config, UDQActive& udq_active, UDAControl control, const UDAValue& value)
+void Group::GroupInjectionProperties::update_uda(const UDQConfig& udq_config,
+                                                 UDQActive& udq_active,
+                                                 const UDAControl control,
+                                                 const UDAValue& value)
 {
     switch (control) {
     case UDAControl::GCONINJE_SURFACE_MAX_RATE:
@@ -493,24 +530,24 @@ void Group::GroupInjectionProperties::update_uda(const UDQConfig& udq_config, UD
     }
 }
 
-
-Group::GroupProductionProperties::GroupProductionProperties() :
-    GroupProductionProperties(UnitSystem(UnitSystem::UnitType::UNIT_TYPE_METRIC), "")
+Group::GroupProductionProperties::GroupProductionProperties()
+    : GroupProductionProperties { UnitSystem { UnitSystem::UnitType::UNIT_TYPE_METRIC }, "" }
 {}
 
-Group::GroupProductionProperties::GroupProductionProperties(const UnitSystem& unit_system, const std::string& gname) :
-    name(gname),
-    oil_target(unit_system.getDimension(UnitSystem::measure::liquid_surface_rate)),
-    water_target(unit_system.getDimension(UnitSystem::measure::liquid_surface_rate)),
-    gas_target(unit_system.getDimension(UnitSystem::measure::gas_surface_rate)),
-    liquid_target(unit_system.getDimension(UnitSystem::measure::liquid_surface_rate)),
-    resv_target(unit_system.getDimension(UnitSystem::measure::rate))
-{
-}
+Group::GroupProductionProperties::GroupProductionProperties(const UnitSystem&  unit_system,
+                                                            const std::string& gname)
+    : name         (gname)
+    , oil_target   (unit_system.getDimension(UnitSystem::measure::liquid_surface_rate))
+    , water_target (unit_system.getDimension(UnitSystem::measure::liquid_surface_rate))
+    , gas_target   (unit_system.getDimension(UnitSystem::measure::gas_surface_rate))
+    , liquid_target(unit_system.getDimension(UnitSystem::measure::liquid_surface_rate))
+    , resv_target  (unit_system.getDimension(UnitSystem::measure::rate))
+{}
 
 Group::GroupProductionProperties Group::GroupProductionProperties::serializationTestObject()
 {
     Group::GroupProductionProperties result(UnitSystem(UnitSystem::UnitType::UNIT_TYPE_METRIC), "Group123");
+
     result.name = "Group123";
     result.cmode = ProductionCMode::PRBL;
     result.group_limit_action = {ExceedAction::WELL,ExceedAction::WELL,ExceedAction::WELL,ExceedAction::WELL};
@@ -526,36 +563,42 @@ Group::GroupProductionProperties Group::GroupProductionProperties::serialization
     return result;
 }
 
-
-bool Group::GroupProductionProperties::operator==(const GroupProductionProperties& other) const {
-    return
-        this->name                    == other.name &&
-        this->cmode                   == other.cmode &&
-        this->group_limit_action      == other.group_limit_action &&
-        this->oil_target              == other.oil_target &&
-        this->water_target            == other.water_target &&
-        this->gas_target              == other.gas_target &&
-        this->liquid_target           == other.liquid_target &&
-        this->guide_rate              == other.guide_rate &&
-        this->guide_rate_def          == other.guide_rate_def &&
-        this->production_controls     == other.production_controls &&
-        this->available_group_control == other.available_group_control &&
-        this->resv_target             == other.resv_target;
+bool Group::GroupProductionProperties::operator==(const GroupProductionProperties& other) const
+{
+    return (this->name                    == other.name)
+        && (this->cmode                   == other.cmode)
+        && (this->group_limit_action      == other.group_limit_action)
+        && (this->oil_target              == other.oil_target)
+        && (this->water_target            == other.water_target)
+        && (this->gas_target              == other.gas_target)
+        && (this->liquid_target           == other.liquid_target)
+        && (this->guide_rate              == other.guide_rate)
+        && (this->guide_rate_def          == other.guide_rate_def)
+        && (this->production_controls     == other.production_controls)
+        && (this->available_group_control == other.available_group_control)
+        && (this->resv_target             == other.resv_target)
+        ;
 }
 
-bool Group::GroupProductionProperties::updateUDQActive(const UDQConfig& udq_config, UDQActive& active) const {
+bool Group::GroupProductionProperties::updateUDQActive(const UDQConfig& udq_config,
+                                                       UDQActive& active) const
+{
     int update_count = 0;
 
-    update_count += active.update(udq_config, this->oil_target, this->name, UDAControl::GCONPROD_OIL_TARGET);
-    update_count += active.update(udq_config, this->water_target, this->name, UDAControl::GCONPROD_WATER_TARGET);
-    update_count += active.update(udq_config, this->gas_target, this->name, UDAControl::GCONPROD_GAS_TARGET);
+    update_count += active.update(udq_config, this->oil_target,    this->name, UDAControl::GCONPROD_OIL_TARGET);
+    update_count += active.update(udq_config, this->water_target,  this->name, UDAControl::GCONPROD_WATER_TARGET);
+    update_count += active.update(udq_config, this->gas_target,    this->name, UDAControl::GCONPROD_GAS_TARGET);
     update_count += active.update(udq_config, this->liquid_target, this->name, UDAControl::GCONPROD_LIQUID_TARGET);
-    update_count += active.update(udq_config, this->resv_target, this->name, UDAControl::GCONPROD_RESV_TARGET);
+    update_count += active.update(udq_config, this->resv_target,   this->name, UDAControl::GCONPROD_RESV_TARGET);
 
-    return (update_count > 0);
+    return update_count > 0;
 }
 
-void Group::GroupProductionProperties::update_uda(const UDQConfig& udq_config, UDQActive& udq_active, UDAControl control, const UDAValue& value) {
+void Group::GroupProductionProperties::update_uda(const UDQConfig& udq_config,
+                                                  UDQActive& udq_active,
+                                                  const UDAControl control,
+                                                  const UDAValue& value)
+{
     switch (control) {
     case UDAControl::GCONPROD_OIL_TARGET:
         this->oil_target = value;
@@ -587,141 +630,150 @@ void Group::GroupProductionProperties::update_uda(const UDQConfig& udq_config, U
     }
 }
 
-
-bool Group::productionGroupControlAvailable() const {
-    if (this->m_name == "FIELD")
-        return false;
-    return this->production_properties.available_group_control;
+bool Group::productionGroupControlAvailable() const
+{
+    return (this->m_name != "FIELD")
+        && this->production_properties.available_group_control;
 }
 
-bool Group::injectionGroupControlAvailable(const Phase phase) const {
-    if (this->m_name == "FIELD")
+bool Group::injectionGroupControlAvailable(const Phase phase) const
+{
+    if (this->m_name == "FIELD") {
         return false;
+    }
 
     auto inj_iter = this->injection_properties.find(phase);
-    if (inj_iter == this->injection_properties.end())
-        return true;
 
-    return inj_iter->second.available_group_control;
+    return inj_iter == this->injection_properties.end()
+        || inj_iter->second.available_group_control;
 }
 
-bool Group::GroupProductionProperties::operator!=(const GroupProductionProperties& other) const {
-    return !(*this == other);
+bool Group::GroupProductionProperties::operator!=(const GroupProductionProperties& other) const
+{
+    return ! (*this == other);
 }
 
-
-
-bool Group::hasType(GroupType gtype) const {
-    return ((this->group_type & gtype) == gtype);
+bool Group::hasType(const GroupType gtype) const
+{
+    return (this->group_type & gtype) == gtype;
 }
 
-void Group::addType(GroupType new_gtype) {
+void Group::addType(const GroupType new_gtype)
+{
     this->group_type = this->group_type | new_gtype;
 }
 
-const Group::GroupType& Group::getGroupType() const {
-    return this-> group_type;
+const Group::GroupType& Group::getGroupType() const
+{
+    return this->group_type;
 }
 
-bool Group::isProductionGroup() const {
-    if (this->hasType(GroupType::PRODUCTION))
-        return true;
-
-    if (!this->m_gpmaint.has_value())
-        return false;
-
-    auto gpmaint_control = this->m_gpmaint->flow_target();
-    return (gpmaint_control == GPMaint::FlowTarget::RESV_PROD);
+bool Group::isProductionGroup() const
+{
+    return this->hasType(GroupType::PRODUCTION)
+        || (this->m_gpmaint.has_value() &&
+            this->m_gpmaint->flow_target() == GPMaint::FlowTarget::RESV_PROD);
 }
 
-bool Group::isInjectionGroup() const {
-    if (this->hasType(GroupType::INJECTION))
-        return true;
-
-    if (!this->m_gpmaint.has_value())
-        return false;
-
-    auto gpmaint_control = this->m_gpmaint->flow_target();
-    if (gpmaint_control == GPMaint::FlowTarget::RESV_PROD)
-        return false;
-
-    return true;
+bool Group::isInjectionGroup() const
+{
+    return this->hasType(GroupType::INJECTION)
+        || (this->m_gpmaint.has_value() &&
+            this->m_gpmaint->flow_target() != GPMaint::FlowTarget::RESV_PROD);
 }
 
-void Group::setProductionGroup() {
+void Group::setProductionGroup()
+{
     this->addType(GroupType::PRODUCTION);
 }
 
-void Group::setInjectionGroup() {
+void Group::setInjectionGroup()
+{
     this->addType(GroupType::INJECTION);
 }
 
-
-std::size_t Group::numWells() const {
+std::size_t Group::numWells() const
+{
     return this->m_wells.size();
 }
 
-const std::vector<std::string>& Group::wells() const {
+const std::vector<std::string>& Group::wells() const
+{
     return this->m_wells.data();
 }
 
-const std::vector<std::string>& Group::groups() const {
+const std::vector<std::string>& Group::groups() const
+{
     return this->m_groups.data();
 }
 
-bool Group::wellgroup() const {
-    if (this->m_groups.size() > 0)
-        return false;
-    return true;
+bool Group::wellgroup() const
+{
+    return this->m_groups.empty();
 }
 
-bool Group::addWell(const std::string& well_name) {
-    if (!this->m_groups.empty())
-        throw std::runtime_error("Groups can not mix group and well children. Trying to add well: " + well_name + " to group: " + this->name());
-
-    if (this->m_wells.count(well_name) == 0) {
-        this->m_wells.insert(well_name);
-        return true;
+bool Group::addWell(const std::string& well_name)
+{
+    if (! this->wellgroup()) {
+        throw std::runtime_error {
+            fmt::format("Groups cannot mix group and well "
+                        "children. Trying to add well {} "
+                        "to group {}", well_name, this->name())
+        };
     }
-    return false;
+
+    return this->m_wells.insert(well_name);
 }
 
-bool Group::hasWell(const std::string& well_name) const  {
-    return (this->m_wells.count(well_name) == 1);
+bool Group::hasWell(const std::string& well_name) const
+{
+    return this->m_wells.contains(well_name);
 }
 
-void Group::delWell(const std::string& well_name) {
-    auto rm_count = this->m_wells.erase(well_name);
-    if (rm_count == 0)
-        throw std::invalid_argument("Group: " + this->name() + " does not have well: " + well_name);
-}
+void Group::delWell(const std::string& well_name)
+{
+    const auto rm_count = this->m_wells.erase(well_name);
 
-bool Group::addGroup(const std::string& group_name) {
-    if (!this->m_wells.empty())
-        throw std::runtime_error("Groups can not mix group and well children. Trying to add group: " + group_name + " to group: " + this->name());
-
-    if (this->m_groups.count(group_name) == 0) {
-        this->m_groups.insert(group_name);
-        return true;
+    if (rm_count == 0) {
+        throw std::invalid_argument {
+            "Group: " + this->name() + " does not have well: " + well_name
+        };
     }
-    return false;
 }
 
-bool Group::hasGroup(const std::string& group_name) const  {
-    return (this->m_groups.count(group_name) == 1);
+bool Group::addGroup(const std::string& group_name)
+{
+    if (!this->m_wells.empty()) {
+        throw std::runtime_error {
+            "Groups can not mix group and well children. "
+            "Trying to add group: " + group_name + " to group: " + this->name()
+        };
+    }
+
+    return this->m_groups.insert(group_name);
 }
 
-void Group::delGroup(const std::string& group_name) {
+bool Group::hasGroup(const std::string& group_name) const
+{
+    return this->m_groups.contains(group_name);
+}
+
+void Group::delGroup(const std::string& group_name)
+{
     auto rm_count = this->m_groups.erase(group_name);
-    if (rm_count == 0)
+
+    if (rm_count == 0) {
         throw std::invalid_argument {
             fmt::format("Group '{}' is not a parent of group: {}",
                         this->name(), group_name)
         };
+    }
 }
 
-bool Group::update_gefac(double gf, bool use_efficiency_in_network_arg) {
+bool Group::update_gefac(const double gf, const bool use_efficiency_in_network_arg)
+{
     bool update = false;
+
     if (this->gefac != gf) {
         this->gefac = gf;
         update = true;
@@ -735,43 +787,46 @@ bool Group::update_gefac(double gf, bool use_efficiency_in_network_arg) {
     return update;
 }
 
-double Group::getGroupEfficiencyFactor(bool network) const {
-    if (network && !(this->use_efficiency_in_network)) {
+double Group::getGroupEfficiencyFactor(const bool network) const
+{
+    if (network && !this->use_efficiency_in_network) {
         return 1.0;
     }
 
     return this->gefac;
 }
 
-bool Group::useEfficiencyInNetwork() const {
+bool Group::useEfficiencyInNetwork() const
+{
     return this->use_efficiency_in_network;
 }
 
-const std::string& Group::parent() const {
+const std::string& Group::parent() const
+{
     return this->parent_group;
 }
 
-std::optional<std::string> Group::control_group() const {
-    if (m_name == "FIELD")
-        return std::nullopt;
-    else
-        return this->parent();
+std::optional<std::string> Group::control_group() const
+{
+    return this->flow_group();
 }
 
-std::optional<std::string> Group::flow_group() const {
-    if (m_name == "FIELD")
+std::optional<std::string> Group::flow_group() const
+{
+    if (this->m_name == "FIELD") {
         return std::nullopt;
-    else
-        return this->parent();
+    }
+
+    return this->parent();
 }
 
-const std::optional<Phase>& Group::topup_phase() const {
+const std::optional<Phase>& Group::topup_phase() const
+{
     return this->m_topup_phase;
 }
 
-
-
-bool Group::updateParent(const std::string& parent) {
+bool Group::updateParent(const std::string& parent)
+{
     if (this->parent_group != parent) {
         this->parent_group = parent;
         return true;
@@ -780,36 +835,43 @@ bool Group::updateParent(const std::string& parent) {
     return false;
 }
 
-Group::ProductionControls Group::productionControls(const SummaryState& st) const {
+Group::ProductionControls
+Group::productionControls(const SummaryState& st) const
+{
     Group::ProductionControls pc;
 
     pc.cmode = this->production_properties.cmode;
     pc.group_limit_action = this->production_properties.group_limit_action;
+
     pc.oil_target = UDA::eval_group_uda(this->production_properties.oil_target, this->m_name, st, this->udq_undefined);
     pc.water_target = UDA::eval_group_uda(this->production_properties.water_target, this->m_name, st, this->udq_undefined);
     pc.gas_target = UDA::eval_group_uda(this->production_properties.gas_target, this->m_name, st, this->udq_undefined);
     pc.liquid_target = UDA::eval_group_uda(this->production_properties.liquid_target, this->m_name, st, this->udq_undefined);
+
     pc.guide_rate = this->production_properties.guide_rate;
     pc.guide_rate_def = this->production_properties.guide_rate_def;
+
     pc.resv_target = UDA::eval_group_uda(this->production_properties.resv_target, this->m_name, st, this->udq_undefined);
 
     return pc;
 }
 
-
-
-
-Group::InjectionControls Group::injectionControls(Phase phase, const SummaryState& st) const {
+Group::InjectionControls
+Group::injectionControls(const Phase phase, const SummaryState& st) const
+{
     Group::InjectionControls ic;
     const auto& inj = this->injection_properties.at(phase);
 
     ic.phase = inj.phase;
     ic.cmode = inj.cmode;
+
     ic.injection_controls = inj.injection_controls;
+
     ic.surface_max_rate = UDA::eval_group_uda_rate(inj.surface_max_rate, this->m_name, st, this->udq_undefined, ic.phase, this->unit_system);
     ic.resv_max_rate = UDA::eval_group_uda(inj.resv_max_rate, this->m_name, st, this->udq_undefined);
     ic.target_reinj_fraction = UDA::eval_group_uda(inj.target_reinj_fraction, this->m_name, st, this->udq_undefined);
     ic.target_void_fraction = UDA::eval_group_uda(inj.target_void_fraction, this->m_name, st, this->udq_undefined);
+
     ic.reinj_group = inj.reinj_group.value_or(this->m_name);
     ic.voidage_group = inj.voidage_group.value_or(this->m_name);
     ic.guide_rate = inj.guide_rate;
@@ -818,58 +880,65 @@ Group::InjectionControls Group::injectionControls(Phase phase, const SummaryStat
     return ic;
 }
 
-bool Group::hasInjectionControl(Phase phase) const {
-    return (this->injection_properties.count(phase) > 0);
+bool Group::hasInjectionControl(const Phase phase) const
+{
+    return this->injection_properties.count(phase) > 0;
 }
 
-
-
-
-Group::ProductionCMode Group::prod_cmode() const {
+Group::ProductionCMode Group::prod_cmode() const
+{
     return this->production_properties.cmode;
 }
 
-bool Group::has_control(Group::ProductionCMode control) const {
-    if (detail::has_control(production_properties.production_controls, control))
-        return true;
-
-    return this->has_gpmaint_control(control);
+bool Group::has_control(const ProductionCMode control) const
+{
+    return detail::has_control(production_properties.production_controls, control)
+        || this->has_gpmaint_control(control);
 }
 
-
-bool Group::has_control(Phase phase, Group::InjectionCMode control) const {
+bool Group::has_control(const Phase phase, const InjectionCMode control) const
+{
     auto prop_iter = this->injection_properties.find(phase);
     if (prop_iter != this->injection_properties.end()) {
-        if (detail::has_control(prop_iter->second.injection_controls, control))
+        if (detail::has_control(prop_iter->second.injection_controls, control)) {
             return true;
+        }
     }
+
     return this->has_gpmaint_control(phase, control);
 }
 
-
-const std::optional<GPMaint>& Group::gpmaint() const {
+const std::optional<GPMaint>& Group::gpmaint() const
+{
     return this->m_gpmaint;
 }
 
-void Group::set_gpmaint(GPMaint gpmaint) {
+void Group::set_gpmaint(const GPMaint gpmaint)
+{
     this->m_gpmaint = std::move(gpmaint);
 }
 
-void Group::set_gpmaint() {
+void Group::set_gpmaint()
+{
     this->m_gpmaint = std::nullopt;
 }
 
-bool Group::has_gpmaint_control(Phase phase, InjectionCMode control) const {
-    if (!this->m_gpmaint.has_value())
+bool Group::has_gpmaint_control(const Phase phase,
+                                const InjectionCMode control) const
+{
+    if (!this->m_gpmaint.has_value()) {
         return false;
+    }
 
-    auto gpmaint_control = this->m_gpmaint->flow_target();
+    const auto gpmaint_control = this->m_gpmaint->flow_target();
     if (phase == Phase::WATER) {
         switch (control) {
         case InjectionCMode::RATE:
             return gpmaint_control == GPMaint::FlowTarget::SURF_WINJ;
+
         case InjectionCMode::RESV:
             return gpmaint_control == GPMaint::FlowTarget::RESV_WINJ;
+
         default:
             return false;
         }
@@ -879,8 +948,10 @@ bool Group::has_gpmaint_control(Phase phase, InjectionCMode control) const {
         switch (control) {
         case InjectionCMode::RATE:
             return gpmaint_control == GPMaint::FlowTarget::SURF_GINJ;
+
         case InjectionCMode::RESV:
             return gpmaint_control == GPMaint::FlowTarget::RESV_GINJ;
+
         default:
             return false;
         }
@@ -890,8 +961,10 @@ bool Group::has_gpmaint_control(Phase phase, InjectionCMode control) const {
         switch (control) {
         case InjectionCMode::RATE:
             return gpmaint_control == GPMaint::FlowTarget::SURF_OINJ;
+
         case InjectionCMode::RESV:
             return gpmaint_control == GPMaint::FlowTarget::RESV_OINJ;
+
         default:
             return false;
         }
@@ -900,363 +973,418 @@ bool Group::has_gpmaint_control(Phase phase, InjectionCMode control) const {
     throw std::logic_error("What the fuck - broken phase?!");
 }
 
-bool Group::has_gpmaint_control(ProductionCMode control) const {
-    if (!this->m_gpmaint.has_value())
+bool Group::has_gpmaint_control(const ProductionCMode control) const
+{
+    if (! this->m_gpmaint.has_value()) {
         return false;
+    }
 
     auto gpmaint_control = this->m_gpmaint->flow_target();
-    return (control == Group::ProductionCMode::RESV && gpmaint_control == GPMaint::FlowTarget::RESV_PROD);
-
+    return (control == Group::ProductionCMode::RESV)
+        && (gpmaint_control == GPMaint::FlowTarget::RESV_PROD);
 }
 
-bool Group::as_choke() const {
+bool Group::as_choke() const
+{
     return this->m_choke_group.has_value();
 }
 
-void Group::as_choke(const std::string& group) {
+void Group::as_choke(const std::string& group)
+{
     this->m_choke_group = group;
 }
 
-const std::string Group::ExceedAction2String( ExceedAction enumValue ) {
+std::string
+Group::ExceedAction2String(const ExceedAction enumValue)
+{
     switch(enumValue) {
     case ExceedAction::NONE:
         return "NONE";
+
     case ExceedAction::CON:
         return "CON";
+
     case ExceedAction::CON_PLUS:
         return "+CON";
+
     case ExceedAction::WELL:
         return "WELL";
+
     case ExceedAction::PLUG:
         return "PLUG";
+
     case ExceedAction::RATE:
         return "RATE";
+
     default:
         throw std::invalid_argument("unhandled enum value");
     }
 }
 
+Group::ExceedAction
+Group::ExceedActionFromString(const std::string& stringValue)
+{
+    if (stringValue == "NONE") { return ExceedAction::NONE; }
+    if (stringValue == "CON")  { return ExceedAction::CON; }
+    if (stringValue == "+CON") { return ExceedAction::CON_PLUS; }
+    if (stringValue == "WELL") { return ExceedAction::WELL; }
+    if (stringValue == "PLUG") { return ExceedAction::PLUG; }
+    if (stringValue == "RATE") { return ExceedAction::RATE; }
 
-Group::ExceedAction Group::ExceedActionFromString( const std::string& stringValue ) {
-
-    if (stringValue == "NONE")
-        return ExceedAction::NONE;
-    else if (stringValue == "CON")
-        return ExceedAction::CON;
-    else if (stringValue == "+CON")
-        return ExceedAction::CON_PLUS;
-    else if (stringValue == "WELL")
-        return ExceedAction::WELL;
-    else if (stringValue == "PLUG")
-        return ExceedAction::PLUG;
-    else if (stringValue == "RATE")
-        return ExceedAction::RATE;
-    else
-        throw std::invalid_argument("Unknown enum state string: " + stringValue );
+    throw std::invalid_argument {
+        "Unknown ExceedAction enum state string: " + stringValue
+    };
 }
 
-Group::ExceedAction Group::ExceedActionFromInt( const int value ) {
+Group::ExceedAction
+Group::ExceedActionFromInt(const int value)
+{
+    if (value <= 0) { return ExceedAction::NONE; }
+    if (value == 4) { return ExceedAction::RATE; }
 
-    if (value <= 0) return ExceedAction::NONE;
-    if (value == 4) return ExceedAction::RATE;
-
-    throw std::invalid_argument(fmt::format("Unknown ExceedAction state integer: {}", value));
+    throw std::invalid_argument {
+        fmt::format("Unknown ExceedAction state integer: {}", value)
+    };
 }
 
-const std::string Group::InjectionCMode2String( InjectionCMode enumValue ) {
-    switch( enumValue ) {
+std::string
+Group::InjectionCMode2String(const InjectionCMode enumValue)
+{
+    switch (enumValue) {
     case InjectionCMode::NONE:
         return "NONE";
+
     case InjectionCMode::RATE:
         return "RATE";
+
     case InjectionCMode::RESV:
         return "RESV";
+
     case InjectionCMode::REIN:
         return "REIN";
+
     case InjectionCMode::VREP:
         return "VREP";
+
     case InjectionCMode::FLD:
         return "FLD";
+
     default:
         throw std::invalid_argument("Unhandled enum value");
     }
 }
 
+Group::InjectionCMode
+Group::InjectionCModeFromString(const std::string& stringValue)
+{
+    if (stringValue == "NONE") { return InjectionCMode::NONE; }
+    if (stringValue == "RATE") { return InjectionCMode::RATE; }
+    if (stringValue == "RESV") { return InjectionCMode::RESV; }
+    if (stringValue == "REIN") { return InjectionCMode::REIN; }
+    if (stringValue == "VREP") { return InjectionCMode::VREP; }
+    if (stringValue == "FLD")  { return InjectionCMode::FLD; }
 
-Group::InjectionCMode Group::InjectionCModeFromString( const std::string& stringValue ) {
-    if (stringValue == "NONE")
-        return InjectionCMode::NONE;
-    else if (stringValue == "RATE")
-        return InjectionCMode::RATE;
-    else if (stringValue == "RESV")
-        return InjectionCMode::RESV;
-    else if (stringValue == "REIN")
-        return InjectionCMode::REIN;
-    else if (stringValue == "VREP")
-        return InjectionCMode::VREP;
-    else if (stringValue == "FLD")
-        return InjectionCMode::FLD;
-    else
-        throw std::invalid_argument("Unknown enum state string: " + stringValue );
+    throw std::invalid_argument {
+        "Unknown Injection Control mode enum state string: " + stringValue
+    };
 }
 
-Group::GroupType operator|(Group::GroupType lhs, Group::GroupType rhs) {
-    return static_cast<Group::GroupType>(static_cast<std::underlying_type<Group::GroupType>::type>(lhs) | static_cast<std::underlying_type<Group::GroupType>::type>(rhs));
+Group::GroupType operator|(const Group::GroupType lhs,
+                           const Group::GroupType rhs)
+{
+    return static_cast<Group::GroupType>(static_cast<std::underlying_type<Group::GroupType>::type>(lhs) |
+                                         static_cast<std::underlying_type<Group::GroupType>::type>(rhs));
 }
 
-
-Group::GroupType operator&(Group::GroupType lhs, Group::GroupType rhs) {
-    return static_cast<Group::GroupType>(static_cast<std::underlying_type<Group::GroupType>::type>(lhs) & static_cast<std::underlying_type<Group::GroupType>::type>(rhs));
+Group::GroupType operator&(const Group::GroupType lhs,
+                           const Group::GroupType rhs)
+{
+    return static_cast<Group::GroupType>(static_cast<std::underlying_type<Group::GroupType>::type>(lhs) &
+                                         static_cast<std::underlying_type<Group::GroupType>::type>(rhs));
 }
 
-
-const std::string Group::ProductionCMode2String( ProductionCMode enumValue ) {
-    switch( enumValue ) {
+std::string
+Group::ProductionCMode2String(const ProductionCMode enumValue)
+{
+    switch (enumValue) {
     case ProductionCMode::NONE:
         return "NONE";
+
     case ProductionCMode::ORAT:
         return "ORAT";
+
     case ProductionCMode::WRAT:
         return "WRAT";
+
     case ProductionCMode::GRAT:
         return "GRAT";
+
     case ProductionCMode::LRAT:
         return "LRAT";
+
     case ProductionCMode::CRAT:
         return "CRAT";
+
     case ProductionCMode::RESV:
         return "RESV";
+
     case ProductionCMode::PRBL:
         return "PRBL";
+
     case ProductionCMode::FLD:
         return "FLD";
+
     default:
-        throw std::invalid_argument("Unhandled enum value");
+        throw std::invalid_argument("Unhandled production control mode enum value");
     }
 }
 
+Group::ProductionCMode
+Group::ProductionCModeFromString(const std::string& stringValue)
+{
+    if (stringValue == "NONE") { return ProductionCMode::NONE; }
+    if (stringValue == "ORAT") { return ProductionCMode::ORAT; }
+    if (stringValue == "WRAT") { return ProductionCMode::WRAT; }
+    if (stringValue == "GRAT") { return ProductionCMode::GRAT; }
+    if (stringValue == "LRAT") { return ProductionCMode::LRAT; }
+    if (stringValue == "CRAT") { return ProductionCMode::CRAT; }
+    if (stringValue == "RESV") { return ProductionCMode::RESV; }
+    if (stringValue == "PRBL") { return ProductionCMode::PRBL; }
+    if (stringValue == "FLD")  { return ProductionCMode::FLD; }
 
-Group::ProductionCMode Group::ProductionCModeFromString( const std::string& stringValue ) {
-    if (stringValue == "NONE")
-        return ProductionCMode::NONE;
-    else if (stringValue == "ORAT")
-        return ProductionCMode::ORAT;
-    else if (stringValue == "WRAT")
-        return ProductionCMode::WRAT;
-    else if (stringValue == "GRAT")
-        return ProductionCMode::GRAT;
-    else if (stringValue == "LRAT")
-        return ProductionCMode::LRAT;
-    else if (stringValue == "CRAT")
-        return ProductionCMode::CRAT;
-    else if (stringValue == "RESV")
-        return ProductionCMode::RESV;
-    else if (stringValue == "PRBL")
-        return ProductionCMode::PRBL;
-    else if (stringValue == "FLD")
-        return ProductionCMode::FLD;
-    else
-        throw std::invalid_argument("Unknown enum state string: " + stringValue );
+    throw std::invalid_argument {
+        "Unknown group production control mode enum state string: " + stringValue
+    };
 }
 
-Group::ProductionCMode Group::ProductionCModeFromInt(int ecl_int) {
+Group::ProductionCMode
+Group::ProductionCModeFromInt(const int ecl_int)
+{
     switch (ecl_int) {
     case 0:
         // The inverse function returns 0 also for ProductionCMode::FLD.
         return ProductionCMode::NONE;
+
     case 1:
         return ProductionCMode::ORAT;
+
     case 2:
         return ProductionCMode::WRAT;
+
     case 3:
         return ProductionCMode::GRAT;
+
     case 4:
         return ProductionCMode::LRAT;
+
     case 5:
         return ProductionCMode::RESV;
-    default:
-        throw std::logic_error(fmt::format("Not recognized value: {} for PRODUCTION CMODE", ecl_int));
     }
+
+    throw std::logic_error {
+        fmt::format("Unrecognized value: {} for group PRODUCTION CMODE", ecl_int)
+    };
 }
 
-int Group::ProductionCMode2Int(Group::ProductionCMode cmode) {
+int Group::ProductionCMode2Int(const ProductionCMode cmode)
+{
     switch (cmode) {
     case Group::ProductionCMode::NONE:
     case Group::ProductionCMode::FLD:
         // Observe that two production cmodes map to integer 0
         return 0;
+
     case Group::ProductionCMode::ORAT:
         return 1;
+
     case Group::ProductionCMode::WRAT:
         return 2;
+
     case Group::ProductionCMode::GRAT:
         return 3;
+
     case Group::ProductionCMode::LRAT:
         return 4;
+
     case Group::ProductionCMode::RESV:
         return 5;
+
     case Group::ProductionCMode::PRBL:
         return 6;
+
     case Group::ProductionCMode::CRAT:
         return 9;
-    default:
-        throw std::logic_error(fmt::format("Not handled enum value for Group Production CMODE"));
     }
+
+    throw std::logic_error {
+        fmt::format("Group production control mode "
+                    "enum value {} is not supported",
+                    static_cast<std::underlying_type_t<ProductionCMode>>(cmode))
+    };
 }
 
-
-
-Group::InjectionCMode Group::InjectionCModeFromInt(int ecl_int) {
+Group::InjectionCMode
+Group::InjectionCModeFromInt(const int ecl_int)
+{
     switch (ecl_int) {
     case 0:
         // The inverse function returns 0 also for InjectionCMode::FLD and InjectionCMode::SALE
         return InjectionCMode::NONE;
+
     case 1:
         return InjectionCMode::RATE;
+
     case 2:
         return InjectionCMode::RESV;
+
     case 3:
         return InjectionCMode::REIN;
+
     case 4:
         return InjectionCMode::VREP;
-    default:
-        throw std::logic_error(fmt::format("Not recognized value: {} for INJECTION CMODE", ecl_int));
     }
+
+    throw std::logic_error {
+        fmt::format("Unrecognized value: {} for group INJECTION CMODE", ecl_int)
+    };
 }
 
-int Group::InjectionCMode2Int(InjectionCMode cmode) {
+int Group::InjectionCMode2Int(const InjectionCMode cmode)
+{
     switch (cmode) {
     case InjectionCMode::NONE:
     case InjectionCMode::FLD:
     case InjectionCMode::SALE:
         return 0;
+
     case InjectionCMode::RATE:
         return 1;
+
     case InjectionCMode::RESV:
         return 2;
+
     case InjectionCMode::REIN:
         return 3;
+
     case InjectionCMode::VREP:
         return 4;
-    default:
-        throw std::logic_error(fmt::format("Not handled enum value for Group Injection CMODE"));
     }
+
+    throw std::logic_error {
+        fmt::format("Unhandled enum value for Group Injection CMODE")
+    };
 }
 
-Group::GuideRateInjTarget Group::GuideRateInjTargetFromString( const std::string& stringValue ) {
-    if (stringValue == "RATE")
-        return GuideRateInjTarget::RATE;
-    else if (stringValue == "RESV")
-        return GuideRateInjTarget::RESV;
-    else if (stringValue == "VOID")
-        return GuideRateInjTarget::VOID;
-    else if (stringValue == "NETV")
-        return GuideRateInjTarget::NETV;
-    else
-        return GuideRateInjTarget::NO_GUIDE_RATE;
+Group::GuideRateInjTarget
+Group::GuideRateInjTargetFromString(const std::string& stringValue)
+{
+    if (stringValue == "RATE") { return GuideRateInjTarget::RATE; }
+    if (stringValue == "RESV") { return GuideRateInjTarget::RESV; }
+    if (stringValue == "VOID") { return GuideRateInjTarget::VOID; }
+    if (stringValue == "NETV") { return GuideRateInjTarget::NETV; }
+
+    return GuideRateInjTarget::NO_GUIDE_RATE;
 }
 
-int Group::GuideRateInjTargetToInt(GuideRateInjTarget target) {
+int Group::GuideRateInjTargetToInt(const GuideRateInjTarget target)
+{
     switch (target) {
     case GuideRateInjTarget::RATE:
         return 1;
+
     case GuideRateInjTarget::RESV:
         return 2;
+
     case GuideRateInjTarget::VOID:
         return 3;
+
     case GuideRateInjTarget::NETV:
         return 4;
-    default:
+
+    case GuideRateInjTarget::NO_GUIDE_RATE:
         return 0;
     }
+
+    return 0;
 }
 
-Group::GuideRateInjTarget Group::GuideRateInjTargetFromInt(int ecl_id) {
+Group::GuideRateInjTarget
+Group::GuideRateInjTargetFromInt(const int ecl_id)
+{
     switch (ecl_id) {
     case 1:
         return GuideRateInjTarget::RATE;
+
     case 2:
         return GuideRateInjTarget::RESV;
+
     case 3:
         return GuideRateInjTarget::VOID;
+
     case 4:
         return GuideRateInjTarget::NETV;
+
     default:
         return GuideRateInjTarget::NO_GUIDE_RATE;
     }
 }
 
+Group::GuideRateProdTarget
+Group::GuideRateProdTargetFromString(const std::string& stringValue)
+{
+    if (stringValue == "OIL")  { return GuideRateProdTarget::OIL;  }
+    if (stringValue == "WAT")  { return GuideRateProdTarget::WAT;  }
+    if (stringValue == "GAS")  { return GuideRateProdTarget::GAS;  }
+    if (stringValue == "LIQ")  { return GuideRateProdTarget::LIQ;  }
+    if (stringValue == "COMB") { return GuideRateProdTarget::COMB; }
+    if (stringValue == "WGA")  { return GuideRateProdTarget::WGA;  }
+    if (stringValue == "CVAL") { return GuideRateProdTarget::CVAL; }
+    if (stringValue == "INJV") { return GuideRateProdTarget::INJV; }
+    if (stringValue == "POTN") { return GuideRateProdTarget::POTN; }
+    if (stringValue == "FORM") { return GuideRateProdTarget::FORM; }
+    if (stringValue == " ")    { return GuideRateProdTarget::NO_GUIDE_RATE; }
 
-
-
-Group::GuideRateProdTarget Group::GuideRateProdTargetFromString( const std::string& stringValue ) {
-    if (stringValue == "OIL")
-        return GuideRateProdTarget::OIL;
-    else if (stringValue == "WAT")
-        return GuideRateProdTarget::WAT;
-    else if (stringValue == "GAS")
-        return GuideRateProdTarget::GAS;
-    else if (stringValue == "LIQ")
-        return GuideRateProdTarget::LIQ;
-    else if (stringValue == "COMB")
-        return GuideRateProdTarget::COMB;
-    else if (stringValue == "WGA")
-        return GuideRateProdTarget::WGA;
-    else if (stringValue == "CVAL")
-        return GuideRateProdTarget::CVAL;
-    else if (stringValue == "INJV")
-        return GuideRateProdTarget::INJV;
-    else if (stringValue == "POTN")
-        return GuideRateProdTarget::POTN;
-    else if (stringValue == "FORM")
-        return GuideRateProdTarget::FORM;
-    else if (stringValue == " ")
-        return GuideRateProdTarget::NO_GUIDE_RATE;
-    else
-        return GuideRateProdTarget::NO_GUIDE_RATE;
+    return GuideRateProdTarget::NO_GUIDE_RATE;
 }
 
-
 // Integer values defined vectoritems/group.hpp
-Group::GuideRateProdTarget Group::GuideRateProdTargetFromInt(int ecl_id) {
-    switch(ecl_id) {
-    case 0:
-        return GuideRateProdTarget::NO_GUIDE_RATE;
-    case 1:
-        return GuideRateProdTarget::OIL;
-    case 2:
-        return GuideRateProdTarget::WAT;
-    case 3:
-        return GuideRateProdTarget::GAS;
-    case 4:
-        return GuideRateProdTarget::LIQ;
-    case 7:
-        return GuideRateProdTarget::POTN;
-    case 8:
-        return GuideRateProdTarget::FORM;
-    case 9:
-        return GuideRateProdTarget::COMB;
+Group::GuideRateProdTarget
+Group::GuideRateProdTargetFromInt(const int ecl_id)
+{
+    switch (ecl_id) {
+    case 0: return GuideRateProdTarget::NO_GUIDE_RATE;
+    case 1: return GuideRateProdTarget::OIL;
+    case 2: return GuideRateProdTarget::WAT;
+    case 3: return GuideRateProdTarget::GAS;
+    case 4: return GuideRateProdTarget::LIQ;
+    case 7: return GuideRateProdTarget::POTN;
+    case 8: return GuideRateProdTarget::FORM;
+    case 9: return GuideRateProdTarget::COMB;
+
     default:
-        throw std::logic_error(fmt::format("Integer GuideRateProdTarget: {} not recognized", ecl_id));
+        throw std::logic_error {
+            fmt::format("Integer GuideRateProdTarget: {} not recognized", ecl_id)
+        };
     }
 }
 
 bool Group::operator==(const Group& data) const
 {
-    return this->name() == data.name() &&
-           this->insert_index() == data.insert_index() &&
-           this->udq_undefined == data.udq_undefined &&
-           this->unit_system == data.unit_system &&
-           this->group_type == data.group_type &&
-           this->getGroupEfficiencyFactor() == data.getGroupEfficiencyFactor() &&
-           this->useEfficiencyInNetwork() == data.useEfficiencyInNetwork() &&
-           this->parent() == data.parent() &&
-           this->m_wells == data.m_wells &&
-           this->m_groups == data.m_groups &&
-           this->m_topup_phase == data.m_topup_phase &&
-           this->injection_properties == data.injection_properties &&
-           this->m_gpmaint == data.m_gpmaint &&
-           this->productionProperties() == data.productionProperties();
+    return (this->name() == data.name())
+        && (this->insert_index() == data.insert_index())
+        && (this->udq_undefined == data.udq_undefined)
+        && (this->unit_system == data.unit_system)
+        && (this->group_type == data.group_type)
+        && (this->getGroupEfficiencyFactor() == data.getGroupEfficiencyFactor())
+        && (this->useEfficiencyInNetwork() == data.useEfficiencyInNetwork())
+        && (this->parent() == data.parent())
+        && (this->m_wells == data.m_wells)
+        && (this->m_groups == data.m_groups)
+        && (this->m_topup_phase == data.m_topup_phase)
+        && (this->injection_properties == data.injection_properties)
+        && (this->m_gpmaint == data.m_gpmaint)
+        && (this->productionProperties() == data.productionProperties())
+        ;
 }
 
-}
+} // namespace Opm

--- a/opm/input/eclipse/Schedule/Group/Group.hpp
+++ b/opm/input/eclipse/Schedule/Group/Group.hpp
@@ -35,24 +35,26 @@
 #include <string>
 
 namespace Opm {
+    class SummaryState;
+    class UDQConfig;
+    class UDQActive;
+} // namespace Opm
 
-namespace RestartIO {
-struct RstGroup;
-}
+namespace Opm::RestartIO {
+    struct RstGroup;
+} // namespace Opm::RestartIO
 
-class SummaryState;
-class UDQConfig;
-class UDQActive;
-
-class Group {
+namespace Opm {
+class Group
+{
 public:
-    // A group can have both injection controls and production controls set at
-    // the same time, i.e. this enum is used as a bitmask.
+    // A group can have both injection controls and production controls set
+    // at the same time, i.e. this enum is used as a bitmask.
     enum class GroupType : unsigned {
         NONE = 0,
         PRODUCTION = 1,
         INJECTION = 2,
-        MIXED = 3
+        MIXED = 3,
     };
 
     enum class ExceedAction {
@@ -63,8 +65,8 @@ public:
         PLUG = 4,
         RATE = 5
     };
-    static const std::string ExceedAction2String( ExceedAction enumValue );
-    static ExceedAction ExceedActionFromString( const std::string& stringValue );
+    static std::string ExceedAction2String(ExceedAction enumValue);
+    static ExceedAction ExceedActionFromString(const std::string& stringValue);
     static ExceedAction ExceedActionFromInt(const int value);
 
     enum class InjectionCMode  : int {
@@ -76,8 +78,8 @@ public:
         FLD  = 16,
         SALE = 32
     };
-    static const std::string InjectionCMode2String( InjectionCMode enumValue );
-    static InjectionCMode InjectionCModeFromString( const std::string& stringValue );
+    static std::string InjectionCMode2String(InjectionCMode enumValue);
+    static InjectionCMode InjectionCModeFromString(const std::string& stringValue);
     static InjectionCMode InjectionCModeFromInt(int ecl_int);
     static int            InjectionCMode2Int(InjectionCMode enumValue);
 
@@ -92,8 +94,8 @@ public:
         PRBL = 64,
         FLD  = 128
     };
-    static const std::string ProductionCMode2String( ProductionCMode enumValue );
-    static ProductionCMode ProductionCModeFromString( const std::string& stringValue );
+    static std::string ProductionCMode2String(ProductionCMode enumValue);
+    static ProductionCMode ProductionCModeFromString(const std::string& stringValue);
     static ProductionCMode ProductionCModeFromInt(int ecl_int);
     static int             ProductionCMode2Int(Group::ProductionCMode cmode);
 
@@ -111,7 +113,7 @@ public:
         FORM = 10,
         NO_GUIDE_RATE = 11
     };
-    static GuideRateProdTarget GuideRateProdTargetFromString( const std::string& stringValue );
+    static GuideRateProdTarget GuideRateProdTargetFromString(const std::string& stringValue);
     static GuideRateProdTarget GuideRateProdTargetFromInt(int ecl_id);
 
     enum class GuideRateInjTarget {
@@ -121,7 +123,7 @@ public:
         RESV = 4,
         NO_GUIDE_RATE = 5
     };
-    static GuideRateInjTarget GuideRateInjTargetFromString( const std::string& stringValue );
+    static GuideRateInjTarget GuideRateInjTargetFromString(const std::string& stringValue);
     static GuideRateInjTarget GuideRateInjTargetFromInt(int ecl_id);
     static int                GuideRateInjTargetToInt(GuideRateInjTarget target);
 
@@ -273,8 +275,15 @@ public:
     };
 
     Group();
-    Group(const std::string& group_name, std::size_t insert_index_arg, double udq_undefined_arg, const UnitSystem& unit_system);
-    Group(const RestartIO::RstGroup& rst_group, std::size_t insert_index_arg, double udq_undefined_arg, const UnitSystem& unit_system);
+    Group(const std::string& group_name,
+          std::size_t insert_index_arg,
+          double udq_undefined_arg,
+          const UnitSystem& unit_system);
+
+    Group(const RestartIO::RstGroup& rst_group,
+          std::size_t insert_index_arg,
+          double udq_undefined_arg,
+          const UnitSystem& unit_system);
 
     static Group serializationTestObject();
 
@@ -380,6 +389,6 @@ private:
 Group::GroupType operator |(Group::GroupType lhs, Group::GroupType rhs);
 Group::GroupType operator &(Group::GroupType lhs, Group::GroupType rhs);
 
-}
+} // namespace Opm
 
 #endif // OPM_GROUP_HPP


### PR DESCRIPTION
In particular

  * Split long lines
  * Put braces around single-statement blocks
  * Move functions' opening braces to new line
  * Prefer logical operators to multiple `if()` conditions
  * Use `IOrderSet<>::insert()`'s return value directly instead of checking `count()` followed by `insert()`
  * Don't return `const` objects by value

While here, also replace the two-argument constructor for forming `IOrderSet<>` objects with an initial sequence of elements.  The two-argument version could potentially lead to forming objects with an inconsistent view of the set's elements and was only used to form serialisation test objects for class Group in any case.