### PR TITLE
fixed: properly integrate with CTest

### DIFF
--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -197,7 +197,6 @@ opm_compile_satellites (${project} additionals EXCLUDE_FROM_ALL "")
 opm_compile_satellites (${project} attic EXCLUDE_FROM_ALL "")
 
 # infrastructure for testing
-enable_testing ()
 include (CTest)
 
 # conditionally disable tests when features aren't available


### PR DESCRIPTION
the CTest include handles the enable_testing() call.

See https://cmake.org/cmake/help/latest/variable/BUILD_TESTING.html