### PR TITLE
fixed: need to check for the full definition line

### DIFF
--- a/cmake/Modules/FindHYPRE.cmake
+++ b/cmake/Modules/FindHYPRE.cmake
@@ -81,13 +81,15 @@ if(HYPRE_FOUND AND NOT TARGET HYPRE::HYPRE)
     find_package(rocsparse REQUIRED)
     find_package(rocrand REQUIRED)
     find_package(rocblas REQUIRED)
+    find_package(rocsolver REQUIRED)
     set_property(TARGET HYPRE::HYPRE APPEND PROPERTY
       INTERFACE_COMPILE_DEFINITIONS HYPRE_USING_HIP)
     set_property(TARGET HYPRE::HYPRE APPEND PROPERTY
       INTERFACE_LINK_LIBRARIES
         roc::rocsparse
         roc::rocrand
-        roc::rocblas)
+        roc::rocblas
+        roc::rocsolver)
     message(STATUS "HYPRE was built with HIP support")
   endif()
 endif()

--- a/cmake/Modules/FindHYPRE.cmake
+++ b/cmake/Modules/FindHYPRE.cmake
@@ -49,11 +49,11 @@ find_package_handle_standard_args(HYPRE
 
 if(HYPRE_FOUND AND NOT TARGET HYPRE::HYPRE)
   file(STRINGS ${HYPRE_INCLUDE_DIRS}/HYPRE_config.h HYPRE_CONFIG)
-  string(FIND "${HYPRE_CONFIG}" "#define HYPRE_USING_CUDA" CUDA_POS)
+  string(FIND "${HYPRE_CONFIG}" "#define HYPRE_USING_CUDA 1" CUDA_POS)
   if(NOT CUDA_POS EQUAL -1)
     set(HYPRE_USING_CUDA ON)
   endif()
-  string(FIND "${HYPRE_CONFIG}" "#define HYPRE_USING_HIP" HIP_POS)
+  string(FIND "${HYPRE_CONFIG}" "#define HYPRE_USING_HIP 1" HIP_POS)
   if(NOT HIP_POS EQUAL -1)
     set(HYPRE_USING_HIP ON)
   endif()


### PR DESCRIPTION
hypre 3.0 has a define HYPRE_USING_CUDA_STREAMS line even when built with HIP which matches the prevous line and thus caused havoc