### PR TITLE
Add Support for WORK Arrays in OPERATE and OPERATER

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -749,9 +749,9 @@ private:
 
     template <typename T>
     Fieldprops::FieldData<T>&
-    init_get(const std::string& keyword,
+    init_get(const std::string&                           keyword,
              const Fieldprops::keywords::keyword_info<T>& kw_info,
-             const bool multiplier_in_edit = false);
+             const bool                                   multiplier_in_edit = false);
 
     std::string region_name(const DeckItem& region_item) const;
 
@@ -803,6 +803,8 @@ private:
         return "__MULT__"sv;
     }
 
+    void resetWorkArrays();
+
     const UnitSystem unit_system;
     std::size_t nx,ny,nz;
     Phases m_phases;
@@ -819,6 +821,11 @@ private:
     std::unordered_map<std::string, Fieldprops::FieldData<int>> int_data;
     std::unordered_map<std::string, Fieldprops::FieldData<double>> double_data;
     std::unordered_map<std::string, std::string> fipreg_shortname_translation{};
+
+    /// Backing store for intermediate WORK<n> arrays.
+    ///
+    /// Cleared at end of each section.
+    std::unordered_map<std::string, Fieldprops::FieldData<double>> work_arrays{};
 
     std::unordered_map<std::string,Fieldprops::TranCalculator> tran;
 


### PR DESCRIPTION
In this initial version we support only the double precision WORK arrays (named "`WORK<n>`" with `<n>` being a positive integer), and only for compressed property arrays like `SOGCR`.  In other words, operating on the "global" MULTZ* arrays is not supported when referencing WORK arrays at this time.  On the other hand, we do not use `REGDIMS(8)` as an upper limit on the number of distinct "WORK" arrays that can be used in the model description.

Integer work arrays ("`IWORK<n>`") are not supported at this time.

We add a new data member, `FieldProps::work_arrays`, of the same type as `FieldProps::double_data`, and select this 'work_arrays' member as the backing store for array references using "WORK<n>".  All WORK arrays are cleared at the end of processing a section (e.g., GRID, PROPS, EDIT).