### PR TITLE
EclMaterialLawManager::InitParams: rename EclMaterialLaw::InitParams

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -354,9 +354,9 @@ if(ENABLE_ECL_INPUT)
     opm/material/fluidmatrixinteractions/EclEpsConfig.cpp
     opm/material/fluidmatrixinteractions/EclEpsGridProperties.cpp
     opm/material/fluidmatrixinteractions/EclHysteresisConfig.cpp
+    opm/material/fluidmatrixinteractions/EclMaterialLawInitParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawHystParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
-    opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
     opm/material/fluidmatrixinteractions/EclMaterialLawReadEffectiveParams.cpp
     opm/material/thermal/EclThermalLawManager.cpp
   )
@@ -1061,6 +1061,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/fluidmatrixinteractions/SplineTwoPhaseMaterialParams.hpp
       opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
       opm/material/fluidmatrixinteractions/TwoPhaseLETCurves.hpp
+      opm/material/fluidmatrixinteractions/EclMaterialLawInitParams.hpp
       opm/material/fluidmatrixinteractions/EclMaterialLawHystParams.hpp
       opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
       opm/material/fluidmatrixinteractions/EclMaterialLawReadEffectiveParams.hpp

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawHystParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawHystParams.cpp
@@ -30,12 +30,12 @@ namespace Opm::EclMaterialLaw {
 /* constructors*/
 template <class Traits>
 HystParams<Traits>::
-HystParams(std::vector<EclEpsScalingPointsInfo<Scalar>>& oilWaterScaledEpsInfoDrainage,
+HystParams(typename Manager<Traits>::Params& params,
            const EclEpsGridProperties& epsGridProperties,
            const EclEpsGridProperties& epsImbGridProperties,
            const EclipseState& eclState,
            const Manager<Traits>& parent)
-    : oilWaterScaledEpsInfoDrainage_(oilWaterScaledEpsInfoDrainage)
+    : params_(params)
     , epsGridProperties_(epsGridProperties)
     , epsImbGridProperties_(epsImbGridProperties)
     , eclState_(eclState)
@@ -91,9 +91,9 @@ setDrainageParamsGasWater(unsigned elemIdx, unsigned satRegionIdx,
             = readScaledEpsPointsDrainage_(elemIdx, EclTwoPhaseSystemType::GasWater, lookupIdxOnLevelZeroAssigner);
         typename TwoPhaseTypes<Traits>::GasWaterEpsParams gasWaterDrainParams;
         gasWaterDrainParams.setConfig(this->parent_.gasWaterConfig());
-        gasWaterDrainParams.setUnscaledPoints(this->parent_.gasWaterUnscaledPoints(satRegionIdx));
+        gasWaterDrainParams.setUnscaledPoints(this->params_.gasWaterUnscaledPointsVector[satRegionIdx]);
         gasWaterDrainParams.setScaledPoints(gasWaterScaledPoints);
-        gasWaterDrainParams.setEffectiveLawParams(this->parent_.gasWaterEffectiveParams(satRegionIdx));
+        gasWaterDrainParams.setEffectiveLawParams(this->params_.gasWaterEffectiveParamVector[satRegionIdx]);
         gasWaterDrainParams.finalize();
         this->gasWaterParams_->setDrainageParams(gasWaterDrainParams,
                                                  gasWaterScaledInfo,
@@ -112,9 +112,9 @@ setDrainageParamsOilGas(unsigned elemIdx, unsigned satRegionIdx,
             = readScaledEpsPointsDrainage_(elemIdx, EclTwoPhaseSystemType::GasOil, lookupIdxOnLevelZeroAssigner);
         typename TwoPhaseTypes<Traits>::GasOilEpsParams gasOilDrainParams;
         gasOilDrainParams.setConfig(this->parent_.gasOilConfig());
-        gasOilDrainParams.setUnscaledPoints(this->parent_.gasOilUnscaledPoints(satRegionIdx));
+        gasOilDrainParams.setUnscaledPoints(this->params_.gasOilUnscaledPointsVector[satRegionIdx]);
         gasOilDrainParams.setScaledPoints(gasOilScaledPoints);
-        gasOilDrainParams.setEffectiveLawParams(this->parent_.gasOilEffectiveParams(satRegionIdx));
+        gasOilDrainParams.setEffectiveLawParams(this->params_.gasOilEffectiveParamVector[satRegionIdx]);
         gasOilDrainParams.finalize();
         this->gasOilParams_->setDrainageParams(gasOilDrainParams,
                                                gasOilScaledInfo,
@@ -138,13 +138,13 @@ setDrainageParamsOilWater(unsigned elemIdx, unsigned satRegionIdx,
     //  since we currently does not support facedir for the scaling points info
     //  When such support is added, we need to extend the below vector which has info for each cell
     //   to include three more vectors, one with info for each facedir of a cell
-    oilWaterScaledEpsInfoDrainage_[elemIdx] = oilWaterScaledInfo;
+    params_.oilWaterScaledEpsInfoDrainage[elemIdx] = oilWaterScaledInfo;
     if (hasOilWater_()) {
         typename TwoPhaseTypes<Traits>::OilWaterEpsParams oilWaterDrainParams;
         oilWaterDrainParams.setConfig(this->parent_.oilWaterConfig());
-        oilWaterDrainParams.setUnscaledPoints(this->parent_.oilWaterUnscaledPoints(satRegionIdx));
+        oilWaterDrainParams.setUnscaledPoints(this->params_.oilWaterUnscaledPointsVector[satRegionIdx]);
         oilWaterDrainParams.setScaledPoints(oilWaterScaledPoints);
-        oilWaterDrainParams.setEffectiveLawParams(this->parent_.oilWaterEffectiveParams(satRegionIdx));
+        oilWaterDrainParams.setEffectiveLawParams(this->params_.oilWaterEffectiveParamVector[satRegionIdx]);
         oilWaterDrainParams.finalize();
         oilWaterParams_->setDrainageParams(oilWaterDrainParams, oilWaterScaledInfo, EclTwoPhaseSystemType::OilWater);
     }
@@ -161,9 +161,9 @@ setImbibitionParamsGasWater(unsigned elemIdx, unsigned imbRegionIdx,
             = readScaledEpsPointsImbibition_(elemIdx, EclTwoPhaseSystemType::GasWater, lookupIdxOnLevelZeroAssigner);
         typename EclMaterialLaw::TwoPhaseTypes<Traits>::GasWaterEpsParams gasWaterImbParamsHyst;
         gasWaterImbParamsHyst.setConfig(this->parent_.gasWaterConfig());
-        gasWaterImbParamsHyst.setUnscaledPoints(this->parent_.gasWaterUnscaledPoints(imbRegionIdx));
+        gasWaterImbParamsHyst.setUnscaledPoints(this->params_.gasWaterUnscaledPointsVector[imbRegionIdx]);
         gasWaterImbParamsHyst.setScaledPoints(gasWaterScaledPoints);
-        gasWaterImbParamsHyst.setEffectiveLawParams(this->parent_.gasWaterEffectiveParams(imbRegionIdx));
+        gasWaterImbParamsHyst.setEffectiveLawParams(this->params_.gasWaterEffectiveParamVector[imbRegionIdx]);
         gasWaterImbParamsHyst.finalize();
         this->gasWaterParams_->setImbibitionParams(gasWaterImbParamsHyst,
                                                    gasWaterScaledInfo,
@@ -183,9 +183,9 @@ setImbibitionParamsOilGas(unsigned elemIdx, unsigned imbRegionIdx,
 
         typename TwoPhaseTypes<Traits>::GasOilEpsParams gasOilImbParamsHyst;
         gasOilImbParamsHyst.setConfig(this->parent_.gasOilConfig());
-        gasOilImbParamsHyst.setUnscaledPoints(this->parent_.gasOilUnscaledPoints(imbRegionIdx));
+        gasOilImbParamsHyst.setUnscaledPoints(this->params_.gasOilUnscaledPointsVector[imbRegionIdx]);
         gasOilImbParamsHyst.setScaledPoints(gasOilScaledPoints);
-        gasOilImbParamsHyst.setEffectiveLawParams(this->parent_.gasOilEffectiveParams(imbRegionIdx));
+        gasOilImbParamsHyst.setEffectiveLawParams(this->params_.gasOilEffectiveParamVector[imbRegionIdx]);
         gasOilImbParamsHyst.finalize();
         this->gasOilParams_->setImbibitionParams(gasOilImbParamsHyst,
                                                  gasOilScaledInfo,
@@ -204,9 +204,9 @@ setImbibitionParamsOilWater(unsigned elemIdx, unsigned imbRegionIdx,
             = readScaledEpsPointsImbibition_(elemIdx, EclTwoPhaseSystemType::OilWater, lookupIdxOnLevelZeroAssigner);
         typename TwoPhaseTypes<Traits>::OilWaterEpsParams oilWaterImbParamsHyst;
         oilWaterImbParamsHyst.setConfig(this->parent_.oilWaterConfig());
-        oilWaterImbParamsHyst.setUnscaledPoints(this->parent_.oilWaterUnscaledPoints(imbRegionIdx));
+        oilWaterImbParamsHyst.setUnscaledPoints(this->params_.oilWaterUnscaledPointsVector[imbRegionIdx]);
         oilWaterImbParamsHyst.setScaledPoints(oilWaterScaledPoints);
-        oilWaterImbParamsHyst.setEffectiveLawParams(this->parent_.oilWaterEffectiveParams(imbRegionIdx));
+        oilWaterImbParamsHyst.setEffectiveLawParams(this->params_.oilWaterEffectiveParamVector[imbRegionIdx]);
         oilWaterImbParamsHyst.finalize();
         this->oilWaterParams_->setImbibitionParams(oilWaterImbParamsHyst,
                                                    oilWaterScaledInfo,

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawHystParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawHystParams.hpp
@@ -52,7 +52,7 @@ public:
     using GasWaterHystParams = typename TwoPhaseTypes<Traits>::GasWaterHystParams;
     using OilWaterHystParams = typename TwoPhaseTypes<Traits>::OilWaterHystParams;
 
-    HystParams(std::vector<EclEpsScalingPointsInfo<Scalar>>& oilWaterScaledEpsInfoDrainage,
+    HystParams(typename Manager<Traits>::Params& params,
                const EclEpsGridProperties& epsGridProperties,
                const EclEpsGridProperties& epsImbGridProperties,
                const EclipseState& eclState,
@@ -121,7 +121,7 @@ private:
     std::shared_ptr<OilWaterHystParams> oilWaterParams_;
     std::shared_ptr<GasWaterHystParams> gasWaterParams_;
 
-    std::vector<EclEpsScalingPointsInfo<Scalar>>& oilWaterScaledEpsInfoDrainage_;
+    typename Manager<Traits>::Params& params_;
     const EclEpsGridProperties& epsGridProperties_;
     const EclEpsGridProperties& epsImbGridProperties_;
     const EclipseState& eclState_;

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawInitParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawInitParams.hpp
@@ -1,0 +1,125 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclMaterialLaw::Manager
+ */
+
+#ifndef OPM_ECL_MATERIAL_LAW_INIT_PARAMS_HPP
+#define OPM_ECL_MATERIAL_LAW_INIT_PARAMS_HPP
+
+#include <opm/material/fluidmatrixinteractions/EclMaterialLawTwoPhaseTypes.hpp>
+#include <opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace Opm {
+    class EclipseState;
+    class FieldPropsManager;
+}
+
+namespace Opm::EclMaterialLaw {
+
+template<class Traits> class HystParams;
+template<class Traits> class Manager;
+
+template<class Traits>
+class InitParams
+{
+    using Scalar = typename Traits::Scalar;
+
+public:
+    InitParams(const Manager<Traits>& parent,
+               const EclipseState& eclState,
+               std::size_t numCompressedElems);
+
+    using LookupFunction = std::function<unsigned(unsigned)>;
+    using IntLookupFunction = std::function<std::vector<int>(const FieldPropsManager&,
+                                                             const std::string&, bool)>;
+    using MaterialLawParams = typename Manager<Traits>::MaterialLawParams;
+
+    // Function argument 'fieldPropIntOnLeadAssigner' needed to lookup
+    // field properties of cells on the leaf grid view for CpGrid with local grid refinement.
+    // Function argument 'lookupIdxOnLevelZeroAssigner' is added to lookup, for each
+    // leaf gridview cell with index 'elemIdx', its 'lookupIdx'
+    // (index of the parent/equivalent cell on level zero).
+    void run(const IntLookupFunction& fieldPropIntOnLeafAssigner,
+             const LookupFunction& lookupIdxOnLevelZeroAssigner);
+
+    typename Manager<Traits>::Params params_;
+
+private:
+    // Function argument 'fieldPropIntOnLeadAssigner' needed to lookup
+    // field properties of cells on the leaf grid view for CpGrid with local grid refinement.
+    void copySatnumArrays_(const IntLookupFunction& fieldPropIntOnLeafAssigner);
+
+    // Function argument 'fieldPropIntOnLeadAssigner' needed to lookup
+    // field properties of cells on the leaf grid view for CpGrid with local grid refinement.
+    void copyIntArray_(std::vector<int>& dest,
+                       const std::string& keyword,
+                       const IntLookupFunction& fieldPropIntOnLeafAssigner) const;
+
+    unsigned imbRegion_(const std::vector<int>& array, unsigned elemIdx) const;
+
+    void initArrays_(std::vector<const std::vector<int>*>& satnumArray,
+                     std::vector<const std::vector<int>*>& imbnumArray,
+                     std::vector<std::vector<MaterialLawParams>*>& mlpArray);
+
+    void initMaterialLawParamVectors_();
+
+    void initOilWaterScaledEpsInfo_();
+
+    // Function argument 'fieldProptOnLeadAssigner' needed to lookup
+    // field properties of cells on the leaf grid view for CpGrid with local grid refinement.
+    void initSatnumRegionArray_(const IntLookupFunction& fieldPropIntOnLeafAssigner);
+
+    void initThreePhaseParams_(HystParams<Traits>& hystParams,
+                               MaterialLawParams& materialParams,
+                               unsigned satRegionIdx,
+                               unsigned elemIdx);
+
+    void readEffectiveParameters_();
+
+    void readUnscaledEpsPointsVectors_();
+
+    template <class Container>
+    void readUnscaledEpsPoints_(Container& dest,
+                                const EclEpsConfig& config,
+                                EclTwoPhaseSystemType system_type);
+
+    unsigned satRegion_(const std::vector<int>& array, unsigned elemIdx) const;
+
+    const Manager<Traits>& parent_;
+    const EclipseState& eclState_;
+    std::size_t numCompressedElems_;
+
+    std::unique_ptr<EclEpsGridProperties> epsImbGridProperties_; // imbibition
+    EclEpsGridProperties epsGridProperties_;    // drainage
+};
+
+} // namespace Opm::EclMaterialLaw
+
+#endif

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawReadEffectiveParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawReadEffectiveParams.cpp
@@ -48,14 +48,10 @@ namespace Opm::EclMaterialLaw {
 /* constructors*/
 template <class Traits>
 ReadEffectiveParams<Traits>::
-ReadEffectiveParams(GasOilEffectiveParamVector& gasOilVector,
-                    GasWaterEffectiveParamVector& gasWaterVector,
-                    OilWaterEffectiveParamVector& oilWaterVector,
+ReadEffectiveParams(typename Manager<Traits>::Params& params,
                     const EclipseState& eclState,
                     const Manager<Traits>& parent)
-    : gasOilVector_(gasOilVector)
-    , gasWaterVector_(gasWaterVector)
-    , oilWaterVector_(oilWaterVector)
+    : params_(params)
     , eclState_(eclState)
     , parent_(parent)
 {
@@ -68,9 +64,9 @@ ReadEffectiveParams<Traits>::
 read()
 {
     const std::size_t numSatRegions = this->eclState_.runspec().tabdims().getNumSatTables();
-    gasOilVector_.resize(numSatRegions);
-    oilWaterVector_.resize(numSatRegions);
-    gasWaterVector_.resize(numSatRegions);
+    params_.gasOilEffectiveParamVector.resize(numSatRegions);
+    params_.oilWaterEffectiveParamVector.resize(numSatRegions);
+    params_.gasWaterEffectiveParamVector.resize(numSatRegions);
     for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++satRegionIdx) {
         readGasOilParameters_(satRegionIdx);
         readOilWaterParameters_(satRegionIdx);
@@ -104,9 +100,9 @@ readGasOilParameters_(unsigned satRegionIdx)
         return;
     }
 
-    gasOilVector_[satRegionIdx] = std::make_shared<GasOilEffectiveParams>();
+    params_.gasOilEffectiveParamVector[satRegionIdx] = std::make_shared<GasOilEffectiveParams>();
 
-    auto& effParams = *gasOilVector_[satRegionIdx];
+    auto& effParams = *params_.gasOilEffectiveParamVector[satRegionIdx];
 
     // the situation for the gas phase is complicated that all saturations are
     // shifted by the connate water saturation.
@@ -277,9 +273,9 @@ readGasWaterParameters_(unsigned satRegionIdx)
         return;
     }
 
-    gasWaterVector_[satRegionIdx] = std::make_shared<GasWaterEffectiveParams>();
+    params_.gasWaterEffectiveParamVector[satRegionIdx] = std::make_shared<GasWaterEffectiveParams>();
 
-    auto& effParams = *gasWaterVector_[satRegionIdx];
+    auto& effParams = *params_.gasWaterEffectiveParamVector[satRegionIdx];
 
     const auto tolcrit = this->eclState_.runspec().saturationFunctionControls()
         .minimumRelpermMobilityThreshold();
@@ -365,13 +361,13 @@ readOilWaterParameters_(unsigned satRegionIdx)
         return;
     }
 
-    oilWaterVector_[satRegionIdx] = std::make_shared<OilWaterEffectiveParams>();
+    params_.oilWaterEffectiveParamVector[satRegionIdx] = std::make_shared<OilWaterEffectiveParams>();
 
     const auto tolcrit = this->eclState_.runspec().saturationFunctionControls()
         .minimumRelpermMobilityThreshold();
 
     const auto& tableManager = this->eclState_.getTableManager();
-    auto& effParams = *oilWaterVector_[satRegionIdx];
+    auto& effParams = *params_.oilWaterEffectiveParamVector[satRegionIdx];
 
     switch (this->eclState_.runspec().saturationFunctionControls().family()) {
     case SatFuncControls::KeywordFamily::Family_I:

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawReadEffectiveParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawReadEffectiveParams.hpp
@@ -70,9 +70,7 @@ class ReadEffectiveParams
         typename TwoPhaseTypes<Traits>::OilWaterEffectiveParamVector;
 
 public:
-    ReadEffectiveParams(GasOilEffectiveParamVector& gasOilVector,
-                        GasWaterEffectiveParamVector& gasWaterVector,
-                        OilWaterEffectiveParamVector& oilWaterVector,
+    ReadEffectiveParams(typename Manager<Traits>::Params& params,
                         const EclipseState& eclState,
                         const Manager<Traits>& parent);
 
@@ -107,9 +105,7 @@ private:
 
     void readOilWaterParameters_(unsigned satRegionIdx);
 
-    GasOilEffectiveParamVector& gasOilVector_;
-    GasWaterEffectiveParamVector& gasWaterVector_;
-    OilWaterEffectiveParamVector& oilWaterVector_;
+    typename Manager<Traits>::Params& params_;
     const EclipseState& eclState_;
     const Manager<Traits>& parent_;
 };


### PR DESCRIPTION
and un-nest the class.

This is the final step in this series. Sorry about the back-and-forth (ie, this removes some accessors added earlier), but they were necessary until I had the final refactor with the Params structure in place.

The Params structure is the tool used to avoid the anti-pattern of friend classes.