### PR TITLE
Emit Well List Contents in RPTSCHED WELSPECS

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WListManager.hpp
+++ b/opm/input/eclipse/Schedule/Well/WListManager.hpp
@@ -114,6 +114,14 @@ public:
     WList& newList(const std::string&              name,
                    const std::vector<std::string>& wname);
 
+    /// Start of sequence of run's current well lists.
+    ///
+    /// Sorted by well list name.
+    auto begin() const { return this->wlists.begin(); }
+
+    /// End of sequence of run's current well lists.
+    auto end() const { return this->wlists.end(); }
+
     /// Sequence of well lists containing named well.
     ///
     /// \param[in] wname Well name.

--- a/opm/output/eclipse/report/WellSpecification.cpp
+++ b/opm/output/eclipse/report/WellSpecification.cpp
@@ -19,11 +19,15 @@
 
 #include <opm/output/eclipse/report/WellSpecification.hpp>
 
+#include <opm/common/utility/String.hpp>
+
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
 #include <opm/input/eclipse/Schedule/Group/GTNode.hpp>
 #include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/Well/WList.hpp>
+#include <opm/input/eclipse/Schedule/Well/WListManager.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
@@ -39,6 +43,10 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace {
 
@@ -1068,11 +1076,145 @@ namespace {
             report_mswell_connection_data(os, well, ctx);
         }
     }
+
+    /// Emit well list report for a single well list.
+    ///
+    /// Contains at least the well list name.  If the well list is empty,
+    /// then the only line emitted will be the one containing the well list
+    /// name followed by an empty column of well names.  Otherwise, the
+    /// wells on the named well list will be printed in the report sheet,
+    /// with at most a specified number of wells per line.
+    ///
+    /// \param[in] indent Leading blanks that indent each line.
+    ///
+    /// \param[in] wellsPerLine Maximum number of well names printed on each
+    /// line.
+    ///
+    /// \param[in] wlistName Well list name.
+    ///
+    /// \param[in] wlistWells Wells associated to the named well list.
+    ///
+    /// \param[in,out] Stream to which to write the well list report.
+    void writeWellListWells(const std::string&                        indent,
+                            const std::vector<std::string>::size_type wellsPerLine,
+                            const std::string&                        wlistName,
+                            const std::vector<std::string>&           wlistWells,
+                            std::ostream&                             os)
+    {
+        const auto numRptLines = wlistWells.empty()
+            ? std::vector<std::string>::size_type{1}
+            : (wlistWells.size() + wellsPerLine - 1) / wellsPerLine;
+
+        for (auto line = 0*numRptLines; line < numRptLines; ++line) {
+            const auto start =          (line + 0) * wellsPerLine;
+            const auto end   = std::min((line + 1) * wellsPerLine, wlistWells.size());
+
+            os << indent
+               << fmt::format(": {:<8s} :{:<100s}:\n",
+                              ((line == 0) ? wlistName : ""),
+                              fmt::format(" {:<8s}",
+                                          fmt::join(wlistWells.begin() + start,
+                                                    wlistWells.begin() + end, " ")));
+        }
+    }
+
+    /// Emit well list report.
+    ///
+    /// Will generate a printed sheet of the form shown below detailing the
+    /// contents of all current well lists.
+    ///
+    ///          WELL LISTS (Date)
+    ///          -----------------
+    ///
+    ///    -------------------------------
+    ///    :  LIST  :                    :
+    ///    -------------------------------
+    ///    :        :                    :
+    ///    :  *A    : A1   A2 [---]  A10 :
+    ///    :        : A11  A12           :
+    ///    :        :                    :
+    ///    :  *B    : B1   B2            :
+    ///    :        :                    :
+    ///    -------------------------------
+    ///
+    /// The first column ('LIST') is 10 characters wide and the well name
+    /// column is 100 characters wide.  Well names are each printed in 10
+    /// characters, with at most 10 well names per line.
+    ///
+    /// \param[in] schedule Collection of dynamic simulation objects.
+    ///
+    /// \param[in] reportStep Zero-based report step index for which to
+    /// generate the well list report.
+    ///
+    /// \param[in,out] Stream to which to write the well list report.
+    void emitWellLists(const Opm::Schedule& schedule,
+                       const std::size_t    reportStep,
+                       std::ostream&        os)
+    {
+        const auto indent = std::string(std::string::size_type{10}, field_padding);
+
+        // Sheet header.
+        //
+        //  WELL LISTS (Date)
+        //  -----------------
+        //
+        {
+            // Upper case for "Jan" -> "JAN" &c.  The rest of the sheet is
+            // upper case, so mixed case month names would look out of place.
+            const auto header = ::Opm::uppercase
+                (fmt::format("WELL LISTS ({:%d-%b-%Y})",
+                             fmt::gmtime(schedule.simTime(reportStep))));
+
+            os << "\n\n"
+               << indent << std::string(std::string::size_type{40}, field_padding)
+               << header << '\n'
+               << indent << std::string(std::string::size_type{40}, field_padding)
+               << std::string(header.size(), divider_character) << "\n\n";
+        }
+
+        const auto hline = std::string(std::string::size_type{113}, divider_character);
+        const auto blank = fmt::format(": {0:8s} : {0:98s} :", "");
+
+        // Column headers.
+        //
+        //  ----------------------------
+        //  :  LIST  :                 :
+        //  ----------------------------
+        //  :        :                 :
+        //
+        // Note: First line in report sheet is intentionally left blank.
+        {
+            os << indent << hline << '\n'
+               << indent << fmt::format(":   LIST   : {0:98s} :\n", "")
+               << indent << hline << '\n'
+               << indent << blank << '\n';
+        }
+
+        // Body of well list report.
+        //
+        // One or more report lines for each well list at the current time.
+        // At most wellsPerLine well names per report line.  First (or only)
+        // report line has the well list name in the 'LIST' column.  Empty
+        // well lists reported as a line containing just the well list name.
+        // Each individual well list ends in a blank line.
+        constexpr auto wellsPerLine = std::vector<std::string>::size_type{10};
+
+        for (const auto& [wlname, wlist] : schedule[reportStep].wlist_manager()) {
+            writeWellListWells(indent, wellsPerLine, wlname, wlist.wells(), os);
+
+            // Blank line after each well list.
+            os << indent << blank << '\n';
+        }
+
+        // Final horizontal line in well list report.
+        os << indent << hline << "\n\n\n";
+    }
 }
 
 // ===========================================================================
 
 void Opm::PrtFile::Reports::wellSpecification(const std::vector<std::string>& changedWells,
+                                              const bool                      changedWellLists,
                                               const std::size_t               reportStep,
                                               const Schedule&                 schedule,
                                               BlockDepthCallback              blockDepth,
@@ -1082,6 +1224,10 @@ void Opm::PrtFile::Reports::wellSpecification(const std::vector<std::string>& ch
 
     if (! changedWells.empty()) {
         emitWellspec(changedWells, ctx, schedule[reportStep], os);
+    }
+
+    if (changedWellLists) {
+        emitWellLists(schedule, reportStep, os);
     }
 
     emitGroupHierarchy(ctx, reportStep, os);

--- a/opm/output/eclipse/report/WellSpecification.hpp
+++ b/opm/output/eclipse/report/WellSpecification.hpp
@@ -33,9 +33,44 @@ namespace Opm {
 
 namespace Opm::PrtFile::Reports {
 
+    /// Call-back type for centre point depth of a grid block.
+    ///
+    /// Input argument is a global (Cartesian) cell index, and return value
+    /// is the centre point depth of that global cell.
     using BlockDepthCallback = std::function<double(std::size_t)>;
 
+    /// Emit textual well specification report to output stream
+    ///
+    /// The well specification report includes
+    ///
+    ///    -# well/group name, well head location, BHP reference depth,
+    ///       preferred phase, shut-in instruction, &c
+    ///
+    ///    -# reservoir connection location, CTF, KH, skin, D-factor
+    ///
+    ///    -# segment/branch topology, segment properties
+    ///
+    /// for all wells that have structurally changed.  Furthermore, we show
+    /// the current group tree and the contents of any well lists that have
+    /// changed since the previous report step.
+    ///
+    /// \param[in] changedWells Wells that have structurally changed since
+    /// the previous report step.
+    ///
+    /// \param[in] changedWellLists Whether or not the contents of any of
+    /// the run's well lists have changed since the previous report step.
+    ///
+    /// \param[in] reportStep Zero-based report step index at which to look
+    /// up dynamic simulation objects.
+    ///
+    /// \param[in] schedule Run's collection of dynamic simulation objects.
+    ///
+    /// \param[in] blockDepth Call-back function for retrieving centre point
+    /// depths of active cells.
+    ///
+    /// \param[in,out] os Stream to which to emit well specification report.
     void wellSpecification(const std::vector<std::string>& changedWells,
+                           const bool                      changedWellLists,
                            const std::size_t               reportStep,
                            const Schedule&                 schedule,
                            BlockDepthCallback              blockDepth,


### PR DESCRIPTION
This PR adds logic to the well specification report, printed in response to the 'WELSPECS' mnemonic of the 'RPTSCHED' keyword, to emit the contents of the run's current well lists as known to the WListManager.  We emit this report if any of the run's well lists have changed structurally since the previous report step.  For context, we define structural changes as adding a new well list, removing one or more wells from one or more well lists, adding one or more wells to one or more existing well lists, or moving one or more wells onto another well list.  The report includes all well lists, even if only one of the well lists have changed.  We also tag the well list report sheet with the current date to make it independent of the surrounding context.