### PR TITLE
Avoiding multiplexer static_assert for nvcc

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
@@ -77,8 +77,8 @@ namespace Opm {
     }                                                                                                                  \
     }
 
-// The static_assert does not compile with gcc 12 and earlier when placed in the multiplexer below.
-#if defined(__GNUC__) && (__GNUC__ < 13)
+// The static_assert does not compile with gcc 12 and earlier (or nvcc) when placed in the multiplexer below.
+#if (defined(__GNUC__) && (__GNUC__ < 13)) || defined(__CUDACC__)
     #define STATIC_ASSERT_ECL_MULTIPLEXER_UNLESS_GCC_LT_13 throw std::logic_error("Unhandled EclMultiplexerApproach")
 #else
     #define STATIC_ASSERT_ECL_MULTIPLEXER_UNLESS_GCC_LT_13 static_assert(false, "Unhandled EclMultiplexerApproach")

--- a/opm/material/fluidmatrixinteractions/SatCurveMultiplexer.hpp
+++ b/opm/material/fluidmatrixinteractions/SatCurveMultiplexer.hpp
@@ -32,8 +32,8 @@
 #include <stdexcept>
 
 
-// The static_assert does not compile with gcc 12 and earlier when placed in the multiplexer calls below.
-#if defined(__GNUC__) && (__GNUC__ < 13)
+// The static_assert does not compile with gcc 12 and earlier (or nvcc) when placed in the multiplexer calls below.
+#if (defined(__GNUC__) && (__GNUC__ < 13)) || defined(__CUDACC__)
     #define STATIC_ASSERT_SATCURVE_MULTIPLEXER_UNLESS_GCC_LT_13 throw std::logic_error("Unhandled SatCurveMultiplexerApproach")
 #else
     #define STATIC_ASSERT_SATCURVE_MULTIPLEXER_UNLESS_GCC_LT_13 static_assert(false, "Unhandled SatCurveMultiplexerApproach")


### PR DESCRIPTION
This should fix some compilation issues occurring on certain combinations of NVCC and GCC.