### PR TITLE
Varnish Compsegs Handling

### DIFF
--- a/opm/input/eclipse/Schedule/MSW/Compsegs.hpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.hpp
@@ -17,68 +17,143 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef COMPSEGS_HPP_
 #define COMPSEGS_HPP_
 
-#include <unordered_map>
 #include <array>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace Opm {
 
-    class Segment;
     class Connection;
-    class WellConnections;
     class DeckKeyword;
-    class WellSegments;
-    class ScheduleGrid;
-    class ParseContext;
     class ErrorGuard;
+    class KeywordLocation;
+    class ParseContext;
+    class ScheduleGrid;
+    class Segment;
+    class WellConnections;
+    class WellSegments;
 
-namespace RestartIO {
+} // namespace Opm
+
+namespace Opm::RestartIO {
+
     struct RstWell;
-}
 
-namespace Compsegs {
+} // namespace Opm::RestartIO
 
+namespace Opm::Compsegs {
 
-/*
-  The COMPSEGS keyword defines a link between connections and segments. This
-  linking is circular because information about the segments is embedded in the
-  connections, and visa versa. The function creates new WellSegments and
-  WellConnections instances where the segment <--> connection linking has been
-  established.
-*/
-
+    /// Allocate well/reservoir connections to well segments.
+    ///
+    /// The COMPSEGS keyword defines a link between reservoir connections
+    /// and well segments.  This link is bidirectional as some segment
+    /// information is embedded in the connection data, and some connection
+    /// information is stored in the segment data.  This function completes
+    /// the connection data for a single well by incorporating connection
+    /// related information from the segment structure.
+    ///
+    /// \param[in] compsegs Raw input segment-to-connection links from the
+    /// COMPSEGS keyword.  Pertains to a single well referenced in the first
+    /// record.
+    ///
+    /// \param[in] input_connections Preliminary well connection objects
+    /// from COMPDAT.
+    ///
+    /// \param[in] input_segments All well segments defined for the well
+    /// referenced in the first record of \p compsegs.
+    ///
+    /// \param[in] grid Run's active cells.
+    ///
+    /// \param[in] parseContext Error handling behaviour.
+    ///
+    /// \param[in,out] errors Run's failure condition container.  On exit,
+    /// also contains any failure conditions encountered while processing \p
+    /// compsegs.
+    ///
+    /// \return Input connections \p input_connections amended to include
+    /// well segment allocation.
     WellConnections
-    processCOMPSEGS(const DeckKeyword& compsegs,
+    processCOMPSEGS(const DeckKeyword&     compsegs,
                     const WellConnections& input_connections,
-                    const WellSegments& input_segments,
-                    const ScheduleGrid& grid,
-                    const ParseContext& parseContext,
-                    ErrorGuard& errors);
+                    const WellSegments&    input_segments,
+                    const ScheduleGrid&    grid,
+                    const ParseContext&    parseContext,
+                    ErrorGuard&            errors);
 
-    struct TrajectorySegment {
-      double startMD;
-      double endMD;
-      std::array<int, 3> ijk;
+    /// Single well segment of a grid-independent well (WELTRAJ/COMPTRAJ
+    /// keywords).
+    struct TrajectorySegment
+    {
+        /// Measured depth along well bore at the start of the segment.
+        double startMD{};
+
+        /// Measured depth along well bore at the end of the segment.
+        double endMD{};
+
+        /// Cartesian IJK tuple of the cell intersected by this segment.
+        std::array<int, 3> ijk{};
     };
 
+    /// Allocate well/reservoir connections to well segements.
+    ///
+    /// \param[in] well_name Named well for which to allocate connections to
+    /// well segments.
+    ///
+    /// \param[in] trajectory_segments Cells intersected by the well bore
+    /// trajectory.
+    ///
+    /// \param[in] segments All well segments defined for well \p well_name,
+    /// from the WELSEGS keyword.
+    ///
+    /// \param[in] input_connections Preliminary well connection objects
+    /// from COMPDAT.
+    ///
+    /// \param[in] grid Run's active cells.
+    ///
+    /// \param[in] location of COMPTRAJ keyword that triggered this
+    /// connection allocation.
+    ///
+    /// \param[in] parseContext Error handling behaviour.
+    ///
+    /// \param[in,out] errors Run's failure condition container.  On exit,
+    /// also contains any failure conditions encountered while processing \p
+    /// compsegs.
+    ///
+    /// \return Input connections \p input_connections amended to include
+    /// well segment allocation.
     WellConnections
-    getConnectionsAndSegmentsFromTrajectory(const std::vector<TrajectorySegment>& trajectory_segments,
-                                            const WellSegments& segments,
-                                            const WellConnections& input_connections,
-                                            const ScheduleGrid& grid);
+    getConnectionsAndSegmentsFromTrajectory(std::string_view                      well_name,
+                                            const std::vector<TrajectorySegment>& trajectory_segments,
+                                            const WellSegments&                   segments,
+                                            const WellConnections&                input_connections,
+                                            const ScheduleGrid&                   grid,
+                                            const KeywordLocation&                location,
+                                            const ParseContext&                   parseContext,
+                                            ErrorGuard&                           errors);
 
-
+    /// Form connection and segment structures for a single well from
+    /// restart file information.
+    ///
+    /// \param[in] rst_well Restart file's notion of a single well.
+    ///
+    /// \param[in] input_connections Preliminary well connection objects
+    /// from restart file.
+    ///
+    /// \param[in] input_segments Preliminary well segment objects from
+    /// restart file.
+    ///
+    /// \return Fully formed and linked well connections and well segments
+    /// from restart file information.
     std::pair<WellConnections, WellSegments>
-    rstUpdate(const RestartIO::RstWell& rst_well,
-              std::vector<Connection> input_connections,
+    rstUpdate(const RestartIO::RstWell&               rst_well,
+              std::vector<Connection>                 input_connections,
               const std::unordered_map<int, Segment>& input_segments);
-}
-}
 
+} // namespace Opm::Compsegs
 
-
-#endif /* COMPSEGS_HPP_ */
+#endif // COMPSEGS_HPP_

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -123,14 +123,6 @@ namespace Opm {
         return m_comp_pressure_drop;
     }
 
-    const std::vector<Segment>::const_iterator WellSegments::begin() const {
-        return this->m_segments.begin();
-    }
-
-    const std::vector<Segment>::const_iterator WellSegments::end() const {
-        return this->m_segments.end();
-    }
-
     const Segment& WellSegments::operator[](size_t idx) const {
         return m_segments[idx];
     }

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -110,8 +110,9 @@ namespace Opm {
 
         bool updateWSEGVALV(const std::vector<std::pair<int, Valve> >& valve_pairs);
         bool updateWSEGAICD(const std::vector<std::pair<int, AutoICD> >& aicd_pairs, const KeywordLocation& location);
-        const std::vector<Segment>::const_iterator begin() const;
-        const std::vector<Segment>::const_iterator end() const;
+
+        auto begin() const { return this->m_segments.begin(); }
+        auto end() const { return this->m_segments.end(); }
 
         void checkSegmentDepthConsistency(const std::string& well_name, const UnitSystem& unit_system) const;
 


### PR DESCRIPTION
In particular, distinguish more clearly between public and private components.  We separate the private components into an anonymous namespace within `Compsegs.cpp` and keep only the public components in the `Opm::Compsegs` namespace.

Furthermore, mark objects 'const' where possible to avoid inadvertent mutation, and split a number of long lines.

Finally, add more context to the grid-independent segment handling in order to generate better diagnostic messages.