### PR TITLE
Remove Unused ParseContext Member Functions

### DIFF
--- a/opm/input/eclipse/Parser/ParseContext.cpp
+++ b/opm/input/eclipse/Parser/ParseContext.cpp
@@ -205,26 +205,6 @@ namespace Opm {
         }
     }
 
-    std::map<std::string,InputErrorAction>::const_iterator ParseContext::begin() const {
-        return m_errorContexts.begin();
-    }
-
-
-    std::map<std::string,InputErrorAction>::const_iterator ParseContext::end() const {
-        return m_errorContexts.end();
-    }
-
-    ParseContext ParseContext::withKey(const std::string& key, InputErrorAction action) const {
-        ParseContext pc(*this);
-        pc.addKey(key, action);
-        return pc;
-    }
-
-    ParseContext& ParseContext::withKey(const std::string& key, InputErrorAction action) {
-        this->addKey(key, action);
-        return *this;
-    }
-
     bool ParseContext::hasKey(const std::string& key) const {
         if (m_errorContexts.find( key ) == m_errorContexts.end())
             return false;

--- a/opm/input/eclipse/Parser/ParseContext.hpp
+++ b/opm/input/eclipse/Parser/ParseContext.hpp
@@ -90,15 +90,11 @@ class KeywordLocation;
         void handleError( const std::string& errorKey, const std::string& msg, const std::optional<KeywordLocation>& location, ErrorGuard& errors)  const;
         void handleUnknownKeyword(const std::string& keyword, const std::optional<KeywordLocation>& location, ErrorGuard& errors) const;
         bool hasKey(const std::string& key) const;
-        ParseContext  withKey(const std::string& key, InputErrorAction action) const;
-        ParseContext& withKey(const std::string& key, InputErrorAction action);
         void updateKey(const std::string& key , InputErrorAction action);
         void update(InputErrorAction action);
         void update(const std::string& keyString , InputErrorAction action);
         void ignoreKeyword(const std::string& keyword);
         InputErrorAction get(const std::string& key) const;
-        std::map<std::string,InputErrorAction>::const_iterator begin() const;
-        std::map<std::string,InputErrorAction>::const_iterator end() const;
         /*
           When the key is added it is inserted in 'strict mode',
           i.e. with the value 'InputError::THROW_EXCEPTION. If you


### PR DESCRIPTION
If we later need to iterate over a `ParseContext` object, we can reintroduce the `begin()`/`end()` member function pair.