### PR TITLE
Drop Region Set From Vector Names in SummaryState::update() Call

### DIFF
--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -3803,7 +3803,8 @@ void updateValue(const Opm::EclIO::SummaryNode& node, const double value, Opm::S
 
     case Cat::Region:
         st.update_region_var(node.fip_region.value_or("FIPNUM"),
-                             node.keyword, node.number, value);
+                             node.keyword.substr(0, 5),
+                             node.number, value);
         break;
 
     default:

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -95,6 +95,10 @@ FIP_A
   500*2
 /
 
+COPY
+  FIPNUM FIPABC /
+/
+
 EQUALS
   FIP_BC 4 4* 1 5 /
   FIP_BC 3 4* 6 7 /
@@ -363,6 +367,30 @@ ROFT
  1 11 /
  1  2 /
  9 10 /
+/
+
+ROFT+ABC
+  1 2 /
+/
+
+ROFT-ABC
+  1 2 /
+/
+
+RGFT+ABC
+  1 2 /
+/
+
+RGFT-ABC
+  1 2 /
+/
+
+RWFT+ABC
+  1 2 /
+/
+
+RWFT-ABC
+  1 2 /
 /
 
 RWFR-


### PR DESCRIPTION
This ensures that the internal logic for generating unique vector keys always computes the same string value.  In turn, this fixes a problem concerning inter-region flow vectors with a user defined region set like

    ROFT_ABC
    ROFT+ABC
    ROFT-ABC

Prior to this PR, these would internally be stored with duplicated region set names and would be incorrectly written as zero in the summary files.