### PR TITLE
Clear UDQ UPDATE NEXT Status at End of Report Step

### DIFF
--- a/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -152,9 +152,12 @@ ScheduleState::ScheduleState(const ScheduleState& src, const time_point& start_t
     {
         auto new_udq = this->udq();
 
-        if (new_udq.clear_pending_assignments()) {
-            // New report step.  All ASSIGNments from previous report steps
-            // have been performed.
+        const auto pending_chng = new_udq.clear_pending_assignments();
+        const auto next_chng = new_udq.clear_update_next_for_new_report_step();
+
+        if (pending_chng || next_chng) {
+            // New report step.  All ASSIGNments and all NEXT updates from
+            // previous report steps have been performed.
             this->udq.update(std::move(new_udq));
         }
     }

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -432,6 +432,18 @@ namespace Opm {
         return update;
     }
 
+    bool UDQConfig::clear_update_next_for_new_report_step()
+    {
+        auto update = false;
+
+        for (auto& def : this->m_definitions) {
+            const auto chng = def.second.clear_update_next_for_new_report_step();
+            update = update || chng;
+        }
+
+        return update;
+    }
+
     void UDQConfig::eval_assign(const WellMatcher&    wm,
                                 const GroupOrder&     go,
                                 SegmentMatcherFactory create_segment_matcher,

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
@@ -353,6 +353,22 @@ namespace Opm {
         /// applied and to prepare for the next report step.
         bool clear_pending_assignments();
 
+        /// Clear "UPDATE NEXT" flags for all pertinent UDQ definitions
+        ///
+        /// This is required by the way we form ScheduleState objects.  The
+        /// function resets UPDATE NEXT to UPDATE OFF, and should typically
+        /// be called at the end of a report step.  If we do not do this,
+        /// then all UDQs with an UPDATE NEXT status will behave as if there
+        /// is an implicit UPDATE NEXT statement at the beginning of each
+        /// subsequent report step and that, in turn, will generate unwanted
+        /// value updates for the quantity.
+        ///
+        /// \return Whether or not any UPDATE NEXT flags were reset to
+        /// UPDATE OFF.  Allows client code to take action, if needed, based
+        /// on the knowledge that all such value updates have been applied
+        /// and to prepare for the next report step.
+        bool clear_update_next_for_new_report_step();
+
         /// Apply all pending assignments.
         ///
         /// Assigns new UDQ values to both the summary and UDQ state objects.

--- a/opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp
@@ -101,6 +101,32 @@ public:
         }
     }
 
+    /// Clear "UPDATE NEXT" flag
+    ///
+    /// This is required by the way we form ScheduleState objects.  The
+    /// function resets UPDATE NEXT to UPDATE OFF, and should typically be
+    /// called at the end of a report step/beginning of the next report
+    /// step.  If we do not do this, then a UDQ define statement with an
+    /// UPDATE NEXT status will behave as if there is an implicit UPDATE
+    /// NEXT statement at the beginning of each subsequent report step and
+    /// that, in turn, will generate unwanted value updates for the
+    /// quantity.
+    ///
+    /// \return Whether or not UPDATE NEXT was reset to UPDATE OFF.  Allows
+    /// client code to take action, if needed, based on the knowledge that
+    /// all such value updates have been applied and to prepare for the next
+    /// report step.
+    bool clear_update_next_for_new_report_step()
+    {
+        if (this->m_update_status == UDQUpdate::NEXT) {
+            this->m_update_status = UDQUpdate::OFF;
+
+            return true;
+        }
+
+        return false;
+    }
+
     bool operator==(const UDQDefine& data) const;
 
     template <class Serializer>


### PR DESCRIPTION
This is a massive hack, but necessary due to the way we load the full SCHEDULE section at the start of the simulation run.

The NEXT flag is supposed to mean that the user-defined quantity gets updated once, at the end of the next time step, and then there are no further updates to the UDQ value until an explicit update is requested.  In the current master sources, however, the NEXT flag gets copied into the `ScheduleState` object created from the previous report step.  This in turn means that every UDQ with an update status of "NEXT" will behave as if there is an implicit "UPDATE NEXT" record for that UDQ at the beginning of the next report step.

That means that the quantity gets updated too frequently which could lead to all kinds of issues if for example the UDQ is used as a UDA in a control keyword such as WCONPROD or GCONINJE.