### PR TITLE
Make the order of distributed wells uniform across ranks

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WellTestState.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestState.hpp
@@ -269,7 +269,7 @@ public:
     std::optional<WellTestState::RestartWell> restart_well(const Opm::WellTestConfig& config, const std::string& wname) const;
 
 private:
-    std::unordered_map<std::string, WTestWell> wells;
+    std::map<std::string, WTestWell> wells; // distributed wells must be ordered uniformly across ranks
     std::unordered_map<std::string, std::unordered_map<int, ClosedCompletion>> completions;
 
     std::vector<std::pair<std::string, int>> updateCompletion(const WellTestConfig& config, double sim_time);


### PR DESCRIPTION
Distributed wells must be ordered uniformly. Otherwise, the program can get deadlocked when it iterates over wells and well communicators on different ranks do not match. One such deadlock was discovered in `BalckoilWellModel::wellTesting`. It iterates over strings of well names which is sourced from `WellTestState::test_wells`. 

These vectors should be ordered uniformly across ranks. In my opinion, the cleanest solution is to store the wells in `WellTestState` in a `map` instead of `unordered_map`. Alternatively, the output of the `test_wells` could be sorted.