### PR TITLE
removing the constructor based on an int value for DynamicEvaluation

### DIFF
--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -1031,7 +1031,16 @@ public:
     // set value of variable
     template <class RhsValueType>
     OPM_HOST_DEVICE constexpr void setValue(const RhsValueType& val)
+{%if numDerivs < 0 %}\
+    {
+        if (data_.size() == 0) {
+            data_.resize(1);
+        }
+        data_[valuepos_()] = val;
+    }
+{% else %}\
     { data_[valuepos_()] = val; }
+{% endif %}\
 
     // return varIdx'th derivative
     OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const

--- a/opm/material/densead/DynamicEvaluation.hpp
+++ b/opm/material/densead/DynamicEvaluation.hpp
@@ -664,7 +664,12 @@ public:
     // set value of variable
     template <class RhsValueType>
     OPM_HOST_DEVICE constexpr void setValue(const RhsValueType& val)
-    { data_[valuepos_()] = val; }
+    {
+        if (data_.size() == 0) {
+            data_.resize(1);
+        }
+        data_[valuepos_()] = val;
+    }
 
     // return varIdx'th derivative
     OPM_HOST_DEVICE const ValueType& derivative(int varIdx) const


### PR DESCRIPTION
There is two parts in the PR. 

1. removing the constructor of DynamicEvaluation based on an int value.  There is some code in the OPM using 1 as a Scalar. DynamicEvaluation might take it as a size. 
2. when the DynamicEvaluation is using default constructor, it is not initialized and it is of size -1.  The following code will generate a DynamicEvaluation with value 1 and size -1. The PR make sure the size will be 0 when assigning a scalar to an uninitialized DynamicEvaluation. 

This PR is trying to fix the usage from the DyanmicEvaluation side without touching the existing usage code. 