### PR TITLE
fixed: do not dereference a null ptr

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawHystParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawHystParams.cpp
@@ -32,7 +32,7 @@ template <class Traits>
 HystParams<Traits>::
 HystParams(typename Manager<Traits>::Params& params,
            const EclEpsGridProperties& epsGridProperties,
-           const EclEpsGridProperties& epsImbGridProperties,
+           const EclEpsGridProperties* epsImbGridProperties,
            const EclipseState& eclState,
            const Manager<Traits>& parent)
     : params_(params)
@@ -286,7 +286,7 @@ HystParams<Traits>::
 readScaledEpsPointsImbibition_(unsigned elemIdx, EclTwoPhaseSystemType type,
                                const LookupFunction& fieldPropIdxOnLevelZero)
 {
-    return readScaledEpsPoints_(epsImbGridProperties_, elemIdx, type, fieldPropIdxOnLevelZero);
+    return readScaledEpsPoints_(*epsImbGridProperties_, elemIdx, type, fieldPropIdxOnLevelZero);
 }
 
 // Make some actual code, by realizing the previously defined templated class

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawHystParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawHystParams.hpp
@@ -54,7 +54,7 @@ public:
 
     HystParams(typename Manager<Traits>::Params& params,
                const EclEpsGridProperties& epsGridProperties,
-               const EclEpsGridProperties& epsImbGridProperties,
+               const EclEpsGridProperties* epsImbGridProperties,
                const EclipseState& eclState,
                const Manager<Traits>& parent);
 
@@ -123,7 +123,7 @@ private:
 
     typename Manager<Traits>::Params& params_;
     const EclEpsGridProperties& epsGridProperties_;
-    const EclEpsGridProperties& epsImbGridProperties_;
+    const EclEpsGridProperties* epsImbGridProperties_;
     const EclipseState& eclState_;
     const Manager<Traits>& parent_;
 };

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawInitParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawInitParams.cpp
@@ -95,7 +95,7 @@ run(const IntLookupFunction& fieldPropIntOnLeafAssigner,
             HystParams<Traits> hystParams{
                 params_,
                 epsGridProperties_,
-                *epsImbGridProperties_,
+                epsImbGridProperties_.get(),
                 this->eclState_,
                 this->parent_
             };


### PR DESCRIPTION
Harmless as such as nothing uses the reference in that case, but tripped debug iterator build.