### PR TITLE
Improve CO2STORE property evaluation performance

### DIFF
--- a/opm/material/components/Brine.hpp
+++ b/opm/material/components/Brine.hpp
@@ -263,10 +263,22 @@ public:
     template <class Evaluation>
     static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure, bool extrapolate = false)
     {
+        const Evaluation rhow = H2O::liquidDensity(temperature, pressure, extrapolate);
+        return liquidDensity(temperature, pressure, rhow);
+    }
+
+    /*!
+     * \copydoc Component::liquidDensity
+     *
+     * Equations given in:
+     * - Batzle & Wang (1992)
+     * - cited by: Adams & Bachu in Geofluids (2002) 2, 257-271
+     */
+    template <class Evaluation>
+    static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure, const Evaluation& rhow)
+    {
         Evaluation tempC = temperature - 273.15;
         Evaluation pMPa = pressure/1.0E6;
-
-        const Evaluation rhow = H2O::liquidDensity(temperature, pressure, extrapolate);
         return
             rhow +
             1000*salinity*(

--- a/opm/material/components/BrineDynamic.hpp
+++ b/opm/material/components/BrineDynamic.hpp
@@ -263,10 +263,22 @@ public:
     template <class Evaluation>
     OPM_HOST_DEVICE static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure, const Evaluation& salinity, bool extrapolate = false)
     {
+        const Evaluation rhow = H2O::liquidDensity(temperature, pressure, extrapolate);
+        return liquidDensity(temperature, pressure, salinity, rhow);
+    }
+
+    /*!
+     * \copydoc Component::liquidDensity
+     *
+     * Equations given in:
+     * - Batzle & Wang (1992)
+     * - cited by: Adams & Bachu in Geofluids (2002) 2, 257-271
+     */
+    template <class Evaluation>
+    OPM_HOST_DEVICE static Evaluation liquidDensity(const Evaluation& temperature, const Evaluation& pressure, const Evaluation& salinity, const Evaluation& rhow)
+    {
         Evaluation tempC = temperature - 273.15;
         Evaluation pMPa = pressure/1.0E6;
-
-        const Evaluation rhow = H2O::liquidDensity(temperature, pressure, extrapolate);
         return
             rhow +
             1000*salinity*(

--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -634,8 +634,8 @@ private:
             return rho_pure * pow(10.0, nacl_exponent * salinity + co2_exponent * XCO2);
         }
         else {
-            const LhsEval& rho_brine = Brine::liquidDensity(T, pl, salinity, extrapolate);
-            const LhsEval& rho_lCO2 = liquidDensityWaterCO2_(T, pl, xlCO2);
+            const LhsEval& rho_brine = Brine::liquidDensity(T, pl, salinity, rho_pure);
+            const LhsEval& rho_lCO2 = liquidDensityWaterCO2_(T, xlCO2, rho_pure);
             const LhsEval& contribCO2 = rho_lCO2 - rho_pure;
             return rho_brine + contribCO2;
         }
@@ -643,15 +643,14 @@ private:
 
     template <class LhsEval>
     OPM_HOST_DEVICE LhsEval liquidDensityWaterCO2_(const LhsEval& temperature,
-                                          const LhsEval& pl,
-                                          const LhsEval& xlCO2) const
+                                                   const LhsEval& xlCO2,
+                                                   const LhsEval& rho_pure) const
     {
         OPM_TIMEFUNCTION_LOCAL();
         Scalar M_CO2 = CO2::molarMass();
         Scalar M_H2O = H2O::molarMass();
 
         const LhsEval& tempC = temperature - 273.15;        /* tempC : temperature in °C */
-        const LhsEval& rho_pure = H2O::liquidDensity(temperature, pl, extrapolate);
         // calculate the mole fraction of CO2 in the liquid. note that xlH2O is available
         // as a function parameter, but in the case of a pure gas phase the value of M_T
         // for the virtual liquid phase can become very large

--- a/opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.hpp
@@ -481,8 +481,8 @@ private:
         }
 
         // calculate individual contribution to density
-        const LhsEval& rho_brine = Brine::liquidDensity(T, pl, salinity, extrapolate);
         const LhsEval& rho_pure = H2O::liquidDensity(T, pl, extrapolate);
+        const LhsEval& rho_brine = Brine::liquidDensity(T, pl, salinity, rho_pure);
         const LhsEval& rho_lH2 = liquidDensityWaterH2_(T, pl, xlH2);
         const LhsEval& contribH2 = rho_lH2 - rho_pure;
 


### PR DESCRIPTION
This is an attempt to speed up property evaluation of CO2STORE cases by ensuring that we calculate (pure) water density once instead of 3 times.

Somewhat surprising to me, it only seemed to give ~5% faster properties, despite the pure water density function showing up as taking a significant part (at least 25%) of the time in profiling. This could be due to cache effects, or other reasons.

I still think it is worthwhile to get this in, even though the effect was less than hoped for.