### PR TITLE
Report Missing SKIPREST Unless DATES Strictly Later Than Restart

### DIFF
--- a/opm/input/eclipse/Schedule/ScheduleDeck.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleDeck.cpp
@@ -334,14 +334,15 @@ void ScheduleDeck::handleDATES(const DeckKeyword&   dates,
 
         const auto currentTime = TimeService::to_time_t(context.last_time);
 
-        if (nextTime < currentTime) {
+        // Recall: difftime(b,a) is portably equivalent to "b-a".
+        if (! (std::difftime(nextTime, currentTime) > 0.0)) {
             const auto* prevstepID = (restart_time > 0)
                 ? "restart time"
                 : "end time of previous report step";
 
             auto msg = fmt::format("Keyword DATES includes time "
                                    "{:%d-%b-%Y %H:%M:%S} which "
-                                   "is earlier than the {}, "
+                                   "is not later than the {}, "
                                    "{:%d-%b-%Y %H:%M:%S}.",
                                    fmt::gmtime(nextTime),
                                    prevstepID,

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -706,7 +706,7 @@ WCONPROD
 /
 
 DATES             -- 3
- 10  JUL 2008 /
+ 11  JUL 2008 /
 /
 )");
     const auto es    = ::Opm::EclipseState { deck };


### PR DESCRIPTION
Issue a diagnostic about a potentially missing `SKIPREST` keyword if any `DATES` record specifies a time that is not strictly later than the restart time.  If a restarted run does not use `SKIPREST`, then all of its explicitly defined DATES must be strictly later than the restart time lest we have negative or zero time step sizes.

This PR effectively tightens up the check introduced in #3035.