### PR TITLE
Fix warnings for builds with -DWITH_NDEBUG=1

### DIFF
--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -770,11 +770,13 @@ public:
     OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
 {% if numDerivs < 0 %}\
+#ifndef NDEBUG
         const int thisSize = size();
         const int otherSize = other.size();
 
         // Allow operation if sizes match or one is constant (size == 0)
         assert(thisSize == otherSize || thisSize == 0 || otherSize == 0);
+#endif
 {% else %}\
         assert(size() == other.size());
 {% endif %}\
@@ -801,11 +803,13 @@ public:
     OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
 {% if numDerivs < 0 %}\
+#ifndef NDEBUG
         const int thisSize = size();
         const int otherSize = other.size();
 
         // Allow operation if sizes match or one is constant (size == 0)
         assert(thisSize == otherSize || thisSize == 0 || otherSize == 0);
+#endif
 {% else %}\
         assert(size() == other.size());
 {% endif %}\
@@ -853,11 +857,13 @@ public:
     OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
 {% if numDerivs < 0 %}\
+#ifndef NDEBUG
         const int thisSize = size();
         const int otherSize = other.size();
 
         // Allow operation if sizes match or one is constant (size == 0)
         assert(thisSize == otherSize || thisSize == 0 || otherSize == 0);
+#endif
 {% else %}\
         assert(size() == other.size());
 {% endif %}\
@@ -882,11 +888,13 @@ public:
     OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
 {% if numDerivs < 0 %}\
+#ifndef NDEBUG
         const int thisSize = size();
         const int otherSize = other.size();
 
         // Allow operation if sizes match or one is constant (size == 0)
         assert(thisSize == otherSize || thisSize == 0 || otherSize == 0);
+#endif
 {% else %}\
         assert(size() == other.size());
 {% endif %}\

--- a/opm/material/densead/DynamicEvaluation.hpp
+++ b/opm/material/densead/DynamicEvaluation.hpp
@@ -454,11 +454,13 @@ public:
     // add two evaluation objects
     OPM_HOST_DEVICE Evaluation operator+(const Evaluation& other) const
     {
+#ifndef NDEBUG
         const int thisSize = size();
         const int otherSize = other.size();
 
         // Allow operation if sizes match or one is constant (size == 0)
         assert(thisSize == otherSize || thisSize == 0 || otherSize == 0);
+#endif
 
         Evaluation result(*this);
 
@@ -481,11 +483,13 @@ public:
     // subtract two evaluation objects
     OPM_HOST_DEVICE Evaluation operator-(const Evaluation& other) const
     {
+#ifndef NDEBUG
         const int thisSize = size();
         const int otherSize = other.size();
 
         // Allow operation if sizes match or one is constant (size == 0)
         assert(thisSize == otherSize || thisSize == 0 || otherSize == 0);
+#endif
 
         Evaluation result(*this);
 
@@ -519,11 +523,13 @@ public:
 
     OPM_HOST_DEVICE Evaluation operator*(const Evaluation& other) const
     {
+#ifndef NDEBUG
         const int thisSize = size();
         const int otherSize = other.size();
 
         // Allow operation if sizes match or one is constant (size == 0)
         assert(thisSize == otherSize || thisSize == 0 || otherSize == 0);
+#endif
 
         Evaluation result(*this);
 
@@ -544,11 +550,13 @@ public:
 
     OPM_HOST_DEVICE Evaluation operator/(const Evaluation& other) const
     {
+#ifndef NDEBUG
         const int thisSize = size();
         const int otherSize = other.size();
 
         // Allow operation if sizes match or one is constant (size == 0)
         assert(thisSize == otherSize || thisSize == 0 || otherSize == 0);
+#endif
 
         Evaluation result(*this);
 


### PR DESCRIPTION
Fix warnings for builds with `-DWITH_NDEBUG=1`