### PR TITLE
Support subsystem local timing.

### DIFF
--- a/opm/material/binarycoefficients/Brine_CO2.hpp
+++ b/opm/material/binarycoefficients/Brine_CO2.hpp
@@ -118,7 +118,7 @@ public:
                            const int& activityModel,
                            bool extrapolate = false)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
 
         // Iterate or not?
         bool iterate = false;
@@ -207,7 +207,7 @@ public:
                                              bool extrapolate = false,
                                              bool spycherPruess2005 = false)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Valgrind::CheckDefined(temperature);
         Valgrind::CheckDefined(pg);
 
@@ -269,7 +269,7 @@ public:
                                              bool extrapolate = false,
                                              bool spycherPruess2005 = false)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Valgrind::CheckDefined(temperature);
         Valgrind::CheckDefined(pg);
 
@@ -526,7 +526,7 @@ private:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE static Evaluation salinityToMolFrac_(const Evaluation& salinity) {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Scalar Mw = H2O::molarMass(); /* molecular weight of water [kg/mol] */
         const Scalar Ms = 58.44e-3; /* molecular weight of NaCl  [kg/mol] */
 
@@ -580,7 +580,7 @@ private:
                                                                      const int& activityModel,
                                                                      bool extrapolate = false)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
 	    // Start point for fixed-point iterations as recommended below in section 2.2
         Evaluation yH2O = H2O::vaporPressure(temperature) / pg;  // ideal mixing
         Evaluation xCO2 = 0.009;  // same as ~0.5 mol/kg
@@ -743,7 +743,7 @@ private:
                                 bool extrapolate = false,
                                 bool spycherPruess2005 = false)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
 	    // Intermediate calculations
         const Evaluation& deltaP = pg / 1e5 - Pref_(temperature, highTemp); // pressure range [bar] from pref to pg[bar]
         Evaluation v_av_H2O = V_avg_H2O_(temperature, highTemp); // average partial molar volume of H2O [cm^3/mol]
@@ -785,7 +785,7 @@ private:
                                 bool extrapolate = false,
                                 bool spycherPruess2005 = false)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
 	    // Intermediate calculations
         const Evaluation& deltaP = pg / 1e5 - Pref_(temperature, highTemp); // pressure range [bar] from pref to pg[bar]
         Evaluation v_av_CO2 = V_avg_CO2_(temperature, highTemp); // average partial molar volume of CO2 [cm^3/mol]
@@ -819,7 +819,7 @@ private:
                                                const Evaluation& xCO2,
                                                const int& activityModel)
     {
-        OPM_TIMEFUNCTION_LOCAL();   
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
 	    // Lambda and xi parameter for either Rumpf et al (1994) (activityModel = 1) or Duan-Sun as modified by Spycher
         // & Pruess (2009) (activityModel = 2) or Duan & Sun (2003) as given in Spycher & Pruess (2005) (activityModel =
         // 3)
@@ -939,7 +939,7 @@ private:
                                               const bool& highTemp,
                                               bool spycherPruess2005 = false)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Evaluation temperatureCelcius = temperature - 273.15;
         std::array<Scalar, 4> c;
         if (highTemp) {

--- a/opm/material/components/CO2.hpp
+++ b/opm/material/components/CO2.hpp
@@ -251,7 +251,7 @@ public:
                                    const Evaluation& pressure,
                                    bool extrapolate = false)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         constexpr Scalar a0 = 0.235156;
         constexpr Scalar a1 = -0.491266;
         constexpr Scalar a2 = 5.211155e-2;
@@ -318,7 +318,7 @@ public:
                                                       const Evaluation& temperature,
                                                       const Evaluation& pressure)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         constexpr Scalar eps = 1e-6;
         // NB!! should be changed to using the derivative from the table (if piecwise linear double derivate is zero).
         // use central differences here because one-sided methods do

--- a/opm/material/components/SimpleHuDuanH2O.hpp
+++ b/opm/material/components/SimpleHuDuanH2O.hpp
@@ -143,7 +143,7 @@ public:
     OPM_HOST_DEVICE static Evaluation vaporPressure(const Evaluation& T)
     {
 
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         if (T > criticalTemperature())
             return criticalPressure();
         if (T < tripleTemperature())
@@ -403,7 +403,7 @@ private:
         // Hu, Duan, Zhu and Chou: PVTx properties of the CO2-H2O and CO2-H2O-NaCl
         // systems below 647 K: Assessment of experimental data and
         // thermodynamics models, Chemical Geology, 2007.
-        OPM_TIMEBLOCK_LOCAL(liquidDensity_);
+        OPM_TIMEBLOCK_LOCAL(liquidDensity_, Subsystem::PvtProps);
         if (T > 647 || pressure > 100e6) {
 #if !OPM_IS_INSIDE_DEVICE_FUNCTION
             const std::string msg =

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -138,7 +138,7 @@ public:
                                    const Params& params,
                                    const FluidState& state)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
         values[gasPhaseIdx] = pcgn<FluidState, Evaluation, Args...>(params, state);
         values[oilPhaseIdx] = 0;
@@ -257,7 +257,7 @@ public:
     static Evaluation pcgn(const Params& params,
                            const FluidState& fs)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         // Maximum attainable oil saturation is 1-SWL.
         const auto Sw = 1.0 - params.Swl() - decay<Evaluation>(fs.saturation(gasPhaseIdx));
         return GasOilMaterialLaw::template twoPhaseSatPcnw<Evaluation, Args...>(params.gasOilParams(), Sw);
@@ -276,7 +276,7 @@ public:
     static Evaluation pcnw(const Params& params,
                            const FluidState& fs)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const auto Sw = decay<Evaluation>(fs.saturation(waterPhaseIdx));
         return OilWaterMaterialLaw::template twoPhaseSatPcnw<Evaluation, Args...>(params.oilWaterParams(), Sw);
     }
@@ -342,7 +342,7 @@ public:
                                        const Params& params,
                                        const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
 
         values[waterPhaseIdx] = krw<FluidState, Evaluation, Args...>(params, fluidState);
@@ -357,7 +357,7 @@ public:
     static Evaluation krg(const Params& params,
                           const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         // Maximum attainable oil saturation is 1-SWL.
         const Evaluation sw = 1.0 - params.Swl() - decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
         return GasOilMaterialLaw::template twoPhaseSatKrn<Evaluation, Args...>(params.gasOilParams(), sw);
@@ -370,7 +370,7 @@ public:
     static Evaluation krw(const Params& params,
                           const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const Evaluation sw = decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
         return OilWaterMaterialLaw::template twoPhaseSatKrw<Evaluation, Args...>(params.oilWaterParams(), sw);
     }
@@ -382,7 +382,7 @@ public:
     static Evaluation krn(const Params& params,
                           const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const Scalar Swco = params.Swl();
 
         const Evaluation sw =
@@ -421,7 +421,7 @@ public:
     static Evaluation relpermOilInOilGasSystem(const Params& params,
                                                const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const Evaluation sw =
             max(Evaluation{ params.Swl() },
                      decay<Evaluation>(fluidState.saturation(waterPhaseIdx)));
@@ -439,7 +439,7 @@ public:
     static Evaluation relpermOilInOilWaterSystem(const Params& params,
                                                  const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const Evaluation sw =
             max(Evaluation{ params.Swl() },
                      decay<Evaluation>(fluidState.saturation(waterPhaseIdx)));
@@ -474,7 +474,7 @@ public:
     template <class FluidState>
     static Scalar clampSaturation(const FluidState& fluidState, const int phaseIndex)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const auto sat = scalarValue(fluidState.saturation(phaseIndex));
         return std::clamp(sat, Scalar{0.0}, Scalar{1.0});
     }

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
@@ -147,7 +147,7 @@ public:
     template <class Evaluation, class ...Args>
     static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         // if no pc hysteresis is enabled, use the drainage curve
         if (!params.config().enableHysteresis() || params.config().pcHysteresisModel() < 0)
             return EffectiveLaw::template twoPhaseSatPcnw<Evaluation, Args...>(params.drainageParams(), Sw);
@@ -267,7 +267,7 @@ public:
     static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
     {
 
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         // if no relperm hysteresis is enabled, use the drainage curve
         if (!params.config().enableHysteresis() || params.config().krHysteresisModel() < 0)
             return EffectiveLaw::template twoPhaseSatKrw<Evaluation, Args...>(params.drainageParams(), Sw);
@@ -303,7 +303,7 @@ public:
     template <class Evaluation, class ...Args>
     static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& Sw)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         // If WAG hysteresis is enabled, the convential hysteresis model is ignored.
         // (Two-phase model, non-wetting: only gas in oil.)
         if (params.gasOilHysteresisWAG()) {

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -275,7 +275,7 @@ public:
     template <class FluidState>
     bool updateHysteresis(const FluidState& fluidState, unsigned elemIdx)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         if (!enableHysteresis())
             return false;
         bool changed = MaterialLaw::updateHysteresis(materialLawParams(elemIdx), fluidState);

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
@@ -211,7 +211,7 @@ public:
                                    const Params& params,
                                    const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         if constexpr (FrontIsEclMultiplexerDispatchV<Args...>) {
             capillaryPressuresT<ContainerT, FluidState, Args...>(values, params, fluidState);
             return;
@@ -246,7 +246,7 @@ public:
                                          Scalar& swMin,
                                          const Params& params)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         OPM_ECL_MULTIPLEXER_MATERIAL_CALL(ActualLaw::oilWaterHysteresisParams(soMax, swMax, swMin, realParams),
                                           doNothing());
     }
@@ -263,7 +263,7 @@ public:
                                             const Scalar& swMin,
                                             Params& params)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         OPM_ECL_MULTIPLEXER_MATERIAL_CALL(ActualLaw::setOilWaterHysteresisParams(soMax, swMax, swMin, realParams),
                                           doNothing());
     }
@@ -280,14 +280,14 @@ public:
                                        Scalar& somin,
                                        const Params& params)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         OPM_ECL_MULTIPLEXER_MATERIAL_CALL(ActualLaw::gasOilHysteresisParams(sgmax, shmax, somin, realParams),
                                           doNothing());
     }
 
     static Scalar trappedGasSaturation(const Params& params, bool maximumTrapping)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         OPM_ECL_MULTIPLEXER_MATERIAL_CALL(return ActualLaw::trappedGasSaturation(realParams, maximumTrapping),
                                           return 0.0);
         return 0.0;
@@ -295,7 +295,7 @@ public:
 
     static Scalar strandedGasSaturation(const Params& params, Scalar Sg, Scalar Kg)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         OPM_ECL_MULTIPLEXER_MATERIAL_CALL(return ActualLaw::strandedGasSaturation(realParams, Sg, Kg),
                                           return 0.0);
         return 0.0;
@@ -303,7 +303,7 @@ public:
 
     static Scalar trappedOilSaturation(const Params& params, bool maximumTrapping) 
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         OPM_ECL_MULTIPLEXER_MATERIAL_CALL(return ActualLaw::trappedOilSaturation(realParams, maximumTrapping),
                                           return 0.0);
         return 0.0;
@@ -311,7 +311,7 @@ public:
 
     static Scalar trappedWaterSaturation(const Params& params)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         OPM_ECL_MULTIPLEXER_MATERIAL_CALL(return ActualLaw::trappedWaterSaturation(realParams),
                                           return 0.0);
         return 0.0;
@@ -328,7 +328,7 @@ public:
                                           const Scalar& somin,
                                           Params& params)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         OPM_ECL_MULTIPLEXER_MATERIAL_CALL(ActualLaw::setGasOilHysteresisParams(sgmax, shmax, somin, realParams),
                                           doNothing());
     }
@@ -426,7 +426,7 @@ public:
                                        const Params& params,
                                        const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         if constexpr (FrontIsEclMultiplexerDispatchV<Args...>) {
             relativePermeabilitiesT<ContainerT, FluidState, Args...>(values, params, fluidState);
             return;
@@ -458,7 +458,7 @@ public:
     static Evaluation relpermOilInOilGasSystem(const Params& params,
                                                const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         switch (params.approach()) {
         case EclMultiplexerApproach::Stone1:
             return Stone1Material::template relpermOilInOilGasSystem<Evaluation>
@@ -489,7 +489,7 @@ public:
     static Evaluation relpermOilInOilWaterSystem(const Params& params,
                                                  const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         switch (params.approach()) {
         case EclMultiplexerApproach::Stone1:
             return Stone1Material::template relpermOilInOilWaterSystem<Evaluation>
@@ -554,7 +554,7 @@ public:
     template <class FluidState>
     static bool updateHysteresis(Params& params, const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         OPM_ECL_MULTIPLEXER_MATERIAL_CALL(return ActualLaw::updateHysteresis(realParams, fluidState),
                                           return false);
         return false;

--- a/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
@@ -458,7 +458,7 @@ public:
     template <class FluidState>
     static Scalar clampSaturation(const FluidState& fluidState, const int phaseIndex)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const auto sat = scalarValue(fluidState.saturation(phaseIndex));
         return std::clamp(sat, Scalar{0.0}, Scalar{1.0});
     }

--- a/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
@@ -444,7 +444,7 @@ public:
     template <class FluidState>
     static Scalar clampSaturation(const FluidState& fluidState, const int phaseIndex)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const auto sat = scalarValue(fluidState.saturation(phaseIndex));
         return std::clamp(sat, Scalar{0.0}, Scalar{1.0});
     }

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -146,7 +146,7 @@ public:
                                    const Params& params,
                                    const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
 
         switch (params.approach()) {
@@ -376,7 +376,7 @@ public:
                                        const Params& params,
                                        const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
 
         switch (params.approach()) {
@@ -451,7 +451,7 @@ public:
     template <class FluidState>
     static bool updateHysteresis(Params& params, const FluidState& fluidState)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         switch (params.approach()) {
         case EclTwoPhaseApproach::GasOil: {
             Scalar So = scalarValue(fluidState.saturation(oilPhaseIdx));

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -99,7 +99,7 @@ public:
     template <class Container, class FluidState>
     OPM_HOST_DEVICE static void capillaryPressures(Container& values, const Params& params, const FluidState& fs)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
 
         values[Traits::wettingPhaseIdx] = 0.0; // reference phase
@@ -120,7 +120,7 @@ public:
     template <class Container, class FluidState>
     OPM_HOST_DEVICE static void relativePermeabilities(Container& values, const Params& params, const FluidState& fs)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
 
         values[Traits::wettingPhaseIdx] = krw<FluidState, Evaluation>(params, fs);
@@ -133,7 +133,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     OPM_HOST_DEVICE static Evaluation pcnw(const Params& params, const FluidState& fs)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const auto& Sw =
             decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
 
@@ -146,7 +146,7 @@ public:
     template <class Evaluation>
     OPM_HOST_DEVICE static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         return eval_(params.SwPcwnSamples(), params.pcwnSamples(), Sw);
     }
 
@@ -184,7 +184,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     OPM_HOST_DEVICE static Evaluation krw(const Params& params, const FluidState& fs)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const auto& sw =
             decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
 
@@ -194,14 +194,14 @@ public:
     template <class Evaluation>
     OPM_HOST_DEVICE static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         return eval_(params.SwKrwSamples(), params.krwSamples(), Sw);
     }
 
     template <class Evaluation>
     OPM_HOST_DEVICE static Evaluation twoPhaseSatKrwInv(const Params& params, const Evaluation& krw)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         return eval_(params.krwSamples(), params.SwKrwSamples(), krw);
     }
 
@@ -212,7 +212,7 @@ public:
     template <class FluidState, class Evaluation = typename FluidState::Scalar>
     OPM_HOST_DEVICE static Evaluation krn(const Params& params, const FluidState& fs)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const auto& sw =
             decay<Evaluation>(fs.saturation(Traits::wettingPhaseIdx));
 
@@ -222,7 +222,7 @@ public:
     template <class Evaluation>
     OPM_HOST_DEVICE static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& Sw)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         return eval_(params.SwKrnSamples(), params.krnSamples(), Sw);
     }
 
@@ -259,7 +259,7 @@ private:
                             const ValueVector& yValues,
                             const Evaluation& x)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         if (xValues.front() < xValues.back())
             return evalAscending_(xValues, yValues, x);
         return evalDescending_(xValues, yValues, x);
@@ -270,7 +270,7 @@ private:
                                      const ValueVector& yValues,
                                      const Evaluation& x)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         if (x <= xValues.front())
             return yValues.front();
         if (x >= xValues.back())
@@ -286,7 +286,7 @@ private:
                                       const ValueVector& yValues,
                                       const Evaluation& x)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         if (x >= xValues.front())
             return yValues.front();
         if (x <= xValues.back())
@@ -302,7 +302,7 @@ private:
                                  const ValueVector& yValues,
                                  const Evaluation& x)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         if (x <= xValues.front())
             return 0.0;
         if (x >= xValues.back())
@@ -321,7 +321,7 @@ private:
     template<class ScalarT>
     OPM_HOST_DEVICE static size_t findSegmentIndex_(const ValueVector& xValues, const ScalarT& x)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         assert(xValues.size() > 1); // we need at least two sampling points!
         size_t n = xValues.size() - 1;
         if (xValues.back() <= x)
@@ -344,7 +344,7 @@ private:
 
     OPM_HOST_DEVICE static size_t findSegmentIndexDescending_(const ValueVector& xValues, Scalar x)
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         assert(xValues.size() > 1); // we need at least two sampling points!
         size_t n = xValues.size() - 1;
         if (x <= xValues.back())

--- a/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
@@ -788,7 +788,7 @@ public:
                                                 unsigned phaseIdx,
                                                 unsigned regionIdx) NOTHING_OR_CONST
     {
-        OPM_TIMEBLOCK_LOCAL(inverseFormationVolumeFactor);
+        OPM_TIMEBLOCK_LOCAL(inverseFormationVolumeFactor, Subsystem::PvtProps);
         assert(phaseIdx <= numPhases);
         assert(regionIdx <= numRegions());
 
@@ -906,7 +906,7 @@ public:
                                                          unsigned phaseIdx,
                                                          unsigned regionIdx) NOTHING_OR_CONST
     {
-        OPM_TIMEBLOCK_LOCAL(saturatedInverseFormationVolumeFactor);
+        OPM_TIMEBLOCK_LOCAL(saturatedInverseFormationVolumeFactor, Subsystem::PvtProps);
         assert(phaseIdx <= numPhases);
         assert(regionIdx <= numRegions());
 
@@ -1050,7 +1050,7 @@ public:
                              unsigned phaseIdx,
                              unsigned regionIdx) NOTHING_OR_CONST
     {
-        OPM_TIMEBLOCK_LOCAL(viscosity);
+        OPM_TIMEBLOCK_LOCAL(viscosity, Subsystem::PvtProps);
         assert(phaseIdx <= numPhases);
         assert(regionIdx <= numRegions());
 
@@ -1363,7 +1363,7 @@ public:
                                               unsigned regionIdx,
                                               const LhsEval& maxOilSaturation) NOTHING_OR_CONST
     {
-        OPM_TIMEBLOCK_LOCAL(saturatedDissolutionFactor);
+        OPM_TIMEBLOCK_LOCAL(saturatedDissolutionFactor, Subsystem::PvtProps);
         assert(phaseIdx <= numPhases);
         assert(regionIdx <= numRegions());
 
@@ -1393,7 +1393,7 @@ public:
                                               unsigned phaseIdx,
                                               unsigned regionIdx) NOTHING_OR_CONST
     {
-        OPM_TIMEBLOCK_LOCAL(saturatedDissolutionFactor);
+        OPM_TIMEBLOCK_LOCAL(saturatedDissolutionFactor, Subsystem::PvtProps);
         assert(phaseIdx <= numPhases);
         assert(regionIdx <= numRegions());
 

--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -211,7 +211,7 @@ public:
                               const Evaluation& Rs,
                               const Evaluation& saltConcentration) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation salinity = salinityFromConcentration(regionIdx, temperature, pressure, saltConcentration);
         const Evaluation xlCO2 = convertRsToXoG_(Rs,regionIdx);
         return (liquidEnthalpyBrineCO2_(temperature,
@@ -229,7 +229,7 @@ public:
                         const Evaluation& pressure,
                         const Evaluation& Rs) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation xlCO2 = convertRsToXoG_(Rs,regionIdx);
         return (liquidEnthalpyBrineCO2_(temperature,
                                        pressure,
@@ -260,7 +260,7 @@ public:
                                  const Evaluation& pressure,
                                  const Evaluation& saltConcentration) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation salinity = salinityFromConcentration(regionIdx, temperature, pressure, saltConcentration);
         if (enableEzrokhiViscosity_) {
             const Evaluation& mu_pure = H2O::liquidViscosity(temperature, pressure, extrapolate);
@@ -282,7 +282,7 @@ public:
                          const Evaluation& /*Rsw*/,
                          const Evaluation& saltConcentration) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         //TODO: The viscosity does not yet depend on the composition
         return saturatedViscosity(regionIdx, temperature, pressure, saltConcentration);
     }
@@ -295,7 +295,7 @@ public:
                                   const Evaluation& temperature,
                                   const Evaluation& pressure) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         if (enableEzrokhiViscosity_) {
             const Evaluation& mu_pure = H2O::liquidViscosity(temperature, pressure, extrapolate);
             const Evaluation& nacl_exponent = ezrokhiExponent_(temperature, ezrokhiViscNaClCoeff_);
@@ -317,7 +317,7 @@ public:
                                                      const Evaluation& pressure,
                                                      const Evaluation& saltconcentration) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation salinity = salinityFromConcentration(regionIdx, temperature,
                                                               pressure, saltconcentration);
         Evaluation rs_sat = rsSat(regionIdx, temperature, pressure, salinity);
@@ -335,7 +335,7 @@ public:
                                             const Evaluation& Rs,
                                             const Evaluation& saltConcentration) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation salinity = salinityFromConcentration(regionIdx, temperature,
                                                               pressure, saltConcentration);
         return (1.0 - convertRsToXoG_(Rs,regionIdx)) * density(regionIdx, temperature,
@@ -385,7 +385,7 @@ public:
                                                      const Evaluation& temperature,
                                                      const Evaluation& pressure) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Evaluation rs_sat = rsSat(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx]));
         return (1.0 - convertRsToXoG_(rs_sat,regionIdx)) * density(regionIdx, temperature, pressure,
                                                                     rs_sat, Evaluation(salinity_[regionIdx]))
@@ -508,7 +508,7 @@ public:
                                     const Evaluation& pressure,
                                     unsigned /*compIdx*/) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         // Diffusion coefficient of CO2 in pure water according to
         // (McLachlan and Danckwerts, 1972)
         const Evaluation log_D_H20 = -4.1764 + 712.52 / temperature
@@ -541,7 +541,7 @@ public:
                        const Evaluation& Rs,
                        const Evaluation& salinity) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Evaluation xlCO2 = convertXoGToxoG_(convertRsToXoG_(Rs,regionIdx), salinity);
         Evaluation result = liquidDensity_(temperature,
                                         pressure,
@@ -558,7 +558,7 @@ public:
                      const Evaluation& pressure,
                      const Evaluation& salinity) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         if (!enableDissolution_) {
             return 0.0;
         }
@@ -598,7 +598,7 @@ private:
                            const LhsEval& xlCO2,
                            const LhsEval& salinity) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Valgrind::CheckDefined(T);
         Valgrind::CheckDefined(pl);
         Valgrind::CheckDefined(xlCO2);
@@ -646,7 +646,7 @@ private:
                                                    const LhsEval& xlCO2,
                                                    const LhsEval& rho_pure) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Scalar M_CO2 = CO2::molarMass();
         Scalar M_H2O = H2O::molarMass();
 
@@ -671,7 +671,7 @@ private:
     template <class LhsEval>
     OPM_HOST_DEVICE LhsEval convertRsToXoG_(const LhsEval& Rs, unsigned regionIdx) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Scalar rho_oRef = brineReferenceDensity_[regionIdx];
         Scalar rho_gRef = co2ReferenceDensity_[regionIdx];
 
@@ -685,7 +685,7 @@ private:
     template <class LhsEval>
     OPM_HOST_DEVICE LhsEval convertXoGToxoG_(const LhsEval& XoG, const LhsEval& salinity) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Scalar M_CO2 = CO2::molarMass();
         LhsEval M_Brine = Brine::molarMass(salinity);
         return XoG*M_Brine / (M_CO2*(1 - XoG) + XoG*M_Brine);
@@ -697,7 +697,7 @@ private:
     template <class LhsEval>
     OPM_HOST_DEVICE LhsEval convertxoGToXoG(const LhsEval& xoG, const LhsEval& salinity) const
     {
-        OPM_TIMEBLOCK_LOCAL(convertxoGToXoG);
+        OPM_TIMEBLOCK_LOCAL(convertxoGToXoG, Subsystem::PvtProps);
         Scalar M_CO2 = CO2::molarMass();
         LhsEval M_Brine = Brine::molarMass(salinity);
 

--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -181,7 +181,7 @@ public:
                         const Evaluation& rv,
                         const Evaluation& rvw) const
     {
-        OPM_TIMEBLOCK_LOCAL(internalEnergy);
+        OPM_TIMEBLOCK_LOCAL(internalEnergy, Subsystem::PvtProps);
         if (gastype_ == Co2StoreConfig::GasMixingType::NONE) {
             // use the gasInternalEnergy of CO2
             return CO2::gasInternalEnergy(co2Tables, temperature, pressure, extrapolate);
@@ -219,7 +219,7 @@ public:
                                   const Evaluation& temperature,
                                   const Evaluation& pressure) const
     {
-        OPM_TIMEBLOCK_LOCAL(saturatedViscosity);
+        OPM_TIMEBLOCK_LOCAL(saturatedViscosity, Subsystem::PvtProps);
         // Neglects impact of vaporized water on the visosity
         return CO2::gasViscosity(co2Tables, temperature, pressure, extrapolate);
     }
@@ -234,7 +234,7 @@ public:
                                             const Evaluation& rv,
                                             const Evaluation& rvw) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         if (!enableVaporization_) {
             return CO2::gasDensity(co2Tables, temperature, pressure, extrapolate) /
                    gasReferenceDensity_[regionIdx];
@@ -275,7 +275,7 @@ public:
                                                      const Evaluation& temperature,
                                                      const Evaluation& pressure) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation rvw = rvwSat_(regionIdx, temperature, pressure,
                                        Evaluation(salinity_[regionIdx]));
         return inverseFormationVolumeFactor(regionIdx, temperature,
@@ -313,7 +313,7 @@ public:
                                               const Evaluation& pressure,
                                               const Evaluation& saltConcentration) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation salinity = salinityFromConcentration(temperature, pressure,
                                                               saltConcentration);
         return rvwSat_(regionIdx, temperature, pressure, salinity);
@@ -403,7 +403,7 @@ private:
                     const LhsEval& pressure,
                     const LhsEval& salinity) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         if (!enableVaporization_) {
             return 0.0;
         }
@@ -435,7 +435,7 @@ private:
     template <class LhsEval>
     OPM_HOST_DEVICE LhsEval convertXgWToRvw(const LhsEval& XgW, unsigned regionIdx) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Scalar rho_wRef = brineReferenceDensity_[regionIdx];
         Scalar rho_gRef = gasReferenceDensity_[regionIdx];
 
@@ -449,7 +449,7 @@ private:
     template <class LhsEval>
     OPM_HOST_DEVICE LhsEval convertRvwToXgW_(const LhsEval& Rvw, unsigned regionIdx) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Scalar rho_wRef = brineReferenceDensity_[regionIdx];
         Scalar rho_gRef = gasReferenceDensity_[regionIdx];
 
@@ -462,7 +462,7 @@ private:
     template <class LhsEval>
     OPM_HOST_DEVICE LhsEval convertxgWToXgW(const LhsEval& xgW, const LhsEval& salinity) const
     {
-        OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Scalar M_CO2 = CO2::molarMass();
         LhsEval M_Brine = Brine::molarMass(salinity);
 


### PR DESCRIPTION
The macros OPM_TIMEBLOCK_LOCAL and OPM_TIMEFUNCTION_LOCAL now take an additional argument, the subsystem (i.e. PvtProps or Assembly) in which the macros is placed. This enables selectively enabling detailed profiling by subsystem.

This only affects the program when DETAILED_PROFILING is set to 1, and the value of that macro is still 0 this PR: you must manually edit that file to turn on invasive profiling. Typically that will turn on instrumentation inside functions called for every cell as opposed to only higher-level functions.

The reason this is needed is to enable invasive profiling of e.g. the well implementation, without using up memory. Profiling a single parallel Norne run with full details probably takes a TB or more memory, so one must terminate the run before completing. This is not always a a big problem, but it is if the code you want to profile is only run after some time, for example when a well is not converging, and that is what you want to profile.

There is also a downstream PR required.

For the manual: Detailed instrumentation using Tracy enabled for individual subsystems of the simulator. This is used by developers to profile the application and improve performance, and not an end user feature.