### PR TITLE
Make sure run functions returning none in PYACTION script are treated as run

### DIFF
--- a/opm/input/eclipse/Python/PyRunModule.cpp
+++ b/opm/input/eclipse/Python/PyRunModule.cpp
@@ -78,7 +78,12 @@ bool PyRunModule::executeInnerRunFunction(const std::function<void(const std::st
     auto cpp_callback = py_actionx_callback(actionx_callback);
     try {
         py::object result = this->run_function(this->opm_embedded.attr("current_ecl_state"), this->opm_embedded.attr("current_schedule"), this->opm_embedded.attr("current_report_step"), this->opm_embedded.attr("current_summary_state"), cpp_callback);
-        return result.cast<bool>();
+        if (!result.is_none()) {
+            return result.cast<bool>();
+        } else {
+            OpmLog::warning("The run function in the PYACTION script did not return a value. Assuming true to make sure changes are picked up.");
+            return true;
+        }
     } catch (const std::exception& e) {
         OpmLog::error(fmt::format("Exception thrown when calling run(ecl_state, schedule, report_step, summary_state, actionx_callback) function of {}: {}", this->module_name, e.what()));
         throw e;


### PR DESCRIPTION
by the simulator. There we assume that an action was not executed if it returns zero or false. We do issue an informational message if this done.

This makes sure that the old version of PYACTION scripts are running and being treated as expected by opm-simulators.

I think this is the proper fix for OPM/opm-simulators#6435 and fixes backwards compatibility.