### PR TITLE
Add Restart File Support for VAPPARS

### DIFF
--- a/opm/io/eclipse/rst/state.hpp
+++ b/opm/io/eclipse/rst/state.hpp
@@ -81,7 +81,8 @@ struct RstState
     std::unordered_map<std::string, std::vector<std::string>> wlists;
 
 private:
-    void load_oil_vaporization(const std::vector<int>& intehead,
+    void load_oil_vaporization(const std::vector<int>&    intehead,
+                               const std::vector<bool>&   logihead,
                                const std::vector<double>& doubhead);
 
     void load_tuning(const std::vector<int>& intehead,

--- a/opm/output/eclipse/CreateDoubHead.cpp
+++ b/opm/output/eclipse/CreateDoubHead.cpp
@@ -187,12 +187,15 @@ createDoubHead(const EclipseState& es,
     auto dh = DoubHEAD{}
         .tuningParameters(sched[lookup_step].tuning(), tconv)
         .timeStamp       (computeTimeStamp(sched, simTime))
-        .drsdt           (sched[lookup_step].oilvap(), usys)
         .udq_param       (rspec.udqParams())
         .guide_rate_param(computeGuideRate(sched, lookup_step))
         .lift_opt_param  (computeLiftOptParam(sched, usys, lookup_step))
         .netBalParams    (getNetworkBalanceParameters(sched, usys, report_step, lookup_step))
         ;
+
+    if (report_step > 0) {
+        dh.phaseMixing(sched[lookup_step].oilvap(), usys);
+    }
 
     if (nextTimeStep > 0.0) {
         using M = ::Opm::UnitSystem::measure;

--- a/opm/output/eclipse/DoubHEAD.cpp
+++ b/opm/output/eclipse/DoubHEAD.cpp
@@ -26,6 +26,7 @@
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/Tuning.hpp>
 
+#include <opm/input/eclipse/Units/Dimension.hpp>
 #include <opm/input/eclipse/Units/Units.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
@@ -76,8 +77,8 @@ enum Index : std::vector<double>::size_type {
     dh_023  =  23,
     dh_024  =  24,
     dRsdt   =  VI::doubhead::dRsDt,
-    dh_026  =  26,
-    dh_027  =  27,
+    OilVapPropensity = VI::doubhead::OilVapPropensity,
+    OilVapDensPropensity = VI::doubhead::OilVapDensPropensity,
     dh_028  =  28,
     dh_029  =  29,
 
@@ -414,18 +415,16 @@ Opm::RestartIO::DoubHEAD::NetBalanceParams::NetBalanceParams(const UnitSystem& u
 Opm::RestartIO::DoubHEAD::DoubHEAD()
     : data_(Index::NUMBER_OF_ITEMS, 0.0)
 {
-    // Numbers below have unknown usage, values have been determined by
-    // experiments to be constant across a range of reference cases.
-    this->data_[Index::dh_024] = 1.0e+20;
-    this->data_[Index::dh_026] = 0.0;
-    this->data_[Index::dh_027] = 0.0;
+    constexpr auto infty = 1.0e+20;
+
+    this->data_[Index::dh_024] = infty;
     this->data_[Index::dh_028] = 0.0;
-    this->data_[Index::dh_054] = 1.0e+20;
-    this->data_[Index::dh_055] = 1.0e+20;
+    this->data_[Index::dh_054] = infty;
+    this->data_[Index::dh_055] = infty;
     this->data_[Index::dh_065] = 0.0;
     this->data_[Index::dh_069] = -1.0;
-    this->data_[Index::dh_080] = 1.0e+20;
-    this->data_[Index::dh_081] = 1.0e+20;
+    this->data_[Index::dh_080] = infty;
+    this->data_[Index::dh_081] = infty;
     this->data_[grpar_e] = 0.0;
     this->data_[grpar_f] = 0.0;
     this->data_[LOmini] = 0.0;
@@ -487,19 +486,19 @@ Opm::RestartIO::DoubHEAD::DoubHEAD()
     this->data_[Index::dh_184] = 1.0e-4;
     this->data_[Index::dh_185] = 0.0;
     this->data_[Index::dh_186] = 0.0;
-    this->data_[Index::dh_187] = 1.0e+20;
-    this->data_[Index::dh_188] = 1.0e+20;
-    this->data_[Index::dh_189] = 1.0e+20;
+    this->data_[Index::dh_187] = infty;
+    this->data_[Index::dh_188] = infty;
+    this->data_[Index::dh_189] = infty;
 
-    this->data_[Index::dh_190] = 1.0e+20;
-    this->data_[Index::dh_191] = 1.0e+20;
-    this->data_[Index::dh_192] = 1.0e+20;
-    this->data_[Index::dh_193] = 1.0e+20;
-    this->data_[Index::dh_194] = 1.0e+20;
-    this->data_[Index::dh_195] = 1.0e+20;
-    this->data_[Index::dh_196] = 1.0e+20;
-    this->data_[Index::dh_197] = 1.0e+20;
-    this->data_[Index::dh_198] = 1.0e+20;
+    this->data_[Index::dh_190] = infty;
+    this->data_[Index::dh_191] = infty;
+    this->data_[Index::dh_192] = infty;
+    this->data_[Index::dh_193] = infty;
+    this->data_[Index::dh_194] = infty;
+    this->data_[Index::dh_195] = infty;
+    this->data_[Index::dh_196] = infty;
+    this->data_[Index::dh_197] = infty;
+    this->data_[Index::dh_198] = infty;
     this->data_[Index::dh_199] = 1.0;
 
     this->data_[Index::dh_200] = 0.0;
@@ -515,7 +514,7 @@ Opm::RestartIO::DoubHEAD::DoubHEAD()
 
     this->data_[Index::dh_210] = 0.0;
     this->data_[Index::dh_211] = 0.0;
-    this->data_[UdqPar_2]      = 1.0E+20;
+    this->data_[UdqPar_2]      = infty;
     this->data_[UdqPar_3]      = 0.0;
     this->data_[UdqPar_4]      = 1.0e-4;
     this->data_[Index::dh_215] = -2.0e+20;
@@ -526,7 +525,7 @@ Opm::RestartIO::DoubHEAD::DoubHEAD()
     this->data_[Index::dh_220] = 0.01;
     this->data_[Index::dh_221] = 1.0;
     this->data_[Index::dh_222] = 0.0;
-    this->data_[Index::dh_223] = 1.0e+20;
+    this->data_[Index::dh_223] = infty;
     this->data_[Index::dh_225] = 0.0;
     this->data_[Index::dh_226] = 0.0;
     this->data_[Index::dh_227] = 0.0;
@@ -549,17 +548,17 @@ Opm::RestartIO::DoubHEAD::DoubHEAD()
     this->data_[Index::XxxLCV] = 0.001;
     this->data_[Index::XxxWFL] = 0.001;
 
-    this->data_[Index::dRsdt]  = 1.0e+20; // "Infinity"
+    this->data_[Index::dRsdt]  = infty;
 
     this->data_[Index::TrgDPR] = 1.0e+6;
     this->data_[Index::TfDIFF] = 1.25;
     this->data_[Index::DdpLim] = 1.0e+6;
     this->data_[Index::DdsLim] = 1.0e+6;
 
-    this->data_[Index::ThrUPT] = 1.0e+20;
-    this->data_[Index::XxxDPR] = 1.0e+20;
+    this->data_[Index::ThrUPT] = infty;
+    this->data_[Index::XxxDPR] = infty;
     this->data_[Index::TrgFIP] = 0.025;
-    this->data_[Index::TrgSFT] = 1.0e+20;
+    this->data_[Index::TrgSFT] = infty;
 }
 
 Opm::RestartIO::DoubHEAD&
@@ -567,7 +566,10 @@ Opm::RestartIO::DoubHEAD::tuningParameters(const Tuning&     tuning,
                                            const double      cnvT)
 {
     // Record 1
-    this->data_[Index::TsInit] = tuning.TSINIT.has_value() ? tuning.TSINIT.value() / cnvT : VI::DoubHeadValue::TSINITNoValue ;
+    this->data_[Index::TsInit] = tuning.TSINIT.has_value()
+        ? tuning.TSINIT.value() / cnvT
+        : VI::DoubHeadValue::TSINITNoValue;
+
     this->data_[Index::TsMaxz] = tuning.TSMAXZ / cnvT;
     this->data_[Index::TsMinz] = tuning.TSMINZ / cnvT;
     this->data_[Index::TsMchp] = tuning.TSMCHP / cnvT;
@@ -634,12 +636,26 @@ Opm::RestartIO::DoubHEAD::nextStep(const double nextTimeStep)
 }
 
 Opm::RestartIO::DoubHEAD&
-Opm::RestartIO::DoubHEAD::drsdt(const OilVaporizationProperties& oilvap,
-                                const UnitSystem&                usys)
+Opm::RestartIO::DoubHEAD::phaseMixing(const OilVaporizationProperties& oilvap,
+                                      const UnitSystem&                usys)
 {
-    if (oilvap.getType() == OilVaporizationProperties::OilVaporization::DRDT) {
+    using VapType = OilVaporizationProperties::OilVaporization;
+
+    switch (oilvap.getType()) {
+    case VapType::DRDT:
         this->data_[dRsdt] = usys.from_si(UnitSystem::measure::gas_oil_ratio_rate,
                                           oilvap.getMaxDRSDT(0));
+        break;
+
+    case VapType::VAPPARS:
+        // No unit conversion needed.  The propensities are dimensionless
+        // parameters.
+        this->data_[OilVapPropensity]     = oilvap.vap1();
+        this->data_[OilVapDensPropensity] = oilvap.vap2();
+        break;
+
+    default:
+        break;
     }
 
     return *this;

--- a/opm/output/eclipse/DoubHEAD.hpp
+++ b/opm/output/eclipse/DoubHEAD.hpp
@@ -79,14 +79,14 @@ namespace Opm { namespace RestartIO {
         DoubHEAD& operator=(const DoubHEAD& rhs) = default;
         DoubHEAD& operator=(DoubHEAD&& rhs) = default;
 
-        DoubHEAD& tuningParameters(const Tuning&     tuning,
-                                   const double      cnvT);
+        DoubHEAD& tuningParameters(const Tuning& tuning,
+                                   const double  cnvT);
 
         DoubHEAD& timeStamp(const TimeStamp& ts);
         DoubHEAD& nextStep(const double nextTimeStep);
 
-        DoubHEAD& drsdt(const OilVaporizationProperties& oilvap,
-                        const UnitSystem&                usys);
+        DoubHEAD& phaseMixing(const OilVaporizationProperties& oilvap,
+                              const UnitSystem&                usys);
 
         DoubHEAD& udq_param(const UDQParams& udqPar);
         DoubHEAD& guide_rate_param(const guideRate& guide_rp);

--- a/opm/output/eclipse/LogiHEAD.cpp
+++ b/opm/output/eclipse/LogiHEAD.cpp
@@ -2,12 +2,14 @@
 
 #include <opm/output/eclipse/VectorItems/logihead.hpp>
 
+#include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
+
 #include <utility>
 #include <vector>
 
 namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
 
-enum index : std::vector<int>::size_type {
+enum index : std::vector<bool>::size_type {
     // Flag to signify live oil (dissolved gas) PVT
     IsLiveOil = VI::logihead::IsLiveOil,
 
@@ -79,6 +81,7 @@ lh_036	=	36	,		//	FALSE
 
     // Flag to indicate that the network option is used
     HasNetwork = VI::logihead::HasNetwork,
+
     // Flag to signify constant oil compressibility
     ConstCo = VI::logihead::ConstCo,
 
@@ -96,7 +99,10 @@ lh_049	=	49	,		//	FALSE
 lh_050	=	50	,		//	FALSE
 lh_051	=	51	,		//	FALSE
 lh_052	=	52	,		//	FALSE
-lh_053	=	53	,		//	FALSE
+
+    // Whether or not VAPPARS is currently active.
+    VapPars = VI::logihead::VapPars,
+
 lh_054	=	54	,		//	FALSE
 lh_055	=	55	,		//	FALSE
 lh_056	=	56	,		//	FALSE
@@ -171,7 +177,7 @@ lh_120	=	120	,		//	FALSE
 // ---------------------------------------------------------------------
 // ---------------------------------------------------------------------
 
-    LOGIHEAD_NUMBER_OF_ITEMS        // MUST be last element of enum.
+    LOGIHEAD_NUMBER_OF_ITEMS,       // MUST be last enumerator.
 };
 
 // =====================================================================
@@ -223,7 +229,16 @@ Opm::RestartIO::LogiHEAD::saturationFunction(const SatfuncFlags& satfunc)
 Opm::RestartIO::LogiHEAD&
 Opm::RestartIO::LogiHEAD::network(const int maxNoNodes)
 {
-    this->data_[HasNetwork  ] = (maxNoNodes >= 1) ? true : false;
+    this->data_[HasNetwork] = maxNoNodes >= 1;
+
+    return *this;
+}
+
+Opm::RestartIO::LogiHEAD&
+Opm::RestartIO::LogiHEAD::phaseMixing(const OilVaporizationProperties& oilvap)
+{
+    this->data_[VapPars] = oilvap.defined() &&
+        (oilvap.getType() == OilVaporizationProperties::OilVaporization::VAPPARS);
 
     return *this;
 }

--- a/opm/output/eclipse/LogiHEAD.hpp
+++ b/opm/output/eclipse/LogiHEAD.hpp
@@ -23,7 +23,13 @@
 
 #include <vector>
 
-namespace Opm { namespace RestartIO {
+namespace Opm {
+
+    class OilVaporizationProperties;
+
+} // namespace Opm
+
+namespace Opm::RestartIO {
 
     class LogiHEAD
     {
@@ -83,8 +89,12 @@ namespace Opm { namespace RestartIO {
         LogiHEAD& variousParam(const bool e300_radial,
                                const bool e100_radial,
                                const int  nswlmx,
-			       const bool enableHyster
-			      );
+                               const bool enableHyster);
+
+        /// Assign oil vaporisation characteristics.
+        ///
+        /// In particular, whether or not VAPPARS is currently active.
+        LogiHEAD& phaseMixing(const OilVaporizationProperties& oilvap);
 
         /// Assign PVT model characteristics.
         ///
@@ -101,18 +111,21 @@ namespace Opm { namespace RestartIO {
         /// \return \code *this \endcode.
         LogiHEAD& saturationFunction(const SatfuncFlags& satfunc);
 
+        /// Logical switch to indicate that the network option is used.
+        LogiHEAD& network(const int maxNoNodes);
+
+        /// Linearised result array.
+        ///
+        /// This is the final output of LogiHEAD assembly.
         const std::vector<bool>& data() const
         {
             return this->data_;
         }
 
-        /// Logical switch to indicate that the network option is used
-        ///
-        LogiHEAD& network(const int maxNoNodes);
     private:
         std::vector<bool> data_;
     };
 
-}} // Opm::RestartIO
+} // Opm::RestartIO
 
 #endif // OPM_LOGIHEAD_HEADER_INCLUDED

--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -174,10 +174,16 @@ namespace {
         rstFile.write("INTEHEAD", ih);
 
         // write LOGIHEAD to restart file
-        rstFile.write("LOGIHEAD", Helpers::createLogiHead(es));
+        if (report_step == 0) {
+            rstFile.write("LOGIHEAD", Helpers::createLogiHead(es));
+        }
+        else {
+            rstFile.write("LOGIHEAD", Helpers::createLogiHead(es, schedule[report_step - 1]));
+        }
 
         // write DOUBHEAD to restart file
-        const auto dh = Helpers::createDoubHead(es, schedule, sim_step, report_step,
+        const auto dh = Helpers::createDoubHead(es, schedule,
+                                                sim_step, report_step,
                                                 simTime, next_step_size);
         rstFile.write("DOUBHEAD", dh);
 

--- a/opm/output/eclipse/VectorItems/doubhead.hpp
+++ b/opm/output/eclipse/VectorItems/doubhead.hpp
@@ -47,6 +47,13 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
         dRsDt   = 25,
 
+        OilVapPropensity = 26, // Oil's propensity to vaporise into
+                               // unsaturated gas phase (VAPPARS(1)).
+
+        OilVapDensPropensity = 27, // Oil's density increase propensity as
+                                   // lighter fractions vaporise
+                                   // (VAPPARS(2)).
+
         Netbalthpc    = 50,    //  Network balancing THP convergence limit (NETBALAN(4))
         Netbalint     = 51,    //  Network balancing interval (NETBALAN(1))
         Netbalnpre    = 53,    //  Network balancing nodal pressure

--- a/opm/output/eclipse/VectorItems/logihead.hpp
+++ b/opm/output/eclipse/VectorItems/logihead.hpp
@@ -22,7 +22,7 @@
 
 #include <vector>
 
-namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems {
+namespace Opm::RestartIO::Helpers::VectorItems {
 
     // This is a subset of the items in src/opm/output/eclipse/LogiHEAD.cpp .
     // Promote items from that list to this in order to make them public.
@@ -40,10 +40,14 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         DirEPS     = 17,    // Directional end-point scaling
         RevEPS     = 18,    // Reversible end-point scaling
         AltEPS     = 19,    // Alternative (3-pt) end-point scaling
-        HasNetwork = 37,     // Indicates Network option used
+        HasNetwork = 37,    // Indicates Network option used
         ConstCo    = 38,    // Constant oil compressibility (PVCDO)
+
+        VapPars    = 53,    // Whether or not VAPPARS is currently active.
+
         HasMSWells = 75,    // Whether or not model has MS Wells.
     };
-}}}} // Opm::RestartIO::Helpers::VectorItems
+
+} // Opm::RestartIO::Helpers::VectorItems
 
 #endif // OPM_OUTPUT_ECLIPSE_VECTOR_LOGIHEAD_HPP

--- a/opm/output/eclipse/WriteRestartHelpers.hpp
+++ b/opm/output/eclipse/WriteRestartHelpers.hpp
@@ -31,6 +31,7 @@ namespace Opm {
     class EclipseGrid;
     class EclipseState;
     class Schedule;
+    class ScheduleState;
     class Well;
     class UnitSystem;
     class UDQActive;
@@ -67,8 +68,23 @@ namespace Opm::RestartIO::Helpers {
     std::vector<double>
     createLgrHeadd();
 
+    /// Static flags, mostly for INIT file purposes.
+    ///
+    /// \param[in] es Static properties and run settings.
+    ///
+    /// \return Output file's logical flag settings.
     std::vector<bool>
     createLogiHead(const EclipseState& es);
+
+    /// Dynamic flags, mostly for restart file purposes.
+    ///
+    /// \param[in] es Static properties and run settings.
+    ///
+    /// \param[in] sched Dynamic simulation objects and settings.
+    ///
+    /// \return Output file's logical flag settings.
+    std::vector<bool>
+    createLogiHead(const EclipseState& es, const ScheduleState& sched);
 
     std::size_t
     entriesPerSACT();


### PR DESCRIPTION
The oil vaporisation parameters defined by the `VAPPARS` keyword go in the `DOUBHEAD` array when active.  This PR adds support for reading and writing those parameters.  Furthermore, item 53 of `LOGIHEAD` identifies whether or not the VAPPARS keyword is currently active.