### PR TITLE
Expose Foam Density Unit

### DIFF
--- a/opm/input/eclipse/Units/UnitSystem.cpp
+++ b/opm/input/eclipse/Units/UnitSystem.cpp
@@ -97,6 +97,7 @@ namespace {
         0.0,
         0.0,
         0.0,
+        0.0,
     };
 
     static const double to_metric[] = {
@@ -147,6 +148,7 @@ namespace {
         1 / Metric::Ymodule,
         1 / Metric::ThermalConductivity,
         1 / (Metric::Time / Metric::GasSurfaceVolume),
+        1 / Metric::FoamDensity,
     };
 
     static const double from_metric[] = {
@@ -197,6 +199,7 @@ namespace {
         Metric::Ymodule,
         Metric::ThermalConductivity,
         Metric::Time / Metric::GasSurfaceVolume,
+        Metric::FoamDensity,
     };
 
     static constexpr const char* metric_names[static_cast<int>(UnitSystem::measure::_count)] = {
@@ -247,6 +250,7 @@ namespace {
         "GPa",
         "KJ/M/DAY/K",
         "DAY/SM3",
+        "KG/M3",
     };
 
     static_assert(numElems(from_metric_offset) == static_cast<std::size_t>(UnitSystem::measure::_count),
@@ -279,6 +283,7 @@ namespace {
         0.0,
         0.0,
         Field::TemperatureOffset,
+        0.0,
         0.0,
         0.0,
         0.0,
@@ -366,7 +371,8 @@ namespace {
         1 / Field::PPM,
         1 / Field::Ymodule,
         1 / Field::ThermalConductivity,
-        1 / (Field::Time / Field::GasSurfaceVolume)
+        1 / (Field::Time / Field::GasSurfaceVolume),
+        1 / Field::FoamDensity,
     };
 
     static const double from_field[] = {
@@ -417,6 +423,7 @@ namespace {
          Field::Ymodule,
          Field::ThermalConductivity,
          Field::Time / Field::GasSurfaceVolume,
+         Field::FoamDensity,
     };
 
     static constexpr const char* field_names[static_cast<int>(UnitSystem::measure::_count)] = {
@@ -467,6 +474,7 @@ namespace {
         "GPa",
         "BTU/FT/DAY/R",
         "DAY/MSCF",
+        "LB/MSCF",
     };
 
     static_assert(numElems(from_field_offset) == static_cast<std::size_t>(UnitSystem::measure::_count),
@@ -499,6 +507,7 @@ namespace {
         0.0,
         0.0,
         Lab::TemperatureOffset,
+        0.0,
         0.0,
         0.0,
         0.0,
@@ -586,7 +595,8 @@ namespace {
         1 / Lab::PPM,
         1 / Lab::Ymodule,
         1 / Lab::ThermalConductivity,
-        1 / (Lab::Time / Lab::GasSurfaceVolume)
+        1 / (Lab::Time / Lab::GasSurfaceVolume),
+        1 / Lab::FoamDensity,
     };
 
     static const double from_lab[] = {
@@ -636,7 +646,8 @@ namespace {
         Lab::PPM,
         Lab::Ymodule,
         Lab::ThermalConductivity,
-        Lab::Time / Lab::GasSurfaceVolume
+        Lab::Time / Lab::GasSurfaceVolume,
+        Lab::FoamDensity,
     };
 
     static constexpr const char* lab_names[static_cast<int>(UnitSystem::measure::_count)] = {
@@ -687,6 +698,7 @@ namespace {
         "GPa",
         "J/CM/HR/K",
         "HR/SCC",
+        "G/SCC",
     };
 
     static_assert(numElems(from_lab_offset) == static_cast<std::size_t>(UnitSystem::measure::_count),
@@ -719,6 +731,7 @@ namespace {
         0.0,
         0.0,
         PVT_M::TemperatureOffset,
+        0.0,
         0.0,
         0.0,
         0.0,
@@ -807,6 +820,7 @@ namespace {
         1 / PVT_M::Ymodule,
         1 / PVT_M::ThermalConductivity,
         1 / (PVT_M::Time / PVT_M::GasSurfaceVolume),
+        1 / PVT_M::FoamDensity,
     };
 
     static const double from_pvt_m[] = {
@@ -857,6 +871,7 @@ namespace {
         PVT_M::Ymodule,
         PVT_M::ThermalConductivity,
         PVT_M::Time / PVT_M::GasSurfaceVolume,
+        PVT_M::FoamDensity,
     };
 
     static constexpr const char* pvt_m_names[static_cast<int>(UnitSystem::measure::_count)] = {
@@ -907,6 +922,7 @@ namespace {
         "GPa",
         "KJ/M/SEC/K",
         "DAY/SM3",
+        "KG/SM3",
     };
 
     static_assert(numElems(from_pvt_m_offset) == static_cast<std::size_t>(UnitSystem::measure::_count),
@@ -930,6 +946,7 @@ namespace {
     // INPUT Unit Conventions
 
     static const double from_input_offset[] = {
+        0.0,
         0.0,
         0.0,
         0.0,
@@ -1027,9 +1044,11 @@ namespace {
         1,
         1,
         1,
+        1,
     };
 
     static const double from_input[] = {
+        1,
         1,
         1,
         1,
@@ -1127,6 +1146,7 @@ namespace {
         "GPa",
         "KJ/M/DAY/K",
         "DAY/SM3",
+        "KG/SM3",
     };
 
     static_assert(numElems(from_input_offset) == static_cast<std::size_t>(UnitSystem::measure::_count),

--- a/opm/input/eclipse/Units/UnitSystem.hpp
+++ b/opm/input/eclipse/Units/UnitSystem.hpp
@@ -89,7 +89,8 @@ namespace Opm {
             ymodule,
             thermalconductivity,
             dfactor,
-            _count // New entries must be added *before* this
+            foamdensity,
+            _count, // New entries must be added *before* this
         };
 
         explicit UnitSystem(int ecl_id);

--- a/tests/parser/UnitTests.cpp
+++ b/tests/parser/UnitTests.cpp
@@ -322,6 +322,8 @@ BOOST_AUTO_TEST_CASE(METRIC_UNITS)
     BOOST_CHECK_CLOSE( metric.to_si( Meas::moles , 1.0 ) , 1000 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::ppm , 1.0 ) , 1.0e-6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::thermalconductivity , 1.0 ) , 1.1574074074074073e-02 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::concentration , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::foamdensity , 1.0 ) , 1.0 , 1.0e-10 );
 
     // ----------------------------------------------------------------
     // SI -> METRIC
@@ -365,7 +367,8 @@ BOOST_AUTO_TEST_CASE(METRIC_UNITS)
     BOOST_CHECK_CLOSE( metric.from_si( Meas::moles , 1 ) , 0.001 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::ppm , 1.0 ) , 1.0e6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::thermalconductivity , 1.1574074074074073e-02 ) , 1.0 , 1.0e-10 );
-
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::concentration , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::foamdensity , 1.0 ) , 1.0 , 1.0e-10 );
 }
 
 BOOST_AUTO_TEST_CASE(FIELD_UNITS)
@@ -418,7 +421,8 @@ BOOST_AUTO_TEST_CASE(FIELD_UNITS)
     BOOST_CHECK_CLOSE( field.to_si( Meas::moles, 1.0 ) , 453.59237 , 1.0e-5 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::ppm, 1.0 ) , 1.0e-6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::thermalconductivity , 1.0 ) , 7.2065719324146973e-02 , 1.0e-10 );
-
+    BOOST_CHECK_CLOSE( field.to_si( Meas::concentration , 1.0 ) , 2.8530101742118243 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::foamdensity , 1.0 ) , 0.016018463373960137 , 1.0e-10 );
 
     // ----------------------------------------------------------------
     // SI -> FIELD
@@ -461,7 +465,8 @@ BOOST_AUTO_TEST_CASE(FIELD_UNITS)
     BOOST_CHECK_CLOSE( field.from_si( Meas::moles , 1.0 ) , 0.0022046226 , 1.0e-5 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::ppm , 1.0 ) , 1.0e6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::thermalconductivity , 7.2065719324146973e-02 ) , 1.0 , 1.0e-10 );
-
+    BOOST_CHECK_CLOSE( field.from_si( Meas::concentration , 1.0 ) , 0.35050698698481197 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::foamdensity , 1.0 ) , 62.427960576144621 , 1.0e-10 );
 }
 
 BOOST_AUTO_TEST_CASE(LAB_UNITS)
@@ -514,7 +519,8 @@ BOOST_AUTO_TEST_CASE(LAB_UNITS)
     BOOST_CHECK_CLOSE( lab.to_si( Meas::moles , 1 ) , 1, 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::ppm , 1.0 ) , 1.0e-6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::thermalconductivity , 1.0 ) , 2.777777777777778e-02 , 1.0e-10 );
-
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::concentration , 1.0 ) , 1000.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::foamdensity , 1.0 ) , 1000.0 , 1.0e-10 );
 
     // ----------------------------------------------------------------
     // SI -> LAB
@@ -558,7 +564,8 @@ BOOST_AUTO_TEST_CASE(LAB_UNITS)
     BOOST_CHECK_CLOSE( lab.from_si( Meas::moles , 1 ) , 1, 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::ppm , 1.0 ) , 1.0e6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::thermalconductivity , 2.777777777777778e-02 ) , 1.0 , 1.0e-10 );
-
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::concentration , 1.0 ) , 1.0e-3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::foamdensity , 1.0 ) , 1.0e-3 , 1.0e-10 );
 }
 
 BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
@@ -611,7 +618,8 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::moles , 1 ) , 1000 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::ppm , 1.0 ) , 1.0e-6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::thermalconductivity , 1.0 ) , 1.1574074074074073e-02 , 1.0e-10 );
-
+    BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::concentration , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::foamdensity , 1.0 ) , 1.0 , 1.0e-10 );
 
     // ----------------------------------------------------------------
     // SI -> PVT-M
@@ -655,7 +663,8 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::moles , 1 ) , 0.001 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::ppm , 1) , 1.e6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::thermalconductivity , 1.1574074074074073e-02 ) , 1.0 , 1.0e-10 );
-
+    BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::concentration , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::foamdensity , 1.0 ) , 1.0 , 1.0e-10 );
 }
 
 BOOST_AUTO_TEST_CASE(TemperatureConversions)


### PR DESCRIPTION
This commit adds a new `UnitSystem::measure` for "foam density" quantities such as those entered in the `WFOAM` keyword.  This is mainly intended for client code that wishes to tag output arrays appropriately for unit conversion in restart file output.

While here, also add unit tests for the 'concentration' unit of measure that was introduced in commit d4e33a461 (PR #4749).