### PR TITLE
Revise Summary::Eval() Function Signature

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -188,15 +188,11 @@ void msim::run_step(const WellTestState& wtest_state,
 
         seconds_elapsed += time_step;
 
-        io.summary().eval(this->st,
-                          report_step,
-                          seconds_elapsed,
-                          well_data,
-                          /* wbp = */ {},
-                          group_nwrk_data,
-                          /* sing_values = */ {},
-                          /* initial_inplace = */ {},
-                          /* inplace = */ {});
+        auto values = out::Summary::DynamicSimulatorState{};
+        values.well_solution = &well_data;
+        values.group_and_nwrk_solution = &group_nwrk_data;
+
+        io.summary().eval(report_step, seconds_elapsed, values, this->st);
 
         this->schedule.getUDQConfig(report_step - 1)
             .eval(report_step,

--- a/tests/test_Summary_GSatProd.cpp
+++ b/tests/test_Summary_GSatProd.cpp
@@ -177,22 +177,17 @@ END
         cse.es.runspec().udqParams().undefinedValue()
     };
 
-    const auto xw = Opm::data::Wells{};
-    const auto wbp = Opm::data::WellBlockAveragePressures{};
-    const auto grp_nwrk = Opm::data::GroupAndNetworkValues{};
-    const auto single = Opm::out::Summary::GlobalProcessParameters{};
+    // No dynamic simulator state in this test.
+    const auto values = Opm::out::Summary::DynamicSimulatorState{};
 
-    const auto ivip = std::optional<Opm::Inplace>{};
-    const auto cvip = Opm::Inplace{};
+    smry.eval(/* report_step = */ 0, /* secs_elapsed = */ 0.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 0, /* ministep_id = */ 0, /* isSubstep = */ false);
 
-    smry.eval(st, 0, 0*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 0, 0, false);
+    smry.eval(/* report_step = */ 1, /* secs_elapsed = */ 1.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 1, /* ministep_id = */ 1, /* isSubstep = */ false);
 
-    smry.eval(st, 1, 1*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 1, 1, false);
-
-    smry.eval(st, 2, 2*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 2, 2, false);
+    smry.eval(/* report_step = */ 2, /* secs_elapsed = */ 2.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 2, /* ministep_id = */ 2, /* isSubstep = */ false);
 
     smry.write();
 
@@ -327,21 +322,18 @@ END
     };
 
     const auto xw = wellSol();
-    const auto wbp = Opm::data::WellBlockAveragePressures{};
-    const auto grp_nwrk = Opm::data::GroupAndNetworkValues{};
-    const auto single = Opm::out::Summary::GlobalProcessParameters{};
+    auto values = Opm::out::Summary::DynamicSimulatorState{};
 
-    const auto ivip = std::optional<Opm::Inplace>{};
-    const auto cvip = Opm::Inplace{};
+    values.well_solution = &xw;
 
-    smry.eval(st, 0, 0*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 0, 0, false);
+    smry.eval(/* report_step = */ 0, /* secs_elapsed = */ 0.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 0, /* ministep_id = */ 0, /* isSubstep = */ false);
 
-    smry.eval(st, 1, 1*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 1, 1, false);
+    smry.eval(/* report_step = */ 1, /* secs_elapsed = */ 1.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 1, /* ministep_id = */ 1, /* isSubstep = */ false);
 
-    smry.eval(st, 2, 2*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 2, 2, false);
+    smry.eval(/* report_step = */ 2, /* secs_elapsed = */ 2.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 2, /* ministep_id = */ 2, /* isSubstep = */ false);
 
     smry.write();
 
@@ -485,21 +477,18 @@ END
     };
 
     const auto xw = wellSol();
-    const auto wbp = Opm::data::WellBlockAveragePressures{};
-    const auto grp_nwrk = Opm::data::GroupAndNetworkValues{};
-    const auto single = Opm::out::Summary::GlobalProcessParameters{};
+    auto values = Opm::out::Summary::DynamicSimulatorState{};
 
-    const auto ivip = std::optional<Opm::Inplace>{};
-    const auto cvip = Opm::Inplace{};
+    values.well_solution = &xw;
 
-    smry.eval(st, 0, 0*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 0, 0, false);
+    smry.eval(/* report_step = */ 0, /* secs_elapsed = */ 0.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 0, /* ministep_id = */ 0, /* isSubstep = */ false);
 
-    smry.eval(st, 1, 1*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 1, 1, false);
+    smry.eval(/* report_step = */ 1, /* secs_elapsed = */ 1.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 1, /* ministep_id = */ 1, /* isSubstep = */ false);
 
-    smry.eval(st, 2, 2*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 2, 2, false);
+    smry.eval(/* report_step = */ 2, /* secs_elapsed = */ 2.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 2, /* ministep_id = */ 2, /* isSubstep = */ false);
 
     smry.write();
 
@@ -638,21 +627,18 @@ END
     };
 
     const auto xw = wellSol();
-    const auto wbp = Opm::data::WellBlockAveragePressures{};
-    const auto grp_nwrk = Opm::data::GroupAndNetworkValues{};
-    const auto single = Opm::out::Summary::GlobalProcessParameters{};
+    auto values = Opm::out::Summary::DynamicSimulatorState{};
 
-    const auto ivip = std::optional<Opm::Inplace>{};
-    const auto cvip = Opm::Inplace{};
+    values.well_solution = &xw;
 
-    smry.eval(st, 0, 0*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 0, 0, false);
+    smry.eval(/* report_step = */ 0, /* secs_elapsed = */ 0.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 0, /* ministep_id = */ 0, /* isSubstep = */ false);
 
-    smry.eval(st, 1, 1*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 1, 1, false);
+    smry.eval(/* report_step = */ 1, /* secs_elapsed = */ 1.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 1, /* ministep_id = */ 1, /* isSubstep = */ false);
 
-    smry.eval(st, 2, 2*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 2, 2, false);
+    smry.eval(/* report_step = */ 2, /* secs_elapsed = */ 2.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 2, /* ministep_id = */ 2, /* isSubstep = */ false);
 
     smry.write();
 
@@ -792,21 +778,18 @@ END
     };
 
     const auto xw = wellSol();
-    const auto wbp = Opm::data::WellBlockAveragePressures{};
-    const auto grp_nwrk = Opm::data::GroupAndNetworkValues{};
-    const auto single = Opm::out::Summary::GlobalProcessParameters{};
+    auto values = Opm::out::Summary::DynamicSimulatorState{};
 
-    const auto ivip = std::optional<Opm::Inplace>{};
-    const auto cvip = Opm::Inplace{};
+    values.well_solution = &xw;
 
-    smry.eval(st, 0, 0*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 0, 0, false);
+    smry.eval(/* report_step = */ 0, /* secs_elapsed = */ 0.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 0, /* ministep_id = */ 0, /* isSubstep = */ false);
 
-    smry.eval(st, 1, 1*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 1, 1, false);
+    smry.eval(/* report_step = */ 1, /* secs_elapsed = */ 1.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 1, /* ministep_id = */ 1, /* isSubstep = */ false);
 
-    smry.eval(st, 2, 2*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 2, 2, false);
+    smry.eval(/* report_step = */ 2, /* secs_elapsed = */ 2.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 2, /* ministep_id = */ 2, /* isSubstep = */ false);
 
     smry.write();
 
@@ -955,21 +938,18 @@ END
     };
 
     const auto xw = wellSol();
-    const auto wbp = Opm::data::WellBlockAveragePressures{};
-    const auto grp_nwrk = Opm::data::GroupAndNetworkValues{};
-    const auto single = Opm::out::Summary::GlobalProcessParameters{};
+    auto values = Opm::out::Summary::DynamicSimulatorState{};
 
-    const auto ivip = std::optional<Opm::Inplace>{};
-    const auto cvip = Opm::Inplace{};
+    values.well_solution = &xw;
 
-    smry.eval(st, 0, 0*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 0, 0, false);
+    smry.eval(/* report_step = */ 0, /* secs_elapsed = */ 0.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 0, /* ministep_id = */ 0, /* isSubstep = */ false);
 
-    smry.eval(st, 1, 1*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 1, 1, false);
+    smry.eval(/* report_step = */ 1, /* secs_elapsed = */ 1.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 1, /* ministep_id = */ 1, /* isSubstep = */ false);
 
-    smry.eval(st, 2, 2*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 2, 2, false);
+    smry.eval(/* report_step = */ 2, /* secs_elapsed = */ 2.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 2, /* ministep_id = */ 2, /* isSubstep = */ false);
 
     smry.write();
 
@@ -1125,21 +1105,18 @@ END
     };
 
     const auto xw = wellSol();
-    const auto wbp = Opm::data::WellBlockAveragePressures{};
-    const auto grp_nwrk = Opm::data::GroupAndNetworkValues{};
-    const auto single = Opm::out::Summary::GlobalProcessParameters{};
+    auto values = Opm::out::Summary::DynamicSimulatorState{};
 
-    const auto ivip = std::optional<Opm::Inplace>{};
-    const auto cvip = Opm::Inplace{};
+    values.well_solution = &xw;
 
-    smry.eval(st, 0, 0*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 0, 0, false);
+    smry.eval(/* report_step = */ 0, /* secs_elapsed = */ 0.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 0, /* ministep_id = */ 0, /* isSubstep = */ false);
 
-    smry.eval(st, 1, 1*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 1, 1, false);
+    smry.eval(/* report_step = */ 1, /* secs_elapsed = */ 1.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 1, /* ministep_id = */ 1, /* isSubstep = */ false);
 
-    smry.eval(st, 2, 2*day(), xw, wbp, grp_nwrk, single, ivip, cvip);
-    smry.add_timestep(st, 2, 2, false);
+    smry.eval(/* report_step = */ 2, /* secs_elapsed = */ 2.0*day(), values, st);
+    smry.add_timestep(st, /* report_step = */ 2, /* ministep_id = */ 2, /* isSubstep = */ false);
 
     smry.write();
 

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -269,14 +269,23 @@ BOOST_AUTO_TEST_CASE(group_keywords)
     cfg.ta.makeSubDir( "PATH" );
     cfg.name = "PATH/CASE";
 
-    SummaryState st(TimeService::now(), 0.0);
+    auto writer = out::Summary {
+        cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name
+    };
 
-    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-    writer.eval(st, 0, 0*day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
-    writer.add_timestep(st, 0, 0, false);
+    auto st = SummaryState { TimeService::now(), 0.0 };
 
-    writer.eval(st, 1, 1*day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
-    writer.add_timestep(st, 1, 1, false);
+    auto values = out::Summary::DynamicSimulatorState{};
+
+    values.well_solution = &cfg.wells;
+    values.wbp = &cfg.wbp;
+    values.group_and_nwrk_solution = &cfg.grp_nwrk;
+
+    writer.eval(/* report_step = */ 0, /* secs_elapsed = */ 0.0*day, values, st);
+    writer.add_timestep(st, /* report_step = */ 0, /* ministep_id = */ 0, /* isSubstep = */ false);
+
+    writer.eval(/* report_step = */ 1, /* secs_elapsed = */ 1.0*day, values, st);
+    writer.add_timestep(st, /* report_step = */ 1, /* ministep_id = */ 1, /* isSubstep = */ false);
 
     writer.write();
 


### PR DESCRIPTION
This commit introduces an aggregate for client code to pass dynamic simulation state objects into the `Summary::eval()` member function. The aggregate is a collection of pointers for which `nullptr` represents "no such value".  This is a large, but hopefully one-time, API cost that prepares for introducing additional dynamic state objects as arguments to `Summary::eval()`.  The short-term use case is adding a more streamlined container for region level vectors that in turn will enable removing the `COPT`-based hack for computing the `ROEW*` vectors.

This protocol, while clearly more opaque than the current approach of having a separate parameter for each object type, is nevertheless expected to be easier to maintain in the future.