### PR TITLE
Add Restart Support for Satellite Production Rates

### DIFF
--- a/opm/io/eclipse/rst/group.cpp
+++ b/opm/io/eclipse/rst/group.cpp
@@ -52,6 +52,7 @@ Opm::RestartIO::RstGroup::RstGroup(const ::Opm::UnitSystem& unit_system,
     inj_gas_guide_rate_def(igrp[header.nwgmax + VI::IGroup::GConInjeGasGuideRateMode]),
     voidage_group_index(igrp[header.nwgmax + VI::IGroup::VoidageGroupIndex]),
     add_gas_lift_gas(igrp[header.nwgmax + VI::IGroup::AddGLiftGasAsProducedGas]),
+    group_type(igrp[header.nwgmax + VI::IGroup::GroupType]),
 
     // -------------------------------------------------------------------------
 

--- a/opm/io/eclipse/rst/group.hpp
+++ b/opm/io/eclipse/rst/group.hpp
@@ -56,6 +56,9 @@ struct RstGroup
     int voidage_group_index;
     int add_gas_lift_gas;
 
+    /// Kind of group (i.e., well, node, or satellite).
+    int group_type{};
+
     float oil_rate_limit;
     float water_rate_limit;
     float gas_rate_limit;

--- a/opm/output/eclipse/VectorItems/group.hpp
+++ b/opm/output/eclipse/VectorItems/group.hpp
@@ -76,8 +76,10 @@ namespace Opm::RestartIO::Helpers::VectorItems {
             };
 
             enum GroupType : int {
-                WellGroup = 0,
-                TreeGroup = 1,
+                WellGroup = 0,      // Group is a well group (children are wells)
+                NodeGroup = 1,      // Group is a node group (children are other groups)
+                SatelliteGroup = 2, // Group is a satellite (GSAT* keywords, no children)
+                SlaveGroup = 3,     // Group is a slave in a reservoir coupling run
             };
 
             enum GLiftGas : int {
@@ -111,6 +113,8 @@ namespace Opm::RestartIO::Helpers::VectorItems {
             WatRateLimit_2 = 53, // Copy of group's water production target/limit
             LiqRateLimit_2 = 54, // Copy of group's liquid production target/limit
             ResvRateLimit_2 = 55, // Copy of group's maximum reservoir volume production rate target/limit
+
+            MeanCaloricValue = 79, // Mean calorific value of produced gas (GSATPROD keyword)
 
             GLOMaxRate    = 91, // Group's maximum lift gas rate
         };
@@ -147,6 +151,8 @@ namespace Opm::RestartIO::Helpers::VectorItems {
             gasResRateLimit_2       =  66, // Copy of group's gas reservoir volume injection rate target/limit
             gasReinjectionLimit_2   =  67, // Copy of group's gas reinjection fraction target/limit
             gasVoidageLimit_2       =  68, // Copy of group's gas voidage injection fraction target/limit
+
+            gasMeanCalorificValue = 83, // Mean calorific value of injected gas (GSATINJE keyword)
         };
 
         namespace Value {


### PR DESCRIPTION
We save the production rates in the regular SGRP items used for GCONPROD and furthermore record the satellite status in the IGRP item used for the "group type".  On restart, we load the group type and record satellite production flag if the group has active production limits when the group type is satellite.

While here, also do slight reformatting of `AggregateGroupData.cpp` to split long lines and insert braces around single statement blocks close to other changes.

Note: LGR items are intentionally omitted here.  Satellite groups do not have children and therefore typically do not influence LGRs.