### PR TITLE
fixed: downloaded pybind11 with sibling builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,7 +346,8 @@ macro(opm-common_targets_hook)
   endif()
 
   if(OPM_ENABLE_EMBEDDED_PYTHON)
-    target_link_libraries(opmcommon PRIVATE $<BUILD_INTERFACE:pybind11::embed>)
+    target_link_libraries(opmcommon PRIVATE $<BUILD_INTERFACE:Python3::Python>)
+    target_include_directories(opmcommon PRIVATE ${pybind11_INCLUDE_DIRS})
     foreach(target opmcommon test_msim_ACTIONX EmbeddedPython PYACTION)
       if(TARGET ${target})
         set_target_properties(${target}

--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -34,4 +34,11 @@ list(APPEND opm-common_DEPS
       "fmt 8.0"
       "QuadMath"
 )
+
+if(opm-common_EMBEDDED_PYTHON)
+  list(APPEND opm-common_DEPS
+    "Python3 COMPONENTS Development.Embed REQUIRED"
+  )
+endif()
+
 find_package_deps(opm-common)


### PR DESCRIPTION
sibling builds are a very alien concept to cmake. there is no such concept, which means the vendored targets leaks into the config file consumed in a separate project. to avoid this, we cannot use the pybind11::embed target, and we have to lookup the python embedding component in the prereqs file.

the world keeps giving. another unexpected workaround fallout; since we link to the opmcommon target downstream,
the pybind11 target leaks to the outside with sibling builds. yet another stop-gap-ish thing.