### PR TITLE
only set -fext-numeric-literals for c++ sources

### DIFF
--- a/cmake/Modules/FindQuadMath.cmake
+++ b/cmake/Modules/FindQuadMath.cmake
@@ -42,7 +42,7 @@ if(QuadMath_FOUND AND NOT TARGET QuadMath::QuadMath)
 
   # Somehow needed for DUNE 2.9/g++-12
   target_compile_options(QuadMath::QuadMath INTERFACE
-    $<$<CXX_COMPILER_ID:GNU>:-fext-numeric-literals>
+    $<$<CXX_COMPILER_ID:GNU>:$<$<COMPILE_LANGUAGE:CXX>:-fext-numeric-literals>>
   )
 
   # Check for numeric_limits specialization


### PR DESCRIPTION
get rid of warning 

```
[288/821] Building C object CMakeFiles/opmsimulators.dir/opm/simulators/linalg/mixed/bsr.c.o
cc1: warning: command-line option '-fext-numeric-literals' is valid for C++/ObjC++ but not for C
```