### PR TITLE
assert to remove an analyzer warning in PhaseUsageInfo

### DIFF
--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -77,6 +77,8 @@ public:
     }
 
     [[nodiscard]] short activeToCanonicalCompIdx(unsigned activeCompIdx) const {
+        // assert to remove an analyzer warning, at the current stage, numPhases == numComponents for black oil
+        assert(numActivePhases_ <= numComponents);
         if (activeCompIdx >= numActivePhases()) {
             return activeCompIdx; // e.g. for solvent
         }


### PR DESCRIPTION
[-Warray-bounds=] warning with function activeToCanonicalCompIdx().