### PR TITLE
changed: handle header file installation using modern cmake mechanism

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.23)
 project(opm-common C CXX)
 
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)

--- a/cmake/Modules/OpmCompile.cmake
+++ b/cmake/Modules/OpmCompile.cmake
@@ -38,9 +38,41 @@ macro (opm_compile opm)
   endif()
   set (${opm}_VERSION "${${opm}_VERSION_MAJOR}.${${opm}_VERSION_MINOR}")
   if (${opm}_SOURCES)
-        add_library (${${opm}_TARGET} ${${opm}_LIBRARY_TYPE}
-                     ${${opm}_SOURCES} ${${opm}_HEADERS}
-                     ${${opm}_PRIVATE_HEADERS}  ${${opm}_GENERATED_HEADERS})
+        add_library(${${opm}_TARGET} ${${opm}_LIBRARY_TYPE})
+        target_sources(${${opm}_TARGET}
+          PRIVATE
+            ${${opm}_SOURCES}
+        )
+        target_sources(${${opm}_TARGET}
+          PRIVATE
+          FILE_SET
+            private_headers
+          TYPE
+            HEADERS
+          FILES
+            ${${opm}_PRIVATE_HEADERS}
+        )
+        target_sources(${${opm}_TARGET}
+          PUBLIC
+          FILE_SET
+            HEADERS
+          BASE_DIRS
+            ${PROJECT_SOURCE_DIR}
+          FILES
+            ${${opm}_HEADERS}
+        )
+        target_sources(${${opm}_TARGET}
+          PUBLIC
+          FILE_SET
+            generated_headers
+          TYPE
+            HEADERS
+          BASE_DIRS
+            ${PROJECT_BINARY_DIR}
+          FILES
+            ${${opm}_GENERATED_HEADERS}
+        )
+
         set_target_properties (${${opm}_TARGET} PROPERTIES
           SOVERSION ${${opm}_VERSION}
           VERSION ${${opm}_VERSION}

--- a/cmake/Modules/OpmInstall.cmake
+++ b/cmake/Modules/OpmInstall.cmake
@@ -11,64 +11,26 @@
 include (GNUInstallDirs)
 
 macro (opm_install opm)
-  foreach (_hdr IN LISTS ${opm}_HEADERS)
-	get_filename_component (_dir ${_hdr} PATH)
-	file (RELATIVE_PATH _rel_dir "${PROJECT_SOURCE_DIR}" "${_dir}")
-	install (
-	  FILES ${_hdr}
-	  DESTINATION include${${opm}_VER_DIR}/${_rel_dir}
-	  )
-  endforeach (_hdr)
-  foreach (_hdr IN LISTS ${opm}_GENERATED_HEADERS)
-	get_filename_component (_dir ${_hdr} PATH)
-        file (RELATIVE_PATH _rel_dir "${PROJECT_BINARY_DIR}" "${_dir}")
-	install (
-	  FILES ${_hdr}
-	  DESTINATION include${${opm}_VER_DIR}/${_rel_dir}
-	  )
-  endforeach (_hdr)
-  install (
-	TARGETS ${${opm}_TARGET} ${${opm}_EXTRA_TARGETS}
-	EXPORT ${opm}-targets
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${${opm}_VER_DIR}
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${${opm}_VER_DIR}
-	)
+  install(
+    TARGETS
+      ${${opm}_TARGET} ${${opm}_EXTRA_TARGETS}
+    EXPORT
+      ${opm}-targets
+    LIBRARY DESTINATION
+      ${CMAKE_INSTALL_LIBDIR}${${opm}_VER_DIR}
+    ARCHIVE DESTINATION
+      ${CMAKE_INSTALL_LIBDIR}${${opm}_VER_DIR}
+    FILE_SET
+      HEADERS
+    FILE_SET
+      generated_headers
+  )
   if(NOT "${${opm}_TARGET}" STREQUAL "")
     export(TARGETS ${${opm}_TARGET} ${${opm}_EXTRA_TARGETS}
             FILE ${opm}-targets.cmake)
     install(EXPORT ${opm}-targets DESTINATION "share/cmake/${opm}")
   endif()
-  # only /usr/lib/debug seems to be searched for debug info; if we have
-  # write access to that directory (package installation), then default
-  # to use it; otherwise put the debug files together with the library
-  # (local installation). everything can be overridden by the option.
-  if (CMAKE_INSTALL_PREFIX STREQUAL "/usr")
-	set (_sys_dbg_def ON)
-  else (CMAKE_INSTALL_PREFIX STREQUAL "/usr")
-	set (_sys_dbg_def OFF)
-  endif (CMAKE_INSTALL_PREFIX STREQUAL "/usr")
-  option (SYSTEM_DEBUG "Put .debug files in GDB debug file directory" ${_sys_dbg_def})
-  set (DEBUG_FILE_DIRECTORY /usr/lib/debug CACHE PATH "GDB debug file directory")
-  mark_as_advanced (DEBUG_FILE_DIRECTORY)
-  if (SYSTEM_DEBUG AND NOT APPLE)
-	set (_dbg_prefix "${DEBUG_FILE_DIRECTORY}/")
-  else (SYSTEM_DEBUG AND NOT APPLE)
-	set (_dbg_prefix "")
-  endif (SYSTEM_DEBUG AND NOT APPLE)
-  # static libraries don't have their debug info stripped, so there is
-  # only a separate file when we are building shared objects
-  if (${opm}_LIBRARY_TYPE STREQUAL "SHARED" AND ${opm}_TARGET AND ${opm}_DEBUG)
-	# on MacOS X, debug files are actually bundles (directories)
-	if (APPLE)
-	  set (_dbg_type DIRECTORY)
-	else ()
-	  set (_dbg_type FILES)
-	endif ()
-	install (
-	  ${_dbg_type} ${PROJECT_BINARY_DIR}/${${opm}_DEBUG}
-	  DESTINATION ${_dbg_prefix}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${${opm}_VER_DIR}
-	  )
-  endif (${opm}_LIBRARY_TYPE STREQUAL "SHARED" AND ${opm}_TARGET AND ${opm}_DEBUG)
+
   # note that the DUNE parts that looks for dune.module is currently (2013-09) not
   # multiarch-aware and will thus put in lib64/ on RHEL and lib/ on Debian
   install (


### PR DESCRIPTION
that is, use filesets. this bumps minimum cmake version to 3.23.

also remove some debug symbol handling that was missed in 3cccb6b52be0d2f4bcc6586e470c5dfd2c8146ac