### PR TITLE
fixed: set ${project}_VERSION in OpmInit, not OpmCompile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ endmacro()
 macro(${project}_files_hook)
   if (OPM_ENABLE_PYTHON)
     make_directory(${PROJECT_BINARY_DIR}/python)
+    set(opm-common_PYTHON_PACKAGE_VERSION ${OPM_PYTHON_PACKAGE_VERSION_TAG})
 
     file(
       COPY
@@ -430,8 +431,6 @@ if(TARGET Boost::unit_test_framework)
 endif()
 
 if (OPM_ENABLE_PYTHON)
-  set(opm-common_PYTHON_PACKAGE_VERSION ${OPM_PYTHON_PACKAGE_VERSION_TAG})
-
   add_custom_target(copy_python ALL
     COMMAND
       $<TARGET_FILE:Python3::Interpreter>

--- a/cmake/Modules/OpmCompile.cmake
+++ b/cmake/Modules/OpmCompile.cmake
@@ -35,7 +35,6 @@ macro(opm_compile opm)
   else()
     add_definitions(${${opm}_DEFINITIONS})
   endif()
-  set(${opm}_VERSION "${${opm}_VERSION_MAJOR}.${${opm}_VERSION_MINOR}")
 
   if(NOT ${opm}_SOURCES)
     set(${opm}_LIBRARY_TYPE INTERFACE)

--- a/cmake/Modules/OpmInit.cmake
+++ b/cmake/Modules/OpmInit.cmake
@@ -6,6 +6,7 @@
 #	project                     From the Module: field
 #	${project}_NAME             Same as above
 #	${project}_DESCRIPTION      From the Description: field
+#	${project}_VERSION          From the Version: field
 #	${project}_VERSION_MAJOR    From the Version: field
 #	${project}_VERSION_MINOR    From the Version: field also
 #
@@ -80,6 +81,7 @@ function (OpmInitProjVars)
   set (${project}_DESCRIPTION "${description}" PARENT_SCOPE)
   set (${project}_VERSION_MAJOR "${major}" PARENT_SCOPE)
   set (${project}_VERSION_MINOR "${minor}" PARENT_SCOPE)
+  set (${project}_VERSION "${major}.${minor}" PARENT_SCOPE)
   set (${project}_LABEL "${label}" PARENT_SCOPE)
 endfunction ()
 


### PR DESCRIPTION
caused missing version fields in python's setup.py after moving code around