### PR TITLE
added: ability to specify a warning file for Doxygen

### DIFF
--- a/cmake/Templates/Doxyfile
+++ b/cmake/Templates/Doxyfile
@@ -1658,3 +1658,11 @@ HTML_EXTRA_STYLESHEET  = @OPM_MACROS_ROOT@/cmake/Templates/style.css
 # with spaces. (This setting is usually overridden in Doxylocal)
 
 INPUT                  = @PROJECT_SOURCE_DIR@/@src_DIR@
+
+# The WARN_LOGFILE tag can be used to specify a file to which warning and error
+# messages should be written. If left blank the output is written to standard
+# error (stderr). In case the file specified cannot be opened for writing the
+# warning and error messages are written to standard error. When as file - is
+# specified the warning and error messages are written to standard output
+# (stdout).
+WARN_LOGFILE           = @OPM_DOXYGEN_LOG_FILE@

--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -96,7 +96,7 @@ function build_module {
   CMAKE_PARAMS="$1"
   DO_TEST_FLAG="$2"
   MOD_SRC_DIR="$3"
-  cmake "$MOD_SRC_DIR" -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=$DO_TEST_FLAG -DCMAKE_TOOLCHAIN_FILE=${configurations[$configuration]} $CMAKE_PARAMS
+  cmake "$MOD_SRC_DIR" -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=$DO_TEST_FLAG -DCMAKE_TOOLCHAIN_FILE=${configurations[$configuration]} -DOPM_DOXYGEN_LOG_FILE=$PWD/doc/doxygen/Warnings.log $CMAKE_PARAMS
   test $? -eq 0 || exit 1
   if test $DO_TEST_FLAG -eq 1
   then


### PR DESCRIPTION
will be used on jenkins. By default errors still go to stderr, but if this option is specified, as in the jenkins build script, they go to the file. This file can then be used for reporting on jenkins, which I intend to do in the weekly static analysis jobs.