### PR TITLE
Write warnings for unsupported TUNING items

### DIFF
--- a/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -261,9 +261,7 @@ void handleTUNING(HandlerContext& handlerContext)
         tuning.TRGLCV = nondefault_or_previous_double(record2, "TRGLCV", tuning.TRGLCV);
         tuning.XXXTTE = nondefault_or_previous_double(record2, "XXXTTE", tuning.XXXTTE);
         tuning.XXXCNV = nondefault_or_previous_double(record2, "XXXCNV", tuning.XXXCNV);
-
         tuning.XXXMBE = nondefault_or_previous_double(record2, "XXXMBE", tuning.XXXMBE);
-
         tuning.XXXLCV = nondefault_or_previous_double(record2, "XXXLCV", tuning.XXXLCV);
         tuning.XXXWFL = nondefault_or_previous_double(record2, "XXXWFL", tuning.XXXWFL);
         tuning.TRGFIP = nondefault_or_previous_double(record2, "TRGFIP", tuning.TRGFIP);
@@ -273,9 +271,26 @@ void handleTUNING(HandlerContext& handlerContext)
             tuning.TRGSFT_has_value = true;
             tuning.TRGSFT = nondefault_or_previous_double(record2, "TRGSFT", tuning.TRGSFT);
         }
+        else {
+            tuning.TRGSFT_has_value = false;
+        }
 
         tuning.THIONX = nondefault_or_previous_double(record2, "THIONX", tuning.THIONX);
         tuning.TRWGHT = nondefault_or_previous_int(record2, "TRWGHT", tuning.TRWGHT);
+
+        // Check for no supported records from the deck to write as a warning.
+        // We check if the deck values are different from the default ones, since the method
+        // record.getItem("").hasValue(0) does not differentiate between deck and default values.
+        // An alternative is to remove the default values for the not supported items in TUNING
+        // and use record.getItem("").hasValue(0).
+        tuning.TRGTTE_has_value = !record2.getItem("TRGTTE").defaultApplied(0);
+        tuning.TRGLCV_has_value = !record2.getItem("TRGLCV").defaultApplied(0);
+        tuning.XXXTTE_has_value = !record2.getItem("XXXTTE").defaultApplied(0);
+        tuning.XXXLCV_has_value = !record2.getItem("XXXLCV").defaultApplied(0);
+        tuning.XXXWFL_has_value = !record2.getItem("XXXWFL").defaultApplied(0);
+        tuning.TRGFIP_has_value = !record2.getItem("TRGFIP").defaultApplied(0);
+        tuning.THIONX_has_value = !record2.getItem("THIONX").defaultApplied(0);
+        tuning.TRWGHT_has_value = !record2.getItem("TRWGHT").defaultApplied(0);
     }
 
     if (numrecords > 2) {
@@ -296,6 +311,21 @@ void handleTUNING(HandlerContext& handlerContext)
             tuning.XXXDPR_has_value = true;
             tuning.XXXDPR = nondefault_or_previous_sidouble(record3, "XXXDPR", tuning.XXXDPR);
         }
+        else {
+            tuning.XXXDPR_has_value = false;
+        }
+
+        tuning.MNWRFP = nondefault_or_previous_int(record3, "MNWRFP", tuning.MNWRFP);
+
+        // Check for no supported records from the deck to write as a warning.
+        tuning.LITMAX_has_value = !record3.getItem("LITMAX").defaultApplied(0);
+        tuning.LITMIN_has_value = !record3.getItem("LITMIN").defaultApplied(0);
+        tuning.MXWSIT_has_value = !record3.getItem("MXWSIT").defaultApplied(0);
+        tuning.MXWPIT_has_value = !record3.getItem("MXWPIT").defaultApplied(0);
+        tuning.DDPLIM_has_value = !record3.getItem("DDPLIM").defaultApplied(0);
+        tuning.DDSLIM_has_value = !record3.getItem("DDSLIM").defaultApplied(0);
+        tuning.TRGDPR_has_value = !record3.getItem("TRGDPR").defaultApplied(0);
+        tuning.MNWRFP_has_value = !record3.getItem("MNWRFP").defaultApplied(0);
     }
 
     handlerContext.state().update_tuning( std::move( tuning ));

--- a/opm/input/eclipse/Schedule/Tuning.cpp
+++ b/opm/input/eclipse/Schedule/Tuning.cpp
@@ -82,6 +82,7 @@ Tuning::Tuning()
     , DDSLIM(TuningKw::DDSLIM::defaultValue)
     , TRGDPR(TuningKw::TRGDPR::defaultValue * Metric::Pressure)
     , XXXDPR(0.0 * Metric::Pressure)
+    , MNWRFP(TuningKw::MNWRFP::defaultValue)
 
     , WSEG_MAX_RESTART(WsegIterKW::MAX_TIMES_REDUCED::defaultValue)
     , WSEG_REDUCTION_FACTOR(WsegIterKW::REDUCTION_FACTOR::defaultValue)
@@ -105,31 +106,48 @@ Tuning Tuning::serializationTestObject() {
     result.TMAXWC_has_value = true;
 
     result.TRGTTE = 11.0;
+    result.TRGTTE_has_value = true;
     result.TRGCNV = 12.0;
     result.TRGMBE = 13.0;
     result.TRGLCV = 14.0;
+    result.TRGLCV_has_value = true;
     result.XXXTTE = 15.0;
+    result.XXXTTE_has_value = true;
     result.XXXCNV = 16.0;
     result.XXXMBE = 17.0;
     result.XXXLCV = 18.0;
+    result.XXXLCV_has_value = true;
     result.XXXWFL = 19.0;
+    result.XXXWFL_has_value = true;
     result.TRGFIP = 20.0;
+    result.TRGFIP_has_value = true;
     result.TRGSFT = 21.0;
     result.TRGSFT_has_value = true;
     result.THIONX = 22.0;
+    result.THIONX_has_value = true;
     result.TRWGHT = 23.0;
+    result.TRWGHT_has_value = true;
 
     result.NEWTMX = 24;
     result.NEWTMN = 25;
     result.LITMAX = 26;
+    result.LITMAX_has_value = true;
     result.LITMIN = 27;
+    result.LITMIN_has_value = true;
     result.MXWSIT = 28;
+    result.MXWSIT_has_value = true;
     result.MXWPIT = 29;
+    result.MXWPIT_has_value = true;
     result.DDPLIM = 30.0;
+    result.DDPLIM_has_value = true;
     result.DDSLIM = 31.0;
+    result.DDSLIM_has_value = true;
     result.TRGDPR = 32.0;
+    result.TRGDPR_has_value = true;
     result.XXXDPR = 33.0;
     result.XXXDPR_has_value = true;
+    result.MNWRFP = 34;
+    result.MNWRFP_has_value = true;
 
     return result;
 }
@@ -147,30 +165,47 @@ bool Tuning::operator==(const Tuning& data) const {
            TMAXWC == data.TMAXWC &&
            TMAXWC_has_value == data.TMAXWC_has_value &&
            TRGTTE == data.TRGTTE &&
+           TRGTTE_has_value == data.TRGTTE_has_value &&
            TRGCNV == data.TRGCNV &&
            TRGMBE == data.TRGMBE &&
            TRGLCV == data.TRGLCV &&
+           TRGLCV_has_value == data.TRGLCV_has_value &&
            XXXTTE == data.XXXTTE &&
+           XXXTTE_has_value == data.XXXTTE_has_value &&
            XXXCNV == data.XXXCNV &&
            XXXMBE == data.XXXMBE &&
            XXXLCV == data.XXXLCV &&
+           XXXLCV_has_value == data.XXXLCV_has_value &&
            XXXWFL == data.XXXWFL &&
+           XXXWFL_has_value == data.XXXWFL_has_value &&
            TRGFIP == data.TRGFIP &&
+           TRGFIP_has_value == data.TRGFIP_has_value &&
            TRGSFT == data.TRGSFT &&
            TRGSFT_has_value == data.TRGSFT_has_value &&
            THIONX == data.THIONX &&
+           THIONX_has_value == data.THIONX_has_value &&
            TRWGHT == data.TRWGHT &&
+           TRWGHT_has_value == data.TRWGHT_has_value &&
            NEWTMX == data.NEWTMX &&
            NEWTMN == data.NEWTMN &&
            LITMAX == data.LITMAX &&
+           LITMAX_has_value == data.LITMAX_has_value &&
            LITMIN == data.LITMIN &&
+           LITMIN_has_value == data.LITMIN_has_value &&
            MXWSIT == data.MXWSIT &&
+           MXWSIT_has_value == data.MXWSIT_has_value &&
            MXWPIT == data.MXWPIT &&
+           MXWPIT_has_value == data.MXWPIT_has_value &&
            DDPLIM == data.DDPLIM &&
+           DDPLIM_has_value == data.DDPLIM_has_value &&
            DDSLIM == data.DDSLIM &&
+           DDSLIM_has_value == data.DDSLIM_has_value &&
            TRGDPR == data.TRGDPR &&
+           TRGDPR_has_value == data.TRGDPR_has_value &&
            XXXDPR == data.XXXDPR &&
            XXXDPR_has_value == data.XXXDPR_has_value &&
+           MNWRFP == data.MNWRFP &&
+           MNWRFP_has_value == data.MNWRFP_has_value &&
            WSEG_MAX_RESTART == data.WSEG_MAX_RESTART &&
            WSEG_REDUCTION_FACTOR == data.WSEG_REDUCTION_FACTOR &&
            WSEG_INCREASE_FACTOR == data.WSEG_INCREASE_FACTOR;

--- a/opm/input/eclipse/Schedule/Tuning.hpp
+++ b/opm/input/eclipse/Schedule/Tuning.hpp
@@ -65,32 +65,49 @@ namespace Opm {
 
         // Record 2
         double TRGTTE;
+        bool TRGTTE_has_value = false;
         double TRGCNV;
         double TRGMBE;
         double TRGLCV;
+        bool TRGLCV_has_value = false;
         double XXXTTE;
+        bool XXXTTE_has_value = false;
         double XXXCNV;
         double XXXMBE;
         double XXXLCV;
+        bool XXXLCV_has_value = false;
         double XXXWFL;
+        bool XXXWFL_has_value = false;
         double TRGFIP;
+        bool TRGFIP_has_value = false;
         double TRGSFT = 0.0;
         bool TRGSFT_has_value = false;
         double THIONX;
+        bool THIONX_has_value = false;
         double TRWGHT;
+        bool TRWGHT_has_value = false;
 
         // Record 3
         int NEWTMX;
         int NEWTMN;
         int LITMAX;
+        bool LITMAX_has_value = false;
         int LITMIN;
+        bool LITMIN_has_value = false;
         int MXWSIT;
+        bool MXWSIT_has_value = false;
         int MXWPIT;
+        bool MXWPIT_has_value = false;
         double DDPLIM;
+        bool DDPLIM_has_value = false;
         double DDSLIM;
+        bool DDSLIM_has_value = false;
         double TRGDPR;
+        bool TRGDPR_has_value = false;
         double XXXDPR;
         bool XXXDPR_has_value = false;
+        int MNWRFP;
+        bool MNWRFP_has_value = false;
 
         /*
           In addition to the values set in the TUNING keyword this Tuning
@@ -126,32 +143,49 @@ namespace Opm {
             serializer(TMAXWC_has_value);
 
             serializer(TRGTTE);
+            serializer(TRGTTE_has_value);
             serializer(TRGCNV);
             serializer(TRGMBE);
             serializer(TRGLCV);
+            serializer(TRGLCV_has_value);
             serializer(XXXTTE);
+            serializer(XXXTTE_has_value);
             serializer(XXXCNV);
             serializer(XXXMBE);
             serializer(XXXLCV);
+            serializer(XXXLCV_has_value);
             serializer(XXXWFL);
+            serializer(XXXWFL_has_value);
             serializer(TRGFIP);
+            serializer(TRGFIP_has_value);
             serializer(TRGSFT);
             serializer(TRGSFT_has_value);
             serializer(THIONX);
+            serializer(THIONX_has_value);
             serializer(TRWGHT);
+            serializer(TRWGHT_has_value);
 
             serializer(NEWTMX);
             serializer(NEWTMN);
             serializer(LITMAX);
+            serializer(LITMAX_has_value);
             serializer(LITMIN);
+            serializer(LITMIN_has_value);
             serializer(MXWSIT);
+            serializer(MXWSIT_has_value);
             serializer(MXWPIT);
+            serializer(MXWPIT_has_value);
             serializer(DDPLIM);
+            serializer(DDPLIM_has_value);
             serializer(DDSLIM);
+            serializer(DDSLIM_has_value);
             serializer(TRGDPR);
+            serializer(TRGDPR_has_value);
             serializer(XXXDPR);
             serializer(XXXDPR_has_value);
-
+            serializer(MNWRFP);
+            serializer(MNWRFP_has_value);
+            
             serializer(WSEG_MAX_RESTART);
             serializer(WSEG_REDUCTION_FACTOR);
             serializer(WSEG_INCREASE_FACTOR);

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/T/TUNING
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/T/TUNING
@@ -179,6 +179,11 @@
         "name": "XXXDPR",
         "value_type": "DOUBLE",
         "dimension": "Pressure"
+      },
+      {
+        "name": "MNWRFP",
+        "value_type": "INT",
+        "default": 4
       }
     ]
   ]

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/T/TUNINGL
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/T/TUNINGL
@@ -179,6 +179,11 @@
         "name": "XXXDPR",
         "value_type": "DOUBLE",
         "dimension": "Pressure"
+      },
+      {
+        "name": "MNWRFP",
+        "value_type": "INT",
+        "default": 4
       }
     ]
   ]

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/T/TUNINGS
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/T/TUNINGS
@@ -184,7 +184,13 @@
       {
         "name": "XXXDPR",
         "value_type": "DOUBLE",
-        "dimension": "Pressure"
+        "dimension": "Pressure",
+        "default": 1000000
+      },
+      {
+        "name": "MNWRFP",
+        "value_type": "INT",
+        "default": 4
       }
     ]
   ]

--- a/opm/output/eclipse/DoubHEAD.cpp
+++ b/opm/output/eclipse/DoubHEAD.cpp
@@ -555,7 +555,6 @@ Opm::RestartIO::DoubHEAD::DoubHEAD()
     this->data_[Index::DdpLim] = 1.0e+6;
     this->data_[Index::DdsLim] = 1.0e+6;
 
-
     this->data_[Index::ThrUPT] = 1.0e+20;
     this->data_[Index::XxxDPR] = 1.0e+20;
     this->data_[Index::TrgFIP] = 0.025;

--- a/tests/parser/TuningTests.cpp
+++ b/tests/parser/TuningTests.cpp
@@ -62,7 +62,7 @@ TSTEP
 TUNING
 2 300 0.3 0.30 6 0.6 0.2 2.25 2E20 /
 0.2 0.002 2E-7 0.0002 11 0.02 2.0E-6 0.002 0.002 0.035 66 0.02 2/
-13 2 26 2 9 9 4.0E6 4.0E6 4.0E6 1/
+13 2 26 2 9 9 4.0E6 4.0E6 4.0E6 1 3/
 DATES
  1 JAN 1982 /  -- 6
  1 JAN 1982 13:55:44 /  --7
@@ -224,6 +224,9 @@ BOOST_AUTO_TEST_CASE(TuningTest)
       double XXXDPR_default = tuning.XXXDPR;
       BOOST_CHECK_EQUAL(false, XXXDPR_has_value);
       BOOST_CHECK_CLOSE(XXXDPR_default, 0.0, diff);
+
+      int MNWRFP_default = tuning.MNWRFP;
+      BOOST_CHECK_EQUAL(MNWRFP_default, 4);
   }
 
 
@@ -338,6 +341,9 @@ BOOST_AUTO_TEST_CASE(TuningTest)
 
       BOOST_CHECK_EQUAL(true, tuning.XXXDPR_has_value);
       BOOST_CHECK_CLOSE(tuning.XXXDPR, 1.0 * Metric::Pressure, diff);
+
+      int MNWRFP = tuning.MNWRFP;
+      BOOST_CHECK_EQUAL(MNWRFP, 3);
   }
 
   /*** TIMESTEP 7 ***/


### PR DESCRIPTION
Following the review in https://github.com/OPM/opm-simulators/pull/6378, we print warning messages for the `TUNING` items that are given in an input deck and OPM Flow does not support. For example, for a record:

> TUNING
>  0.5 1 1E-03 /
>  0.1 /
>  20 2 50 1*  20 /

These warnings will be printed:

> Warning: Tuning item 2-1 (TRGTTE) is not supported.
> 
> Warning: Tuning item 3-3 (LITMAX) is not supported.
> 
> Warning: Tuning item 3-5 (MXWSIT) is not supported.

In addition, adding the missing item `MNWRFP`.