### PR TITLE
[LGR] EclipseGridLGR::generate_refined_coord refactored

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -517,8 +517,9 @@ namespace Opm {
         std::array<int, 3> low_fatherIJK {};
         std::array<int, 3> up_fatherIJK {};
         std::vector<int> m_hostnum;
-        std::vector<double> generate_refined_coord(const std::vector<double>& coord,
-                                                   const std::array<int,3>&   parent_nxyz);
+
+        std::vector<double> generate_refined_coord(const std::vector<double>& ,
+                                                   const std::array<int,3>&);
 
         std::vector<double> generate_refined_zcorn(const std::vector<double>& coord,
                                                    const std::vector<double>& zcorn,


### PR DESCRIPTION
PR [#4839](https://github.com/OPM/opm-common/pull/4839) introduced `EclipseGridLGR::generate_refined_coord()` to interpolate LGR pillars in `COORD`. Although the implementation works as expected, it introduced more overhead than necessary.

This PR revisits that implementation following suggestions from @bska. It makes use of `CoordMapper` and adopts a simpler data structure to handle the pillar interpolation.

The goal is to reduce unnecessary overhead, simplify the logic, and make the code easier to understand and maintain.
