### PR TITLE
Set C++ standard to 20 for dune-common >= 2.11

### DIFF
--- a/cmake/Modules/Finddune-common.cmake
+++ b/cmake/Modules/Finddune-common.cmake
@@ -82,3 +82,7 @@ endif(MPI_C_FOUND)
 # make version number available in config.h
 include (UseDuneVer)
 find_dune_version ("dune" "common")
+
+if(${DUNE_COMMON_VERSION_MAJOR}.${DUNE_COMMON_VERSION_MINOR} VERSION_GREATER_EQUAL "2.11")
+  set(CMAKE_CXX_STANDARD 20)
+endif()


### PR DESCRIPTION
This change ensures that the C++ standard is set to 20 when using dune-common version 2.11 or greater. The reasoning is that (the soon to be released) dune 2.11 will require mandatory C++20.

Note that this requires https://github.com/OPM/opm-simulators/pull/6518 for smooth transition into C++20 later on.