### PR TITLE
changed: add a helper class for two phase material law types

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1062,6 +1062,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
       opm/material/fluidmatrixinteractions/TwoPhaseLETCurves.hpp
       opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+      opm/material/fluidmatrixinteractions/EclMaterialLawTwoPhaseTypes.hpp
       opm/material/fluidmatrixinteractions/DirectionalMaterialLawParams.hpp
       opm/material/fluidmatrixinteractions/DirectionalMaterialLawParams.hpp
       opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -144,7 +144,8 @@ initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
 // TODO: Better (proper?) handling of mixed wettability systems - see ecl kw OPTIONS switch 74
 // Note: Without OPTIONS[74] the negative part of the Pcow curve is not scaled
 template<class TraitsT>
-std::pair<typename TraitsT::Scalar, bool> EclMaterialLawManager<TraitsT>::
+std::pair<typename TraitsT::Scalar, bool>
+EclMaterialLawManager<TraitsT>::
 applySwatinit(unsigned elemIdx,
               Scalar pcow,
               Scalar Sw)
@@ -160,7 +161,7 @@ applySwatinit(unsigned elemIdx,
 
     // specify a fluid state which only stores the saturations
     using FluidState = SimpleModularFluidState<Scalar,
-                                                numPhases,
+                                                TraitsT::numPhases,
                                                 /*numComponents=*/0,
                                                 /*FluidSystem=*/void, /* -> don't care */
                                                 /*storePressure=*/false,
@@ -172,9 +173,9 @@ applySwatinit(unsigned elemIdx,
                                                 /*storeViscosity=*/false,
                                                 /*storeEnthalpy=*/false>;
     FluidState fs;
-    fs.setSaturation(waterPhaseIdx, Sw);
-    fs.setSaturation(gasPhaseIdx, 0);
-    fs.setSaturation(oilPhaseIdx, 0);
+    fs.setSaturation(TraitsT::wettingPhaseIdx, Sw);
+    fs.setSaturation(TraitsT::gasPhaseIdx, 0);
+    fs.setSaturation(TraitsT::nonWettingPhaseIdx, 0);
     std::array<Scalar, numPhases> pc = { 0 };
     MaterialLaw::capillaryPressures(pc, materialLawParams(elemIdx), fs);
     Scalar pcowAtSw = pc[oilPhaseIdx] - pc[waterPhaseIdx];
@@ -440,7 +441,8 @@ oilWaterScaledEpsPointsDrainage(unsigned elemIdx)
 }
 
 template<class TraitsT>
-const typename EclMaterialLawManager<TraitsT>::MaterialLawParams& EclMaterialLawManager<TraitsT>::
+const typename EclMaterialLawManager<TraitsT>::MaterialLawParams&
+EclMaterialLawManager<TraitsT>::
 materialLawParamsFunc_(unsigned elemIdx, FaceDir::DirEnum facedir) const
 {
     using Dir = FaceDir::DirEnum;

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
@@ -32,9 +32,9 @@ HystParams(EclMaterialLawManager<Traits>::InitParams& init_params) :
     init_params_{init_params}, parent_{init_params_.parent_},
     eclState_{init_params_.eclState_}
 {
-    gasOilParams_ = std::make_shared<GasOilTwoPhaseHystParams>();
-    oilWaterParams_ = std::make_shared<OilWaterTwoPhaseHystParams>();
-    gasWaterParams_ = std::make_shared<GasWaterTwoPhaseHystParams>();
+    gasOilParams_ = std::make_shared<GasOilHystParams>();
+    oilWaterParams_ = std::make_shared<OilWaterHystParams>();
+    gasWaterParams_ = std::make_shared<GasWaterHystParams>();
 }
 
 /* public methods, alphabetically sorted */
@@ -53,7 +53,7 @@ finalize()
 }
 
 template <class Traits>
-std::shared_ptr<typename EclMaterialLawManager<Traits>::GasOilTwoPhaseHystParams>
+std::shared_ptr<typename EclMaterialLaw::TwoPhaseTypes<Traits>::GasOilHystParams>
 EclMaterialLawManager<Traits>::InitParams::HystParams::
 getGasOilParams()
 {
@@ -61,7 +61,7 @@ getGasOilParams()
 }
 
 template <class Traits>
-std::shared_ptr<typename EclMaterialLawManager<Traits>::OilWaterTwoPhaseHystParams>
+std::shared_ptr<typename EclMaterialLaw::TwoPhaseTypes<Traits>::OilWaterHystParams>
 EclMaterialLawManager<Traits>::InitParams::HystParams::
 getOilWaterParams()
 {
@@ -69,7 +69,7 @@ getOilWaterParams()
 }
 
 template <class Traits>
-std::shared_ptr<typename EclMaterialLawManager<Traits>::GasWaterTwoPhaseHystParams>
+std::shared_ptr<typename EclMaterialLaw::TwoPhaseTypes<Traits>::GasWaterHystParams>
 EclMaterialLawManager<Traits>::InitParams::HystParams::
 getGasWaterParams()
 {
@@ -102,7 +102,7 @@ setDrainageParamsGasWater(unsigned elemIdx, unsigned satRegionIdx,
     if (hasGasWater_()) {
         auto [gasWaterScaledInfo, gasWaterScaledPoints]
             = readScaledEpsPointsDrainage_(elemIdx, EclTwoPhaseSystemType::GasWater, lookupIdxOnLevelZeroAssigner);
-        GasWaterEpsTwoPhaseParams gasWaterDrainParams;
+        typename EclMaterialLaw::TwoPhaseTypes<Traits>::GasWaterEpsParams gasWaterDrainParams;
         gasWaterDrainParams.setConfig(this->parent_.gasWaterConfig_);
         gasWaterDrainParams.setUnscaledPoints(this->parent_.gasWaterUnscaledPointsVector_[satRegionIdx]);
         gasWaterDrainParams.setScaledPoints(gasWaterScaledPoints);
@@ -121,7 +121,7 @@ setDrainageParamsOilGas(unsigned elemIdx, unsigned satRegionIdx,
     if (hasGasOil_()) {
         auto [gasOilScaledInfo, gasOilScaledPoints]
             = readScaledEpsPointsDrainage_(elemIdx, EclTwoPhaseSystemType::GasOil, lookupIdxOnLevelZeroAssigner);
-        GasOilEpsTwoPhaseParams gasOilDrainParams;
+        typename EclMaterialLaw::TwoPhaseTypes<Traits>::GasOilEpsParams gasOilDrainParams;
         gasOilDrainParams.setConfig(this->parent_.gasOilConfig_);
         gasOilDrainParams.setUnscaledPoints(this->parent_.gasOilUnscaledPointsVector_[satRegionIdx]);
         gasOilDrainParams.setScaledPoints(gasOilScaledPoints);
@@ -149,7 +149,7 @@ setDrainageParamsOilWater(unsigned elemIdx, unsigned satRegionIdx,
     //   to include three more vectors, one with info for each facedir of a cell
     this->parent_.oilWaterScaledEpsInfoDrainage_[elemIdx] = oilWaterScaledInfo;
     if (hasOilWater_()) {
-        OilWaterEpsTwoPhaseParams oilWaterDrainParams;
+        typename EclMaterialLaw::TwoPhaseTypes<Traits>::OilWaterEpsParams oilWaterDrainParams;
         oilWaterDrainParams.setConfig(this->parent_.oilWaterConfig_);
         oilWaterDrainParams.setUnscaledPoints(this->parent_.oilWaterUnscaledPointsVector_[satRegionIdx]);
         oilWaterDrainParams.setScaledPoints(oilWaterScaledPoints);
@@ -168,7 +168,7 @@ setImbibitionParamsGasWater(unsigned elemIdx, unsigned imbRegionIdx,
     if (hasGasWater_()) {
         auto [gasWaterScaledInfo, gasWaterScaledPoints]
             = readScaledEpsPointsImbibition_(elemIdx, EclTwoPhaseSystemType::GasWater, lookupIdxOnLevelZeroAssigner);
-        GasWaterEpsTwoPhaseParams gasWaterImbParamsHyst;
+        typename EclMaterialLaw::TwoPhaseTypes<Traits>::GasWaterEpsParams gasWaterImbParamsHyst;
         gasWaterImbParamsHyst.setConfig(this->parent_.gasWaterConfig_);
         gasWaterImbParamsHyst.setUnscaledPoints(this->parent_.gasWaterUnscaledPointsVector_[imbRegionIdx]);
         gasWaterImbParamsHyst.setScaledPoints(gasWaterScaledPoints);
@@ -191,7 +191,7 @@ setImbibitionParamsOilGas(unsigned elemIdx, unsigned imbRegionIdx,
         auto [gasOilScaledInfo, gasOilScaledPoints]
             = readScaledEpsPointsImbibition_(elemIdx, EclTwoPhaseSystemType::GasOil, lookupIdxOnLevelZeroAssigner);
 
-        GasOilEpsTwoPhaseParams gasOilImbParamsHyst;
+        typename EclMaterialLaw::TwoPhaseTypes<Traits>::GasOilEpsParams gasOilImbParamsHyst;
         gasOilImbParamsHyst.setConfig(this->parent_.gasOilConfig_);
         gasOilImbParamsHyst.setUnscaledPoints(this->parent_.gasOilUnscaledPointsVector_[imbRegionIdx]);
         gasOilImbParamsHyst.setScaledPoints(gasOilScaledPoints);
@@ -212,7 +212,7 @@ setImbibitionParamsOilWater(unsigned elemIdx, unsigned imbRegionIdx,
     if (hasOilWater_()) {
         auto [oilWaterScaledInfo, oilWaterScaledPoints]
             = readScaledEpsPointsImbibition_(elemIdx, EclTwoPhaseSystemType::OilWater, lookupIdxOnLevelZeroAssigner);
-        OilWaterEpsTwoPhaseParams oilWaterImbParamsHyst;
+        typename EclMaterialLaw::TwoPhaseTypes<Traits>::OilWaterEpsParams oilWaterImbParamsHyst;
         oilWaterImbParamsHyst.setConfig(this->parent_.oilWaterConfig_);
         oilWaterImbParamsHyst.setUnscaledPoints(this->parent_.oilWaterUnscaledPointsVector_[imbRegionIdx]);
         oilWaterImbParamsHyst.setScaledPoints(oilWaterScaledPoints);

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
@@ -92,7 +92,7 @@ readGasOilParameters_(GasOilEffectiveParamVector& dest, unsigned satRegionIdx)
         // we don't read anything if either the gas or the oil phase is not active
         return;
 
-    dest[satRegionIdx] = std::make_shared<GasOilEffectiveTwoPhaseParams>();
+    dest[satRegionIdx] = std::make_shared<GasOilEffectiveParams>();
 
     auto& effParams = *dest[satRegionIdx];
 
@@ -184,12 +184,12 @@ template <class Traits>
 template <class TableType>
 void
 EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
-readGasOilFamily2_(GasOilEffectiveTwoPhaseParams& effParams,
-                        const Scalar Swco,
-                        const double tolcrit,
-                        const TableType& sofTable,
-                        const SgfnTable& sgfnTable,
-                        const std::string& columnName)
+readGasOilFamily2_(GasOilEffectiveParams& effParams,
+                   const Scalar Swco,
+                   const double tolcrit,
+                   const TableType& sofTable,
+                   const SgfnTable& sgfnTable,
+                   const std::string& columnName)
 {
     // convert the saturations of the SGFN keyword from gas to oil saturations
     std::vector<double> SoSamples(sgfnTable.numRows());
@@ -210,10 +210,10 @@ readGasOilFamily2_(GasOilEffectiveTwoPhaseParams& effParams,
 template <class Traits>
 void
 EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
-readGasOilSgof_(GasOilEffectiveTwoPhaseParams& effParams,
-                        const Scalar Swco,
-                        const double tolcrit,
-                        const SgofTable& sgofTable)
+readGasOilSgof_(GasOilEffectiveParams& effParams,
+                const Scalar Swco,
+                const double tolcrit,
+                const SgofTable& sgofTable)
 {
     // convert the saturations of the SGOF keyword from gas to oil saturations
     std::vector<double> SoSamples(sgofTable.numRows());
@@ -233,10 +233,10 @@ readGasOilSgof_(GasOilEffectiveTwoPhaseParams& effParams,
 template <class Traits>
 void
 EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
-readGasOilSlgof_(GasOilEffectiveTwoPhaseParams& effParams,
-                        const Scalar Swco,
-                        const double tolcrit,
-                        const SlgofTable& slgofTable)
+readGasOilSlgof_(GasOilEffectiveParams& effParams,
+                 const Scalar Swco,
+                 const double tolcrit,
+                 const SlgofTable& slgofTable)
 {
     // convert the saturations of the SLGOF keyword from "liquid" to oil saturations
     std::vector<double> SoSamples(slgofTable.numRows());
@@ -262,7 +262,7 @@ readGasWaterParameters_(GasWaterEffectiveParamVector& dest, unsigned satRegionId
         // we don't read anything if either the gas or the water phase is not active or if oil is present
         return;
 
-    dest[satRegionIdx] = std::make_shared<GasWaterEffectiveTwoPhaseParams>();
+    dest[satRegionIdx] = std::make_shared<GasWaterEffectiveParams>();
 
     auto& effParams = *dest[satRegionIdx];
 
@@ -345,7 +345,7 @@ readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionId
         // we don't read anything if either the water or the oil phase is not active
         return;
 
-    dest[satRegionIdx] = std::make_shared<OilWaterEffectiveTwoPhaseParams>();
+    dest[satRegionIdx] = std::make_shared<OilWaterEffectiveParams>();
 
     const auto tolcrit = this->eclState_.runspec().saturationFunctionControls()
         .minimumRelpermMobilityThreshold();

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawTwoPhaseTypes.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawTwoPhaseTypes.hpp
@@ -1,0 +1,91 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclMaterialLawManager
+ */
+#ifndef OPM_ECL_MATERIAL_LAW_TYPES_HPP
+#define OPM_ECL_MATERIAL_LAW_TYPES_HPP
+
+#include <opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp>
+#include <opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp>
+#include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
+#include <opm/material/fluidmatrixinteractions/SatCurveMultiplexer.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace Opm::EclMaterialLaw {
+
+/*!
+ *  \brief Helper class defining various two-phase types used in
+ *         three-phase material laws.
+ */
+
+template <class Traits>
+class TwoPhaseTypes
+{
+public:
+    using GasOilTraits = TwoPhaseMaterialTraits<typename Traits::Scalar,
+                                                Traits::nonWettingPhaseIdx,
+                                                Traits::gasPhaseIdx>;
+    using OilWaterTraits = TwoPhaseMaterialTraits<typename Traits::Scalar,
+                                                  Traits::wettingPhaseIdx,
+                                                  Traits::nonWettingPhaseIdx>;
+    using GasWaterTraits = TwoPhaseMaterialTraits<typename Traits::Scalar,
+                                                  Traits::wettingPhaseIdx,
+                                                  Traits::gasPhaseIdx>;
+
+    // the two-phase material law which is defined on effective (unscaled) saturations
+    using GasOilEffectiveLaw = SatCurveMultiplexer<GasOilTraits>;
+    using OilWaterEffectiveLaw = SatCurveMultiplexer<OilWaterTraits>;
+    using GasWaterEffectiveLaw = SatCurveMultiplexer<GasWaterTraits>;
+
+    using GasOilEffectiveParams = typename GasOilEffectiveLaw::Params;
+    using OilWaterEffectiveParams = typename OilWaterEffectiveLaw::Params;
+    using GasWaterEffectiveParams = typename GasWaterEffectiveLaw::Params;
+
+    // the two-phase material law which is defined on absolute (scaled) saturations
+    using GasOilEpsLaw = EclEpsTwoPhaseLaw<GasOilEffectiveLaw>;
+    using OilWaterEpsLaw = EclEpsTwoPhaseLaw<OilWaterEffectiveLaw>;
+    using GasWaterEpsLaw = EclEpsTwoPhaseLaw<GasWaterEffectiveLaw>;
+    using GasOilEpsParams = typename GasOilEpsLaw::Params;
+    using OilWaterEpsParams = typename OilWaterEpsLaw::Params;
+    using GasWaterEpsParams = typename GasWaterEpsLaw::Params;
+
+    // the scaled two-phase material laws with hysteresis
+    using GasOilLaw = EclHysteresisTwoPhaseLaw<GasOilEpsLaw>;
+    using OilWaterLaw = EclHysteresisTwoPhaseLaw<OilWaterEpsLaw>;
+    using GasWaterLaw = EclHysteresisTwoPhaseLaw<GasWaterEpsLaw>;
+    using GasOilHystParams = typename GasOilLaw::Params;
+    using OilWaterHystParams = typename OilWaterLaw::Params;
+    using GasWaterHystParams = typename GasWaterLaw::Params;
+
+    using GasOilEffectiveParamVector = std::vector<std::shared_ptr<GasOilEffectiveParams>>;
+    using OilWaterEffectiveParamVector = std::vector<std::shared_ptr<OilWaterEffectiveParams>>;
+    using GasWaterEffectiveParamVector = std::vector<std::shared_ptr<GasWaterEffectiveParams>>;
+};
+
+} // namespace Opm::EclMaterialLaw
+
+#endif


### PR DESCRIPTION
to simplify reuse.

The nesting allows sharing these type aliases in the subclasses. When splitting out the nested classes, a lot of these need to be repeated. This adds a helper class to limit the repeating to a handful of using statements from the helper instead.

Extracted from https://github.com/OPM/opm-common/pull/4706