### PR TITLE
Bump OPM version to 2025.10.1

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -5,8 +5,8 @@
 
 Module: opm-common
 Description: Open Porous Media Initiative shared infrastructure
-Version: 2025.10
-Label: 2025.10
+Version: 2025.10.1
+Label: 2025.10.1
 Maintainer: opm@opm-project.org
 MaintainerName: OPM community
 Url: http://opm-project.org


### PR DESCRIPTION
Bump OPM version to 2025.10.1 (Reason: next PR backporting https://github.com/OPM/opm-common/pull/4831)