### PR TITLE
Added include of cstdint

### DIFF
--- a/opm/input/eclipse/Schedule/HandlerContext.hpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.hpp
@@ -24,6 +24,7 @@
 #include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <set>
 #include <string>


### PR DESCRIPTION
The enum is based on `std::unint8_t`, which is not available without including `cstdint`.