### PR TITLE
Conditionally Link More Tests to Dune-Common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,7 +406,15 @@ if(dune-common_FOUND)
       get_filename_component(tgt ${src} NAME_WE)
       target_link_libraries(${tgt} dunecommon)
     endforeach()
-    target_link_libraries(test_SymmTensor dunecommon)
+
+    foreach(tst test_SymmTensor test_densead test_EvaluationFormat
+        test_binarycoefficients test_components test_blackoilfluidstate
+        test_blackoilfluidsystem_nonstatic test_fluidmatrixinteractions
+        test_fluidsystems test_tabulation test_h2brinepvt test_co2brinepvt
+        test_eclblackoilfluidsystem test_eclblackoilfluidsystemnonstatic
+        test_eclblackoilpvt)
+      target_link_libraries(${tst} dunecommon)
+    endforeach()
   endif()
   if(BUILD_EXAMPLES)
     target_link_libraries(co2brinepvt dunecommon)


### PR DESCRIPTION
Continuation of commit 6387f9317 (PR #4663).  Following commit 17d9ab348 (PR #4774) more tests must link to Dune-common in order to get the correct include paths for `<dune/common/typetraits.hh>` that gets transitively included through [`Evaluation.hpp`](https://github.com/OPM/opm-common/blob/899ae3afae7c23d54b017db45c45ac29908d0e2e/opm/material/densead/Evaluation.hpp#L46-L48).