### PR TITLE
Remove warning ignoring duplicate libraries

### DIFF
--- a/cmake/Modules/OpmInit.cmake
+++ b/cmake/Modules/OpmInit.cmake
@@ -41,6 +41,11 @@ macro(OpmSetPolicies)
   if(POLICY CMP0074)
     cmake_policy(SET CMP0074 NEW)
   endif()
+
+  # de-duplicates libraries for capable linkers (Apple ld64, lld, MSVC)
+  if(POLICY CMP0156)
+    cmake_policy(SET CMP0156 NEW)
+  endif()
 endmacro()
 
 


### PR DESCRIPTION
This PR adds a CMake policy to fix the repetitive warning (observed using clang and macOS) when building opm-grid and opm-simulators (available for CMake ≥ 3.29):

`ld: warning: ignoring duplicate libraries: '-ldl', '-lm'`