### PR TITLE
consistently use Boost::unit_test_framework target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,18 +93,6 @@ macro(${project}_config_hook)
       set(OPM_PROJECT_EXTRA_CODE_INSTALLED "${OPM_PROJECT_EXTRA_CODE_INSTALLED}
                                             set(HAVE_ECL_OUTPUT 1)")
     endif()
-    # CMake 3.30.0 requires to find Boost in CONFIG mode or
-    # we need to use the correct search mode in previous cmake versions too.
-    # Otherwise not finding one boost component below will mark the previously found ones as not
-    # found again. (Code stolen from UseDynamicBoost.cmake)
-    if(Boost_DIR OR (CMAKE_VERSION VERSION_GREATER_EQUAL 3.30.0))
-      set(_Boost_CONFIG_MODE CONFIG)
-    endif()
-    find_package(Boost COMPONENTS filesystem regex unit_test_framework ${_Boost_CONFIG_MODE})
-
-    if (HAVE_DYNAMIC_BOOST_TEST)
-      set_target_properties(Boost::unit_test_framework PROPERTIES INTERFACE_COMPILE_DEFINITIONS BOOST_TEST_DYN_LINK=1)
-    endif()
   endif()
 
   include(CheckIncludeFile)
@@ -200,12 +188,11 @@ macro(${project}_tests_hook)
     list(APPEND opm-common_EXTRA_TARGETS compareECL rst_deck)
 
     # Add the tests
-    set(_libs opmcommon
-              ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+    set(_libs opmcommon Boost::unit_test_framework)
 
     opm_add_test(test_EclFilesComparator
       CONDITION
-        ENABLE_ECL_INPUT AND Boost_UNIT_TEST_FRAMEWORK_FOUND
+        ENABLE_ECL_INPUT AND TARGET Boost::unit_test_framework
       SOURCES
         tests/test_EclFilesComparator.cpp
         test_util/EclFilesComparator.cpp
@@ -217,7 +204,7 @@ macro(${project}_tests_hook)
 
     opm_add_test(test_EclRegressionTest
       CONDITION
-        ENABLE_ECL_INPUT AND Boost_UNIT_TEST_FRAMEWORK_FOUND
+        ENABLE_ECL_INPUT AND TARGET Boost::unit_test_framework
       SOURCES
         tests/test_EclRegressionTest.cpp
         test_util/EclFilesComparator.cpp
@@ -322,9 +309,8 @@ if (ENABLE_MOCKSIM AND ENABLE_ECL_INPUT)
   opm_add_target_options(TARGET msim)
   target_link_libraries(msim PRIVATE mocksim)
 
-  if (Boost_UNIT_TEST_FRAMEWORK_FOUND)
-    set(_libs mocksim opmcommon
-      ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+  if (TARGET Boost::unit_test_framework)
+    set(_libs mocksim opmcommon Boost::unit_test_framework)
 
     foreach( test test_msim test_msim_ACTIONX test_msim_EXIT)
       opm_add_test(${test} SOURCES tests/msim/${test}.cpp
@@ -369,7 +355,7 @@ if(dune-common_FOUND)
   endif()
 endif()
 
-if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
+if(TARGET Boost::unit_test_framework)
   foreach(test ACTIONX EmbeddedPython PYACTION)
     set_tests_properties(${test} PROPERTIES
                          ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/python:$ENV{PYTHONPATH}")

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -93,11 +93,7 @@ find_and_append_package_list_to (${project} ${${project}_DEPS})
 # set aliases to probed variables
 include (OpmAliases)
 
-# remove the dependency on the testing framework from the main library;
-# it is not possible to query for Boost twice with different components.
-list (REMOVE_ITEM "${project}_LIBRARIES" "${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}")
-
-# detect if Boost is in a shared library
+# find Boost::unit_test_framework and detect if Boost is in a shared library
 include (UseDynamicBoost)
 
 # Run conditional file hook

--- a/cmake/Modules/UseDynamicBoost.cmake
+++ b/cmake/Modules/UseDynamicBoost.cmake
@@ -1,19 +1,20 @@
-# When using Boost >= 1.70 and e.g. CMake 3.18 we need to make sure that
-# subsequent searches are using config mode too. Otherwise the library
-# list will be completely messed up. We use a set Boost_Dir to detect that
-# previous searches were done using config mode.
-if(Boost_DIR)
-  set(_Boost_CONFIG_MODE CONFIG)
+if(TARGET Boost::unit_test_framework AND DEFINED HAVE_DYNAMIC_BOOST_TEST)
+  return()
 endif()
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30.0)
+	set(_Boost_CONFIG_MODE CONFIG)
+endif()
+
 find_package (Boost 1.44.0 COMPONENTS unit_test_framework QUIET ${_Boost_CONFIG_MODE})
 
-if (Boost_UNIT_TEST_FRAMEWORK_FOUND)
+if(TARGET Boost::unit_test_framework)
   # setup to do a test compile
-  include (CMakePushCheckState)
-  cmake_push_check_state ()
-  include (CheckCXXSourceCompiles)
-  list (APPEND CMAKE_REQUIRED_INCLUDES ${Boost_INCLUDE_DIRS})
-  list (APPEND CMAKE_REQUIRED_LIBRARIES ${Boost_LIBRARIES})
+  include(CMakePushCheckState)
+  cmake_push_check_state()
+  include(CheckCXXSourceCompiles)
+  list(APPEND CMAKE_REQUIRED_INCLUDES ${Boost_INCLUDE_DIRS})
+  list(APPEND CMAKE_REQUIRED_LIBRARIES ${Boost_LIBRARIES})
 
   unset(HAVE_DYNAMIC_BOOST_TEST CACHE)
   check_cxx_source_compiles("
@@ -29,15 +30,19 @@ BOOST_AUTO_TEST_CASE(DynlinkConfigureTest) {
                       \"work: f(2) = \" << f(2));
 }" HAVE_DYNAMIC_BOOST_TEST)
   cmake_pop_check_state ()
-else (Boost_UNIT_TEST_FRAMEWORK_FOUND)
+else()
   # no Boost, no compile
   set (HAVE_DYNAMIC_BOOST_TEST 0)
-endif (Boost_UNIT_TEST_FRAMEWORK_FOUND)
+endif()
+
+if(HAVE_DYNAMIC_BOOST_TEST)
+  set_target_properties(Boost::unit_test_framework PROPERTIES INTERFACE_COMPILE_DEFINITIONS BOOST_TEST_DYN_LINK=1)
+endif()
 
 # save this for later
-set (HAVE_DYNAMIC_BOOST_TEST "${HAVE_DYNAMIC_BOOST_TEST}"
+set(HAVE_DYNAMIC_BOOST_TEST "${HAVE_DYNAMIC_BOOST_TEST}"
   CACHE BOOL "Whether Boost::Test is dynamically linked or not"
-  )
+)
 
 # include in config.h
 list (APPEND TESTING_CONFIG_VARS "HAVE_DYNAMIC_BOOST_TEST")

--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -26,7 +26,7 @@ endif()
 
 list(APPEND opm-common_DEPS
       # various runtime library enhancements
-      "Boost 1.44.0 COMPONENTS unit_test_framework REQUIRED ${_Boost_CONFIG_MODE}"
+      "Boost 1.44.0 REQUIRED ${_Boost_CONFIG_MODE}"
       "cJSON"
       # Still it produces compile errors complaining that it
       # cannot format UDQVarType. Hence we use the same version


### PR DESCRIPTION
remove redundant boost find call. main module only needs the header less (ie no component) boost.
centralize find call for the unit_test_framework component in UseDynamicBoost only. cmake >= 3.23 behaves properly with multiple calls so there is no problem any longer