### PR TITLE
Fix python setup.py warnings

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,5 +1,7 @@
-project(install_python_binding)
-
 cmake_minimum_required(VERSION 3.15)
+# NOTE (2025-09-12): cmake_minimum_required must precede project() to avoid
+# the developer warning: 'cmake_minimum_required() should be called prior to
+# this top-level project() call.'
+project(install_python_binding)
 
 install(CODE "message(\"Dummy install\")")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,3 +5,11 @@ requires= [
   "cmake>=3.15",
   "ninja"
 ]
+# NOTE (2025-09-12): Explicitly declare the PEP 517 backend used by
+# `python -m build`, aligning with setuptools + scikit-build classic.
+build-backend = "setuptools.build_meta"
+
+# TODO (modernization): Future migration to scikit-build-core and PEP 621.
+# - Define metadata in a [project] table and configure scikit-build under
+#   [tool.scikit-build] or [tool.scikit-build-core]. This would enable
+#   dropping setup.py.in entirely and simplify versioning.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,12 +1,13 @@
 [build-system]
+# NOTE: Raise the setuptools floor to >=61 to align with modern
+# pyproject-based builds and leave room for partial PEP 621 adoption later.
 requires= [
-  "setuptools>=42",
+  "setuptools>=61",
   "scikit-build>=0.13",
   "cmake>=3.15",
   "ninja"
 ]
-# NOTE (2025-09-12): Explicitly declare the PEP 517 backend used by
-# `python -m build`, aligning with setuptools + scikit-build classic.
+# PEP 517 backend used by `python -m build` with classic scikit-build.
 build-backend = "setuptools.build_meta"
 
 # TODO (modernization): Future migration to scikit-build-core and PEP 621.

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -43,11 +43,13 @@ setup(
             ],
     package_data={'opm' : ['$<TARGET_FILE_NAME:opmcommon_python>']},
     include_package_data=True,
-    license='Open Source',
+    # SPDX license expression to replace deprecated license classifier usage.
+    license='GPL-3.0-or-later',
     install_requires=requires,
     python_requires='>=3.6',
+    # NOTE (2025-09-12): Remove deprecated license classifier in favor of
+    # SPDX license expression above. Keep non-license classifiers only.
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     ],
 )

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -12,6 +12,12 @@ with open("README.md", "r") as fh:
 with open("requirements.txt", "r") as fh:
     requires = [line.rstrip() for line in fh]
 
+# NOTE (2025-09-12): Removed legacy `setup_requires` and `test_suite` arguments.
+# - `setup_requires` triggered setuptools' deprecated fetch_build_eggs path
+#   and is incompatible with modern PEP 517 builds. Build-time deps belong in
+#   pyproject.toml (we already use scikit-build there).
+# - `test_suite` is not a recognized distribution option and caused
+#   "Unknown distribution option: 'test_suite'" warnings.
 setup(
     name='opm',
     version = '@opm-common_VERSION@' + '@opm-common_PYTHON_PACKAGE_VERSION@',
@@ -38,8 +44,6 @@ setup(
     package_data={'opm' : ['$<TARGET_FILE_NAME:opmcommon_python>']},
     include_package_data=True,
     license='Open Source',
-    test_suite='tests',
-    setup_requires=["pytest-runner", 'setuptools_scm'],
     install_requires=requires,
     python_requires='>=3.6',
     classifiers=[


### PR DESCRIPTION
From private communication with @akva2: When building the python modules in the docker container (see [opm-simulators/python/docker](https://github.com/OPM/opm-simulators/tree/master/python/docker)) some warnings were shown when running `python setup.py`, see [generate-pypi-package.sh](https://github.com/OPM/opm-simulators/blob/00e9b6b276e0f5d0f9e4cdf619987a327c40294c/python/docker/scripts/generate-pypi-package.sh#L145). Try to modernize to use [pypa/build](https://build.pypa.io/en/stable/) instead to get rid of warnings. See also companion PR https://github.com/OPM/opm-simulators/pull/6461

Example warning:
```
#16 959.8 /opt/python/cp312-cp312/lib/python3.12/site-packages/setuptools/_distutils/cmd.py:90: SetuptoolsDeprecationWarning: setup.py install is deprecated.
#16 959.8 !!
#16 959.8 
#16 959.8         ********************************************************************************
#16 959.8         Please avoid running ``setup.py`` directly.
#16 959.8         Instead, use pypa/build, pypa/installer or other
#16 959.8         standards-based tools.
#16 959.8 
#16 959.8         By 2025-Oct-31, you need to update your project and remove deprecated calls
#16 959.8         or your builds will no longer be supported.
#16 959.8 
#16 959.8         See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
#16 959.8         ********************************************************************************
#16 959.8 
#16 959.8 !!

```