### PR TITLE
HybridNewtonFlag NNModel type handling

### DIFF
--- a/opm/ml/ml_model.cpp
+++ b/opm/ml/ml_model.cpp
@@ -346,6 +346,9 @@ namespace ML
     }
 
     template class NNModel<float>;
+    template class NNModel<Opm::DenseAd::Evaluation<float, 3>>;
+    template class NNModel<Opm::DenseAd::Evaluation<float, 2>>;
+    template class NNModel<Opm::DenseAd::Evaluation<float, 1>>;
 
     template class NNModel<double>;
     template class NNModel<Opm::DenseAd::Evaluation<double, 6>>;


### PR DESCRIPTION
Added NNModel type supports. 
Linked to:This PR builds upon 
[OPM/opm-simulators#6424](https://github.com/OPM/opm-simulators/pull/6424), which introduces the Hybrid Newton flag.
