### PR TITLE
Polish ScheduleDeck Implementation Files

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -695,7 +695,7 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
 
         for (auto report_step = load_start; report_step < load_end; report_step++) {
             std::size_t keyword_index = 0;
-            auto& block = this->m_sched_deck[report_step];
+            const auto& block = this->m_sched_deck[report_step];
             auto time_type = block.time_type();
             if (time_type == ScheduleTimeType::DATES || time_type == ScheduleTimeType::TSTEP) {
                 const auto& start_date = Schedule::formatDate(std::chrono::system_clock::to_time_t(block.start_time()));
@@ -1777,7 +1777,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
 
         this->snapshots.resize(reportStep + 1);
 
-        auto& input_block = this->m_sched_deck[reportStep];
+        auto& input_block = this->m_sched_deck.mutableKeywordBlock(reportStep);
         ScheduleLogger logger(ScheduleLogger::select_stream(true, false), // will log to OpmLog::debug
                               prefix, this->m_sched_deck.location());
 
@@ -1883,7 +1883,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
                                   prefix, action.name()));
 
         this->snapshots.resize(reportStep + 1);
-        auto& input_block = this->m_sched_deck[reportStep];
+        auto& input_block = this->m_sched_deck.mutableKeywordBlock(reportStep);
 
         std::unordered_map<std::string, double> wpimult_global_factor;
         for (const auto& keyword : action) {

--- a/opm/input/eclipse/Schedule/ScheduleDeck.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleDeck.hpp
@@ -30,7 +30,6 @@
 #include <iosfwd>
 #include <vector>
 
-
 namespace Opm {
 
     struct ScheduleRestartInfo;
@@ -41,35 +40,111 @@ namespace Opm {
     class Runspec;
     class UnitSystem;
 
-    /*
-      The purpose of the ScheduleDeck class is to serve as a container holding
-      all the keywords of the SCHEDULE section, when the Schedule class is
-      assembled that is done by iterating over the contents of the ScheduleDeck.
-      The ScheduleDeck class can be indexed with report step through operator[].
-      Internally the ScheduleDeck class is a vector of ScheduleBlock instances -
-      one for each report step.
-    */
+} // namespace Opm
 
-    class ScheduleDeck {
+namespace Opm {
+
+    /// All SCHEDULE section keywords in a simulation run.
+    ///
+    /// Knows how to partition the schedule section into report steps.  In
+    /// turn, we form the Schedule object by iterating over the contents of
+    /// the ScheduleDeck.  Finally, class ScheduleDeck provides indexed
+    /// access through operator[] whose argument is a report step.
+    /// Internally the ScheduleDeck class is a vector of ScheduleBlock
+    /// instances, one for each report step.
+    class ScheduleDeck
+    {
     public:
-        explicit ScheduleDeck(time_point start_time, const Deck& deck, const ScheduleRestartInfo& rst_info);
+        /// Default constructor.
+        ///
+        /// Forms an object that's mostly usable as the target of a
+        /// deserialisation operation.
         ScheduleDeck();
-        void add_block(ScheduleTimeType time_type, const time_point& t,
-                       ScheduleDeckContext& context, const KeywordLocation& location);
-        void add_TSTEP(const DeckKeyword& TSTEPKeyword, ScheduleDeckContext& context);
-        ScheduleBlock& operator[](const std::size_t index);
+
+        /// Constructor.
+        ///
+        /// \param[in] start_time Simulation start time inferred from the
+        /// START keyword.
+        ///
+        /// \param[in] deck Simulation model description.
+        ///
+        /// \param[in] rst_info Restart step and restart time in restarted
+        /// simulation runs, and whether or not the SKIPREST keyword is
+        /// active in the run.
+        explicit ScheduleDeck(const time_point&          start_time,
+                              const Deck&                deck,
+                              const ScheduleRestartInfo& rst_info);
+
+        /// Model input associated to a single report step.
+        ///
+        /// Bounds-checked, mutable version.
+        ///
+        /// \param[in] index Report step.  Must be in the range 0..size()-1.
+        /// This function will throw an exception if the bound is violated.
+        ///
+        /// \return Mutable collection of input keywords associated to
+        /// report step \p index.
+        ScheduleBlock& mutableKeywordBlock(const std::size_t index);
+
+        /// Model input associated to a single report step.
+        ///
+        /// Bounds-checked, immutable version.
+        ///
+        /// \param[in] index Report step.  Must be in the range 0..size()-1.
+        /// This function will throw an exception if the bound is violated.
+        ///
+        /// \return Input keywords associated to report step \p index.
         const ScheduleBlock& operator[](const std::size_t index) const;
-        std::vector<ScheduleBlock>::const_iterator begin() const;
-        std::vector<ScheduleBlock>::const_iterator end() const;
-        std::size_t size() const;
+
+        /// Start of report step sequence.
+        ///
+        /// Provided mostly to enable using standard algorithms and
+        /// range-for for iterating over the ScheduleDeck.
+        auto begin() const { return this->m_blocks.begin(); }
+
+        /// One past the end of report step sequence.
+        ///
+        /// Provided mostly to enable using standard algorithms and
+        /// range-for for iterating over the ScheduleDeck.
+        auto end() const { return this->m_blocks.end(); }
+
+        /// Number of report steps in SCHEDULE section.
+        auto size() const { return this->m_blocks.size(); }
+
+        /// Report step index of restarted simulation's restart step.
         std::size_t restart_offset() const;
+
+        /// Location of simulation run's SCHEDULE section keyword.
         const KeywordLocation& location() const;
+
+        /// Simulated time, in seconds, since start of simulation.
+        ///
+        /// \param[in] timeStep Report step.
+        ///
+        /// \return Simulated time in seconds, at start of report step \p
+        /// timeStep, since beginning of the simulation.
         double seconds(std::size_t timeStep) const;
 
+        /// Equality predicate.
+        ///
+        /// \param[in] other Object against which \code *this \endcode will
+        /// be tested for equality.
+        ///
+        /// \return Whether or not \code *this \endcode is the same as \p
+        /// other.
         bool operator==(const ScheduleDeck& other) const;
+
+        /// Create a serialisation test object.
         static ScheduleDeck serializationTestObject();
+
+        /// Convert between byte array and object representation.
+        ///
+        /// \tparam Serializer Byte array conversion protocol.
+        ///
+        /// \param[in,out] serializer Byte array conversion object.
         template<class Serializer>
-        void serializeOp(Serializer& serializer) {
+        void serializeOp(Serializer& serializer)
+        {
             serializer(m_restart_time);
             serializer(m_restart_offset);
             serializer(skiprest);
@@ -77,16 +152,82 @@ namespace Opm {
             serializer(m_location);
         }
 
+        /// Write schedule section keywords to output stream.
+        ///
+        /// Mostly for debugging support and the opmpack utility.
+        ///
+        /// \param[in,out] os Output stream.
+        ///
+        /// \param[in] usys Run's unit system for converting quantities in
+        /// internal (SI) units to run's input units.
         void dump_deck(std::ostream& os, const UnitSystem& usys) const;
 
+        /// Discard input keywords for a single report step.
+        ///
+        /// This provides memory savings for runs that don't need dynamic
+        /// ACTION* processing.
+        ///
+        /// \param[in] idx Report step for which to discard input keywords
+        /// that have already been internalised into a \c Schedule object.
         void clearKeywords(const std::size_t idx);
 
     private:
+        /// Simulation restart time (for restarted runs).
         time_point m_restart_time{};
+
+        /// Simulation restart step (for restarted runs).
         std::size_t m_restart_offset{};
+
+        /// Whether or not SKIPREST is active in a restarted run.
         bool skiprest{false};
+
+        /// Location of run's SCHEDULE section keyword.
         KeywordLocation m_location{};
+
+        /// Input keyword blocks.
+        ///
+        /// One block for each report step.
         std::vector<ScheduleBlock> m_blocks{};
+
+        /// Process DATES keyword.
+        ///
+        /// Creates one entry in m_blocks for each record in DATES.
+        ///
+        /// \param[in] keyword DATES keyword.
+        ///
+        /// \param[in] restart_time Simulation restart time.  Needed for
+        /// diagnostic purposes.
+        ///
+        /// \param[in,out] context Tracking of current simulated time.
+        void handleDATES(const DeckKeyword&   keyword,
+                         const std::time_t    restart_time,
+                         ScheduleDeckContext& context);
+
+        /// Create a ScheduleBlock for a new report step.
+        ///
+        /// Increases size of \c m_blocks by one element.
+        ///
+        /// \param[in] time_type Kind of time stepping keyword.
+        ///
+        /// \param[in] t Time point at which this time stepping was entered.
+        ///
+        /// \param[in] location Location of this time stepping keyword.
+        ///
+        /// \param[in,out] context Tracking of current simulated time.
+        void add_block(ScheduleTimeType       time_type,
+                       const time_point&      t,
+                       const KeywordLocation& location,
+                       ScheduleDeckContext&   context);
+
+        /// Process TSTEP keyword.
+        ///
+        /// Creates one entry in m_blocks for each element in TSTEP.
+        ///
+        /// \param[in] TSTEPKeyword TSTEP keyword.
+        ///
+        /// \param[in,out] context Tracking of current simulated time.
+        void add_TSTEP(const DeckKeyword&   TSTEPKeyword,
+                       ScheduleDeckContext& context);
     };
 }
 


### PR DESCRIPTION
In particular

  * Add Doxygen-style function documentation
  * Move keyword handling functions out of public API since they're only used inside the implementation
  * Rename non-const subscript operator to `mutableKeywordBlock()` for clearer call site semantics
  * Move function opening braces to start of new line
  * Prefer `//`-style comments
  * Add braces around single statement blocks
  * Split long lines
  * Implement `begin()`/`end()` inline to avoid explicit type names
  * Split `DATES` handling out to separate helper function