### PR TITLE
fixed: do not force header-only boost in unit test

### DIFF
--- a/tests/test_PhaseUsageInfo.cpp
+++ b/tests/test_PhaseUsageInfo.cpp
@@ -23,7 +23,7 @@
  */
 
 #define BOOST_TEST_MODULE PhaseUsageInfoTest
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include "config.h"
 
 #if HAVE_ECL_INPUT


### PR DESCRIPTION
in particular this causes issues on rhel8 as the boost test version used there (1.66) does not compile as c++-20