### PR TITLE
Rsconst enq

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -374,6 +374,7 @@ list(APPEND MAIN_SOURCE_FILES
   opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.cpp
   opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.cpp
   opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.cpp
+  opm/material/fluidsystems/blackoilpvt/ConstantRsDeadOilPvt.cpp
   opm/material/fluidsystems/blackoilpvt/DeadOilPvt.cpp
   opm/material/fluidsystems/blackoilpvt/DryGasPvt.cpp
   opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.cpp
@@ -1441,6 +1442,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp
   opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
   opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+  opm/material/fluidsystems/blackoilpvt/ConstantRsDeadOilPvt.hpp
   opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
   opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
   opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.hpp

--- a/opm/input/eclipse/EclipseState/Tables/RsconstTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/RsconstTable.hpp
@@ -1,0 +1,35 @@
+/*
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef OPM_PARSER_RSCONST_TABLE_HPP
+#define OPM_PARSER_RSCONST_TABLE_HPP
+
+#include "SimpleTable.hpp"
+
+namespace Opm {
+
+    class DeckItem;
+
+    class RsconstTable : public SimpleTable {
+    public:
+       explicit RsconstTable( const DeckRecord& record);
+        const TableColumn& getRsColumn() const;
+        const TableColumn& getPbubColumn() const;
+    };
+}
+
+#endif

--- a/opm/input/eclipse/EclipseState/Tables/SimpleTable.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/SimpleTable.cpp
@@ -217,12 +217,12 @@ namespace Opm {
         // (std::invalid_argument).
         if (m_jfunc) {
             std::cerr << "Developer warning: Pressure column "
-                "is read with JFUNC in deck.\n";
+                      << "is read with JFUNC in deck.\n";
+            return;
         }
-        else {
-            std::cerr << "Developer warning: Raw values from JFUNC column "
-                "is read, but JFUNC not provided in deck.\n";
-        }
+
+        std::cerr << "Developer warning: Raw values from JFUNC column "
+                  << "is read, but JFUNC not provided in deck.\n";
     }
 
     bool SimpleTable::operator==(const SimpleTable& data) const

--- a/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -81,6 +81,7 @@
 #include <opm/input/eclipse/EclipseState/Tables/RockwnodTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/OverburdTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/RsvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/RsconstTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PbvdTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PdvdTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/RtempvdTable.hpp>
@@ -321,6 +322,8 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         result.m_tabdims = Tabdims::serializationTestObject();
         result.m_regdims = Regdims::serializationTestObject();
         result.m_eqldims = Eqldims::serializationTestObject();
+        result.m_aqudims = Aqudims::serializationTestObject();
+
         result.hasImptvd = true;
         result.hasEnptvd = true;
         result.hasEqlnum = true;
@@ -462,6 +465,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         addTables( "PVDG", m_tabdims.getNumPVTTables());
         addTables( "PVDO", m_tabdims.getNumPVTTables());
+        addTables( "RSCONST", 1);
         addTables( "PVDS", m_tabdims.getNumPVTTables());
 
         addTables( "SPECHEAT", m_tabdims.getNumPVTTables());
@@ -615,6 +619,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         initPlyrockTables(deck);
         initPlymaxTables(deck);
+        initRsconstTables(deck);
         initRTempTables(deck);
         initZmfvdTables(deck);
         initRocktabTables(deck);
@@ -855,7 +860,19 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         }
     }
 
+    void TableManager::initRsconstTables(const Deck& deck) {
+        const std::string keywordName = "RSCONST";
+        if (!deck.hasKeyword(keywordName)) {
+            return;
+        }
 
+        const auto& keyword = deck[keywordName].back();
+
+        auto& container = forceGetTables(keywordName, 1);
+        const auto& tableRecord = keyword.getRecord(0);
+        std::shared_ptr<RsconstTable> table = std::make_shared<RsconstTable>(tableRecord);
+        container.addTable(0, table);
+    }
 
     void TableManager::initRocktabTables(const Deck& deck) {
         if (!deck.hasKeyword("ROCKTAB"))
@@ -1117,6 +1134,10 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
     const TableContainer& TableManager::getAqutabTables() const {
         return getTables("AQUTAB");
     }
+
+     const TableContainer& TableManager::getRsconstTables() const {
+        return getTables("RSCONST");
+   }
 
     const TableContainer& TableManager::getFoamadsTables() const {
         return getTables("FOAMADS");
@@ -1653,8 +1674,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
     void TableManager::initSimpleTableContainer(const Deck& deck,
                                                 const std::string& keywordName,
                                                 const std::string& tableName,
-                                                size_t numTables)
-    {
+                                                size_t numTables) {
         if (!deck.hasKeyword(keywordName)) {
             return; // the table is not featured by the deck...
         }

--- a/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
@@ -112,6 +112,7 @@ namespace Opm {
         const TableContainer& getImptvdTables() const;
         const TableContainer& getPvdgTables() const;
         const TableContainer& getPvdoTables() const;
+        const TableContainer& getRsconstTables() const;
         const TableContainer& getPvdsTables() const;
         const TableContainer& getSpecheatTables() const;
         const TableContainer& getSpecrockTables() const;
@@ -302,6 +303,7 @@ namespace Opm {
         void initRocktabTables(const Deck& deck);
 
         void initPlymaxTables(const Deck& deck);
+        void initRsconstTables(const Deck& deck);
         void initPlyrockTables(const Deck& deck);
         void initPlyshlogTables(const Deck& deck);
 

--- a/opm/input/eclipse/EclipseState/Tables/Tables.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Tables.cpp
@@ -52,6 +52,7 @@
 #include <opm/input/eclipse/EclipseState/Tables/PmiscTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PvdgTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PvdoTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/RsconstTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PvdsTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PvtgTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PvtgwTable.hpp>
@@ -1154,6 +1155,18 @@ PvdoTable::getViscosityColumn() const
     return SimpleTable::getColumn(2);
 }
 
+const TableColumn&
+RsconstTable::getRsColumn() const
+{
+    return SimpleTable::getColumn(0);
+}
+
+const TableColumn&
+RsconstTable::getPbubColumn() const
+{
+    return SimpleTable::getColumn(1);
+}
+
 SwfnTable::SwfnTable(const DeckItem& item, const bool jfunc, const int tableID)
 {
     m_schema.addColumn(ColumnSchema("SW", Table::STRICTLY_INCREASING, Table::DEFAULT_NONE));
@@ -1403,6 +1416,24 @@ PlymaxTable::PlymaxTable(const DeckRecord& record)
 
         column.addValue(record.getItem(colIdx).getSIDouble(0), "PLYMAX");
     }
+}
+
+RsconstTable::RsconstTable(const DeckRecord& record)
+{
+    m_schema.addColumn(ColumnSchema("RS", Table::RANDOM, Table::DEFAULT_NONE));
+    m_schema.addColumn(ColumnSchema("PBUB", Table::RANDOM, Table::DEFAULT_NONE));
+
+    addColumns();
+
+    // RSCONST has two items - get them by index
+    const auto& rsItem = record.getItem(0);
+    const auto& pbItem = record.getItem(1);
+
+    auto& rsColumn = getColumn(0);
+    auto& pbColumn = getColumn(1);
+
+    rsColumn.addValue(rsItem.getSIDouble(0), "RSCONST");
+    pbColumn.addValue(pbItem.getSIDouble(0), "RSCONST");
 }
 
 const TableColumn&

--- a/opm/material/fluidsystems/BlackOilFluidSystem.cpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.cpp
@@ -88,6 +88,16 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
         waterPvt_.initFromState(eclState, schedule);
     }
 
+    // set if we are using constrs tables
+   if ((!eclState.getSimulationConfig().hasDISGAS()) && (!phaseIsActive(gasPhaseIdx))) {
+      if (eclState.getTableManager().hasTables("RSCONST")) {
+          const auto& rsConstTables = eclState.getTableManager().getRsconstTables();
+          if (!rsConstTables.empty()) {
+              setEnableConstantRs(oilPvt_.approach() == OilPvtApproach::ConstantRsDeadOil);
+          }
+      }
+   }
+
     // set the reference densities of all PVT regions
     for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
         setReferenceDensities(oilPvt_.approach()   == OilPvtApproach::NoOil     ? 700.0  : oilPvt_.oilReferenceDensity(regionIdx),
@@ -202,6 +212,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
     template<> T BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::reservoirTemperature_ = 0.0; \
     template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::enableDissolvedGas_ = true; \
     template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::enableDissolvedGasInWater_ = false; \
+    template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::enableConstantRs_ = false; \
     template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::enableVaporizedOil_ = false; \
     template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::enableVaporizedWater_ = false; \
     template<> bool BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices, VectorWithDefaultAllocator>::enableDiffusion_ = false; \

--- a/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
@@ -189,6 +189,7 @@ public:
                           bool _enableDissolvedGasInWater_,
                           bool _enableVaporizedOil_,
                           bool _enableVaporizedWater_,
+                          bool _enableConstantRs_,
                           bool _enableDiffusion_,
                           Storage<std::array<Scalar, 3>>&& _referenceDensity_,
                           Storage<std::array<Scalar, 3>>&& _molarMass_,
@@ -207,6 +208,7 @@ public:
         , enableDissolvedGasInWater_(_enableDissolvedGasInWater_)
         , enableVaporizedOil_(_enableVaporizedOil_)
         , enableVaporizedWater_(_enableVaporizedWater_)
+        , enableConstantRs_(_enableConstantRs_)
         , enableDiffusion_(_enableDiffusion_)
         , referenceDensity_(std::move(_referenceDensity_))
         , molarMass_(std::move(_molarMass_))
@@ -300,6 +302,16 @@ public:
      */
     STATIC_OR_DEVICE void setEnableDissolvedGasInWater(bool yesno)
     { enableDissolvedGasInWater_ = yesno; }
+
+     /*!
+     * \brief Specify whether the fluid system should use constant Rs tables
+     *
+     * This is used when DISGAS is not active and gas phase is inactive,
+     * but constant Rs tables are provided.
+     */
+     STATIC_OR_DEVICE void setEnableConstantRs(bool yesno)
+    { enableConstantRs_ = yesno; }
+
     /*!
      * \brief Specify whether the fluid system should consider diffusion
      *
@@ -506,6 +518,12 @@ public:
     STATIC_OR_DEVICE bool enableVaporizedWater() NOTHING_OR_CONST
     { return enableVaporizedWater_; }
 
+     /*!
+     * \brief Returns whether constant Rs tables should be used
+     */
+     STATIC_OR_DEVICE bool enableConstantRs() NOTHING_OR_CONST
+     { return enableConstantRs_; }
+
     /*!
      * \brief Returns whether the fluid system should consider diffusion
      *
@@ -592,6 +610,16 @@ public:
 
         switch (phaseIdx) {
         case oilPhaseIdx: {
+            if (enableConstantRs()) {
+                // dead oil but positive constant Rs
+                const LhsEval& Rs = oilPvt_.saturatedGasDissolutionFactor(regionIdx, T, p);
+                const LhsEval& bo = oilPvt_.inverseFormationVolumeFactor(regionIdx, T, p, Rs);
+
+                return
+                    bo*referenceDensity(oilPhaseIdx, regionIdx)
+                    + Rs*bo*referenceDensity(gasPhaseIdx, regionIdx);
+            }
+
             if (enableDissolvedGas()) {
                 // miscible oil
                 const LhsEval& Rs = BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
@@ -689,6 +717,16 @@ public:
 
         switch (phaseIdx) {
         case oilPhaseIdx: {
+            if (enableConstantRs()) {
+                // dead oil but positive constant Rs
+                const LhsEval& Rs = oilPvt_.saturatedGasDissolutionFactor(regionIdx, T, p);
+                const LhsEval& bo = oilPvt_.inverseFormationVolumeFactor(regionIdx, T, p, Rs);
+
+                return
+                    bo*referenceDensity(oilPhaseIdx, regionIdx)
+                    + Rs*bo*referenceDensity(gasPhaseIdx, regionIdx);
+            }
+
             if (enableDissolvedGas()) {
                 // miscible oil
                 const LhsEval& Rs = saturatedDissolutionFactor<FluidState, LhsEval>(fluidState, oilPhaseIdx, regionIdx);
@@ -1753,6 +1791,7 @@ private:
     STATIC_OR_NOTHING bool enableDissolvedGasInWater_;
     STATIC_OR_NOTHING bool enableVaporizedOil_;
     STATIC_OR_NOTHING bool enableVaporizedWater_;
+    STATIC_OR_NOTHING bool enableConstantRs_;
     STATIC_OR_NOTHING bool enableDiffusion_;
 
     // HACK for GCC 4.4: the array size has to be specified using the literal value '3'
@@ -1781,6 +1820,7 @@ private:
         , enableDissolvedGasInWater_(other.enableDissolvedGasInWater_)
         , enableVaporizedOil_(other.enableVaporizedOil_)
         , enableVaporizedWater_(other.enableVaporizedWater_)
+        , enableConstantRs_(other.enableConstantRs_)
         , enableDiffusion_(other.enableDiffusion_)
         , referenceDensity_(StorageT<typename decltype(referenceDensity_)::value_type>(other.referenceDensity_))
         , molarMass_(StorageT<typename decltype(molarMass_)::value_type>(other.molarMass_))
@@ -1812,6 +1852,7 @@ initBegin(std::size_t numPvtRegions)
     enableDissolvedGasInWater_ = false;
     enableVaporizedOil_ = false;
     enableVaporizedWater_ = false;
+    enableConstantRs_ = false;
     enableDiffusion_ = false;
 
     surfaceTemperature = 273.15 + 15.56; // [K]
@@ -1998,7 +2039,8 @@ template<> T BOFS<T>::reservoirTemperature_;                                    
 template<> bool BOFS<T>::enableDissolvedGas_;                                         \
 template<> bool BOFS<T>::enableDissolvedGasInWater_;                                  \
 template<> bool BOFS<T>::enableVaporizedOil_;                                         \
-template<> bool BOFS<T>::enableVaporizedWater_;                                       \
+template<> bool BOFS<T>::enableVaporizedWater_;                                  \
+template<> bool BOFS<T>::enableConstantRs_;                                     \
 template<> bool BOFS<T>::enableDiffusion_;                                            \
 template<> BOFS<T>::OilPvt BOFS<T>::oilPvt_;                                          \
 template<> BOFS<T>::GasPvt BOFS<T>::gasPvt_;                                          \
@@ -2060,6 +2102,7 @@ copy_to_gpu(const FLUIDSYSTEM_CLASSNAME<Scalar, IndexTraits>& oldFluidSystem) {
         oldFluidSystem.enableDissolvedGasInWater_,
         oldFluidSystem.enableVaporizedOil_,
         oldFluidSystem.enableVaporizedWater_,
+        oldFluidSystem.enableConstantRs_,
         oldFluidSystem.enableDiffusion_,
         std::move(newReferenceDensity),
         std::move(newMolarMass),
@@ -2097,6 +2140,7 @@ make_view(FLUIDSYSTEM_CLASSNAME<Scalar, IndexTraits, GpuBuffer>& oldFluidSystem)
         oldFluidSystem.enableDissolvedGasInWater_,
         oldFluidSystem.enableVaporizedOil_,
         oldFluidSystem.enableVaporizedWater_,
+        oldFluidSystem.enableConstantRs_,
         oldFluidSystem.enableDiffusion_,
         std::move(newReferenceDensity),
         std::move(newMolarMass),

--- a/opm/material/fluidsystems/blackoilpvt/ConstantRsDeadOilPvt.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantRsDeadOilPvt.cpp
@@ -1,0 +1,145 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+#include <opm/material/fluidsystems/blackoilpvt/ConstantRsDeadOilPvt.hpp>
+
+#include <opm/common/ErrorMacros.hpp>
+
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PvdoTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/RsconstTable.hpp>
+
+#include <fmt/format.h>
+
+namespace Opm {
+
+template<class Scalar>
+void ConstantRsDeadOilPvt<Scalar>::
+initFromState(const EclipseState& eclState, [[maybe_unused]] const Schedule& schedule)
+{
+    const auto& pvdoTables = eclState.getTableManager().getPvdoTables();
+    const auto& densityTable = eclState.getTableManager().getDensityTable();
+
+    if (pvdoTables.size() != densityTable.size()) {
+        OPM_THROW(std::runtime_error,
+                  fmt::format("Table sizes mismatch. PVDO: {}, DensityTable: {}\n",
+                              pvdoTables.size(), densityTable.size()));
+    }
+
+    std::size_t regions = pvdoTables.size();
+    setNumRegions(regions);
+
+    // Check for RSCONST keyword - single global value
+    const auto& rsConstTables = eclState.getTableManager().getRsconstTables();
+    if (!rsConstTables.empty()) {
+        // RSCONST has Rs and Pb.
+        const auto& rsConst = rsConstTables[0];
+        const Scalar rs = rsConst.getColumn(0)[0];
+        const Scalar pb = rsConst.getColumn(1)[0];
+
+        if (rs < 0.0) {
+            OPM_THROW(std::invalid_argument,
+                      fmt::format("Invalid RSCONST value: Rs must be non-negative, got {}", rs));
+        }
+        if (pb <= 0.0) {
+            OPM_THROW(std::invalid_argument,
+                      fmt::format("Invalid RSCONST value: Pb must be positive, got {}", pb));
+        }
+
+        setConstantRs(rs);
+        setBubblePointPressure(pb);
+    }
+
+    for (unsigned regionIdx = 0; regionIdx < regions; ++regionIdx) {
+        Scalar rhoRefO = densityTable[regionIdx].oil;
+        Scalar rhoRefG = densityTable[regionIdx].gas;
+        Scalar rhoRefW = densityTable[regionIdx].water;
+
+        setReferenceDensities(regionIdx, rhoRefO, rhoRefG, rhoRefW);
+
+        const auto& pvdoTable = pvdoTables.getTable<PvdoTable>(regionIdx);
+
+        // Set up Bo and μo from PVDO (Rs doesn't affect these)
+        const auto& BColumn(pvdoTable.getFormationFactorColumn());
+        std::vector<Scalar> invBColumn(BColumn.size());
+        for (unsigned i = 0; i < invBColumn.size(); ++i)
+            invBColumn[i] = 1.0 / BColumn[i];
+
+        inverseOilB_[regionIdx].setXYArrays(pvdoTable.numRows(),
+                                            pvdoTable.getPressureColumn(),
+                                            invBColumn);
+        oilMu_[regionIdx].setXYArrays(pvdoTable.numRows(),
+                                      pvdoTable.getPressureColumn(),
+                                      pvdoTable.getViscosityColumn());
+    }
+
+    initEnd();
+}
+
+template<class Scalar>
+void ConstantRsDeadOilPvt<Scalar>::setNumRegions(std::size_t numRegions)
+{
+    oilReferenceDensity_.resize(numRegions);
+    gasReferenceDensity_.resize(numRegions);
+    inverseOilB_.resize(numRegions);
+    inverseOilBMu_.resize(numRegions);
+    oilMu_.resize(numRegions);
+}
+
+template<class Scalar>
+void ConstantRsDeadOilPvt<Scalar>::initEnd()
+{
+    // Calculate invBo/μo table for efficiency
+    std::size_t regions = oilMu_.size();
+    for (unsigned regionIdx = 0; regionIdx < regions; ++regionIdx) {
+        const auto& oilmu = oilMu_[regionIdx];
+        const auto& invOilB = inverseOilB_[regionIdx];
+        
+        // Should have same number of samples
+        if (oilmu.numSamples() != invOilB.numSamples()) {
+            OPM_THROW(std::runtime_error,
+                     fmt::format("Table sizes mismatch in region {}. Bo: {}, μo: {}\n",
+                                 regionIdx, invOilB.numSamples(), oilmu.numSamples()));
+        }
+
+        std::vector<Scalar> invBMuColumn(oilmu.numSamples());
+        std::vector<Scalar> pressureColumn(oilmu.numSamples());
+
+        for (unsigned pIdx = 0; pIdx < oilmu.numSamples(); ++pIdx) {
+            pressureColumn[pIdx] = invOilB.xAt(pIdx);
+            invBMuColumn[pIdx] = invOilB.valueAt(pIdx) / oilmu.valueAt(pIdx);
+        }
+
+        inverseOilBMu_[regionIdx].setXYArrays(pressureColumn.size(),
+                                              pressureColumn,
+                                              invBMuColumn);
+    }
+}
+
+template class ConstantRsDeadOilPvt<double>;
+template class ConstantRsDeadOilPvt<float>;
+
+} // namespace Opm

--- a/opm/material/fluidsystems/blackoilpvt/ConstantRsDeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantRsDeadOilPvt.hpp
@@ -1,0 +1,295 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::ConstantRsDeadOilPvt
+ */
+#ifndef OPM_CONSTANT_RS_DEAD_OIL_PVT_HPP
+#define OPM_CONSTANT_RS_DEAD_OIL_PVT_HPP
+
+#include <opm/material/common/Tabulated1DFunction.hpp>
+#include <opm/material/common/MathToolbox.hpp>
+#include <opm/common/Exceptions.hpp>
+
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace Opm {
+
+class EclipseState;
+class Schedule;
+
+/*!
+ * \brief This class represents the Pressure-Volume-Temperature relations of dead oil
+ *        with constant dissolved gas (RSCONST keyword).
+ * 
+ * RSCONST provides two global values: constant Rs and constant bubble point pressure.
+ * Oil properties (Bo, μo) come from PVDO tables and are independent of Rs.
+ */
+template <class Scalar>
+class ConstantRsDeadOilPvt
+{
+public:
+    using TabulatedOneDFunction = Tabulated1DFunction<Scalar>;
+
+    /*!
+     * \brief Initialize the oil parameters via the data specified by the PVDO ECL keyword
+     *        with additional constant Rs from RSCONST.
+     */
+    void initFromState(const EclipseState& eclState, const Schedule& schedule);
+
+    void setNumRegions(std::size_t numRegions);
+
+    void setVapPars(const Scalar, const Scalar)
+    {
+        // No vaporization parameters for constant Rs
+    }
+
+    /*!
+     * \brief Initialize the reference densities of all fluids for a given PVT region
+     */
+    void setReferenceDensities(unsigned regionIdx,
+                               Scalar rhoRefOil,
+                               Scalar rhoRefGas,
+                               Scalar /*rhoRefWater*/)
+    {
+        oilReferenceDensity_[regionIdx] = rhoRefOil;
+        gasReferenceDensity_[regionIdx] = rhoRefGas;
+    }
+
+    /*!
+     * \brief Set the constant Rs value (global for all regions)
+     */
+    void setConstantRs(Scalar rsConst)
+    { constantRs_ = rsConst; }
+
+    /*!
+     * \brief Set the bubble point pressure (global for all regions)
+     */
+    void setBubblePointPressure(Scalar pbub)
+    { bubblePointPressure_ = pbub; }
+
+    /*!
+     * \brief Initialize the function for the oil formation volume factor
+     */
+    void setInverseOilFormationVolumeFactor(unsigned regionIdx,
+                                            const TabulatedOneDFunction& invBo)
+    { inverseOilB_[regionIdx] = invBo; }
+
+    /*!
+     * \brief Initialize the viscosity of the oil phase.
+     */
+    void setOilViscosity(unsigned regionIdx, const TabulatedOneDFunction& muo)
+    { oilMu_[regionIdx] = muo; }
+
+    /*!
+     * \brief Finish initializing the oil phase PVT properties.
+     */
+    void initEnd();
+
+    /*!
+     * \brief Return the number of PVT regions which are considered by this PVT-object.
+     */
+    unsigned numRegions() const
+    { return inverseOilBMu_.size(); }
+
+    /*!
+     * \brief Returns the specific enthalpy [J/kg] of oil given a set of parameters.
+     */
+    template <class Evaluation>
+    Evaluation internalEnergy(unsigned,
+                        const Evaluation&,
+                        const Evaluation&,
+                        const Evaluation&) const
+    {
+        throw std::runtime_error("Requested the enthalpy of oil but the thermal "
+                                 "option is not enabled");
+    }
+
+    Scalar hVap(unsigned) const
+    {
+        throw std::runtime_error("Requested the hvap of oil but the thermal "
+                                 "option is not enabled");
+    }
+
+    /*!
+     * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
+     *        Rs is ignored - viscosity depends only on pressure via PVDO table.
+     */
+    template <class Evaluation>
+    Evaluation viscosity(unsigned regionIdx,
+                         const Evaluation& temperature,
+                         const Evaluation& pressure,
+                         const Evaluation& /*Rs*/) const
+    { return saturatedViscosity(regionIdx, temperature, pressure); }
+
+    /*!
+     * \brief Returns the dynamic viscosity [Pa s] of oil given a pressure.
+     *        Uses PVDO table directly.
+     */
+    template <class Evaluation>
+    Evaluation saturatedViscosity(unsigned regionIdx,
+                                  const Evaluation& /*temperature*/,
+                                  const Evaluation& pressure) const
+    {
+        const Evaluation& invBo = inverseOilB_[regionIdx].eval(pressure, /*extrapolate=*/true);
+        const Evaluation& invMuoBo = inverseOilBMu_[regionIdx].eval(pressure, /*extrapolate=*/true);
+        return invBo / invMuoBo;
+    }
+
+    /*!
+     * \brief Returns the formation volume factor [-] of the fluid phase.
+     *        Rs is ignored - Bo depends only on pressure via PVDO table.
+     */
+    template <class Evaluation>
+    Evaluation inverseFormationVolumeFactor(unsigned regionIdx,
+                                            const Evaluation& /*temperature*/,
+                                            const Evaluation& pressure,
+                                            const Evaluation& /*Rs*/) const
+    { return inverseOilB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
+
+    /*!
+     * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::ValueType>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx)
+    {
+        const LhsEval& p = decay<LhsEval>(fluidState.pressure(FluidState::oilPhaseIdx));
+        const auto segIdx = this->inverseOilB_[regionIdx].findSegmentIndex(p, /*extrapolate=*/ true);
+        const auto& invBo = this->inverseOilB_[regionIdx].eval(p, SegmentIndex{segIdx});
+        const auto& invMuoBo = this->inverseOilBMu_[regionIdx].eval(p, SegmentIndex{segIdx});
+        return { invBo, invBo / invMuoBo };
+    }
+
+    /*!
+     * \brief Returns the formation volume factor [-] of oil.
+     *        Uses PVDO table directly.
+     */
+    template <class Evaluation>
+    Evaluation saturatedInverseFormationVolumeFactor(unsigned regionIdx,
+                                                     const Evaluation& /*temperature*/,
+                                                     const Evaluation& pressure) const
+    { return inverseOilB_[regionIdx].eval(pressure, /*extrapolate=*/true); }
+
+    /*!
+     * \brief Returns the constant gas dissolution factor \f$R_s\f$ [m^3/m^3] of the oil phase.
+     *        Same value for all regions.
+     *        Enforces that pressure must be >= bubble point pressure.
+     */
+    template <class Evaluation>
+    Evaluation saturatedGasDissolutionFactor(unsigned /*regionIdx*/,
+                                             const Evaluation& /*temperature*/,
+                                             const Evaluation& pressure) const
+    {
+        // Enforce bubble point constraint from RSCONST manual:
+        // "The run will terminate if the pressure in any grid block falls below this value."
+        if (pressure < bubblePointPressure_) {
+            throw NumericalProblem(
+                "Pressure is below RSCONST bubble point pressure of " +
+                std::to_string(bubblePointPressure_)
+            );
+        }
+        return constantRs_;
+    }
+
+    /*!
+     * \brief Returns the constant gas dissolution factor \f$R_s\f$ [m^3/m^3] of the oil phase.
+     *        Same value for all regions.
+     *        Enforces that pressure must be >= bubble point pressure.
+     */
+    template <class Evaluation>
+    Evaluation saturatedGasDissolutionFactor(unsigned /*regionIdx*/,
+                                             const Evaluation& /*temperature*/,
+                                             const Evaluation& pressure,
+                                             const Evaluation& /*oilSaturation*/,
+                                             const Evaluation& /*maxOilSaturation*/) const
+    {
+        // Enforce bubble point constraint from RSCONST manual:
+        // "The run will terminate if the pressure in any grid block falls below this value."
+        if (pressure < bubblePointPressure_) {
+            throw NumericalProblem(
+                "Pressure is below RSCONST bubble point pressure of " +
+                std::to_string(bubblePointPressure_)
+            );
+        }
+        return constantRs_;
+    }
+
+    /*!
+     * \brief Returns the bubble point pressure [Pa] from RSCONST.
+     *        Same value for all regions.
+     */
+    template <class Evaluation>
+    Evaluation saturationPressure(unsigned /*regionIdx*/,
+                                  const Evaluation& /*temperature*/,
+                                  const Evaluation& /*Rs*/) const
+    { return bubblePointPressure_; }
+
+    template <class Evaluation>
+    Evaluation diffusionCoefficient(const Evaluation& /*temperature*/,
+                                    const Evaluation& /*pressure*/,
+                                    unsigned /*compIdx*/) const
+    {
+        throw std::runtime_error("Not implemented: The PVT model does not provide "
+                                 "a diffusionCoefficient()");
+    }
+
+    Scalar oilReferenceDensity(unsigned regionIdx) const
+    { return oilReferenceDensity_[regionIdx]; }
+
+    Scalar gasReferenceDensity(unsigned regionIdx) const
+    { return gasReferenceDensity_[regionIdx]; }
+
+    Scalar constantRs() const
+    { return constantRs_; }
+
+    Scalar bubblePointPressure() const
+    { return bubblePointPressure_; }
+
+    const std::vector<TabulatedOneDFunction>& inverseOilB() const
+    { return inverseOilB_; }
+
+    const std::vector<TabulatedOneDFunction>& oilMu() const
+    { return oilMu_; }
+
+    const std::vector<TabulatedOneDFunction>& inverseOilBMu() const
+    { return inverseOilBMu_; }
+
+private:
+
+    std::vector<Scalar> oilReferenceDensity_{};
+    std::vector<Scalar> gasReferenceDensity_{};
+    std::vector<TabulatedOneDFunction> inverseOilB_{};
+    std::vector<TabulatedOneDFunction> oilMu_{};
+    std::vector<TabulatedOneDFunction> inverseOilBMu_{};
+    
+    // Global constants from RSCONST (same for all regions)
+    Scalar constantRs_ = 0.0;           // Constant Rs value from RSCONST
+    Scalar bubblePointPressure_ = 0.0;  // Bubble point pressure from RSCONST
+};
+
+} // namespace Opm
+
+#endif

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.cpp
@@ -27,6 +27,8 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 
+#include <stdexcept>
+
 namespace Opm {
 
 template <class Scalar, bool enableThermal>
@@ -58,6 +60,10 @@ OilPvtMultiplexer<Scalar,enableThermal>::
         delete &getRealPvt<OilPvtApproach::BrineH2>();
         break;
     }
+    case OilPvtApproach::ConstantRsDeadOil: {
+        delete &getRealPvt<OilPvtApproach::ConstantRsDeadOil>();
+        break;
+    }
     case OilPvtApproach::NoOil:
         break;
     }
@@ -80,6 +86,16 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
         setApproach(OilPvtApproach::ThermalOil);
     else if (!eclState.getTableManager().getPvcdoTable().empty())
         setApproach(OilPvtApproach::ConstantCompressibilityOil);
+    else if (eclState.getTableManager().hasTables("RSCONST")
+             && !eclState.getTableManager().getRsconstTables().empty()) {
+        if (eclState.runspec().phases().active(Phase::GAS)
+            || eclState.getSimulationConfig().hasDISGAS())
+        {
+            throw std::invalid_argument(
+                "RSCONST requires dead-oil mode with GAS and DISGAS disabled.");
+        }
+        setApproach(OilPvtApproach::ConstantRsDeadOil);
+    }
     else if (eclState.getTableManager().hasTables("PVDO"))
         setApproach(OilPvtApproach::DeadOil);
     else if (!eclState.getTableManager().getPvtoTables().empty())
@@ -145,6 +161,10 @@ setApproach(OilPvtApproach appr)
         realOilPvt_ = new BrineH2Pvt<Scalar>;
         break;
 
+    case OilPvtApproach::ConstantRsDeadOil:
+        realOilPvt_ = new ConstantRsDeadOilPvt<Scalar>;
+        break;
+
     case OilPvtApproach::NoOil:
         throw std::logic_error("Not implemented: Oil PVT of this deck!");
     }
@@ -176,6 +196,9 @@ operator=(const OilPvtMultiplexer<Scalar,enableThermal>& data)
         break;
     case OilPvtApproach::BrineH2:
         realOilPvt_ = new BrineH2Pvt<Scalar>(*static_cast<const BrineH2Pvt<Scalar>*>(data.realOilPvt_));
+        break;
+    case OilPvtApproach::ConstantRsDeadOil:
+        realOilPvt_ = new ConstantRsDeadOilPvt<Scalar>(*static_cast<const ConstantRsDeadOilPvt<Scalar>*>(data.realOilPvt_));
         break;
     default:
         break;

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -33,6 +33,7 @@
 #include <opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp>
 #include <opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp>
 #include <opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/ConstantRsDeadOilPvt.hpp>
 
 namespace Opm {
 
@@ -71,6 +72,11 @@ class Schedule;
         codeToCall;                                                               \
         __VA_ARGS__;                                                              \
     }                                                                             \
+    case OilPvtApproach::ConstantRsDeadOil: {                                     \
+        auto& pvtImpl = getRealPvt<OilPvtApproach::ConstantRsDeadOil>();          \
+        codeToCall;                                                               \
+        __VA_ARGS__;                                                              \
+    }                                                                             \
     default:                                                                      \
     case OilPvtApproach::NoOil:                                                   \
         throw std::logic_error("Not implemented: Oil PVT of this deck!");         \
@@ -83,7 +89,8 @@ enum class OilPvtApproach {
     ConstantCompressibilityOil,
     ThermalOil,
     BrineCo2,
-    BrineH2
+    BrineH2,
+    ConstantRsDeadOil
 };
 
 /*!
@@ -348,6 +355,20 @@ public:
     {
         assert(approach() == approachV);
         return *static_cast<const BrineH2Pvt<Scalar>* >(realOilPvt_);
+    }
+
+    template <OilPvtApproach approachV>
+    typename std::enable_if<approachV == OilPvtApproach::ConstantRsDeadOil, ConstantRsDeadOilPvt<Scalar> >::type& getRealPvt()
+    {
+        assert(approach() == approachV);
+        return *static_cast<ConstantRsDeadOilPvt<Scalar>* >(realOilPvt_);
+    }
+
+    template <OilPvtApproach approachV>
+    typename std::enable_if<approachV == OilPvtApproach::ConstantRsDeadOil, const ConstantRsDeadOilPvt<Scalar> >::type& getRealPvt() const
+    {
+        assert(approach() == approachV);
+        return *static_cast<const ConstantRsDeadOilPvt<Scalar>* >(realOilPvt_);
     }
 
     OilPvtMultiplexer<Scalar,enableThermal>&

--- a/tests/material/test_eclblackoilpvt.cpp
+++ b/tests/material/test_eclblackoilpvt.cpp
@@ -53,6 +53,7 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Python/Python.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Units/Units.hpp>
 
 #include <tuple>
 
@@ -133,6 +134,48 @@ static constexpr const char* deckString1 =
     "              1.1e-3       2.25    2.015 /\n"
     "/\n"
     "\n";
+
+static Opm::Deck makeRSCONSTDeck(const std::string& rsconstRecord,
+                                 const std::string& extraRunspec = "")
+{
+    return Opm::Parser{}.parseString(
+        "RUNSPEC\n"
+        "DIMENS\n"
+        "  1 1 1 /\n"
+        "TABDIMS\n"
+        "  1 /\n"
+        "OIL\n"
+        "WATER\n"
+        + extraRunspec +
+        "METRIC\n"
+        "GRID\n"
+        "DX\n"
+        "  100 /\n"
+        "DY\n"
+        "  100 /\n"
+        "DZ\n"
+        "  10 /\n"
+        "TOPS\n"
+        "  1000 /\n"
+        "PORO\n"
+        "  0.2 /\n"
+        "PERMX\n"
+        "  100 /\n"
+        "PERMY\n"
+        "  100 /\n"
+        "PERMZ\n"
+        "  20 /\n"
+        "PROPS\n"
+        "DENSITY\n"
+        "  800 1000 1 /\n"
+        "PVDO\n"
+        "  100 1.1 2\n"
+        "  200 1.0 2 /\n"
+        "RSCONST\n"
+        "  " + rsconstRecord + " /\n"
+        "SCHEDULE\n"
+        "END\n");
+}
 
 template <class Evaluation, class OilPvt, class GasPvt, class WaterPvt>
 void ensurePvtApi(const OilPvt& oilPvt, const GasPvt& gasPvt, const WaterPvt& waterPvt)
@@ -286,6 +329,81 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ConstantCompressibilityWater, Scalar, Types)
     BOOST_CHECK_MESSAGE(std::abs(tmp - refTmp) <= tolerance,
                         "The reference water viscosity at region 1 is supposed to be " <<
                         refTmp << ". (is " << tmp << ")");
+}
+
+BOOST_AUTO_TEST_CASE(RSCONST_RequiresDeadOilMode)
+{
+    const auto deck2 = makeRSCONSTDeck("0.37 101.5", "GAS\nDISGAS\n");
+    const Opm::EclipseState eclState2(deck2);
+    const Opm::Schedule schedule2(deck2, eclState2, std::make_shared<Opm::Python>());
+
+    Opm::OilPvtMultiplexer<double> oilPvt;
+    BOOST_CHECK_THROW(oilPvt.initFromState(eclState2, schedule2), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(RSCONST_UsesConstantRsAcrossPressure)
+{
+    const auto deck2 = makeRSCONSTDeck("0.37 101.5");
+    const Opm::EclipseState eclState2(deck2);
+    const Opm::Schedule schedule2(deck2, eclState2, std::make_shared<Opm::Python>());
+
+    Opm::OilPvtMultiplexer<double> oilPvt;
+    oilPvt.initFromState(eclState2, schedule2);
+
+    // Bubble point is 101.5 barsa = 101.5e5 Pa, so use pressures above this
+    const auto rsAtBubble = oilPvt.saturatedGasDissolutionFactor(0, 300.0, 101.5e5);
+    const auto rsHighP = oilPvt.saturatedGasDissolutionFactor(0, 300.0, 5.0e7);
+
+    BOOST_CHECK_CLOSE(rsAtBubble, 0.37, 1e-12);
+    BOOST_CHECK_CLOSE(rsHighP, 0.37, 1e-12);
+}
+
+BOOST_AUTO_TEST_CASE(RSCONST_BubblePointMappedToSaturationPressure)
+{
+    const auto deck2 = makeRSCONSTDeck("0.37 101.5");
+    const Opm::EclipseState eclState2(deck2);
+    const Opm::Schedule schedule2(deck2, eclState2, std::make_shared<Opm::Python>());
+
+    Opm::OilPvtMultiplexer<double> oilPvt;
+    oilPvt.initFromState(eclState2, schedule2);
+
+    const auto pb1 = oilPvt.saturationPressure(0, 300.0, 0.1);
+    const auto pb2 = oilPvt.saturationPressure(0, 300.0, 0.6);
+
+    BOOST_CHECK_CLOSE(pb1, 101.5 * Opm::unit::barsa, 1e-8);
+    BOOST_CHECK_CLOSE(pb2, 101.5 * Opm::unit::barsa, 1e-8);
+}
+
+BOOST_AUTO_TEST_CASE(RSCONST_ThrowsBelowBubblePoint)
+{
+    const auto deck2 = makeRSCONSTDeck("0.37 101.5");
+    const Opm::EclipseState eclState2(deck2);
+    const Opm::Schedule schedule2(deck2, eclState2, std::make_shared<Opm::Python>());
+
+    Opm::OilPvtMultiplexer<double> oilPvt;
+    oilPvt.initFromState(eclState2, schedule2);
+
+    // Bubble point from RSCONST: 101.5 barsa = 101.5e5 Pa = 10.15 MPa
+    const double bubblePointPa = 101.5e5;
+
+    // Test 1: pressure BELOW bubble point should throw NumericalProblem
+    const double pressureBelowPb = 50e5;  // 50 barsa < 101.5 barsa
+    BOOST_CHECK_THROW(
+        oilPvt.saturatedGasDissolutionFactor(0, 300.0, pressureBelowPb),
+        Opm::NumericalProblem
+    );
+
+    // Test 2: pressure AT bubble point should NOT throw
+    const double pressureAtPb = bubblePointPa;
+    BOOST_CHECK_NO_THROW(
+        oilPvt.saturatedGasDissolutionFactor(0, 300.0, pressureAtPb)
+    );
+
+    // Test 3: pressure ABOVE bubble point should NOT throw
+    const double pressureAbovePb = 200e5;  // 200 barsa > 101.5 barsa
+    BOOST_CHECK_NO_THROW(
+        oilPvt.saturatedGasDissolutionFactor(0, 300.0, pressureAbovePb)
+    );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -198,6 +198,24 @@ Opm::Deck createSingleRecordDeckWithJFuncBrokenDirection() {
     return parser.parseString(deckData);
 }
 
+Opm::Deck createDeckWithRSCONST()
+{
+    return Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+WATER
+METRIC
+
+TABDIMS
+  1 /
+
+PROPS
+RSCONST
+  0.37 101.5 /
+
+END
+)");
+}
+
 
 /// used in BOOST_CHECK_CLOSE
 static float epsilon() {
@@ -223,6 +241,24 @@ BOOST_AUTO_TEST_CASE( CreateTablesWithVd ) {
     BOOST_CHECK( tables.useEnptvd() );
 }
 
+BOOST_AUTO_TEST_CASE(CreateTablesWithRSCONST)
+{
+    const auto deck = createDeckWithRSCONST();
+    Opm::TableManager tables(deck);
+
+    const auto& rsconstTables = tables.getRsconstTables();
+    BOOST_REQUIRE_EQUAL(rsconstTables.size(), 1U);
+
+    const auto& rsCol = rsconstTables[0].getColumn(0);
+    const auto& pbCol = rsconstTables[0].getColumn(1);
+
+    BOOST_REQUIRE_EQUAL(rsCol.size(), 1U);
+    BOOST_REQUIRE_EQUAL(pbCol.size(), 1U);
+
+    BOOST_CHECK_CLOSE(rsCol[0], 0.37, epsilon());
+    BOOST_CHECK_CLOSE(pbCol[0], 101.5 * Opm::unit::barsa, 1e-8);
+}
+
 BOOST_AUTO_TEST_CASE( CreateTablesWithJFunc ) {
     auto deck = createSingleRecordDeckWithJFunc();
     Opm::TableManager tables(deck);
@@ -241,7 +277,7 @@ BOOST_AUTO_TEST_CASE( CreateTablesWithJFunc ) {
     for (size_t tab = 0; tab < swfnTab.size(); tab++) {
         const auto& t = swfnTab.getTable(tab);
 
-        //TODO uncomment BOOST_CHECK_THROW( t.getColumn("PCOW"), std::invalid_argument );
+       //TODO uncomment BOOST_CHECK_THROW( t.getColumn("PCOW"), std::invalid_argument );
 
         for (size_t c_idx = 0; c_idx < t.numColumns(); c_idx++) {
             const auto& col = t.getColumn(c_idx);
@@ -253,7 +289,7 @@ BOOST_AUTO_TEST_CASE( CreateTablesWithJFunc ) {
     }
 
     const auto& tt = swfnTab.getTable<Opm::SwfnTable>(0);
-    //TODO uncomment BOOST_CHECK_THROW(tt.getPcowColumn(), std::invalid_argument);
+    //TODO uncommentBOOST_CHECK_THROW(tt.getPcowColumn(), std::invalid_argument);
 
     const auto& col = tt.getJFuncColumn();
     for (size_t i = 0; i < col.size(); i++) {


### PR DESCRIPTION
This is some steps toward supporting RSCONST: where we have a two-phase oil water system and the oil
should be treated as dead oil! Here we use PVDO   to get the  PVT properties + Rs as a single constant scaling factor.
The keyword causes the oil density to be modified to include the "dissolved" gas, and causes the
gas flow rates to be set equal to Rs * the oil flow rate.
see https://github.com/OPM/opm-simulators/pull/6839 for the related changes in opm-simulators