### PR TITLE
changed: extract MPI_2 check from Finddune-common

### DIFF
--- a/cmake/Modules/Finddune-common.cmake
+++ b/cmake/Modules/Finddune-common.cmake
@@ -57,7 +57,6 @@ int main (void) {
   HAVE_NULLPTR;
   HAVE_STATIC_ASSERT;
   HAVE_SHARED_PTR;
-  MPI_2;
   SHARED_PTR_HEADER;
   SHARED_PTR_NAMESPACE;
   HAVE_TYPE_TRAITS;
@@ -66,17 +65,6 @@ int main (void) {
   HAVE_CXA_DEMANGLE
   ")
 #debug_find_vars ("dune-common")
-
-if(MPI_C_FOUND)
-  # check for MPI version 2
-  include(CMakePushCheckState)
-  include(CheckFunctionExists)
-  cmake_push_check_state()
-  set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES};${MPI_C_LIBRARIES})
-  set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES};${MPI_C_INCLUDES})
-  check_function_exists(MPI_Finalized MPI_2)
-  cmake_pop_check_state()
-endif(MPI_C_FOUND)
 
 # make version number available in config.h
 include (UseDuneVer)

--- a/cmake/Modules/MPIChecks.cmake
+++ b/cmake/Modules/MPIChecks.cmake
@@ -1,0 +1,18 @@
+function(mpi_checks)
+  cmake_parse_arguments(PARAM "" "TARGET" "" ${ARGN})
+  if(NOT PARAM_TARGET)
+    message(FATAL_ERROR "Function needs a TARGET parameter")
+  endif()
+  get_target_property(TARGET_LINKS ${PARAM_TARGET} INTERFACE_LINK_LIBRARIES)
+  if("${TARGET_LINKS}" MATCHES "libmpi.so") # TODO: change to target name
+    # check for MPI version 2
+    include(CMakePushCheckState)
+    include(CheckFunctionExists)
+    cmake_push_check_state()
+    set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES};${MPI_C_LIBRARIES})
+    set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES};${MPI_C_INCLUDES})
+    check_function_exists(MPI_Finalized MPI_2)
+    cmake_pop_check_state()
+    target_compile_definitions(${PARAM_TARGET} PUBLIC MPI_2=${MPI_2})
+  endif()
+endfunction()

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -18,6 +18,7 @@
 include(OpmCompile)
 include(UseOnlyNeeded)
 include(UseFastBuilds)
+include(MPIChecks)
 include(UseOpenMP)
 include(UseOptimization)
 include(UseRunPath)
@@ -180,6 +181,9 @@ opm_compile (${project})
 # when building with static libraries to get correct linker order.
 # Thus it is kept outside opm_add_target_options function.
 use_openmp(TARGET ${${project}_TARGET})
+
+# MPI version probes
+mpi_checks(TARGET ${${project}_TARGET})
 
 opm_add_target_options(TARGET ${${project}_TARGET})
 


### PR DESCRIPTION
and conditionally add definition to target.

this is a system property, no reason to do this through config.h