### PR TITLE
FIX. Dont include satellites among the  wellgroups

### DIFF
--- a/opm/input/eclipse/Schedule/Group/Group.cpp
+++ b/opm/input/eclipse/Schedule/Group/Group.cpp
@@ -797,7 +797,7 @@ const std::vector<std::string>& Group::groups() const
 
 bool Group::wellgroup() const
 {
-    return this->m_groups.empty();
+    return this->m_groups.empty() && !groupIsSatellite(this->satellite_status);
 }
 
 bool Group::addWell(const std::string& well_name)


### PR DESCRIPTION
This was needed to fix the parallel implementation of GSATPROD (see https://github.com/OPM/opm-simulators/pull/6725). This could also be fixed in opm-simulators, but I think it makes sense that group.wellGroup() returns false if the group is a satellite. 