### PR TITLE
Enable compatibility with newer CMake and Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,13 +107,14 @@ macro (config_hook)
       set(OPM_PROJECT_EXTRA_CODE_INSTALLED "${OPM_PROJECT_EXTRA_CODE_INSTALLED}
                                             set(HAVE_ECL_OUTPUT 1)")
     endif()
-    # We need to use the correct search mode. Otherwise not finding one
-    # boost component beloq will mark the previously found ones as not
-    # found again. (Code stolen from UseDynamicBoost.cmake
-    if(Boost_DIR)
+    # CMake 3.30.0 requires to find Boost in CONFIG mode or
+    # we need to use the correct search mode in previous cmake versions too.
+    # Otherwise not finding one boost component below will mark the previously found ones as not
+    # found again. (Code stolen from UseDynamicBoost.cmake)
+    if(Boost_DIR OR (CMAKE_VERSION VERSION_GREATER_EQUAL 3.30.0))
       set(_Boost_CONFIG_MODE CONFIG)
     endif()
-    find_package(Boost COMPONENTS filesystem regex system unit_test_framework ${_Boost_CONFIG_MODE})
+    find_package(Boost COMPONENTS filesystem regex unit_test_framework ${_Boost_CONFIG_MODE})
 
     if (HAVE_DYNAMIC_BOOST_TEST)
       set_target_properties(Boost::unit_test_framework PROPERTIES INTERFACE_COMPILE_DEFINITIONS BOOST_TEST_DYN_LINK=1)

--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -21,9 +21,14 @@ set (opm-common_DEPS
 	"Valgrind"
 )
 
+# CMake 3.30.0 requires to find Boost in CONFIG mode
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30.0)
+	set(_Boost_CONFIG_MODE CONFIG)
+endif()
+
 list(APPEND opm-common_DEPS
       # various runtime library enhancements
-      "Boost 1.44.0 COMPONENTS system unit_test_framework REQUIRED"
+      "Boost 1.44.0 COMPONENTS unit_test_framework REQUIRED ${_Boost_CONFIG_MODE}"
       "cjson"
       # Still it produces compile errors complaining that it
       # cannot format UDQVarType. Hence we use the same version


### PR DESCRIPTION
* Avoid warning when finding Boost libraries with CMake 3.30.0 or newer.
* Newer versions of Boost config (>=1.88) do not properly handle the system component.  But since it's not used, this patch removes it.