### PR TITLE
Use more compact enums.

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FaceDir.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FaceDir.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_FACEDIR_HPP
 #define OPM_FACEDIR_HPP
 
+#include <cstdint>
 #include <string>
 
 namespace Opm {
@@ -27,7 +28,7 @@ namespace Opm {
 
     namespace FaceDir {
 
-        enum DirEnum {
+        enum DirEnum : std::uint8_t {
             Unknown = 0,
             XPlus   = 1,
             XMinus  = 2,

--- a/opm/input/eclipse/Schedule/Group/GuideRate.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.hpp
@@ -34,7 +34,7 @@
 namespace Opm {
 
 class Schedule;
-enum class WellGuideRateTarget;
+enum class WellGuideRateTarget : std::uint8_t;
 
 } // namespace Opm
 

--- a/opm/input/eclipse/Schedule/Group/GuideRateModel.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRateModel.hpp
@@ -25,12 +25,12 @@
 
 namespace Opm {
 
-enum class WellGuideRateTarget;
+enum class WellGuideRateTarget : std::uint8_t;
 
 class GuideRateModel {
 public:
 
-    enum class Target {
+    enum class Target : std::uint8_t {
         OIL = 0,
         LIQ = 1,
         GAS = 2,

--- a/opm/input/eclipse/Schedule/HandlerContext.hpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.hpp
@@ -45,7 +45,7 @@ class ScheduleGrid;
 class ScheduleState;
 struct ScheduleStatic;
 struct SimulatorUpdate;
-enum class WellStatus;
+enum class WellStatus : std::uint8_t;
 class WelSegsSet;
 }
 

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -74,10 +74,10 @@ namespace Opm {
     class TracerConfig;
     class UDQConfig;
     class Well;
-    enum class WellGasInflowEquation;
+    enum class WellGasInflowEquation : std::uint8_t;
     class WellMatcher;
-    enum class WellProducerCMode;
-    enum class WellStatus;
+    enum class WellProducerCMode : std::uint16_t;
+    enum class WellStatus : std::uint8_t;
     class WelSegsSet;
     class WellTestConfig;
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/Well/WellEnums.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellEnums.hpp
@@ -20,12 +20,13 @@
 #ifndef WELL_ENUMS_HPP
 #define WELL_ENUMS_HPP
 
+#include <cstdint>
 #include <iosfwd>
 #include <string>
 
 namespace Opm {
 
-enum class WellStatus {
+enum class WellStatus : std::uint8_t {
     OPEN = 1,
     STOP = 2,
     SHUT = 3,
@@ -37,7 +38,7 @@ enum class WellStatus {
   of which controls are present, i.e. the 2^n structure must
   be intact.
 */
-enum class WellInjectorCMode : int{
+enum class WellInjectorCMode : std::uint16_t {
     RATE =  1 ,
     RESV =  2 ,
     BHP  =  4 ,
@@ -54,7 +55,7 @@ enum class WellInjectorCMode : int{
   WHISTCTL to cancel its effect.
 */
 
-enum class WellProducerCMode : int {
+enum class WellProducerCMode : std::uint16_t  {
     NONE =     0,
     ORAT =     1,
     WRAT =     2,
@@ -68,7 +69,7 @@ enum class WellProducerCMode : int {
     CMODE_UNDEFINED = 1024
 };
 
-enum class WellWELTARGCMode {
+enum class WellWELTARGCMode : std::uint8_t {
     ORAT =  1,
     WRAT =  2,
     GRAT =  3,
@@ -82,7 +83,7 @@ enum class WellWELTARGCMode {
     GUID = 11
 };
 
-enum class WellGuideRateTarget {
+enum class WellGuideRateTarget : std::uint8_t {
     OIL = 0,
     WAT = 1,
     GAS = 2,
@@ -95,7 +96,7 @@ enum class WellGuideRateTarget {
     UNDEFINED = 9
 };
 
-enum class WellGasInflowEquation {
+enum class WellGasInflowEquation : std::uint8_t {
     STD = 0,
     R_G = 1,
     P_P = 2,


### PR DESCRIPTION
Primary motivation is downstream: the struct `ResidualNBInfo` contains a `FaceDir::DirEnum`, and we have one for every neighbour of every cell in the `TpfaLinearizer` so the memory usage adds up.

While at it, also reduced the sizes of the enums in WellEnums.hpp.

Requires a downstream PR to update forward-declarations.