### PR TITLE
Add Missing Header

### DIFF
--- a/opm/input/eclipse/Schedule/HandlerContext.hpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.hpp
@@ -24,6 +24,7 @@
 #include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <set>
 #include <string>


### PR DESCRIPTION
Following #4735 we must have a valid declaration of `std::uint8_t` in scope.