### PR TITLE
Potential fix for issue with summary vector RTIPTHEA (opm-simulators#3870)

### DIFF
--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1084,7 +1084,7 @@ establishRegionContext(const DeckKeyword&       keyword,
 {
     auto region_name = std::string { "FIPNUM" };
 
-    if (keyword.name().size() > 5) {
+    if (keyword.name().size() > 5 && keyword.name().substr(0, 2) != "RT") {
         region_name = "FIP" + keyword.name().substr(5, 3);
 
         if (! field_props.has_int(region_name)) {


### PR DESCRIPTION
2022-04-PRE: Summary Vector RTIPTHEA Not Reported as Unsupported (Minor Issue) [opm-simulators#3870](https://github.com/OPM/opm-simulators/issues/3870)

The issue seems to be that all REGION summary vectors with greater than 5 characters are assumed to use a user defined region set. But this is not true for RTIPTHEA, and others starting with RT.