### PR TITLE
source build configuration script in build scripts

### DIFF
--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if test -z "$BTYPES"
+then
+  source $TOOLCHAIN_DIR/build-configurations.sh
+fi
+
 declare -A configurations
 
 declare -A EXTRA_MODULE_FLAGS


### PR DESCRIPTION
This exposes, or well, is a step to expose, another tech debt from the jenkins setup: the configuration of build types to execute. In particular this needs to run inside the docker when the builder is dockerized and hence needs to run as part of the build script.

Currently this looks somewhat like

```bash
#!/bin/bash

declare -a AVAILABLE_BTYPES

AVAILABLE_BTYPES=(
  clang
  clang-lto
  debug
  hipify
  lto
  rocm
  serial
  serial_debug
  serial_shared
  shared
)

if ! grep -q "nodefault" <<< $ghprbCommentBody
then
  BTYPES="default"
  CMAKE_TOOLCHAIN_FILES="$TOOLCHAIN_DIR/default.cmake"
fi

for BTYPE in ${AVAILABLE_BTYPES[*]}
do
  if grep -q " ${BTYPE}" <<< $ghprbCommentBody
  then
    BTYPES="$BTYPES $BTYPE"
    CMAKE_TOOLCHAIN_FILES="${CMAKE_TOOLCHAIN_FILES} $TOOLCHAIN_DIR/$BTYPE.cmake"
  fi
done

export BUILDTHREADS=16
export TESTTHREADS=16
export CTEST_TIMEOUT=1500
export BTYPES
export CMAKE_TOOLCHAIN_FILES
export OPENBLAS_NUM_THREADS=1
export OMP_NUM_THREADS=2
```

so basically this script parses the pull request trigger for configurations to process, as well as setting build parameters such as number of build jobs.

This will eventually be put under revision control along with the rest of the jenkins builder setup.