### PR TITLE
mark format strings runtime

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WDFAC.hpp
+++ b/opm/input/eclipse/Schedule/Well/WDFAC.hpp
@@ -194,7 +194,7 @@ namespace Opm {
             }
 
             throw std::runtime_error {
-                fmt::format("Unknown D-Factor model '{}'",
+                fmt::format(fmt::runtime("Unknown D-Factor model '{}'"),
                             static_cast<int>(this->m_type))
             };
         }

--- a/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
@@ -2035,11 +2035,11 @@ copy_to_gpu(const FLUIDSYSTEM_CLASSNAME<Scalar, IndexTraits>& oldFluidSystem) {
     using GpuBuffer9Array = GpuBuffer<std::array<Scalar, 9>>;
 
     OPM_ERROR_IF(oldFluidSystem.gasPvt_.approach() != GasPvtApproach::Co2Gas,
-        fmt::format("Incompatible gas PVT approach. Given {}, expected {} (GasPvtApproach::Co2Gas).",
+        fmt::format(fmt::runtime("Incompatible gas PVT approach. Given {}, expected {} (GasPvtApproach::Co2Gas)."),
                      int(oldFluidSystem.gasPvt_.approach()), int(GasPvtApproach::Co2Gas)));
 
     OPM_ERROR_IF(oldFluidSystem.waterPvt_.approach() != WaterPvtApproach::BrineCo2,
-        fmt::format("Incompatible water PVT approach. Given {}, expected {} (WaterPvtApproach::BrineCo2).",
+        fmt::format(fmt::runtime("Incompatible water PVT approach. Given {}, expected {} (WaterPvtApproach::BrineCo2)."),
                     int(oldFluidSystem.waterPvt_.approach()), int(WaterPvtApproach::BrineCo2)));
 
     OPM_ERROR_IF(oldFluidSystem.oilPvt_.isActive(),

--- a/opm/ml/ml_model.hpp
+++ b/opm/ml/ml_model.hpp
@@ -111,10 +111,10 @@ namespace ML
             OPM_ERROR_IF(dims_.size() != 1, "Invalid indexing for tensor");
 
             OPM_ERROR_IF(!(i < dims_[0] && i >= 0),
-                         fmt::format(" Invalid i:  "
+                         fmt::format(fmt::runtime(" Invalid i:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      i,
                                      dims_[0]));
 
@@ -126,10 +126,10 @@ namespace ML
             OPM_ERROR_IF(dims_.size() != 1, "Invalid indexing for tensor");
 
             OPM_ERROR_IF(!(i < dims_[0] && i >= 0),
-                         fmt::format(" Invalid i:  "
+                         fmt::format(fmt::runtime(" Invalid i:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      i,
                                      dims_[0]));
 
@@ -140,17 +140,17 @@ namespace ML
         {
             OPM_ERROR_IF(dims_.size() != 2, "Invalid indexing for tensor");
             OPM_ERROR_IF(!(i < dims_[0] && i >= 0),
-                         fmt::format(" Invalid i:  "
+                         fmt::format(fmt::runtime(" Invalid i:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      i,
                                      dims_[0]));
             OPM_ERROR_IF(!(j < dims_[1] && j >= 0),
-                         fmt::format(" Invalid j:  "
+                         fmt::format(fmt::runtime(" Invalid j:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      j,
                                      dims_[1]));
 
@@ -161,17 +161,17 @@ namespace ML
         {
             OPM_ERROR_IF(dims_.size() != 2, "Invalid indexing for tensor");
             OPM_ERROR_IF(!(i < dims_[0] && i >= 0),
-                         fmt::format(" Invalid i:  "
+                         fmt::format(fmt::runtime(" Invalid i:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      i,
                                      dims_[0]));
             OPM_ERROR_IF(!(j < dims_[1] && j >= 0),
-                         fmt::format(" Invalid j:  "
+                         fmt::format(fmt::runtime(" Invalid j:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      j,
                                      dims_[1]));
             return data_[dims_[1] * i + j];
@@ -181,24 +181,24 @@ namespace ML
         {
             OPM_ERROR_IF(dims_.size() != 3, "Invalid indexing for tensor");
             OPM_ERROR_IF(!(i < dims_[0] && i >= 0),
-                         fmt::format(" Invalid i:  "
+                         fmt::format(fmt::runtime(" Invalid i:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      i,
                                      dims_[0]));
             OPM_ERROR_IF(!(j < dims_[1] && j >= 0),
-                         fmt::format(" Invalid j:  "
+                         fmt::format(fmt::runtime(" Invalid j:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      j,
                                      dims_[1]));
             OPM_ERROR_IF(!(k < dims_[2] && k >= 0),
-                         fmt::format(" Invalid k:  "
+                         fmt::format(fmt::runtime(" Invalid k:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      k,
                                      dims_[2]));
 
@@ -209,24 +209,24 @@ namespace ML
         {
             OPM_ERROR_IF(dims_.size() != 3, "Invalid indexing for tensor");
             OPM_ERROR_IF(!(i < dims_[0] && i >= 0),
-                         fmt::format(" Invalid i:  "
+                         fmt::format(fmt::runtime(" Invalid i:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      i,
                                      dims_[0]));
             OPM_ERROR_IF(!(j < dims_[1] && j >= 0),
-                         fmt::format(" Invalid j:  "
+                         fmt::format(fmt::runtime(" Invalid j:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      j,
                                      dims_[1]));
             OPM_ERROR_IF(!(k < dims_[2] && k >= 0),
-                         fmt::format(" Invalid k:  "
+                         fmt::format(fmt::runtime(" Invalid k:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      k,
                                      dims_[2]));
 
@@ -237,31 +237,31 @@ namespace ML
         {
             OPM_ERROR_IF(dims_.size() != 4, "Invalid indexing for tensor");
             OPM_ERROR_IF(!(i < dims_[0] && i >= 0),
-                         fmt::format(" Invalid i:  "
+                         fmt::format(fmt::runtime(" Invalid i:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      i,
                                      dims_[0]));
             OPM_ERROR_IF(!(j < dims_[1] && j >= 0),
-                         fmt::format(" Invalid j:  "
+                         fmt::format(fmt::runtime(" Invalid j:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      j,
                                      dims_[1]));
             OPM_ERROR_IF(!(k < dims_[2] && k >= 0),
-                         fmt::format(" Invalid k:  "
+                         fmt::format(fmt::runtime(" Invalid k:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      k,
                                      dims_[2]));
             OPM_ERROR_IF(!(l < dims_[3] && l >= 0),
-                         fmt::format(" Invalid l:  "
+                         fmt::format(fmt::runtime(" Invalid l:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      l,
                                      dims_[3]));
 
@@ -272,31 +272,31 @@ namespace ML
         {
             OPM_ERROR_IF(dims_.size() != 4, "Invalid indexing for tensor");
             OPM_ERROR_IF(!(i < dims_[0] && i >= 0),
-                         fmt::format(" Invalid i:  "
+                         fmt::format(fmt::runtime(" Invalid i:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      i,
                                      dims_[0]));
             OPM_ERROR_IF(!(j < dims_[1] && j >= 0),
-                         fmt::format(" Invalid j:  "
+                         fmt::format(fmt::runtime(" Invalid j:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      j,
                                      dims_[1]));
             OPM_ERROR_IF(!(k < dims_[2] && k >= 0),
-                         fmt::format(" Invalid k:  "
+                         fmt::format(fmt::runtime(" Invalid k:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      k,
                                      dims_[2]));
             OPM_ERROR_IF(!(l < dims_[3] && l >= 0),
-                         fmt::format(" Invalid l:  "
+                         fmt::format(fmt::runtime(" Invalid l:  "
                                      "{}"
                                      "  max: "
-                                     "{}",
+                                     "{}"),
                                      l,
                                      dims_[3]));
 
@@ -576,8 +576,8 @@ namespace ML
             break;
         default:
             OPM_ERROR_IF(true,
-                         fmt::format("\n Unsupported activation type "
-                                     "{}",
+                         fmt::format(fmt::runtime("\n Unsupported activation type "
+                                     "{}"),
                                      activation));
         }
 
@@ -802,8 +802,8 @@ namespace ML
     {
         std::ifstream file(filename.c_str(), std::ios::binary);
         OPM_ERROR_IF(!file.is_open(),
-                     fmt::format("\n Unable to open file "
-                                 "{}",
+                     fmt::format(fmt::runtime("\n Unable to open file "
+                                 "{}"),
                                  filename.c_str()));
 
         unsigned int num_layers = 0;
@@ -833,12 +833,12 @@ namespace ML
             }
 
             OPM_ERROR_IF(!layer,
-                         fmt::format("\n Unknown layer type "
-                                     "{}",
+                         fmt::format(fmt::runtime("\n Unknown layer type "
+                                     "{}"),
                                      layer_type));
             OPM_ERROR_IF(!layer->loadLayer(file),
-                         fmt::format("\n Failed to load layer "
-                                     "{}",
+                         fmt::format(fmt::runtime("\n Failed to load layer "
+                                     "{}"),
                                      i));
 
             layers_.emplace_back(std::move(layer));
@@ -859,8 +859,8 @@ namespace ML
             }
 
             OPM_ERROR_IF(!(layers_[i]->apply(temp_in, out)),
-                         fmt::format("\n Failed to apply layer "
-                                     "{}",
+                         fmt::format(fmt::runtime("\n Failed to apply layer "
+                                     "{}"),
                                      i));
         }
         return true;


### PR DESCRIPTION
Similar to, and with the same reasoning, as https://github.com/OPM/opm-simulators/pull/6832

This also show we have been naughty and use fmt in headers, but that is a separate issue.