### PR TITLE
CMakeLists_files.cmake: make it 'official'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,9 +552,5 @@ if(OPM_ENABLE_EMBEDDED_PYTHON AND NOT OPM_ENABLE_PYTHON)
   set(OPM_ENABLE_PYTHON ON CACHE BOOL "Enable python bindings?" FORCE)
 endif()
 
-# read the list of components from this file (in the project directory);
-# it should set various lists with the names of the files to include
-include (CMakeLists_files.cmake)
-
 # all setup common to the OPM library modules is done here
 include (OpmLibMain)

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -102,6 +102,8 @@ if(COMMAND ${project}_files_hook)
   cmake_language(CALL ${project}_files_hook)
 endif()
 
+include(CMakeLists_files.cmake)
+
 # this module contains code to figure out which files is where
 include (OpmFiles)
 


### PR DESCRIPTION
read it from OpmLibMain, at the appropriate spot in the chain. In particular we want to read it
after prereqs have been processed since sources and tests added will depend on prereq availability.

in simulators another hook was abused to make this happen. now it's clear and clean.