### PR TITLE
add support for tracy in generic build system

### DIFF
--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -23,6 +23,7 @@ include(MPIChecks)
 include(UseOpenMP)
 include(UseOptimization)
 include(UseRunPath)
+include(UseTracy)
 include(UseWarnings)
 
 # needed for Debian installation scheme
@@ -52,6 +53,9 @@ function(opm_add_target_options)
 
   # Parallel programming.
   use_openmp(TARGET ${PARAM_TARGET})
+
+  # Tracy profiler
+  use_tracy(TARGET ${PARAM_TARGET})
 
   # output binaries in 'bin' folder
   set_target_properties(${PARAM_TARGET}

--- a/cmake/Modules/UseTracy.cmake
+++ b/cmake/Modules/UseTracy.cmake
@@ -1,0 +1,17 @@
+option(USE_TRACY_PROFILER "Enable tracy profiling" OFF)
+
+if(USE_TRACY_PROFILER)
+  find_package(Tracy)
+endif()
+
+function(use_tracy)
+  cmake_parse_arguments(PARAM "" "TARGET" "" ${ARGN})
+  if(NOT PARAM_TARGET)
+    message(FATAL_ERROR "Function needs a TARGET parameter")
+  endif()
+
+  if(TARGET Tracy::TracyClient)
+    target_link_libraries(${PARAM_TARGET} PUBLIC Tracy::TracyClient)
+    target_compile_definitions(${PARAM_TARGET} PUBLIC USE_TRACY=1)
+  endif()
+endfunction()


### PR DESCRIPTION
Now it can be used in all modules, not just simulators.