### PR TITLE
Add support for binary input files in FileDeck and rst_deck

### DIFF
--- a/examples/rst_deck.cpp
+++ b/examples/rst_deck.cpp
@@ -356,9 +356,9 @@ std::pair<Options, std::string> load_options(int argc, char **argv)
         }
 
         if (opt.mode == Opm::FileDeck::OutputMode::COPY) {
-            const auto target = fs::path(target_arg).parent_path();
+            const auto target = fs::path(fs::absolute(target_arg)).parent_path();
             if (fs::exists(target)) {
-                const auto input = fs::path(opt.input_deck).parent_path();
+                const auto input = fs::path(fs::absolute(opt.input_deck)).parent_path();
                 if (fs::equivalent(target, input)) {
                     opt.mode = Opm::FileDeck::OutputMode::SHARE;
                 }

--- a/opm/common/OpmLog/KeywordLocation.hpp
+++ b/opm/common/OpmLog/KeywordLocation.hpp
@@ -42,6 +42,7 @@ public:
     std::string keyword;
     std::string filename = "<memory string>";
     std::size_t lineno = 0;
+    static constexpr std::size_t LINENO_BINARY = 99999999;
 
     KeywordLocation() = default;
     KeywordLocation(std::string kw, std::string fname, std::size_t lno) :
@@ -50,7 +51,7 @@ public:
         lineno(lno)
     {}
 
-
+    bool is_binary() const { return lineno == LINENO_BINARY; }
     std::string format(const std::string& msg_fmt) const;
 
     static KeywordLocation serializationTestObject()

--- a/opm/input/eclipse/Deck/DeckKeyword.cpp
+++ b/opm/input/eclipse/Deck/DeckKeyword.cpp
@@ -38,6 +38,14 @@ namespace Opm {
     {
     }
 
+    DeckKeyword::DeckKeyword(const KeywordLocation& location, const ParserKeyword& parserKeyword) :
+        m_keywordName(parserKeyword.getName()),
+        m_location(location),
+        m_isDataKeyword(false),
+        m_slashTerminated(!parserKeyword.hasFixedSize())
+    {
+    }
+
     DeckKeyword::DeckKeyword(const KeywordLocation& location, const std::string& keywordName) :
         m_keywordName(keywordName),
         m_location(location),
@@ -163,8 +171,8 @@ namespace Opm {
         }
     }
 
-    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<int>& data) :
-        DeckKeyword(parserKeyword)
+    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<int>& data, const KeywordLocation& location) :
+        DeckKeyword(location, parserKeyword)
     {
         if (!parserKeyword.isDataKeyword())
             throw std::invalid_argument("Deckkeyword '" + name() + "' is not a data keyword.");
@@ -185,8 +193,8 @@ namespace Opm {
     }
 
 
-    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<double>& data, const UnitSystem& system_active, const UnitSystem& system_default) :
-        DeckKeyword(parserKeyword)
+    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<double>& data, const UnitSystem& system_active, const UnitSystem& system_default, const KeywordLocation& location) :
+        DeckKeyword(location, parserKeyword)
     {
         if (!parserKeyword.isDataKeyword())
             throw std::invalid_argument("Deckkeyword '" + name() + "' is not a data keyword.");

--- a/opm/input/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/input/eclipse/Deck/DeckKeyword.hpp
@@ -41,10 +41,11 @@ namespace Opm {
 
         DeckKeyword();
         explicit DeckKeyword(const ParserKeyword& parserKeyword);
+        DeckKeyword(const KeywordLocation& location, const ParserKeyword& parserKeyword);
         DeckKeyword(const KeywordLocation& location, const std::string& keywordName);
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<std::vector<DeckValue>>& record_list, const UnitSystem& system_active, const UnitSystem& system_default);
-        DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<int>& data);
-        DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<double>& data, const UnitSystem& system_active, const UnitSystem& system_default);
+        DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<int>& data, const KeywordLocation& location = KeywordLocation {});
+        DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<double>& data, const UnitSystem& system_active, const UnitSystem& system_default, const KeywordLocation& location = KeywordLocation {});
 
         static DeckKeyword serializationTestObject();
 

--- a/opm/input/eclipse/Deck/DeckTree.cpp
+++ b/opm/input/eclipse/Deck/DeckTree.cpp
@@ -94,11 +94,8 @@ void DeckTree::add_include(std::string parent_file, std::string include_file) {
 }
 
 bool DeckTree::has_include(const std::string& fname) const {
-    if (this->nodes.count(fname) == 0) {
-        return false;
-    }
-    const auto& node = this->nodes.at(fname);
-    return !node.include_files.empty();
+    const auto fileIt = this->nodes.find(fname);
+    return (fileIt != this->nodes.end()) && !fileIt->second.include_files.empty();
 }
 
 }

--- a/opm/input/eclipse/Deck/DeckTree.cpp
+++ b/opm/input/eclipse/Deck/DeckTree.cpp
@@ -94,6 +94,9 @@ void DeckTree::add_include(std::string parent_file, std::string include_file) {
 }
 
 bool DeckTree::has_include(const std::string& fname) const {
+    if (this->nodes.count(fname) == 0) {
+        return false;
+    }
     const auto& node = this->nodes.at(fname);
     return !node.include_files.empty();
 }

--- a/opm/input/eclipse/Deck/FileDeck.cpp
+++ b/opm/input/eclipse/Deck/FileDeck.cpp
@@ -216,9 +216,6 @@ void FileDeck::Block::load(const Deck& deck, std::size_t deck_index)
     const auto& loc = deck[deck_index].location();
     const auto& current_file = loc.filename;
     this->is_binary = loc.is_binary();
-    if (is_binary) {
-        fname = current_file;
-    }
     while (true) {
         this->keywords.push_back(deck[deck_index]);
 
@@ -536,12 +533,8 @@ void FileDeck::dump_shared(std::ostream& stream,
         else {
             // Should ideally use fs::relative()
             std::string include_file = fs::proximate(block.fname, output_dir).generic_string();
-            if (include_file.find(block.fname) == std::string::npos) {
-                block.is_binary ? IMPORT(stream, include_file) : INCLUDE(stream, include_file);
-            }
-            else {
-                block.is_binary ? IMPORT(stream, block.fname) : INCLUDE(stream, block.fname);
-            }
+            const auto& fname = include_file.find(block.fname) == std::string::npos ? include_file : block.fname;
+            block.is_binary ? IMPORT(stream, fname) : INCLUDE(stream, fname);
         }
     }
 }

--- a/opm/input/eclipse/Deck/FileDeck.cpp
+++ b/opm/input/eclipse/Deck/FileDeck.cpp
@@ -63,6 +63,14 @@ INCLUDE
 )", fname);
     }
 
+    void IMPORT(std::ostream& stream, const std::string& fname)
+    {
+        stream << fmt::format(R"(
+IMPORT
+   '{}' /
+)", fname);
+    }
+
     void touch_file(const fs::path& file)
     {
         if (fs::exists(file)) {
@@ -170,7 +178,7 @@ bool FileDeck::Index::operator<(const Index& other) const
 }
 
 FileDeck::FileDeck(const Deck& deck)
-    : input_directory(deck.getInputPath())
+    : input_directory(fs::absolute(deck.getInputPath().empty() ? fs::current_path() : fs::path(deck.getInputPath())))
     , deck_tree(deck.tree())
 {
     if (deck.empty()) {
@@ -183,6 +191,9 @@ FileDeck::FileDeck(const Deck& deck)
 
         FileDeck::Block block(current_file);
         block.load(deck, deck_index);
+        if (block.is_binary) {
+            this->deck_tree.add_include(this->blocks.back().fname, block.fname);
+        }
         deck_index += block.size();
         this->blocks.push_back(std::move(block));
 
@@ -202,8 +213,12 @@ const DeckKeyword& FileDeck::operator[](const Index& index) const
 
 void FileDeck::Block::load(const Deck& deck, std::size_t deck_index)
 {
-    const auto current_file = deck[deck_index].location().filename;
-
+    const auto& loc = deck[deck_index].location();
+    const auto& current_file = loc.filename;
+    this->is_binary = loc.is_binary();
+    if (is_binary) {
+        fname = current_file;
+    }
     while (true) {
         this->keywords.push_back(deck[deck_index]);
 
@@ -490,6 +505,7 @@ void FileDeck::dump(const std::string& output_dir,
 
         for (std::size_t block_index = 1; block_index < this->blocks.size(); ++block_index) {
             const auto& block = this->blocks[block_index];
+            // For now, originally binary files will be written as GRDECL
             const auto& include_file = this->dump_block(block, output_dir, {}, context);
 
             if (block.fname != this->deck_tree.root()) {
@@ -521,10 +537,10 @@ void FileDeck::dump_shared(std::ostream& stream,
             // Should ideally use fs::relative()
             std::string include_file = fs::proximate(block.fname, output_dir).generic_string();
             if (include_file.find(block.fname) == std::string::npos) {
-                INCLUDE(stream, include_file);
+                block.is_binary ? IMPORT(stream, include_file) : INCLUDE(stream, include_file);
             }
             else {
-                INCLUDE(stream, block.fname);
+                block.is_binary ? IMPORT(stream, block.fname) : INCLUDE(stream, block.fname);
             }
         }
     }

--- a/opm/input/eclipse/Deck/FileDeck.hpp
+++ b/opm/input/eclipse/Deck/FileDeck.hpp
@@ -117,7 +117,7 @@ private:
     private:
         std::string fname;
         std::vector<DeckKeyword> keywords;
-
+        bool is_binary {false};
         friend FileDeck;
     };
 

--- a/opm/input/eclipse/Deck/ImportContainer.cpp
+++ b/opm/input/eclipse/Deck/ImportContainer.cpp
@@ -25,6 +25,7 @@
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/OpmLog/KeywordLocation.hpp>
 #include <opm/io/eclipse/EclFile.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
@@ -47,19 +48,20 @@ ImportContainer::ImportContainer(const Parser& parser, const UnitSystem& unit_sy
             continue;
         }
 
+        KeywordLocation location(name, fname, KeywordLocation::LINENO_BINARY);
         const auto& parser_item = parser_kw.getRecord(0).get(0);
         if (parser_item.dataType() == type_tag::fdouble) {
             if (data_type == EclIO::REAL) {
                 auto& float_data = ecl_file.get<float>(kw_index);
                 std::vector<double> double_data{ float_data.begin(), float_data.end() };
-                this->keywords.emplace_back(parser_kw, double_data, unit_system, unit_system);
+                this->keywords.emplace_back(parser_kw, double_data, unit_system, unit_system, location);
             } else if (data_type == EclIO::DOUB) {
                 auto& double_data = ecl_file.get<double>(kw_index);
-                this->keywords.emplace_back(parser_kw, double_data, unit_system, unit_system);
+                this->keywords.emplace_back(parser_kw, double_data, unit_system, unit_system, location);
             }
         } else if (parser_item.dataType() == type_tag::integer) {
             const auto& data = ecl_file.get<int>(kw_index);
-            this->keywords.emplace_back(parser_kw, data);
+            this->keywords.emplace_back(parser_kw, data, location);
         } else
             throw std::logic_error(fmt::format("File: {} keyword:{}\nIMPORT keyword only supports integer and floating point data keywords", fname, name));
 


### PR DESCRIPTION
Allows rst_deck to function with binary (IMPORT'ed) input files. Works with all modes (inline|copy|shared), but for now the 'copy' mode will write ASCII format files even though the input was binary. 