### PR TITLE
changed: use env to obtain python3 binary to use

### DIFF
--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/env python3
 #
 # This script provides "hand loop-unrolled" specializations of the
 # Evaluation class of dense automatic differentiation so that the


### PR DESCRIPTION
Use env to obtain python binary.

Mostly to follow https://github.com/OPM/opm-simulators/pull/6578

While this is not run much on user systems, use env here as well to ensure consistency, ie, that only a single python environment is used on CI.