### PR TITLE
Jenkins build scripts: add static analysis

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -9,3 +9,9 @@ This expects to run on a jenkins instance with opm-common as the 'origin' remote
 
 It will build and test opm-common. It can be used both for post-merge builds
 of the master branch and for a github pull request builder job.
+
+**static_analysis.sh**:
+This expects to run on a jenkins instance with opm-common as the 'origin' remote.
+
+It will run and build opm-common using various configurations, and then
+run static analysis.

--- a/jenkins/static_analysis.sh
+++ b/jenkins/static_analysis.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source ${TOOLCHAIN_DIR}/build-configurations-sca.sh
+source `dirname $0`/build-opm-module.sh
+
+$WORKSPACE/jenkins/build.sh
+
+run_static_analysis opm-common


### PR DESCRIPTION
Another tech debt closed. This puts the script and functions for static analysis that was previously internal on the jenkins box under revision control.