### PR TITLE
Group::InjectionCMode2String should handle SALE control

### DIFF
--- a/opm/input/eclipse/Schedule/Group/Group.cpp
+++ b/opm/input/eclipse/Schedule/Group/Group.cpp
@@ -1199,6 +1199,9 @@ Group::InjectionCMode2String(const InjectionCMode enumValue)
     case InjectionCMode::FLD:
         return "FLD";
 
+    case InjectionCMode::SALE:
+        return "SALE";
+
     default:
         throw std::invalid_argument("Unhandled enum value");
     }


### PR DESCRIPTION
It throws the the InjectionCMode is `SALE`.  Saw this when outputting for debugging. 