### PR TITLE
enable c++ 20

### DIFF
--- a/cmake/Modules/OpmInit.cmake
+++ b/cmake/Modules/OpmInit.cmake
@@ -116,15 +116,8 @@ if (NOT USE_MPI)
   set (CMAKE_DISABLE_FIND_PACKAGE_MPI TRUE)
 endif ()
 
-# Compiler standard version needs to be requested here as prereqs is included
-# before OpmLibMain and some tests need/use CXX_STANDARD_VERSION (e.g. pybind11)
-# Languages and global compiler settings
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# We do not want language extensions enabled
 set(CMAKE_CXX_EXTENSIONS OFF)
-
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 
 option (USE_SUPERLU "Use SuperLU direct solvers for AMG (if umfpack is not found)" ON)

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -63,6 +63,9 @@ function(opm_add_target_options)
     LIBRARY_OUTPUT_DIRECTORY
       lib
   )
+
+  # Set C11 and C++-20
+  target_compile_features(${PARAM_TARGET} PUBLIC cxx_std_20 c_std_11)
 endfunction()
 
 # Various compiler extension checks


### PR DESCRIPTION
Time to move on, it's 2026 and c++-20 is now available everywhere relevant.

This enables c++-20 and moves enablement to target compile features, like modern cmake intended.

The requirement on compilers is a bit muddy, but right now, without using any c++-20 features, it's likely g++-12 and clang 14-ish is enough. But we plan to start using some features that will bump the g++ requirement to g++-14 and clang requirement to 18-ish, so consider this your heads up gents and ladies.