### PR TITLE
fixed: only run sequential norne when requested

### DIFF
--- a/jenkins/handle-run-trigger.sh
+++ b/jenkins/handle-run-trigger.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Handle run trigger
-if grep -q " norne" <<< $ghprbCommentBody
+if grep -qE " norne\>" <<< $ghprbCommentBody
 then
   if grep -q "serial" <<< $ghprbCommentBody
   then
@@ -11,7 +11,7 @@ then
   fi
   test $? -eq 0 || exit 1
 fi
-if grep -q " norne_parallel" <<< $ghprbCommentBody
+if grep -qE " norne_parallel\>" <<< $ghprbCommentBody
 then
   $WORKSPACE/deps/opm-simulators/jenkins/run-norne.sh default 4
   test $? -eq 0 || exit 1


### PR DESCRIPTION
grep matched norne_parallel as well