### PR TITLE
throw when GOC lies below WOC in EQUIL keyword

### DIFF
--- a/examples/opmpack.cpp
+++ b/examples/opmpack.cpp
@@ -19,6 +19,7 @@
 
 #include <opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 
@@ -166,7 +167,7 @@ int main(int argc, char** argv)
 
         const auto& deck = pack_deck(argv[arg_offset], os);
         if (copy_binary) {
-            Opm::InitConfig init_config(deck);
+            Opm::InitConfig init_config(deck, Opm::Runspec(deck).phases());
             if (init_config.restartRequested()) {
                 Opm::IOConfig io_config(deck);
                 fs::path restart_file(io_config.getRestartFileName( init_config.getRestartRootName(), init_config.getRestartStep(), false ));

--- a/opm/input/eclipse/EclipseState/EclipseConfig.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseConfig.cpp
@@ -26,8 +26,8 @@
 
 namespace Opm {
 
-    EclipseConfig::EclipseConfig(const Deck& deck) :
-        m_initConfig(deck),
+    EclipseConfig::EclipseConfig(const Deck& deck, const Phases& phases) :
+        m_initConfig(deck, phases),
         fip_config(deck),
         io_config(deck)
     {

--- a/opm/input/eclipse/EclipseState/EclipseConfig.hpp
+++ b/opm/input/eclipse/EclipseState/EclipseConfig.hpp
@@ -27,12 +27,13 @@
 namespace Opm {
 
     class Deck;
+    class Phases;
 
     class EclipseConfig
     {
     public:
         EclipseConfig() = default;
-        explicit EclipseConfig(const Deck& deck);
+        EclipseConfig(const Deck& deck, const Phases& phases);
         EclipseConfig(const InitConfig& initConfig,
                       const FIPConfig& fip_conf,
                       const IOConfig& io_conf);

--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -133,7 +133,7 @@ namespace Opm {
     try
         : m_tables(            deck )
         , m_runspec(           deck )
-        , m_eclipseConfig(     deck )
+        , m_eclipseConfig(     deck, m_runspec.phases() )
         , m_deckUnitSystem(    deck.getActiveUnitSystem() )
         , m_inputGrid(         deck, nullptr )
         , m_inputNnc(          m_inputGrid, deck)

--- a/opm/input/eclipse/EclipseState/InitConfig/Equil.hpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/Equil.hpp
@@ -7,6 +7,8 @@
 namespace Opm {
     class DeckKeyword;
     class DeckRecord;
+    class KeywordLocation;
+    class Phases;
 
     class EquilRecord {
         public:
@@ -18,7 +20,7 @@ namespace Opm {
                         bool wet_gas_init,
                         int target_accuracy,
                         bool humid_gas_init);
-            explicit EquilRecord(const DeckRecord& record);
+            EquilRecord(const DeckRecord& record, const Phases& phases, int region, const KeywordLocation& location);
 
             static EquilRecord serializationTestObject();
             double datumDepth() const;
@@ -67,7 +69,7 @@ namespace Opm {
     class StressEquilRecord {
         public:
             StressEquilRecord() = default;
-            explicit StressEquilRecord(const DeckRecord& record);
+            StressEquilRecord(const DeckRecord& record, const Phases& phases, int region, const KeywordLocation& location);
 
             static StressEquilRecord serializationTestObject();
 
@@ -136,7 +138,7 @@ namespace Opm {
             using const_iterator = typename std::vector<RecordType>::const_iterator;
 
             EquilContainer() = default;
-            explicit EquilContainer( const DeckKeyword& );
+            EquilContainer( const DeckKeyword&, const Phases& );
 
             static EquilContainer serializationTestObject();
 

--- a/opm/input/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -43,14 +43,14 @@
 
 namespace {
 
-    Opm::Equil equils(const Opm::Deck& deck)
+    Opm::Equil equils(const Opm::Deck& deck, const Opm::Phases& phases)
     {
         if (! deck.hasKeyword<Opm::ParserKeywords::EQUIL>()) {
             return {};
         }
 
         return Opm::Equil {
-            deck.get<Opm::ParserKeywords::EQUIL>().back()
+            deck.get<Opm::ParserKeywords::EQUIL>().back(), phases
         };
     }
 
@@ -67,9 +67,9 @@ namespace {
 
 namespace Opm {
 
-    InitConfig::InitConfig(const Deck& deck)
-        : equil        { equils(deck) }
-        , stress_equil { stressequils(deck) }
+    InitConfig::InitConfig(const Deck& deck, const Phases& phases)
+        : equil        { equils(deck, phases) }
+        , stress_equil { stressequils(deck), phases }
         , foamconfig   { deck }
         , m_filleps    { PROPSSection{deck}.hasKeyword(ParserKeywords::FILLEPS::keywordName) }
         , m_gravity    { ! deck.hasKeyword<ParserKeywords::NOGRAV>() }

--- a/opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp
@@ -28,6 +28,7 @@
 namespace Opm {
 
     class Deck;
+    class Phases;
 
 } // namespace Opm
 
@@ -48,7 +49,7 @@ namespace Opm {
         /// Internalises the run's initialisation-related information.
         ///
         /// \param[in] deck Run's model description.
-        explicit InitConfig(const Deck& deck);
+        InitConfig(const Deck& deck, const Phases& phases);
 
         /// Create a serialisation test object.
         static InitConfig serializationTestObject();

--- a/tests/parser/InitConfigTest.cpp
+++ b/tests/parser/InitConfigTest.cpp
@@ -26,6 +26,7 @@
 #include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
 
 #include <opm/input/eclipse/Units/Units.hpp>
 
@@ -279,7 +280,7 @@ BOOST_AUTO_TEST_CASE(InitConfigTest)
 {
     {
         const auto deck = createDeck(deckStr());
-        const InitConfig cfg(deck);
+        const InitConfig cfg(deck, Runspec(deck).phases());
         BOOST_CHECK_EQUAL(cfg.restartRequested(), true);
         BOOST_CHECK_EQUAL(cfg.getRestartStep(), 5);
         BOOST_CHECK_EQUAL(cfg.getRestartRootName(), "BASE");
@@ -287,7 +288,7 @@ BOOST_AUTO_TEST_CASE(InitConfigTest)
 
     {
         const Deck deck2 = createDeck(deckStr2());
-        InitConfig cfg2(deck2);
+        InitConfig cfg2(deck2, Runspec(deck2).phases());
         BOOST_CHECK_EQUAL(cfg2.restartRequested(), false);
         BOOST_CHECK_EQUAL(cfg2.getRestartStep(), 0);
         BOOST_CHECK_EQUAL(cfg2.getRestartRootName(), "");
@@ -300,24 +301,24 @@ BOOST_AUTO_TEST_CASE(InitConfigTest)
 
     {
         const Deck deck3 = createDeck(deckStr3());
-        BOOST_CHECK_THROW(InitConfig{deck3}, OpmInputError);
+        BOOST_CHECK_THROW(InitConfig(deck3, Runspec(deck3).phases()), OpmInputError);
     }
 
     {
         const Deck deck3_seq0 = createDeck(deckStr3_seq0());
-        BOOST_CHECK_THROW(InitConfig{deck3_seq0}, OpmInputError);
+        BOOST_CHECK_THROW(InitConfig(deck3_seq0, Runspec(deck3_seq0).phases()), OpmInputError);
     }
 
     {
         const Deck deck4 = createDeck(deckStr4());
-        BOOST_CHECK_NO_THROW(InitConfig{deck4});
+        BOOST_CHECK_NO_THROW(InitConfig(deck4, Runspec(deck4).phases()));
     }
 }
 
 BOOST_AUTO_TEST_CASE(InitConfigWithoutEquil)
 {
     const auto deck = createDeck(deckStr());
-    const InitConfig config(deck);
+    const InitConfig config(deck, Runspec(deck).phases());
 
     BOOST_CHECK(! config.hasEquil());
     BOOST_CHECK_THROW(config.getEquil(), std::runtime_error);
@@ -326,7 +327,7 @@ BOOST_AUTO_TEST_CASE(InitConfigWithoutEquil)
 BOOST_AUTO_TEST_CASE(InitConfigWithEquil)
 {
     const auto deck = createDeck(deckWithEquil());
-    const InitConfig config(deck);
+    const InitConfig config(deck, Runspec(deck).phases());
 
     BOOST_CHECK(config.hasEquil());
     BOOST_CHECK_NO_THROW(config.getEquil());
@@ -335,7 +336,7 @@ BOOST_AUTO_TEST_CASE(InitConfigWithEquil)
 BOOST_AUTO_TEST_CASE(InitConfigWithStrEquil)
 {
     const auto deck = createDeck(deckWithStrEquil());
-    const InitConfig config(deck);
+    const InitConfig config(deck, Runspec(deck).phases());
 
     BOOST_CHECK(config.hasStressEquil());
     BOOST_CHECK_NO_THROW(config.getStressEquil());
@@ -344,7 +345,7 @@ BOOST_AUTO_TEST_CASE(InitConfigWithStrEquil)
 BOOST_AUTO_TEST_CASE(EquilOperations)
 {
     const auto deck = createDeck(deckWithEquil());
-    const InitConfig config(deck);
+    const InitConfig config(deck, Runspec(deck).phases());
 
     const auto& equil = config.getEquil();
 
@@ -369,7 +370,7 @@ BOOST_AUTO_TEST_CASE(EquilOperations)
 BOOST_AUTO_TEST_CASE(StrEquilOperations)
 {
     const auto deck = createDeck(deckWithStrEquil());
-    const InitConfig config(deck);
+    const InitConfig config(deck, Runspec(deck).phases());
 
     const auto& equil = config.getStressEquil();
 
@@ -418,25 +419,25 @@ BOOST_AUTO_TEST_CASE(RestartCWD)
 
     {
         const Deck deck = Parser{}.parseFile("simulation/CASE.DATA");
-        const InitConfig init_config(deck);
+        const InitConfig init_config(deck, Runspec(deck).phases());
         BOOST_CHECK_EQUAL(init_config.getRestartRootName(), "simulation/BASE");
     }
 
     {
         const Deck deck = Parser{}.parseFile("simulation/CASE5.DATA");
-        const InitConfig init_config(deck);
+        const InitConfig init_config(deck, Runspec(deck).phases());
         BOOST_CHECK_EQUAL(init_config.getRestartRootName(), "/abs/path/BASE");
     }
 
     {
         const Deck deck = Parser{}.parseFile("CWD_CASE.DATA");
-        const InitConfig init_config(deck);
+        const InitConfig init_config(deck, Runspec(deck).phases());
         BOOST_CHECK_EQUAL(init_config.getRestartRootName(), "BASE");
     }
 
     {
         const Deck deck = Parser{}.parseFile("CASE5.DATA");
-        const InitConfig init_config(deck);
+        const InitConfig init_config(deck, Runspec(deck).phases());
         BOOST_CHECK_EQUAL(init_config.getRestartRootName(), "/abs/path/BASE");
     }
 }

--- a/tests/parser/ThresholdPressureTest.cpp
+++ b/tests/parser/ThresholdPressureTest.cpp
@@ -275,7 +275,7 @@ struct Setup
             tablemanager(deck),
             grid(10, 3, 4),
             fp(deck, Opm::Phases{true, true, true}, grid, tablemanager),
-            initConfig(deck),
+            initConfig(deck, Opm::Phases{true, true, true}),
             threshPres(initConfig.restartRequested(), deck, fp)
     {
         if (ft) {
@@ -291,7 +291,7 @@ struct Setup
             tablemanager(deck),
             grid(10, 3, 4),
             fp(deck, Opm::Phases{true, true, true}, grid, tablemanager),
-            initConfig(deck),
+            initConfig(deck, Opm::Phases{true, true, true}),
             threshPres(initConfig.restartRequested(), deck, fp)
     {
     }


### PR DESCRIPTION
In its current form, it gives the following error message when three phases are all present. 

```
Error: 
An error occurred while creating the reservoir properties
Internal error: EQUILIBRATION DATA ERROR FOR REGION 1,
THE GAS-OIL CONTACT LIES BELOW THE WATER-OIL CONTACT.


Error: Unrecoverable errors while loading input:
EQUILIBRATION DATA ERROR FOR REGION 1,
THE GAS-OIL CONTACT LIES BELOW THE WATER-OIL CONTACT.
```

not totally sure whether it is the correct place to throw, while it is first prototype.