### PR TITLE
fixed: install generated headers in proper path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,12 +88,9 @@ include (CMakeLists_files.cmake)
 
 macro (config_hook)
   if(ENABLE_ECL_INPUT)
-    # For this project
-    include_directories(${EXTRA_INCLUDES} ${PROJECT_BINARY_DIR}/include)
-    # For downstreams
-    list(APPEND EXTRA_INCLUDES ${PROJECT_BINARY_DIR}/include)
+    include_directories(${EXTRA_INCLUDES} ${PROJECT_BINARY_DIR})
     set(OPM_PROJECT_EXTRA_CODE_INTREE "${OPM_PROJECT_EXTRA_CODE_INTREE}
-                                       list(APPEND opm-common_INCLUDE_DIRS ${EXTRA_INCLUDES})")
+                                        list(APPEND opm-common_INCLUDE_DIRS ${EXTRA_INCLUDES} ${PROJECT_BINARY_DIR})")
     if(ENABLE_ECL_INPUT)
       set(OPM_PROJECT_EXTRA_CODE_INTREE "${OPM_PROJECT_EXTRA_CODE_INTREE}
                                          set(HAVE_ECL_INPUT 1)")
@@ -153,7 +150,6 @@ macro (sources_hook)
         list(INSERT opm-common_SOURCES 0 ${PROJECT_BINARY_DIR}/ParserKeywords/${name}.cpp)
         list(INSERT opm-common_SOURCES 0 ${PROJECT_BINARY_DIR}/ParserKeywords/ParserInit${name}.cpp)
         list(INSERT opm-common_SOURCES 0 ${PROJECT_BINARY_DIR}/ParserKeywords/Builtin${name}.cpp)
-        list(INSERT opm-common_GENERATED_HEADERS 0 ${PROJECT_BINARY_DIR}/include/opm/input/eclipse/Parser/ParserKeywords/${name}.hpp)
     endforeach()
     if (OPM_ENABLE_EMBEDDED_PYTHON)
       list(INSERT opm-common_SOURCES 0 ${PROJECT_BINARY_DIR}/python/cxx/builtin_pybind11.cpp)
@@ -207,9 +203,6 @@ macro (tests_hook)
 endmacro (tests_hook)
 
 macro (install_hook)
-  install(DIRECTORY ${PROJECT_BINARY_DIR}/include/
-          DESTINATION include
-          PATTERN *.hpp)
 endmacro (install_hook)
 
 # Used to append entries from one list to another.

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1617,6 +1617,15 @@ if(ENABLE_ECL_OUTPUT)
         opm/utility/EModel.hpp
         opm/utility/WellStructureViz.hpp
         )
+    foreach (name A B C D E F G H I J K L M N O P Q R S T U V W X Y Z)
+      list(APPEND GENERATED_HEADER_FILES
+          opm/input/eclipse/Parser/ParserKeywords/${name}.hpp
+          opm/input/eclipse/Parser/ParserKeywords/ParserInit${name}.hpp
+      )
+    endforeach()
+    list(APPEND GENERATED_HEADER_FILES
+        opm/input/eclipse/Parser/ParserKeywords/Builtin.hpp
+    )
 endif()
 
 if(ENABLE_ECL_INPUT OR ENABLE_ECL_OUTPUT)

--- a/CopyHeaders.cmake
+++ b/CopyHeaders.cmake
@@ -14,7 +14,7 @@ endif()
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
                         ${BASE_DIR}/tmp_gen/include/opm/input/eclipse/Parser/ParserKeywords/Builtin.hpp
-                        ${BASE_DIR}/include/opm/input/eclipse/Parser/ParserKeywords/Builtin.hpp)
+                        ${BASE_DIR}/opm/input/eclipse/Parser/ParserKeywords/Builtin.hpp)
 
 
 file(GLOB HDRS ${BASE_DIR}/tmp_gen/include/opm/input/eclipse/Parser/ParserKeywords/*.hpp)
@@ -23,7 +23,7 @@ foreach(HDR ${HDRS})
   file(RELATIVE_PATH hdr ${BASE_DIR}/tmp_gen/include/opm/input/eclipse/Parser/ParserKeywords ${HDR})
   execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
                           ${HDR}
-                          ${BASE_DIR}/include/opm/input/eclipse/Parser/ParserKeywords/${hdr})
+                          ${BASE_DIR}/opm/input/eclipse/Parser/ParserKeywords/${hdr})
 
 endforeach()
 

--- a/GenerateKeywords.cmake
+++ b/GenerateKeywords.cmake
@@ -60,10 +60,10 @@ foreach (name A B C D E F G H I J K L M N O P Q R S T U V W X Y Z)
                           ${PROJECT_BINARY_DIR}/tmp_gen/ParserKeywords/Builtin${name}.cpp
                           ${PROJECT_BINARY_DIR}/tmp_gen/include/opm/input/eclipse/Parser/ParserKeywords/ParserInit${name}.hpp)
   list(APPEND _target_output ${PROJECT_BINARY_DIR}/ParserKeywords/${name}.cpp
-                             ${PROJECT_BINARY_DIR}/include/opm/input/eclipse/Parser/ParserKeywords/${name}.hpp
+                             ${PROJECT_BINARY_DIR}/opm/input/eclipse/Parser/ParserKeywords/${name}.hpp
                              ${PROJECT_BINARY_DIR}/ParserKeywords/ParserInit${name}.cpp
                              ${PROJECT_BINARY_DIR}/ParserKeywords/Builtin${name}.cpp
-                             ${PROJECT_BINARY_DIR}/include/opm/input/eclipse/Parser/ParserKeywords/ParserInit${name}.hpp)
+                             ${PROJECT_BINARY_DIR}/opm/input/eclipse/Parser/ParserKeywords/ParserInit${name}.hpp)
 endforeach()
 
 foreach(name TestKeywords.cpp ParserInit.cpp)
@@ -71,7 +71,7 @@ foreach(name TestKeywords.cpp ParserInit.cpp)
   list(APPEND _tmp_output ${PROJECT_BINARY_DIR}/tmp_gen/${name})
 endforeach()
 
-list(APPEND _target_output ${PROJECT_BINARY_DIR}/include/opm/input/eclipse/Parser/ParserKeywords/Builtin.hpp)
+list(APPEND _target_output ${PROJECT_BINARY_DIR}/opm/input/eclipse/Parser/ParserKeywords/Builtin.hpp)
 list(APPEND _tmp_output ${PROJECT_BINARY_DIR}/tmp_gen/include/opm/input/eclipse/Parser/ParserKeywords/Builtin.hpp)
 
 set(GEN_DEPS ${_tmp_output})

--- a/opm/input/eclipse/EclipseState/Aquifer/AquiferFlux.cpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/AquiferFlux.cpp
@@ -18,7 +18,7 @@
  */
 
 #include <opm/input/eclipse/EclipseState/Aquifer/AquiferFlux.hpp>
-#include <include/opm/input/eclipse/Parser/ParserKeywords/A.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/A.hpp>
 
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>


### PR DESCRIPTION
- drop include/ component from build-tree paths to obtain correct relative paths
- drop EXTRA_INCLUDES entry for the BINARY dir. this should not end up in config files
- list headers for installation in CMakeLists_files.cmake instead of manually adding to project variables
- drop additional installation call for the includes

This was a perfect storm as the installed config file had the binary directory include path, so jenkins would never fail.
It also had the additional install call which meant the headers DID in fact also get installed in the proper location. So I probably did in fact check the change, I just did not check that there was an additional copy.