### PR TITLE
changed: use target_compile_options and target_compile_definitions for warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,11 +394,13 @@ if(dune-common_FOUND)
         test_fluidsystems test_tabulation test_h2brinepvt test_co2brinepvt
         test_eclblackoilfluidsystem test_eclblackoilfluidsystemnonstatic
         test_eclblackoilpvt)
+      use_warnings(${tst})
       target_link_libraries(${tst} PRIVATE dunecommon)
     endforeach()
   endif()
   if(BUILD_EXAMPLES)
     target_link_libraries(co2brinepvt PRIVATE dunecommon)
+    use_warnings(co2brinepvt)
   endif()
 endif()
 
@@ -440,6 +442,7 @@ if (OPM_ENABLE_PYTHON)
   if(TARGET pybind11::pybind11)
     target_link_libraries(opmcommon_python PRIVATE
                           pybind11::pybind11)
+    use_warnings(opmcommon_python)
   else()
     target_include_directories(opmcommon_python SYSTEM PRIVATE ${pybind11_INCLUDE_DIRS})
   endif()

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -47,13 +47,6 @@ include (UseFastBuilds)
 # optimize full if we're not doing a debug build
 include (UseOptimization)
 
-# turn on all warnings; this must be done before adding any
-# dependencies, in case they alter the list of warnings
-option(OPM_ENABLE_WARNINGS "Enable warning flags?" ON)
-if(OPM_ENABLE_WARNINGS)
-  include (UseWarnings)
-endif()
-
 # parallel programming
 include (UseOpenMP)
 find_openmp (${project})
@@ -164,6 +157,10 @@ execute_process (COMMAND
 include (OpmCompile)
 opm_compile (${project})
 
+# optionally turn on all warnings
+include(UseWarnings)
+use_warnings(${${project}_TARGET})
+
 # installation of CMake modules to help user programs locate the library
 include (OpmProject)
 opm_cmake_config (${project})
@@ -219,7 +216,6 @@ if (COMMAND install_hook)
 endif (COMMAND install_hook)
 opm_install (${project})
 message (STATUS "This build defaults to installing in ${CMAKE_INSTALL_PREFIX}")
-
 
 # use this target to check local git commits
 add_custom_target(check-commits

--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -61,6 +61,7 @@ macro (opm_compile_satellites opm satellite excl_all test_regexp)
     endif()
     get_filename_component (_sat_NAME "${_sat_FILE}" NAME_WE)
     add_executable (${_sat_NAME} ${excl_all} ${_sat_FILE})
+    use_warnings(${_sat_NAME})
     add_dependencies (${satellite} ${_sat_NAME})
     # Ensure individual test executables depend on data files so they can be built independently
     if (${satellite}_DATAFILES)
@@ -296,6 +297,7 @@ macro(opm_add_test TestName)
     if (CURTEST_ONLY_COMPILE)
       # only compile the binary but do not run it as a test
       add_executable("${CURTEST_EXE_NAME}" ${CURTEST_EXCLUDE_FROM_ALL} ${CURTEST_SOURCES})
+      use_warnings(${CURTEST_EXE_NAME})
       target_link_libraries (${CURTEST_EXE_NAME} PRIVATE ${CURTEST_LIBRARIES})
       get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
       if(HAVE_DYNAMIC_BOOST_TEST)
@@ -314,6 +316,7 @@ macro(opm_add_test TestName)
         # run-only case occurs if the binary is already compiled by an
         # earlier test.)
         add_executable("${CURTEST_EXE_NAME}" ${CURTEST_EXCLUDE_FROM_ALL} ${CURTEST_SOURCES})
+        use_warnings(${CURTEST_EXE_NAME})
         if(HAVE_DYNAMIC_BOOST_TEST)
           set_target_properties (${CURTEST_EXE_NAME} PROPERTIES
                                  COMPILE_DEFINITIONS BOOST_TEST_DYN_LINK)

--- a/cmake/Modules/UseWarnings.cmake
+++ b/cmake/Modules/UseWarnings.cmake
@@ -1,22 +1,36 @@
 # - Turn on warnings when compiling
 
-include (AddOptions)
 include (UseCompVer)
 is_compiler_gcc_compatible ()
 
-if (CXX_COMPAT_GCC)
-  # default warnings flags, if not set by user
-  set_default_option (CXX _warn_flag "-Wall -Wextra -Wshadow" "(^|\ )-W")
-  if (_warn_flag)
-	message (STATUS "All warnings enabled: ${_warn_flag}")
-	add_options (ALL_LANGUAGES ALL_BUILDS "${_warn_flag}")
-  endif (_warn_flag)
-  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
-    add_options (CXX ALL_BUILDS -Wno-dangling-reference)
-  endif()
-endif ()
+option(OPM_ENABLE_WARNINGS "Enable warning flags?" ON)
+option(SILENCE_EXTERNAL_WARNINGS "Disable some warnings from external packages" OFF)
 
-option(SILENCE_EXTERNAL_WARNINGS "Disable some warnings from external packages (requires GCC 4.6 or newer)" OFF)
-if(SILENCE_EXTERNAL_WARNINGS AND CXX_COMPAT_GCC)
-  add_definitions(-DSILENCE_EXTERNAL_WARNINGS)
+if(CXX_COMPAT_GCC AND OPM_ENABLE_WARNINGS)
+  set(_warn_flag "-Wall -Wextra -Wshadow")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+    string(APPEND _warn_flag " -Wno-dangling-reference")
+  endif()
+  message(STATUS "All warnings enabled: ${_warn_flag}")
 endif()
+
+macro(use_warnings target)
+  if (CXX_COMPAT_GCC AND OPM_ENABLE_WARNINGS)
+    # default warnings flags, if not set by user
+    target_compile_options(${target}
+      PRIVATE
+        $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wextra -Wshadow>
+        $<$<COMPILE_LANGUAGE:C>:-Wall -Wextra -Wshadow>
+    )
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+      target_compile_options(${target}
+        PRIVATE
+          $<$<COMPILE_LANGUAGE:CXX>:-Wno-dangling-reference>
+      )
+    endif()
+  endif ()
+
+  if(SILENCE_EXTERNAL_WARNINGS AND CXX_COMPAT_GCC)
+    target_compile_definitions(${${opm_}_TARGET} PRIVATE SILENCE_EXTERNAL_WARNINGS)
+  endif()
+endmacro()


### PR DESCRIPTION
make them private so they don't affect downstreams.

we have to set add them for each target we build, mostly handled by macros but there are some exceptions.