### PR TITLE
changed: remove global option for use of PETSc

### DIFF
--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -60,9 +60,6 @@ find_openmp (${project})
 include (UseThreads)
 find_threads (${project})
 
-# PETSc is optional
-option (USE_PETSC "Use PETSc iterative solvers" OFF)
-
 # callback hook to setup additional dependencies
 if (COMMAND prereqs_hook)
 	prereqs_hook ()


### PR DESCRIPTION
if we ever restore PETSc support (it does not work at all currently) it should be local to the buildsystem where it is used