### PR TITLE
fixed: downloaded cjson with super-build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,7 @@ include (OpmLibMain)
 if(NOT TARGET cjson)
   include(DownloadCjson)
   target_sources(opmcommon PRIVATE $<TARGET_OBJECTS:cjson>)
-  target_include_directories(opmcommon PRIVATE ${PROJECT_BINARY_DIR}/_deps)
+  target_include_directories(opmcommon PRIVATE ${CMAKE_BINARY_DIR}/_deps)
 endif()
 
 if (ENABLE_MOCKSIM AND ENABLE_ECL_INPUT)

--- a/cmake/Modules/DownloadCjson.cmake
+++ b/cmake/Modules/DownloadCjson.cmake
@@ -9,6 +9,6 @@ add_library(cjson OBJECT)
 target_sources(cjson PRIVATE ${cjson_SOURCE_DIR}/cJSON.c)
 execute_process(
   COMMAND
-    ${CMAKE_COMMAND} -E create_symlink ${cjson_SOURCE_DIR} ${PROJECT_BINARY_DIR}/_deps/cjson
+    ${CMAKE_COMMAND} -E create_symlink ${cjson_SOURCE_DIR} ${CMAKE_BINARY_DIR}/_deps/cjson
 )
-target_include_directories(cjson INTERFACE ${PROJECT_BINARY_DIR}/_deps)
+target_include_directories(cjson INTERFACE ${CMAKE_BINARY_DIR}/_deps)


### PR DESCRIPTION
FetchContent downloads to the global CMAKE_BINARY_DIR, not PROJECT_BINARY_DIR

So many things..