### PR TITLE
WECON keyword item 9: remove comment 'Not supported'

### DIFF
--- a/opm/input/eclipse/share/keywords/000_Eclipse100/W/WECON
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/W/WECON
@@ -59,7 +59,7 @@
       "item": 9,
       "name": "FOLLOW_ON_WELL",
       "value_type": "STRING",
-      "default": "'",
+      "default": "'"
    },
     {
       "item": 10,

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/W/WECON
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/W/WECON
@@ -60,7 +60,6 @@
       "name": "FOLLOW_ON_WELL",
       "value_type": "STRING",
       "default": "'",
-      "comment": "Not supported"
    },
     {
       "item": 10,


### PR DESCRIPTION
Following on from:
Support opening of following-on well [opm-simulators#6050](https://github.com/OPM/opm-simulators/pull/6050)