### PR TITLE
use updated cuda version string variable

### DIFF
--- a/cmake/Modules/FindAMGX.cmake
+++ b/cmake/Modules/FindAMGX.cmake
@@ -51,7 +51,7 @@ if(AMGX_FOUND)
         )
 
         # Since AMGX is basically unversioned we need to use cuda version to decide
-        if(CUDA_VERSION VERSION_LESS 12.9)
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.9)
           set(EXTRA_LIBS CUDA::nvToolsExt)
         endif()
 


### PR DESCRIPTION
Modernization in opm-simulators means we no longer use FindCUDA.cmake (it's long deprecated). This again means we do not have CUDA_VERSION string but rather a CMAKE_CUDA_COMPILER_VERSION string. adjust accordingly.