### PR TITLE
Change Oil Vaporisation Properties to a Ptr_Member

### DIFF
--- a/opm/input/eclipse/Schedule/MixingRateControlKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/MixingRateControlKeywordHandlers.cpp
@@ -19,14 +19,21 @@
 
 #include "MixingRateControlKeywordHandlers.hpp"
 
-#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
-
-#include <opm/input/eclipse/Parser/ParserKeywords/D.hpp>
-
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleStatic.hpp>
 
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+
+#include <opm/input/eclipse/Parser/ParserKeywords/D.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/V.hpp>
+
 #include "HandlerContext.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace Opm {
 
@@ -34,92 +41,162 @@ namespace {
 
 void handleDRSDT(HandlerContext& handlerContext)
 {
-    const std::size_t numPvtRegions = handlerContext.static_schedule().m_runspec.tabdims().getNumPVTTables();
+    const std::size_t numPvtRegions = handlerContext.static_schedule()
+        .m_runspec.tabdims().getNumPVTTables();
+
     std::vector<double> maximums(numPvtRegions);
     std::vector<std::string> options(numPvtRegions);
+
     for (const auto& record : handlerContext.keyword) {
-        const auto& max = record.getItem<ParserKeywords::DRSDT::DRSDT_MAX>().getSIDouble(0);
-        const auto& option = record.getItem<ParserKeywords::DRSDT::OPTION>().get< std::string >(0);
+        const auto max = record
+            .getItem<ParserKeywords::DRSDT::DRSDT_MAX>()
+            .getSIDouble(0);
+
+        const auto option = record
+            .getItem<ParserKeywords::DRSDT::OPTION>()
+            .get<std::string>(0);
+
         std::fill(maximums.begin(), maximums.end(), max);
         std::fill(options.begin(), options.end(), option);
-        auto& ovp = handlerContext.state().oilvap();
+
+        auto ovp = handlerContext.state().oilvap();
         OilVaporizationProperties::updateDRSDT(ovp, maximums, options);
+
+        handlerContext.state().oilvap.update(std::move(ovp));
     }
 }
 
 void handleDRSDTCON(HandlerContext& handlerContext)
 {
-    const std::size_t numPvtRegions = handlerContext.static_schedule().m_runspec.tabdims().getNumPVTTables();
+    const std::size_t numPvtRegions = handlerContext.static_schedule()
+        .m_runspec.tabdims().getNumPVTTables();
+
     std::vector<double> maximums(numPvtRegions);
     std::vector<std::string> options(numPvtRegions);
     std::vector<double> psis(numPvtRegions);
     std::vector<double> omegas(numPvtRegions);
+
     std::size_t pvtRegionIdx = 0;
     for (const auto& record : handlerContext.keyword) {
-        const auto& max = record.getItem<ParserKeywords::DRSDTCON::DRSDT_MAX>().getSIDouble(0);
-        const auto& omega = record.getItem<ParserKeywords::DRSDTCON::OMEGA>().getSIDouble(0);
-        const auto& psi = record.getItem<ParserKeywords::DRSDTCON::PSI>().getSIDouble(0);
-        const auto& option = record.getItem<ParserKeywords::DRSDTCON::OPTION>().get< std::string >(0);
+        const auto max = record
+            .getItem<ParserKeywords::DRSDTCON::DRSDT_MAX>()
+            .getSIDouble(0);
+
+        const auto omega = record
+            .getItem<ParserKeywords::DRSDTCON::OMEGA>()
+            .getSIDouble(0);
+
+        const auto psi = record
+            .getItem<ParserKeywords::DRSDTCON::PSI>()
+            .getSIDouble(0);
+
+        const auto option = record
+            .getItem<ParserKeywords::DRSDTCON::OPTION>()
+            .get<std::string>(0);
+
         maximums[pvtRegionIdx] = max;
-        options[pvtRegionIdx] = option;
-        psis[pvtRegionIdx] = psi;
-        omegas[pvtRegionIdx] = omega;
-        pvtRegionIdx++;
+        options [pvtRegionIdx] = option;
+        psis    [pvtRegionIdx] = psi;
+        omegas  [pvtRegionIdx] = omega;
+
+        ++pvtRegionIdx;
     }
-    auto& ovp = handlerContext.state().oilvap();
+
+    auto ovp = handlerContext.state().oilvap();
     OilVaporizationProperties::updateDRSDTCON(ovp, maximums, options, psis, omegas);
+
+    handlerContext.state().oilvap.update(std::move(ovp));
 }
 
 void handleDRSDTR(HandlerContext& handlerContext)
 {
-    const std::size_t numPvtRegions = handlerContext.static_schedule().m_runspec.tabdims().getNumPVTTables();
+    const std::size_t numPvtRegions = handlerContext.static_schedule()
+        .m_runspec.tabdims().getNumPVTTables();
+
     std::vector<double> maximums(numPvtRegions);
     std::vector<std::string> options(numPvtRegions);
+
     std::size_t pvtRegionIdx = 0;
     for (const auto& record : handlerContext.keyword) {
-        const auto& max = record.getItem<ParserKeywords::DRSDTR::DRSDT_MAX>().getSIDouble(0);
-        const auto& option = record.getItem<ParserKeywords::DRSDTR::OPTION>().get< std::string >(0);
+        const auto max = record
+            .getItem<ParserKeywords::DRSDTR::DRSDT_MAX>()
+            .getSIDouble(0);
+
+        const auto& option = record
+            .getItem<ParserKeywords::DRSDTR::OPTION>()
+            .get<std::string>(0);
+
         maximums[pvtRegionIdx] = max;
         options[pvtRegionIdx] = option;
-        pvtRegionIdx++;
+
+        ++pvtRegionIdx;
     }
-    auto& ovp = handlerContext.state().oilvap();
+
+    auto ovp = handlerContext.state().oilvap();
     OilVaporizationProperties::updateDRSDT(ovp, maximums, options);
+
+    handlerContext.state().oilvap.update(std::move(ovp));
 }
 
 void handleDRVDT(HandlerContext& handlerContext)
 {
-    const std::size_t numPvtRegions = handlerContext.static_schedule().m_runspec.tabdims().getNumPVTTables();
+    const std::size_t numPvtRegions = handlerContext.static_schedule()
+        .m_runspec.tabdims().getNumPVTTables();
+
     std::vector<double> maximums(numPvtRegions);
     for (const auto& record : handlerContext.keyword) {
-        const auto& max = record.getItem<ParserKeywords::DRVDTR::DRVDT_MAX>().getSIDouble(0);
+        const auto max = record
+            .getItem<ParserKeywords::DRVDTR::DRVDT_MAX>()
+            .getSIDouble(0);
+
         std::fill(maximums.begin(), maximums.end(), max);
-        auto& ovp = handlerContext.state().oilvap();
+
+        auto ovp = handlerContext.state().oilvap();
         OilVaporizationProperties::updateDRVDT(ovp, maximums);
+
+        handlerContext.state().oilvap.update(std::move(ovp));
     }
 }
 
 void handleDRVDTR(HandlerContext& handlerContext)
 {
-    std::size_t numPvtRegions = handlerContext.static_schedule().m_runspec.tabdims().getNumPVTTables();
-    std::size_t pvtRegionIdx = 0;
+    const std::size_t numPvtRegions = handlerContext.static_schedule()
+        .m_runspec.tabdims().getNumPVTTables();
+
     std::vector<double> maximums(numPvtRegions);
+
+    std::size_t pvtRegionIdx = 0;
     for (const auto& record : handlerContext.keyword) {
-        const auto& max = record.getItem<ParserKeywords::DRVDTR::DRVDT_MAX>().getSIDouble(0);
-        maximums[pvtRegionIdx] = max;
-        pvtRegionIdx++;
+        maximums[pvtRegionIdx] = record
+            .getItem<ParserKeywords::DRVDTR::DRVDT_MAX>()
+            .getSIDouble(0);
+
+        ++pvtRegionIdx;
     }
-    auto& ovp = handlerContext.state().oilvap();
+
+    auto ovp = handlerContext.state().oilvap();
     OilVaporizationProperties::updateDRVDT(ovp, maximums);
+
+    handlerContext.state().oilvap.update(std::move(ovp));
 }
 
 void handleVAPPARS(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::VAPPARS;
+
     for (const auto& record : handlerContext.keyword) {
-        double vap1 = record.getItem("OIL_VAP_PROPENSITY").get< double >(0);
-        double vap2 = record.getItem("OIL_DENSITY_PROPENSITY").get< double >(0);
-        auto& ovp = handlerContext.state().oilvap();
+        const auto vap1 = record
+            .getItem<Kw::OIL_VAP_PROPENSITY>()
+            .get<double>(0);
+
+        const auto vap2 = record
+            .getItem<Kw::OIL_DENSITY_PROPENSITY>()
+            .get<double>(0);
+
+        auto ovp = handlerContext.state().oilvap();
         OilVaporizationProperties::updateVAPPARS(ovp, vap1, vap2);
+
+        handlerContext.state().oilvap.update(std::move(ovp));
     }
 }
 

--- a/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -301,18 +301,6 @@ int ScheduleState::nupcol() const {
     return this->m_nupcol.value();
 }
 
-void ScheduleState::update_oilvap(OilVaporizationProperties oilvap) {
-    this->m_oilvap = std::move(oilvap);
-}
-
-const OilVaporizationProperties& ScheduleState::oilvap() const {
-    return this->m_oilvap;
-}
-
-OilVaporizationProperties& ScheduleState::oilvap() {
-    return this->m_oilvap;
-}
-
 void ScheduleState::update_geo_keywords(std::vector<DeckKeyword> geo_keywords) {
     this->m_geo_keywords = std::move(geo_keywords);
 }
@@ -369,7 +357,6 @@ void ScheduleState::rptonly(const bool only)
 bool ScheduleState::operator==(const ScheduleState& other) const {
 
     return this->m_start_time == other.m_start_time
-        && this->m_oilvap == other.m_oilvap
         && this->m_sim_step == other.m_sim_step
         && this->m_month_num == other.m_month_num
         && this->m_save_step == other.m_save_step
@@ -401,6 +388,7 @@ bool ScheduleState::operator==(const ScheduleState& other) const {
         && this->guide_rate.get() == other.guide_rate.get()
         && this->rft_config.get() == other.rft_config.get()
         && this->udq.get() == other.udq.get()
+        && this->oilvap() == other.oilvap()
         && this->bhp_defaults.get() == other.bhp_defaults.get()
         && this->source.get() == other.source.get()
         && this->wcycle() == other.wcycle()
@@ -431,7 +419,6 @@ ScheduleState ScheduleState::serializationTestObject() {
     ts.groups = map_member<std::string, Group>::serializationTestObject();
     ts.m_events = Events::serializationTestObject();
     ts.m_nupcol = Nupcol::serializationTestObject();
-    ts.update_oilvap( Opm::OilVaporizationProperties::serializationTestObject() );
     ts.m_message_limits = MessageLimits::serializationTestObject();
     ts.m_whistctl_mode = Well::ProducerCMode::THP;
     ts.target_wellpi = {{"WELL1", 1000}, {"WELL2", 2000}};
@@ -460,6 +447,7 @@ ScheduleState ScheduleState::serializationTestObject() {
     ts.glo.update( GasLiftOpt::serializationTestObject() );
     ts.rft_config.update( RFTConfig::serializationTestObject() );
     ts.rst_config.update( RSTConfig::serializationTestObject() );
+    ts.oilvap.update(OilVaporizationProperties::serializationTestObject());
     ts.source.update( Source::serializationTestObject() );
     ts.wcycle.update(WCYCLE::serializationTestObject());
     ts.wlist_tracker.update(WellListChangeTracker::serializationTestObject());

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -467,10 +467,6 @@ namespace Opm {
         void update_nupcol(int nupcol);
         int nupcol() const;
 
-        void update_oilvap(OilVaporizationProperties oilvap);
-        const OilVaporizationProperties& oilvap() const;
-        OilVaporizationProperties& oilvap();
-
         void update_events(Events events);
         Events& events();
         const Events& events() const;
@@ -535,6 +531,8 @@ namespace Opm {
         ptr_member<RFTConfig> rft_config;
         ptr_member<RSTConfig> rst_config;
 
+        ptr_member<OilVaporizationProperties> oilvap;
+
         ptr_member<BHPDefaults> bhp_defaults;
         ptr_member<Source> source;
         ptr_member<WCYCLE> wcycle;
@@ -591,6 +589,8 @@ namespace Opm {
                                   return this->rft_config;
             else if constexpr ( std::is_same_v<T, RSTConfig> )
                                   return this->rst_config;
+            else if constexpr ( std::is_same_v<T, OilVaporizationProperties> )
+                                  return this->oilvap;
             else if constexpr ( std::is_same_v<T, BHPDefaults> )
                                   return this->bhp_defaults;
             else if constexpr ( std::is_same_v<T, Source> )
@@ -650,6 +650,7 @@ namespace Opm {
             serializer(rpt_config);
             serializer(rft_config);
             serializer(rst_config);
+            serializer(this->oilvap);
             serializer(bhp_defaults);
             serializer(source);
             serializer(wcycle);
@@ -675,7 +676,6 @@ namespace Opm {
             serializer(m_save_step);
             serializer(m_tuning);
             serializer(m_nupcol);
-            serializer(m_oilvap);
             serializer(m_events);
             serializer(m_wellgroup_events);
             serializer(m_geo_keywords);
@@ -698,7 +698,6 @@ namespace Opm {
 
         Tuning m_tuning{};
         Nupcol m_nupcol{};
-        OilVaporizationProperties m_oilvap{};
         Events m_events{};
         WellGroupEvents m_wellgroup_events{};
         std::vector<DeckKeyword> m_geo_keywords{};

--- a/opm/input/eclipse/Schedule/ScheduleStatic.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleStatic.hpp
@@ -22,13 +22,13 @@
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 
 #include <opm/input/eclipse/Schedule/MessageLimits.hpp>
-#include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
 #include <opm/input/eclipse/Schedule/RPTConfig.hpp>
 #include <opm/input/eclipse/Schedule/RSTConfig.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleRestartInfo.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <array>
 #include <memory>
 #include <optional>
 #include <string>
@@ -91,9 +91,8 @@ struct ScheduleStatic
     /// Whether or not run activates the gas-lift optimisation facility.
     bool gaslift_opt_active{false};
 
-    /// Limits on gas re-solution and oil vaporisation rates (e.g., DRSTD in
-    /// SOLUTION section).
-    std::optional<OilVaporizationProperties> oilVap{};
+    /// Oil vaporisation propensities (i.e., VAPPARS in SOLUTION section).
+    std::optional<std::array<double,2>> oilVap{};
 
     /// Whether or not this run is externally controlled by another
     /// simulation run (reservoir coupling facility).


### PR DESCRIPTION
At the time of putting the oil vaporisation properties into the ScheduleState, [5f78173af #2191], the `ptr_member` abstraction [acb1284ef, #2284] did not exist.  There was consequently no easy way to share the state.  Since then, the size of the `OilVaporizationProperties` class grown considerably and it now makes sense to share the state between report steps unless the data changes.

Affect this sharing by changing the private `m_oilvap` data member into a public `ptr_member<>` called `oilvap`.