### PR TITLE
Changed assert to abort in ErrorMacros for GPU use

### DIFF
--- a/opm/common/ErrorMacros.hpp
+++ b/opm/common/ErrorMacros.hpp
@@ -24,11 +24,14 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
-#include <cstdlib>
 #include <string>
 #include <exception>
 #include <stdexcept>
 #include <cassert>
+
+#if OPM_IS_COMPILING_WITH_GPU_COMPILER
+#include <stdlib.h> // for abort()
+#endif
 
 // macros for reporting to stderr
 #ifdef OPM_VERBOSE // Verbose mode


### PR DESCRIPTION
Assure that we actually abort a GPU kernel also when NDEBUG is defined. This will also remove some warnings in missing return statements for PR OPM/opm-simulators#6391