### PR TITLE
Make `scaler_layers` import optional to avoid TensorFlow requirement

### DIFF
--- a/python/opm/ml/ml_tools/__init__.py
+++ b/python/opm/ml/ml_tools/__init__.py
@@ -1,2 +1,12 @@
+# Always import kerasify (no extra dependencies)
 from .kerasify import *
-from .scaler_layers import *
+
+# Try to import scaler_layers (requires TensorFlow)
+try:
+    from .scaler_layers import *
+except ImportError:
+    import warnings
+    warnings.warn(
+        "Optional module 'scaler_layers' not loaded. "
+        "Requires TensorFlow. Install 'tensorflow' to enable."
+    )


### PR DESCRIPTION
Currently, importing `from opm.ml.ml_tools.kerasify import export_model` can fail if TensorFlow is not installed because `scaler_layers` is imported in `__init__.py`.

This PR makes the import of `scaler_layers` optional, so users can use `kerasify` without installing TensorFlow.



