### PR TITLE
EclMaterialLawManager: put in namespace and rename

### DIFF
--- a/examples/hysteresis.cpp
+++ b/examples/hysteresis.cpp
@@ -78,7 +78,7 @@ struct Fixture {
                                                     /*storeDensity=*/false,
                                                     /*storeViscosity=*/false,
                                                     /*storeEnthalpy=*/false>;
-    using MaterialLawManager = Opm::EclMaterialLaw::EclMaterialLawManager<MaterialTraits>;
+    using MaterialLawManager = Opm::EclMaterialLaw::Manager<MaterialTraits>;
     using MaterialLaw = typename MaterialLawManager::MaterialLaw;
 };
 

--- a/examples/hysteresis.cpp
+++ b/examples/hysteresis.cpp
@@ -78,7 +78,7 @@ struct Fixture {
                                                     /*storeDensity=*/false,
                                                     /*storeViscosity=*/false,
                                                     /*storeEnthalpy=*/false>;
-    using MaterialLawManager = Opm::EclMaterialLawManager<MaterialTraits>;
+    using MaterialLawManager = Opm::EclMaterialLaw::EclMaterialLawManager<MaterialTraits>;
     using MaterialLaw = typename MaterialLawManager::MaterialLaw;
 };
 

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -38,12 +38,6 @@
 namespace Opm {
 
 template<class TraitsT>
-EclMaterialLawManager<TraitsT>::EclMaterialLawManager() = default;
-
-template<class TraitsT>
-EclMaterialLawManager<TraitsT>::~EclMaterialLawManager() = default;
-
-template<class TraitsT>
 void EclMaterialLawManager<TraitsT>::
 initFromState(const EclipseState& eclState)
 {

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -38,7 +38,7 @@
 namespace Opm::EclMaterialLaw {
 
 template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+void Manager<TraitsT>::
 initFromState(const EclipseState& eclState)
 {
     // get the number of saturation regions and the number of cells in the deck
@@ -126,7 +126,7 @@ initFromState(const EclipseState& eclState)
 }
 
 template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+void Manager<TraitsT>::
 initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
                       const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner,
                       const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
@@ -139,7 +139,7 @@ initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
 // Note: Without OPTIONS[74] the negative part of the Pcow curve is not scaled
 template<class TraitsT>
 std::pair<typename TraitsT::Scalar, bool>
-EclMaterialLawManager<TraitsT>::
+Manager<TraitsT>::
 applySwatinit(unsigned elemIdx,
               Scalar pcow,
               Scalar Sw)
@@ -214,8 +214,9 @@ applySwatinit(unsigned elemIdx,
 
 template<class TraitsT>
 void
-EclMaterialLawManager<TraitsT>::applyRestartSwatInit(const unsigned elemIdx,
-                                                     const Scalar   maxPcow)
+Manager<TraitsT>::
+applyRestartSwatInit(const unsigned elemIdx,
+                     const Scalar   maxPcow)
 {
     // Maximum capillary pressure adjusted from SWATINIT data.
 
@@ -231,8 +232,8 @@ EclMaterialLawManager<TraitsT>::applyRestartSwatInit(const unsigned elemIdx,
 }
 
 template<class TraitsT>
-const typename EclMaterialLawManager<TraitsT>::MaterialLawParams&
-EclMaterialLawManager<TraitsT>::
+const typename Manager<TraitsT>::MaterialLawParams&
+Manager<TraitsT>::
 connectionMaterialLawParams(unsigned satRegionIdx, unsigned elemIdx) const
 {
     MaterialLawParams& mlp = const_cast<MaterialLawParams&>(materialLawParams_[elemIdx]);
@@ -321,7 +322,8 @@ connectionMaterialLawParams(unsigned satRegionIdx, unsigned elemIdx) const
 }
 
 template<class TraitsT>
-int EclMaterialLawManager<TraitsT>::
+int
+Manager<TraitsT>::
 getKrnumSatIdx(unsigned elemIdx, FaceDir::DirEnum facedir) const
 {
     using Dir = FaceDir::DirEnum;
@@ -348,7 +350,8 @@ getKrnumSatIdx(unsigned elemIdx, FaceDir::DirEnum facedir) const
 }
 
 template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+void
+Manager<TraitsT>::
 oilWaterHysteresisParams(Scalar& soMax,
                          Scalar& swMax,
                          Scalar& swMin,
@@ -362,7 +365,8 @@ oilWaterHysteresisParams(Scalar& soMax,
 }
 
 template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+void
+Manager<TraitsT>::
 setOilWaterHysteresisParams(const Scalar& soMax,
                             const Scalar& swMax,
                             const Scalar& swMin,
@@ -376,7 +380,8 @@ setOilWaterHysteresisParams(const Scalar& soMax,
 }
 
 template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+void
+Manager<TraitsT>::
 gasOilHysteresisParams(Scalar& sgmax,
                        Scalar& shmax,
                        Scalar& somin,
@@ -390,7 +395,8 @@ gasOilHysteresisParams(Scalar& sgmax,
 }
 
 template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+void
+Manager<TraitsT>::
 setGasOilHysteresisParams(const Scalar& sgmax,
                           const Scalar& shmax,
                           const Scalar& somin,
@@ -405,7 +411,7 @@ setGasOilHysteresisParams(const Scalar& sgmax,
 
 template<class TraitsT>
 EclEpsScalingPoints<typename TraitsT::Scalar>&
-EclMaterialLawManager<TraitsT>::
+Manager<TraitsT>::
 oilWaterScaledEpsPointsDrainage(unsigned elemIdx)
 {
     auto& materialParams = materialLawParams_[elemIdx];
@@ -435,8 +441,8 @@ oilWaterScaledEpsPointsDrainage(unsigned elemIdx)
 }
 
 template<class TraitsT>
-const typename EclMaterialLawManager<TraitsT>::MaterialLawParams&
-EclMaterialLawManager<TraitsT>::
+const typename Manager<TraitsT>::MaterialLawParams&
+Manager<TraitsT>::
 materialLawParamsFunc_(unsigned elemIdx, FaceDir::DirEnum facedir) const
 {
     using Dir = FaceDir::DirEnum;
@@ -461,7 +467,8 @@ materialLawParamsFunc_(unsigned elemIdx, FaceDir::DirEnum facedir) const
 }
 
 template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+void
+Manager<TraitsT>::
 readGlobalEpsOptions_(const EclipseState& eclState)
 {
     oilWaterEclEpsConfig_.initFromState(eclState, EclTwoPhaseSystemType::OilWater);
@@ -470,14 +477,16 @@ readGlobalEpsOptions_(const EclipseState& eclState)
 }
 
 template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+void
+Manager<TraitsT>::
 readGlobalHysteresisOptions_(const EclipseState& state)
 {
     hysteresisConfig_.initFromState(state.runspec());
 }
 
 template<class TraitsT>
-void EclMaterialLawManager<TraitsT>::
+void
+Manager<TraitsT>::
 readGlobalThreePhaseOptions_(const Runspec& runspec)
 {
     bool gasEnabled = runspec.phases().active(Phase::GAS);
@@ -514,10 +523,9 @@ readGlobalThreePhaseOptions_(const Runspec& runspec)
     }
 }
 
-
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,0,1,2>>;
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,0,1,2>>;
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,2,0,1>>;
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,2,0,1>>;
+template class Manager<ThreePhaseMaterialTraits<double,0,1,2>>;
+template class Manager<ThreePhaseMaterialTraits<float,0,1,2>>;
+template class Manager<ThreePhaseMaterialTraits<double,2,0,1>>;
+template class Manager<ThreePhaseMaterialTraits<float,2,0,1>>;
 
 } // namespace Opm::EclMaterialLaw

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -35,7 +35,7 @@
 
 #include <algorithm>
 
-namespace Opm {
+namespace Opm::EclMaterialLaw {
 
 template<class TraitsT>
 void EclMaterialLawManager<TraitsT>::
@@ -520,4 +520,4 @@ template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,0,1,2>>;
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,2,0,1>>;
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,2,0,1>>;
 
-} // namespace Opm
+} // namespace Opm::EclMaterialLaw

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -92,9 +92,6 @@ public:
     using MaterialLawParams = typename MaterialLaw::Params;
     using DirectionalMaterialLawParamsPtr = std::unique_ptr<DirectionalMaterialLawParams<MaterialLawParams>>;
 
-    EclMaterialLawManager();
-    ~EclMaterialLawManager();
-
 private:
     using GasOilScalingPointsVector = std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar>>>;
     using OilWaterScalingPointsVector = std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar>>>;

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -64,6 +64,10 @@ class SgofTable;
 class SlgofTable;
 class TableColumn;
 
+}
+
+namespace Opm::EclMaterialLaw {
+
 /*!
  * \ingroup fluidmatrixinteractions
  *

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -75,7 +75,7 @@ namespace Opm::EclMaterialLaw {
  *        for a complete ECL deck.
  */
 template <class TraitsT>
-class EclMaterialLawManager
+class Manager
 {
     using Traits = TraitsT;
     using Scalar = typename Traits::Scalar;
@@ -108,7 +108,7 @@ private:
     // This class' implementation is defined in "EclMaterialLawManagerInitParams.cpp"
     class InitParams {
     public:
-        InitParams(EclMaterialLawManager<TraitsT>& parent, const EclipseState& eclState, size_t numCompressedElems);
+        InitParams(Manager<TraitsT>& parent, const EclipseState& eclState, size_t numCompressedElems);
         // \brief Function argument 'fieldPropIntOnLeadAssigner' needed to lookup
         //        field properties of cells on the leaf grid view for CpGrid with local grid refinement.
         //        Function argument 'lookupIdxOnLevelZeroAssigner' is added to lookup, for each
@@ -160,7 +160,7 @@ private:
             using GasWaterHystParams = typename EclMaterialLaw::TwoPhaseTypes<Traits>::GasWaterHystParams;
             using OilWaterHystParams = typename EclMaterialLaw::TwoPhaseTypes<Traits>::OilWaterHystParams;
 
-            explicit HystParams(EclMaterialLawManager<TraitsT>::InitParams& init_params);
+            explicit HystParams(Manager<TraitsT>::InitParams& init_params);
             void finalize();
             std::shared_ptr<GasOilHystParams> getGasOilParams();
             std::shared_ptr<OilWaterHystParams> getOilWaterParams();
@@ -197,8 +197,8 @@ private:
             readScaledEpsPointsImbibition_(unsigned elemIdx, EclTwoPhaseSystemType type,
                                            const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
 
-            EclMaterialLawManager<TraitsT>::InitParams& init_params_;
-            EclMaterialLawManager<TraitsT>& parent_;
+            Manager<TraitsT>::InitParams& init_params_;
+            Manager<TraitsT>& parent_;
             const EclipseState& eclState_;
             std::shared_ptr<GasOilHystParams> gasOilParams_;
             std::shared_ptr<OilWaterHystParams> oilWaterParams_;
@@ -212,7 +212,7 @@ private:
             using OilWaterEffectiveParams = typename EclMaterialLaw::TwoPhaseTypes<Traits>::OilWaterEffectiveParams;
 
         public:
-            explicit ReadEffectiveParams(EclMaterialLawManager<TraitsT>::InitParams& init_params);
+            explicit ReadEffectiveParams(Manager<TraitsT>::InitParams& init_params);
             void read();
         private:
             std::vector<double> normalizeKrValues_(const double tolcrit, const TableColumn& krValues) const;
@@ -237,12 +237,12 @@ private:
             void readGasWaterParameters_(GasWaterEffectiveParamVector& dest, unsigned satRegionIdx);
             void readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionIdx);
 
-            EclMaterialLawManager<TraitsT>::InitParams& init_params_;
-            EclMaterialLawManager<TraitsT>& parent_;
+            Manager<TraitsT>::InitParams& init_params_;
+            Manager<TraitsT>& parent_;
             const EclipseState& eclState_;
         }; // end of "class ReadEffectiveParams"
 
-        EclMaterialLawManager<TraitsT>& parent_;
+        Manager<TraitsT>& parent_;
         const EclipseState& eclState_;
         size_t numCompressedElems_;
 

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
@@ -23,7 +23,7 @@
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
 #include <opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp>
 
-namespace Opm {
+namespace Opm::EclMaterialLaw {
 
 /* constructors*/
 template <class Traits>
@@ -312,5 +312,4 @@ template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,0,1,2>>::Ini
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,2,0,1>>::InitParams::HystParams;
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,2,0,1>>::InitParams::HystParams;
 
-
-} // namespace Opm
+} // namespace Opm::EclMaterialLaw

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
@@ -27,8 +27,8 @@ namespace Opm::EclMaterialLaw {
 
 /* constructors*/
 template <class Traits>
-EclMaterialLawManager<Traits>::InitParams::HystParams::
-HystParams(EclMaterialLawManager<Traits>::InitParams& init_params) :
+Manager<Traits>::InitParams::HystParams::
+HystParams(Manager<Traits>::InitParams& init_params) :
     init_params_{init_params}, parent_{init_params_.parent_},
     eclState_{init_params_.eclState_}
 {
@@ -41,7 +41,7 @@ HystParams(EclMaterialLawManager<Traits>::InitParams& init_params) :
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+Manager<Traits>::InitParams::HystParams::
 finalize()
 {
     if (hasGasOil_())
@@ -53,24 +53,24 @@ finalize()
 }
 
 template <class Traits>
-std::shared_ptr<typename EclMaterialLaw::TwoPhaseTypes<Traits>::GasOilHystParams>
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+std::shared_ptr<typename TwoPhaseTypes<Traits>::GasOilHystParams>
+Manager<Traits>::InitParams::HystParams::
 getGasOilParams()
 {
     return gasOilParams_;
 }
 
 template <class Traits>
-std::shared_ptr<typename EclMaterialLaw::TwoPhaseTypes<Traits>::OilWaterHystParams>
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+std::shared_ptr<typename TwoPhaseTypes<Traits>::OilWaterHystParams>
+Manager<Traits>::InitParams::HystParams::
 getOilWaterParams()
 {
     return oilWaterParams_;
 }
 
 template <class Traits>
-std::shared_ptr<typename EclMaterialLaw::TwoPhaseTypes<Traits>::GasWaterHystParams>
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+std::shared_ptr<typename TwoPhaseTypes<Traits>::GasWaterHystParams>
+Manager<Traits>::InitParams::HystParams::
 getGasWaterParams()
 {
     return gasWaterParams_;
@@ -78,7 +78,7 @@ getGasWaterParams()
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+Manager<Traits>::InitParams::HystParams::
 setConfig(unsigned satRegionIdx)
 {
     this->gasOilParams_->setConfig(this->parent_.hysteresisConfig_);
@@ -95,14 +95,14 @@ setConfig(unsigned satRegionIdx)
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+Manager<Traits>::InitParams::HystParams::
 setDrainageParamsGasWater(unsigned elemIdx, unsigned satRegionIdx,
                           const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
     if (hasGasWater_()) {
         auto [gasWaterScaledInfo, gasWaterScaledPoints]
             = readScaledEpsPointsDrainage_(elemIdx, EclTwoPhaseSystemType::GasWater, lookupIdxOnLevelZeroAssigner);
-        typename EclMaterialLaw::TwoPhaseTypes<Traits>::GasWaterEpsParams gasWaterDrainParams;
+        typename TwoPhaseTypes<Traits>::GasWaterEpsParams gasWaterDrainParams;
         gasWaterDrainParams.setConfig(this->parent_.gasWaterConfig_);
         gasWaterDrainParams.setUnscaledPoints(this->parent_.gasWaterUnscaledPointsVector_[satRegionIdx]);
         gasWaterDrainParams.setScaledPoints(gasWaterScaledPoints);
@@ -114,14 +114,14 @@ setDrainageParamsGasWater(unsigned elemIdx, unsigned satRegionIdx,
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+Manager<Traits>::InitParams::HystParams::
 setDrainageParamsOilGas(unsigned elemIdx, unsigned satRegionIdx,
                         const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
     if (hasGasOil_()) {
         auto [gasOilScaledInfo, gasOilScaledPoints]
             = readScaledEpsPointsDrainage_(elemIdx, EclTwoPhaseSystemType::GasOil, lookupIdxOnLevelZeroAssigner);
-        typename EclMaterialLaw::TwoPhaseTypes<Traits>::GasOilEpsParams gasOilDrainParams;
+        typename TwoPhaseTypes<Traits>::GasOilEpsParams gasOilDrainParams;
         gasOilDrainParams.setConfig(this->parent_.gasOilConfig_);
         gasOilDrainParams.setUnscaledPoints(this->parent_.gasOilUnscaledPointsVector_[satRegionIdx]);
         gasOilDrainParams.setScaledPoints(gasOilScaledPoints);
@@ -133,7 +133,7 @@ setDrainageParamsOilGas(unsigned elemIdx, unsigned satRegionIdx,
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+Manager<Traits>::InitParams::HystParams::
 setDrainageParamsOilWater(unsigned elemIdx, unsigned satRegionIdx,
                           const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
@@ -149,7 +149,7 @@ setDrainageParamsOilWater(unsigned elemIdx, unsigned satRegionIdx,
     //   to include three more vectors, one with info for each facedir of a cell
     this->parent_.oilWaterScaledEpsInfoDrainage_[elemIdx] = oilWaterScaledInfo;
     if (hasOilWater_()) {
-        typename EclMaterialLaw::TwoPhaseTypes<Traits>::OilWaterEpsParams oilWaterDrainParams;
+        typename TwoPhaseTypes<Traits>::OilWaterEpsParams oilWaterDrainParams;
         oilWaterDrainParams.setConfig(this->parent_.oilWaterConfig_);
         oilWaterDrainParams.setUnscaledPoints(this->parent_.oilWaterUnscaledPointsVector_[satRegionIdx]);
         oilWaterDrainParams.setScaledPoints(oilWaterScaledPoints);
@@ -161,7 +161,7 @@ setDrainageParamsOilWater(unsigned elemIdx, unsigned satRegionIdx,
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+Manager<Traits>::InitParams::HystParams::
 setImbibitionParamsGasWater(unsigned elemIdx, unsigned imbRegionIdx,
                             const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
@@ -177,13 +177,12 @@ setImbibitionParamsGasWater(unsigned elemIdx, unsigned imbRegionIdx,
         this->gasWaterParams_->setImbibitionParams(gasWaterImbParamsHyst,
                                                    gasWaterScaledInfo,
                                                    EclTwoPhaseSystemType::GasWater);
-
     }
 }
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+Manager<Traits>::InitParams::HystParams::
 setImbibitionParamsOilGas(unsigned elemIdx, unsigned imbRegionIdx,
                           const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
@@ -191,7 +190,7 @@ setImbibitionParamsOilGas(unsigned elemIdx, unsigned imbRegionIdx,
         auto [gasOilScaledInfo, gasOilScaledPoints]
             = readScaledEpsPointsImbibition_(elemIdx, EclTwoPhaseSystemType::GasOil, lookupIdxOnLevelZeroAssigner);
 
-        typename EclMaterialLaw::TwoPhaseTypes<Traits>::GasOilEpsParams gasOilImbParamsHyst;
+        typename TwoPhaseTypes<Traits>::GasOilEpsParams gasOilImbParamsHyst;
         gasOilImbParamsHyst.setConfig(this->parent_.gasOilConfig_);
         gasOilImbParamsHyst.setUnscaledPoints(this->parent_.gasOilUnscaledPointsVector_[imbRegionIdx]);
         gasOilImbParamsHyst.setScaledPoints(gasOilScaledPoints);
@@ -205,14 +204,14 @@ setImbibitionParamsOilGas(unsigned elemIdx, unsigned imbRegionIdx,
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+Manager<Traits>::InitParams::HystParams::
 setImbibitionParamsOilWater(unsigned elemIdx, unsigned imbRegionIdx,
                             const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
     if (hasOilWater_()) {
         auto [oilWaterScaledInfo, oilWaterScaledPoints]
             = readScaledEpsPointsImbibition_(elemIdx, EclTwoPhaseSystemType::OilWater, lookupIdxOnLevelZeroAssigner);
-        typename EclMaterialLaw::TwoPhaseTypes<Traits>::OilWaterEpsParams oilWaterImbParamsHyst;
+        typename TwoPhaseTypes<Traits>::OilWaterEpsParams oilWaterImbParamsHyst;
         oilWaterImbParamsHyst.setConfig(this->parent_.oilWaterConfig_);
         oilWaterImbParamsHyst.setUnscaledPoints(this->parent_.oilWaterUnscaledPointsVector_[imbRegionIdx]);
         oilWaterImbParamsHyst.setScaledPoints(oilWaterScaledPoints);
@@ -221,7 +220,6 @@ setImbibitionParamsOilWater(unsigned elemIdx, unsigned imbRegionIdx,
         this->oilWaterParams_->setImbibitionParams(oilWaterImbParamsHyst,
                                                    oilWaterScaledInfo,
                                                    EclTwoPhaseSystemType::OilWater);
-
     }
 }
 
@@ -229,7 +227,7 @@ setImbibitionParamsOilWater(unsigned elemIdx, unsigned imbRegionIdx,
 
 template <class Traits>
 bool
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+Manager<Traits>::InitParams::HystParams::
 hasGasOil_()
 {
     return this->parent_.hasGas && this->parent_.hasOil;
@@ -237,7 +235,7 @@ hasGasOil_()
 
 template <class Traits>
 bool
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+Manager<Traits>::InitParams::HystParams::
 hasGasWater_()
 {
     return this->parent_.hasGas && this->parent_.hasWater && !this->parent_.hasOil;
@@ -245,19 +243,19 @@ hasGasWater_()
 
 template <class Traits>
 bool
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+Manager<Traits>::InitParams::HystParams::
 hasOilWater_()
 {
     return this->parent_.hasOil && this->parent_.hasWater;
 }
 
 template <class Traits>
-std::tuple<
-  EclEpsScalingPointsInfo<typename EclMaterialLawManager<Traits>::Scalar>,
-  EclEpsScalingPoints<typename EclMaterialLawManager<Traits>::Scalar>
->
-EclMaterialLawManager<Traits>::InitParams::HystParams::
-readScaledEpsPoints_(const EclEpsGridProperties& epsGridProperties, unsigned elemIdx, EclTwoPhaseSystemType type,
+std::tuple<EclEpsScalingPointsInfo<typename Traits::Scalar>,
+           EclEpsScalingPoints<typename Traits::Scalar>>
+Manager<Traits>::InitParams::HystParams::
+readScaledEpsPoints_(const EclEpsGridProperties& epsGridProperties,
+                     unsigned elemIdx,
+                     EclTwoPhaseSystemType type,
                      const std::function<unsigned(unsigned)>& fieldPropIdxOnLevelZero)
 {
     const EclEpsConfig& config =
@@ -281,11 +279,9 @@ readScaledEpsPoints_(const EclEpsGridProperties& epsGridProperties, unsigned ele
 }
 
 template <class Traits>
-std::tuple<
-  EclEpsScalingPointsInfo<typename EclMaterialLawManager<Traits>::Scalar>,
-  EclEpsScalingPoints<typename EclMaterialLawManager<Traits>::Scalar>
->
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+std::tuple<EclEpsScalingPointsInfo<typename Traits::Scalar>,
+           EclEpsScalingPoints<typename Traits::Scalar>>
+Manager<Traits>::InitParams::HystParams::
 readScaledEpsPointsDrainage_(unsigned elemIdx, EclTwoPhaseSystemType type,
                              const std::function<unsigned(unsigned)>& fieldPropIdxOnLevelZero)
 {
@@ -294,11 +290,9 @@ readScaledEpsPointsDrainage_(unsigned elemIdx, EclTwoPhaseSystemType type,
 }
 
 template <class Traits>
-std::tuple<
-  EclEpsScalingPointsInfo<typename EclMaterialLawManager<Traits>::Scalar>,
-  EclEpsScalingPoints<typename EclMaterialLawManager<Traits>::Scalar>
->
-EclMaterialLawManager<Traits>::InitParams::HystParams::
+std::tuple<EclEpsScalingPointsInfo<typename Traits::Scalar>,
+           EclEpsScalingPoints<typename Traits::Scalar>>
+Manager<Traits>::InitParams::HystParams::
 readScaledEpsPointsImbibition_(unsigned elemIdx, EclTwoPhaseSystemType type,
                                const std::function<unsigned(unsigned)>& fieldPropIdxOnLevelZero)
 {
@@ -307,9 +301,9 @@ readScaledEpsPointsImbibition_(unsigned elemIdx, EclTwoPhaseSystemType type,
 }
 
 // Make some actual code, by realizing the previously defined templated class
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,0,1,2>>::InitParams::HystParams;
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,0,1,2>>::InitParams::HystParams;
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,2,0,1>>::InitParams::HystParams;
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,2,0,1>>::InitParams::HystParams;
+template class Manager<ThreePhaseMaterialTraits<double,0,1,2>>::InitParams::HystParams;
+template class Manager<ThreePhaseMaterialTraits<float,0,1,2>>::InitParams::HystParams;
+template class Manager<ThreePhaseMaterialTraits<double,2,0,1>>::InitParams::HystParams;
+template class Manager<ThreePhaseMaterialTraits<float,2,0,1>>::InitParams::HystParams;
 
 } // namespace Opm::EclMaterialLaw

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
@@ -32,8 +32,8 @@ namespace Opm::EclMaterialLaw {
 /* constructors*/
 
 template <class Traits>
-EclMaterialLawManager<Traits>::InitParams::
-InitParams(EclMaterialLawManager<Traits>& parent, const EclipseState& eclState, size_t numCompressedElems) :
+Manager<Traits>::InitParams::
+InitParams(Manager<Traits>& parent, const EclipseState& eclState, size_t numCompressedElems) :
     parent_{parent},
     eclState_{eclState},
     numCompressedElems_{numCompressedElems}
@@ -52,7 +52,7 @@ InitParams(EclMaterialLawManager<Traits>& parent, const EclipseState& eclState, 
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::
+Manager<Traits>::InitParams::
 run(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>&
     fieldPropIntOnLeafAssigner,
     const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
@@ -96,8 +96,9 @@ run(const std::function<std::vector<int>(const FieldPropsManager&, const std::st
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::
-copySatnumArrays_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
+Manager<Traits>::InitParams::
+copySatnumArrays_(const std::function<std::vector<int>(const FieldPropsManager&,
+                                                       const std::string&, bool)>& fieldPropIntOnLeafAssigner)
 {
     copyIntArray_(this->parent_.krnumXArray_, "KRNUMX", fieldPropIntOnLeafAssigner);
     copyIntArray_(this->parent_.krnumYArray_, "KRNUMY", fieldPropIntOnLeafAssigner);
@@ -115,9 +116,11 @@ copySatnumArrays_(const std::function<std::vector<int>(const FieldPropsManager&,
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::
-copyIntArray_(std::vector<int>& dest, const std::string& keyword,
-              const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
+Manager<Traits>::InitParams::
+copyIntArray_(std::vector<int>& dest,
+              const std::string& keyword,
+              const std::function<std::vector<int>(const FieldPropsManager&,
+                                                   const std::string&, bool)>& fieldPropIntOnLeafAssigner)
 {
     if (this->eclState_.fieldProps().has_int(keyword)) {
         dest = fieldPropIntOnLeafAssigner(this->eclState_.fieldProps(), keyword, /*needsTranslation*/true);
@@ -126,7 +129,7 @@ copyIntArray_(std::vector<int>& dest, const std::string& keyword,
 
 template <class Traits>
 unsigned
-EclMaterialLawManager<Traits>::InitParams::
+Manager<Traits>::InitParams::
 imbRegion_(std::vector<int>& array, unsigned elemIdx)
 {
     std::vector<int>& default_vec = this->parent_.imbnumRegionArray_;
@@ -135,11 +138,10 @@ imbRegion_(std::vector<int>& array, unsigned elemIdx)
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::
-initArrays_(
-        std::vector<std::vector<int>*>& satnumArray,
-        std::vector<std::vector<int>*>& imbnumArray,
-        std::vector<std::vector<MaterialLawParams>*>& mlpArray)
+Manager<Traits>::InitParams::
+initArrays_(std::vector<std::vector<int>*>& satnumArray,
+            std::vector<std::vector<int>*>& imbnumArray,
+            std::vector<std::vector<MaterialLawParams>*>& mlpArray)
 {
     satnumArray.push_back(&this->parent_.satnumRegionArray_);
     imbnumArray.push_back(&this->parent_.imbnumRegionArray_);
@@ -163,7 +165,7 @@ initArrays_(
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::
+Manager<Traits>::InitParams::
 initMaterialLawParamVectors_()
 {
     this->parent_.materialLawParams_.resize(this->numCompressedElems_);
@@ -175,7 +177,7 @@ initMaterialLawParamVectors_()
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::
+Manager<Traits>::InitParams::
 initOilWaterScaledEpsInfo_()
 {
     // This vector will be updated in the hystParams.setDrainageOilWater() in the run() method
@@ -184,8 +186,9 @@ initOilWaterScaledEpsInfo_()
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::
-initSatnumRegionArray_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
+Manager<Traits>::InitParams::
+initSatnumRegionArray_(const std::function<std::vector<int>(const FieldPropsManager&,
+                                                            const std::string&, bool)>& fieldPropIntOnLeafAssigner)
 {
     // copy the SATNUM grid property. in some cases this is not necessary, but it
     // should not require much memory anyway...
@@ -201,7 +204,7 @@ initSatnumRegionArray_(const std::function<std::vector<int>(const FieldPropsMana
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::
+Manager<Traits>::InitParams::
 initThreePhaseParams_(HystParams &hystParams,
                       MaterialLawParams& materialParams,
                       unsigned satRegionIdx,
@@ -266,7 +269,7 @@ initThreePhaseParams_(HystParams &hystParams,
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::
+Manager<Traits>::InitParams::
 readEffectiveParameters_()
 {
     ReadEffectiveParams effectiveReader {*this};
@@ -276,7 +279,7 @@ readEffectiveParameters_()
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::
+Manager<Traits>::InitParams::
 readUnscaledEpsPointsVectors_()
 {
     if (this->parent_.hasGas && this->parent_.hasOil) {
@@ -305,7 +308,7 @@ readUnscaledEpsPointsVectors_()
 template <class Traits>
 template <class Container>
 void
-EclMaterialLawManager<Traits>::InitParams::
+Manager<Traits>::InitParams::
 readUnscaledEpsPoints_(Container& dest,
                        const EclEpsConfig& config,
                        EclTwoPhaseSystemType system_type)
@@ -320,7 +323,7 @@ readUnscaledEpsPoints_(Container& dest,
 
 template <class Traits>
 unsigned
-EclMaterialLawManager<Traits>::InitParams::
+Manager<Traits>::InitParams::
 satRegion_(std::vector<int>& array, unsigned elemIdx)
 {
     std::vector<int>& default_vec = this->parent_.satnumRegionArray_;
@@ -329,8 +332,10 @@ satRegion_(std::vector<int>& array, unsigned elemIdx)
 
 template <class Traits>
 unsigned
-EclMaterialLawManager<Traits>::InitParams::
-satOrImbRegion_(std::vector<int>& array, std::vector<int>& default_vec, unsigned elemIdx)
+Manager<Traits>::InitParams::
+satOrImbRegion_(std::vector<int>& array,
+                std::vector<int>& default_vec,
+                unsigned elemIdx)
 {
     int value;
     if (array.size() > 0) {
@@ -343,9 +348,9 @@ satOrImbRegion_(std::vector<int>& array, std::vector<int>& default_vec, unsigned
 }
 
 // Make some actual code, by realizing the previously defined templated class
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,0,1,2>>::InitParams;
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,0,1,2>>::InitParams;
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,2,0,1>>::InitParams;
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,2,0,1>>::InitParams;
+template class Manager<ThreePhaseMaterialTraits<double,0,1,2>>::InitParams;
+template class Manager<ThreePhaseMaterialTraits<float,0,1,2>>::InitParams;
+template class Manager<ThreePhaseMaterialTraits<double,2,0,1>>::InitParams;
+template class Manager<ThreePhaseMaterialTraits<float,2,0,1>>::InitParams;
 
 } // namespace Opm::EclMaterialLaw

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
@@ -27,7 +27,7 @@
 #include <opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp>
 
 
-namespace Opm {
+namespace Opm::EclMaterialLaw {
 
 /* constructors*/
 
@@ -348,4 +348,4 @@ template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,0,1,2>>::Ini
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,2,0,1>>::InitParams;
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,2,0,1>>::InitParams;
 
-} // namespace Opm
+} // namespace Opm::EclMaterialLaw

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
@@ -34,7 +34,7 @@
 
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 
-namespace Opm {
+namespace Opm::EclMaterialLaw {
 
 /* constructors*/
 template <class Traits>
@@ -458,5 +458,4 @@ template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,0,1,2>>::Ini
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,2,0,1>>::InitParams::ReadEffectiveParams;
 template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,2,0,1>>::InitParams::ReadEffectiveParams;
 
-
-} // namespace Opm
+} // namespace Opm::EclMaterialLaw

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
@@ -38,8 +38,8 @@ namespace Opm::EclMaterialLaw {
 
 /* constructors*/
 template <class Traits>
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
-ReadEffectiveParams(EclMaterialLawManager<Traits>::InitParams& init_params) :
+Manager<Traits>::InitParams::ReadEffectiveParams::
+ReadEffectiveParams(Manager<Traits>::InitParams& init_params) :
     init_params_{init_params}, parent_{init_params_.parent_},
     eclState_{init_params_.eclState_}
 {
@@ -48,7 +48,7 @@ ReadEffectiveParams(EclMaterialLawManager<Traits>::InitParams& init_params) :
 /* public methods */
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+Manager<Traits>::InitParams::ReadEffectiveParams::
 read() {
     auto& gasOilVector = this->parent_.gasOilEffectiveParamVector_;
     auto& oilWaterVector = this->parent_.oilWaterEffectiveParamVector_;
@@ -70,7 +70,7 @@ read() {
 // Relative permeability values not strictly greater than 'tolcrit' treated as zero.
 template <class Traits>
 std::vector<double>
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+Manager<Traits>::InitParams::ReadEffectiveParams::
 normalizeKrValues_(const double tolcrit, const TableColumn& krValues) const
 {
     auto kr = krValues.vectorCopy();
@@ -85,7 +85,7 @@ normalizeKrValues_(const double tolcrit, const TableColumn& krValues) const
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+Manager<Traits>::InitParams::ReadEffectiveParams::
 readGasOilParameters_(GasOilEffectiveParamVector& dest, unsigned satRegionIdx)
 {
     if (!this->parent_.hasGas || !this->parent_.hasOil)
@@ -183,7 +183,7 @@ readGasOilParameters_(GasOilEffectiveParamVector& dest, unsigned satRegionIdx)
 template <class Traits>
 template <class TableType>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+Manager<Traits>::InitParams::ReadEffectiveParams::
 readGasOilFamily2_(GasOilEffectiveParams& effParams,
                    const Scalar Swco,
                    const double tolcrit,
@@ -209,7 +209,7 @@ readGasOilFamily2_(GasOilEffectiveParams& effParams,
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+Manager<Traits>::InitParams::ReadEffectiveParams::
 readGasOilSgof_(GasOilEffectiveParams& effParams,
                 const Scalar Swco,
                 const double tolcrit,
@@ -232,7 +232,7 @@ readGasOilSgof_(GasOilEffectiveParams& effParams,
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+Manager<Traits>::InitParams::ReadEffectiveParams::
 readGasOilSlgof_(GasOilEffectiveParams& effParams,
                  const Scalar Swco,
                  const double tolcrit,
@@ -255,7 +255,7 @@ readGasOilSlgof_(GasOilEffectiveParams& effParams,
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+Manager<Traits>::InitParams::ReadEffectiveParams::
 readGasWaterParameters_(GasWaterEffectiveParamVector& dest, unsigned satRegionIdx)
 {
     if (!this->parent_.hasGas || !this->parent_.hasWater || this->parent_.hasOil)
@@ -338,7 +338,7 @@ readGasWaterParameters_(GasWaterEffectiveParamVector& dest, unsigned satRegionId
 
 template <class Traits>
 void
-EclMaterialLawManager<Traits>::InitParams::ReadEffectiveParams::
+Manager<Traits>::InitParams::ReadEffectiveParams::
 readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionIdx)
 {
     if (!this->parent_.hasOil || !this->parent_.hasWater)
@@ -453,9 +453,9 @@ readOilWaterParameters_(OilWaterEffectiveParamVector& dest, unsigned satRegionId
 }
 
 // Make some actual code, by realizing the previously defined templated class
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,0,1,2>>::InitParams::ReadEffectiveParams;
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,0,1,2>>::InitParams::ReadEffectiveParams;
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<double,2,0,1>>::InitParams::ReadEffectiveParams;
-template class EclMaterialLawManager<ThreePhaseMaterialTraits<float,2,0,1>>::InitParams::ReadEffectiveParams;
+template class Manager<ThreePhaseMaterialTraits<double,0,1,2>>::InitParams::ReadEffectiveParams;
+template class Manager<ThreePhaseMaterialTraits<float,0,1,2>>::InitParams::ReadEffectiveParams;
+template class Manager<ThreePhaseMaterialTraits<double,2,0,1>>::InitParams::ReadEffectiveParams;
+template class Manager<ThreePhaseMaterialTraits<float,2,0,1>>::InitParams::ReadEffectiveParams;
 
 } // namespace Opm::EclMaterialLaw

--- a/tests/material/test_eclmateriallawmanager.cpp
+++ b/tests/material/test_eclmateriallawmanager.cpp
@@ -609,7 +609,7 @@ struct Fixture {
                                                     /*storeDensity=*/false,
                                                     /*storeViscosity=*/false,
                                                     /*storeEnthalpy=*/false>;
-    using MaterialLawManager = Opm::EclMaterialLaw::EclMaterialLawManager<MaterialTraits>;
+    using MaterialLawManager = Opm::EclMaterialLaw::Manager<MaterialTraits>;
     using MaterialLaw = typename MaterialLawManager::MaterialLaw;
 };
 

--- a/tests/material/test_eclmateriallawmanager.cpp
+++ b/tests/material/test_eclmateriallawmanager.cpp
@@ -609,7 +609,7 @@ struct Fixture {
                                                     /*storeDensity=*/false,
                                                     /*storeViscosity=*/false,
                                                     /*storeEnthalpy=*/false>;
-    using MaterialLawManager = Opm::EclMaterialLawManager<MaterialTraits>;
+    using MaterialLawManager = Opm::EclMaterialLaw::EclMaterialLawManager<MaterialTraits>;
     using MaterialLaw = typename MaterialLawManager::MaterialLaw;
 };
 

--- a/tests/material/test_hysteresis.cpp
+++ b/tests/material/test_hysteresis.cpp
@@ -721,7 +721,7 @@ struct Fixture {
                                                     /*storeDensity=*/false,
                                                     /*storeViscosity=*/false,
                                                     /*storeEnthalpy=*/false>;
-    using MaterialLawManager = Opm::EclMaterialLaw::EclMaterialLawManager<MaterialTraits>;
+    using MaterialLawManager = Opm::EclMaterialLaw::Manager<MaterialTraits>;
     using MaterialLaw = typename MaterialLawManager::MaterialLaw;
 };
 

--- a/tests/material/test_hysteresis.cpp
+++ b/tests/material/test_hysteresis.cpp
@@ -721,7 +721,7 @@ struct Fixture {
                                                     /*storeDensity=*/false,
                                                     /*storeViscosity=*/false,
                                                     /*storeEnthalpy=*/false>;
-    using MaterialLawManager = Opm::EclMaterialLawManager<MaterialTraits>;
+    using MaterialLawManager = Opm::EclMaterialLaw::EclMaterialLawManager<MaterialTraits>;
     using MaterialLaw = typename MaterialLawManager::MaterialLaw;
 };
 


### PR DESCRIPTION
The nested classes (ref https://github.com/OPM/opm-common/pull/4706) naturally gives a grouping of the manager and its utility classes. When un-nesting this becomes less clear, so to keep this intact, we achieve this by using a ```namespace Opm::EclMaterialLaw``` instead. Since ```Opm::EclMaterialLaw::EclMaterialLawManager``` is a mouthful, I have opted to rename the class to Manager, ie, ```Opm::EclMaterialLaw::Manager```