### PR TITLE
Add load model method to load back exported machine learning model

### DIFF
--- a/python/opm/ml/ml_tools/load_model.py
+++ b/python/opm/ml/ml_tools/load_model.py
@@ -1,3 +1,20 @@
+#   Copyright (C) 2025 NORCE Research AS.
+
+#   This file is part of the Open Porous Media project (OPM).
+
+#   OPM is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+
+#   OPM is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+
+#   You should have received a copy of the GNU General Public License
+#   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
 import struct
 import numpy as np
 
@@ -6,6 +23,7 @@ from opm.ml.ml_tools.kerasify import (
     ACTIVATION_LINEAR, ACTIVATION_RELU, ACTIVATION_SOFTPLUS, 
     ACTIVATION_TANH, ACTIVATION_SIGMOID, ACTIVATION_HARD_SIGMOID,
 )
+
 from opm.ml.ml_tools.scaler_layers import (
     MinMaxScalerLayer,
     MinMaxUnScalerLayer,

--- a/python/tests/test_load_model.py
+++ b/python/tests/test_load_model.py
@@ -1,3 +1,20 @@
+#   Copyright (C) 2025 NORCE Research AS.
+
+#   This file is part of the Open Porous Media project (OPM).
+
+#   OPM is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+
+#   OPM is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+
+#   You should have received a copy of the GNU General Public License
+#   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
 import unittest
 import numpy as np
 import tempfile


### PR DESCRIPTION
After exporting a ML model thanks to `export_model`, `load_model` now allows to load it back. This proves useful if one wants to train a model, export it to OPM. Then gets new data and wants to fine-tune the model.  