### PR TITLE
OpmCompilerChecks: remove pre gcc-9 (gcc-8) support

### DIFF
--- a/cmake/Modules/OpmCompilerChecks.cmake
+++ b/cmake/Modules/OpmCompilerChecks.cmake
@@ -91,14 +91,3 @@ CHECK_CXX_SOURCE_COMPILES("
    };
 "  HAS_ATTRIBUTE_DEPRECATED_MSG
 )
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
-    list(APPEND ${project}_LIBRARIES stdc++fs)
-  endif()
-endif()
-
-option(OPM_CLANG_WITH_STDC++FS "Using libstdc++ with clang and we want to link to stdc++fs" OFF)
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND OPM_CLANG_WITH_STDC++FS)
-  list(APPEND ${project}_LIBRARIES stdc++fs)
-endif()


### PR DESCRIPTION
and support for older clangs. we need a compiler with full c++-17 suppport these days and thus these checks are outdated