### PR TITLE
changed: consistently use keyword based target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,10 +305,10 @@ include (OpmLibMain)
 if (ENABLE_MOCKSIM AND ENABLE_ECL_INPUT)
   add_library(mocksim
               msim/src/msim.cpp)
-  target_link_libraries(mocksim opmcommon)
+  target_link_libraries(mocksim PRIVATE opmcommon)
   target_include_directories(mocksim PUBLIC msim/include)
   add_executable(msim examples/msim.cpp)
-  target_link_libraries(msim mocksim)
+  target_link_libraries(msim PRIVATE mocksim)
 
   if (Boost_UNIT_TEST_FRAMEWORK_FOUND)
     set(_libs mocksim opmcommon
@@ -350,7 +350,7 @@ if(ENABLE_ECL_INPUT)
     )
 
   foreach(target compareECL convertECL summary rewriteEclFile arraylist)
-    target_link_libraries(${target} opmcommon)
+    target_link_libraries(${target} PRIVATE opmcommon)
     install(TARGETS ${target} DESTINATION bin)
   endforeach()
 
@@ -398,7 +398,7 @@ if(dune-common_FOUND)
   if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
     foreach(src ${DUNE_TEST_SOURCE_FILES})
       get_filename_component(tgt ${src} NAME_WE)
-      target_link_libraries(${tgt} dunecommon)
+      target_link_libraries(${tgt} PRIVATE dunecommon)
     endforeach()
 
     foreach(tst test_SymmTensor test_densead test_EvaluationFormat
@@ -407,11 +407,11 @@ if(dune-common_FOUND)
         test_fluidsystems test_tabulation test_h2brinepvt test_co2brinepvt
         test_eclblackoilfluidsystem test_eclblackoilfluidsystemnonstatic
         test_eclblackoilpvt)
-      target_link_libraries(${tst} dunecommon)
+      target_link_libraries(${tst} PRIVATE dunecommon)
     endforeach()
   endif()
   if(BUILD_EXAMPLES)
-    target_link_libraries(co2brinepvt dunecommon)
+    target_link_libraries(co2brinepvt PRIVATE dunecommon)
   endif()
 endif()
 

--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -80,7 +80,7 @@ macro (opm_compile_satellites opm satellite excl_all test_regexp)
     else (NOT "${test_regexp}" STREQUAL "")
       set (_test_lib "")
     endif (NOT "${test_regexp}" STREQUAL "")
-    target_link_libraries (${_sat_NAME} ${${opm}_TARGET} ${${opm}_LIBRARIES} ${_test_lib})
+    target_link_libraries (${_sat_NAME} PRIVATE ${${opm}_TARGET} ${${opm}_LIBRARIES} ${_test_lib})
 
     # variable with regular expression doubles as a flag for
     # whether tests should be setup or not
@@ -296,7 +296,7 @@ macro(opm_add_test TestName)
     if (CURTEST_ONLY_COMPILE)
       # only compile the binary but do not run it as a test
       add_executable("${CURTEST_EXE_NAME}" ${CURTEST_EXCLUDE_FROM_ALL} ${CURTEST_SOURCES})
-      target_link_libraries (${CURTEST_EXE_NAME} ${CURTEST_LIBRARIES})
+      target_link_libraries (${CURTEST_EXE_NAME} PRIVATE ${CURTEST_LIBRARIES})
       get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
       if(HAVE_DYNAMIC_BOOST_TEST)
         set_target_properties (${CURTEST_EXE_NAME} PROPERTIES
@@ -318,7 +318,7 @@ macro(opm_add_test TestName)
           set_target_properties (${CURTEST_EXE_NAME} PROPERTIES
                                  COMPILE_DEFINITIONS BOOST_TEST_DYN_LINK)
         endif()
-        target_link_libraries (${CURTEST_EXE_NAME} ${CURTEST_LIBRARIES})
+        target_link_libraries (${CURTEST_EXE_NAME} PRIVATE ${CURTEST_LIBRARIES})
         get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
 
         if(CURTEST_DEPENDS)


### PR DESCRIPTION
a first step required to move the build system to a modern target based approach