### PR TITLE
Add Infrastructure for Dynamic Connection Level Summary Vectors

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -561,6 +561,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/test_Summary.cpp
   tests/test_SummaryNode.cpp
   tests/test_SummaryConfigNode.cpp
+  tests/test_SummaryDynamicConnectionVectors.cpp
   tests/test_Summary_Group.cpp
   tests/test_Summary_GSatProd.cpp
   tests/test_Tables.cpp

--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -58,6 +58,7 @@
 #include <iterator>
 #include <limits>
 #include <map>
+#include <memory>
 #include <regex>
 #include <set>
 #include <stdexcept>
@@ -74,6 +75,76 @@
 namespace Opm {
 
 namespace {
+
+    /// Tracks the set of connection cell global indices that have been
+    /// registered for a particular (keyword, well) pair.
+    ///
+    /// Used to deduplicate connection-level summary vectors: when the same
+    /// cell is encountered more than once while expanding a well-connection
+    /// keyword (e.g., through both current and possible-future connections),
+    /// only the first occurrence results in a new summary vector entry.
+    class ConnectionSet
+    {
+    public:
+        /// Record a connection cell global index.
+        ///
+        /// \param[in] connCell Global index of the reservoir cell that
+        ///   hosts the connection.
+        ///
+        /// \return Result of the underlying \c unordered_set insertion: a
+        ///   pair whose \c second element is \c true if \p connCell was not
+        ///   previously known and was newly inserted, or \c false if it was
+        ///   already present.  The \c first element is an iterator to the
+        ///   element in the set.
+        decltype(auto) insert(const std::size_t connCell)
+        {
+            return this->conns_.insert(connCell);
+        }
+
+    private:
+        /// Set of connection cell global indices seen so far.
+        std::unordered_set<std::size_t> conns_{};
+    };
+
+    /// Maps well names to their respective connection cell sets for a
+    /// single connection-level summary keyword.
+    ///
+    /// One instance of this class is kept per distinct connection summary
+    /// keyword name (e.g., "COPR").  It aggregates, for every well that
+    /// appears under that keyword, the global cell indices of all
+    /// connections that have already produced a summary vector entry.  This
+    /// prevents the same (keyword, well, cell) triple from generating
+    /// duplicate entries when connections are encountered via both the
+    /// current scheduled connection list and the possible-future-connections
+    /// set.
+    class KnownWellConnections
+    {
+    public:
+        /// Retrieve the connection set for a named well, creating it on
+        /// first access.
+        ///
+        /// \param[in] wellName Name of the well whose connection set is
+        ///   requested.
+        ///
+        /// \return Reference to the \c ConnectionSet that records which
+        ///   cell global indices have already been registered for
+        ///   \p wellName under the owning keyword.
+        ConnectionSet& connections(const std::string& wellName)
+        {
+            const auto& [wellPos, inserted] =
+                this->wellConns_.try_emplace(wellName);
+
+            if (inserted) {
+                wellPos->second = std::make_unique<ConnectionSet>();
+            }
+
+            return *wellPos->second;
+        }
+
+    private:
+        /// Per-well connection cell sets, keyed by well name.
+        std::unordered_map<std::string, std::unique_ptr<ConnectionSet>> wellConns_;
+    };
 
     /// Callback type: given a grid identifier, returns the grid's dimensions.
     ///
@@ -136,6 +207,25 @@ namespace {
             this->regSets_
                 .emplace_back(this->declaredMaxRegID_)
                 .summariseContents(regIDs);
+        }
+
+        /// Retrieve the well-connection tracker for a named connection
+        /// summary keyword, creating it on first access.
+        ///
+        /// Each distinct connection-level keyword (e.g., "COPR") maintains
+        /// its own \c KnownWellConnections instance so that deduplication of
+        /// connection cell global indices is scoped to that keyword.
+        ///
+        /// \param[in] connVector Name of the connection summary keyword
+        ///   (e.g., the result of \code DeckKeyword::name() \endcode).
+        ///
+        /// \return Reference to the \c KnownWellConnections object
+        ///   associated with \p connVector.  A new, empty object is
+        ///   inserted and returned if \p connVector has not been seen
+        ///   before.
+        KnownWellConnections& wellConnsForConnVector(const std::string& connVector)
+        {
+            return this->uniqueConnVectors_.try_emplace(connVector).first->second;
         }
 
         /// Retrieve maximum supported region ID in named region set.
@@ -214,6 +304,10 @@ namespace {
 
         /// Currently known region sets.
         std::vector<RegSet> regSets_{};
+
+        /// Currently known connection vectors and their associated
+        /// well/connection IDs.
+        std::unordered_map<std::string, KnownWellConnections> uniqueConnVectors_{};
     };
 
     void SummaryConfigContext::RegSet::summariseContents(const std::vector<int>& regIDs)
@@ -1456,17 +1550,38 @@ void keywordMISC(SummaryConfig::keyword_list& list,
     keywordMISC(list, keyword.name(), keyword.location());
 }
 
-void handleConnectionCell(const std::size_t            connCell,
+void handleConnectionCell(const bool                   isGeomechWithFracturingRun,
+                          const std::size_t            connCell,
                           SummaryConfigNode&           param,
-                          SummaryConfig::keyword_list& list)
+                          ConnectionSet&               knownConns,
+                          SummaryConfig::keyword_list& list,
+                          SummaryConfig::keyword_list& extraFracturingVectors)
 {
-    list.push_back(param.number(static_cast<int>(connCell) + 1));
+    const auto& [global_index_position, inserted] = knownConns.insert(connCell);
+
+    if (! inserted) {
+        return;
+    }
+
+    // New vector identified.
+    list.push_back(param.number(static_cast<int>(*global_index_position) + 1));
+
+    if (isGeomechWithFracturingRun) {
+        constexpr auto NumExtraAllocatedGeomechConns = std::size_t{20};
+
+        extraFracturingVectors.insert(extraFracturingVectors.end(),
+                                      NumExtraAllocatedGeomechConns,
+                                      param.number(-1));
+    }
 }
 
-void connKeywordDefaultedConns(const SummaryConfigNode&        param0,
+void connKeywordDefaultedConns(const bool                      isGeomechWithFracturingRun,
+                               const SummaryConfigNode&        param0,
                                const Schedule&                 schedule,
                                const std::vector<std::string>& wellNames,
-                               SummaryConfig::keyword_list&    list)
+                               KnownWellConnections&           keywordWellConns,
+                               SummaryConfig::keyword_list&    list,
+                               SummaryConfig::keyword_list&    extraFracturingVectors)
 {
     auto param = param0;
 
@@ -1475,20 +1590,23 @@ void connKeywordDefaultedConns(const SummaryConfigNode&        param0,
     for (const auto& wellName : wellNames) {
         param.namedEntity(wellName);
 
+        auto& knownConns = keywordWellConns.connections(wellName);
+
         if (auto wellPos = possibleFutureConns.find(wellName);
             wellPos != possibleFutureConns.end())
         {
             std::ranges::for_each(wellPos->second,
-                                  [&param, &list]
+                                  [isGeomechWithFracturingRun, &knownConns, &param, &list, &extraFracturingVectors]
                                   (const int global_index)
-                                  { handleConnectionCell(global_index, param, list); });
+                                  { handleConnectionCell(isGeomechWithFracturingRun, global_index, param,
+                                                         knownConns, list, extraFracturingVectors); });
         }
 
-        const auto& connections = schedule.getWellatEnd(wellName).getConnections();
-        std::ranges::for_each(connections,
-                              [&param, &list]
+        std::ranges::for_each(schedule.getWellatEnd(wellName).getConnections(),
+                              [isGeomechWithFracturingRun, &knownConns, &param, &list, &extraFracturingVectors]
                               (const Connection& conn)
-                              { handleConnectionCell(conn.global_index(), param, list); });
+                              { handleConnectionCell(isGeomechWithFracturingRun, conn.global_index(), param,
+                                                     knownConns, list, extraFracturingVectors); });
     }
 }
 
@@ -1496,9 +1614,16 @@ void connKeywordSpecifiedConn(const SummaryConfigNode&        param0,
                               const int                       global_index,
                               const Schedule&                 schedule,
                               const std::vector<std::string>& wellNames,
+                              KnownWellConnections&           keywordWellConns,
                               SummaryConfig::keyword_list&    list)
 {
     auto param = param0;
+
+    // We're processing a vector pertaining to a specific connection cell.
+    // No need to allocate space for extra connections that might result
+    // from fracturing processes.
+    const auto isGeomechWithFracturingRun = false;
+    auto extraFracturingVectors = SummaryConfig::keyword_list{};
 
     const auto& possibleFutureConns = schedule.getPossibleFutureConnections();
 
@@ -1511,7 +1636,9 @@ void connKeywordSpecifiedConn(const SummaryConfigNode&        param0,
         {
             param.namedEntity(wellName);
 
-            handleConnectionCell(global_index, param, list);
+            handleConnectionCell(isGeomechWithFracturingRun, global_index, param,
+                                 keywordWellConns.connections(wellName),
+                                 list, extraFracturingVectors);
         }
     }
 }
@@ -1571,12 +1698,15 @@ void keywordLC(SummaryConfig::keyword_list& list,
     }
 }
 
-void connectionKeyword(const DeckKeyword&           keyword,
+void connectionKeyword(const bool                   isGeomechWithFracturingRun,
+                       const DeckKeyword&           keyword,
                        const Schedule&              schedule,
                        const CellIndexMapper&       gridDims,
                        const ParseContext&          parseContext,
                        ErrorGuard&                  errors,
-                       SummaryConfig::keyword_list& list)
+                       SummaryConfigContext&        context,
+                       SummaryConfig::keyword_list& list,
+                       SummaryConfig::keyword_list& extraFracturingVectors)
 {
     if (is_connection_completion(keyword.name())) {
         keywordCL(list, parseContext, errors,
@@ -1584,6 +1714,8 @@ void connectionKeyword(const DeckKeyword&           keyword,
 
         return;
     }
+
+    auto& uniqueVectors = context.wellConnsForConnVector(keyword.name());
 
     auto param = SummaryConfigNode {
         keyword.name(), SummaryConfigNode::Category::Connection, keyword.location()
@@ -1605,24 +1737,27 @@ void connectionKeyword(const DeckKeyword&           keyword,
 
         if (record.getItem(1).defaultApplied(0)) {
             // (I,J,K) coordinate tuple defaulted.  Match all connections.
-            connKeywordDefaultedConns(param, schedule, well_names, list);
+            connKeywordDefaultedConns(isGeomechWithFracturingRun, param, schedule, well_names,
+                                      uniqueVectors, list, extraFracturingVectors);
         }
         else {
             // (I,J,K) coordinate specified.  Match that connection for all
             // matching wells.
             const auto ijk = getijk(record);
-            const auto globalDims = gridDims("");
-            const auto ci = static_cast<std::size_t>(ijk[0]);
-            const auto cj = static_cast<std::size_t>(ijk[1]);
-            const auto ck = static_cast<std::size_t>(ijk[2]);
+            const auto ci  = static_cast<std::size_t>(ijk[0]);
+            const auto cj  = static_cast<std::size_t>(ijk[1]);
+            const auto ck  = static_cast<std::size_t>(ijk[2]);
 
-            if (globalDims.getNX() > 0 &&
-                ci < globalDims.getNX() &&
-                cj < globalDims.getNY() &&
-                ck < globalDims.getNZ()) {
+            const auto globalDims = gridDims("");
+
+            if ((globalDims.getNX() > 0)  &&
+                (ci < globalDims.getNX()) &&
+                (cj < globalDims.getNY()) &&
+                (ck < globalDims.getNZ()))
+            {
                 connKeywordSpecifiedConn(param,
                                          globalDims.getGlobalIndex(ci, cj, ck),
-                                         schedule, well_names, list);
+                                         schedule, well_names, uniqueVectors, list);
             }
         }
     }
@@ -1853,6 +1988,7 @@ void handleKW(const std::vector<std::string>& node_names,
               const std::vector<std::string>& node_names_with_wells,
               const std::vector<int>&         analyticAquiferIDs,
               const std::vector<int>&         numericAquiferIDs,
+              const bool                      isGeomechWithFracturingRun,
               const DeckKeyword&              keyword,
               const Schedule&                 schedule,
               const FieldPropsManager&        field_props,
@@ -1861,6 +1997,7 @@ void handleKW(const std::vector<std::string>& node_names,
               ErrorGuard&                     errors,
               SummaryConfigContext&           context,
               SummaryConfig::keyword_list&    list,
+              SummaryConfig::keyword_list&    extraFracturingVectors,
               const bool                      excludeFieldFromGroupKw = true)
 {
     using Cat = SummaryConfigNode::Category;
@@ -1870,14 +2007,16 @@ void handleKW(const std::vector<std::string>& node_names,
     const auto cat = parseKeywordCategory(keyword.name());
     switch (cat) {
     case Cat::Well:
-        if (keyword.name()[0] == 'L') {
+        if (keyword.name().front() == 'L') {
             keywordLW(list, parseContext, errors, keyword, schedule);
-        } else {
+        }
+        else {
             if (is_well_comp(keyword.name())) {
                 OpmLog::warning(OpmInputError::format("Unhandled summary keyword {keyword}\n"
                                                       "In {file} line {line}", keyword.location()));
                 return;
             }
+
             keywordW(list, parseContext, errors, keyword, schedule);
         }
         break;
@@ -1905,12 +2044,13 @@ void handleKW(const std::vector<std::string>& node_names,
         break;
 
     case Cat::Connection:
-        if (keyword.name()[0] == 'L') {
+        if (keyword.name().front() == 'L') {
             keywordLC(list, parseContext, errors, keyword, schedule, gridDims);
         }
         else {
-            connectionKeyword(keyword, schedule, gridDims,
-                              parseContext, errors, list);
+            connectionKeyword(isGeomechWithFracturingRun, keyword, schedule, gridDims,
+                              parseContext, errors, context,
+                              list, extraFracturingVectors);
         }
         break;
 
@@ -2289,15 +2429,22 @@ SummaryConfig::SummaryConfig(const Deck&              deck,
 
         const auto analyticAquifers = analyticAquiferIDs(aquiferConfig);
         const auto numericAquifers = numericAquiferIDs(aquiferConfig);
+        const auto isGeomechWithFracturingRun = [rspec = Runspec { deck }]()
+        {
+            return rspec.mech() && rspec.frac();
+        }();
 
         for (const auto& kw : section) {
             if (is_processing_instruction(kw.name())) {
                 handleProcessingInstruction(kw.name());
             }
             else {
-                handleKW(node_names, node_names_with_wells, analyticAquifers, numericAquifers,
+                handleKW(node_names, node_names_with_wells,
+                         analyticAquifers, numericAquifers,
+                         isGeomechWithFracturingRun,
                          kw, schedule, field_props, gridDims,
-                         parseContext, errors, context, this->m_keywords);
+                         parseContext, errors, context,
+                         this->m_keywords, this->extraFracturingVectors_);
             }
         }
 
@@ -2383,8 +2530,10 @@ SummaryConfig::SummaryConfig(const keyword_list&          keywords,
 
 SummaryConfig SummaryConfig::serializationTestObject()
 {
-    SummaryConfig result;
-    result.m_keywords = {SummaryConfigNode::serializationTestObject()};
+    SummaryConfig result{};
+
+    result.m_keywords = { SummaryConfigNode::serializationTestObject() };
+    result.extraFracturingVectors_ = { SummaryConfigNode::serializationTestObject() };
     result.short_keywords = {"test1"};
     result.summary_keywords = {"test2"};
     result.noSumLgr_ = true;
@@ -2398,20 +2547,52 @@ SummaryConfig& SummaryConfig::merge(const SummaryConfig& other)
                             other.m_keywords.begin(),
                             other.m_keywords.end());
 
+    this->extraFracturingVectors_.insert(this->extraFracturingVectors_.end(),
+                                         other.extraFracturingVectors_.begin(),
+                                         other.extraFracturingVectors_.end());
+
     uniq(this->m_keywords);
+
+    // Note: We *intentionally* don't call uniq(extraFracturingVectors_)
+    // here.  All extra fracturing vectors have .number == -1 and would
+    // collapse down to a single node for each distinct vector in uniq().
+    // That defeats the purpose of preallocating a set of partially complete
+    // nodes for subsequent dynamic use.  Instead we disgruntlingly accept
+    // that merge() will (typically) expand the set of preallocated nodes
+    // for this purpose.
 
     return *this;
 }
 
 SummaryConfig& SummaryConfig::merge(SummaryConfig&& other)
 {
-    auto fst = std::make_move_iterator(other.m_keywords.begin());
-    auto lst = std::make_move_iterator(other.m_keywords.end());
-    this->m_keywords.insert(this->m_keywords.end(), fst, lst);
+    {
+        auto fst = std::make_move_iterator(other.m_keywords.begin());
+        auto lst = std::make_move_iterator(other.m_keywords.end());
 
-    other.m_keywords.clear();
+        this->m_keywords.insert(this->m_keywords.end(), fst, lst);
+
+        other.m_keywords.clear();
+    }
+
+    {
+        auto fst = std::make_move_iterator(other.extraFracturingVectors_.begin());
+        auto lst = std::make_move_iterator(other.extraFracturingVectors_.end());
+
+        this->extraFracturingVectors_.insert(this->extraFracturingVectors_.end(), fst, lst);
+
+        other.extraFracturingVectors_.clear();
+    }
 
     uniq(this->m_keywords);
+
+    // Note: We *intentionally* don't call uniq(extraFracturingVectors_)
+    // here.  All extra fracturing vectors have .number == -1 and would
+    // collapse down to a single node for each distinct vector in uniq().
+    // That defeats the purpose of preallocating a set of partially complete
+    // nodes for subsequent dynamic use.  Instead we disgruntlingly accept
+    // that merge() will (typically) expand the set of preallocated nodes
+    // for this purpose.
 
     return *this;
 }
@@ -2455,6 +2636,13 @@ SummaryConfig::registerRequisiteUDQorActionSummaryKeys(const std::vector<std::st
         const auto analyticAquifers = analyticAquiferIDs(es.aquifer());
         const auto numericAquifers = numericAquiferIDs(es.aquifer());
 
+        // For all we know, we're in a geomechanical run.  However, for
+        // this particular aspect of configuring summary vectors we can
+        // ignore that additional complexity.
+        const auto isGeomechWithFracturingRun = false;
+
+        auto extraFracturing = keyword_list{};
+
         const auto parseCtx = ParseContext { InputErrorAction::IGNORE };
         auto errors = ErrorGuard {};
 
@@ -2463,12 +2651,15 @@ SummaryConfig::registerRequisiteUDQorActionSummaryKeys(const std::vector<std::st
         };
 
         for (const auto& vector_name : extraKeys) {
-            handleKW(node_names, node_names_with_wells, analyticAquifers, numericAquifers,
+            handleKW(node_names, node_names_with_wells,
+                     analyticAquifers, numericAquifers,
+                     isGeomechWithFracturingRun,
                      DeckKeyword { KeywordLocation{}, vector_name },
                      sched, es.globalFieldProps(),
                      makeGlobalCellIndexMapper(es.gridDims()),
                      parseCtx, errors,
                      ctxt, candidateSummaryNodes,
+                     extraFracturing,
                      excludeFieldFromGroupKw);
         }
     }
@@ -2627,10 +2818,11 @@ std::set<std::string> SummaryConfig::fip_regions_interreg_flow() const
 
 bool SummaryConfig::operator==(const Opm::SummaryConfig& data) const
 {
-    return (this->m_keywords      == data.m_keywords)
-        && (this->short_keywords   == data.short_keywords)
-        && (this->summary_keywords == data.summary_keywords)
-        && (this->noSumLgr_        == data.noSumLgr_)
+    return (this->m_keywords              == data.m_keywords)
+        && (this->extraFracturingVectors_ == data.extraFracturingVectors_)
+        && (this->short_keywords          == data.short_keywords)
+        && (this->summary_keywords        == data.summary_keywords)
+        && (this->noSumLgr_               == data.noSumLgr_)
         ;
 }
 

--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -462,6 +462,12 @@ namespace Opm {
         /// Number of summary vectors in current collection.
         std::size_t size() const { return this->m_keywords.size(); }
 
+        /// Partially defined summary vectors relating to fracturing processes.
+        const keyword_list& extraFracturingVectors() const
+        {
+            return this->extraFracturingVectors_;
+        }
+
         /// Incorporate other vector collection into current.
         ///
         /// \param[in] other Collection of vector definitions.
@@ -577,10 +583,11 @@ namespace Opm {
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
-            serializer(m_keywords);
-            serializer(short_keywords);
-            serializer(summary_keywords);
-            serializer(noSumLgr_);
+            serializer(this->m_keywords);
+            serializer(this->extraFracturingVectors_);
+            serializer(this->short_keywords);
+            serializer(this->summary_keywords);
+            serializer(this->noSumLgr_);
         }
 
         /// Whether or not to create a human-readable .RSM file at the end
@@ -648,6 +655,10 @@ namespace Opm {
     private:
         /// Run's configured summary vectors.
         keyword_list m_keywords{};
+
+        /// Additional and incomplete summary vectors defined for run-time
+        /// allocation in runs featuring fracturing processes.
+        keyword_list extraFracturingVectors_{};
 
         /// Summary vector names.
         ///

--- a/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
+++ b/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
@@ -20,8 +20,11 @@
 #ifndef SIMULATOR_UPDATE_HPP
 #define SIMULATOR_UPDATE_HPP
 
+#include <cstddef>
 #include <string>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 namespace Opm {
 
@@ -33,11 +36,19 @@ struct SimulatorUpdate
 {
     static SimulatorUpdate serializationTestObject()
     {
+        using namespace std::string_literals;
+
         SimulatorUpdate simulatorUpdate;
+
         simulatorUpdate.tran_update = true;
         simulatorUpdate.well_structure_changed = true;
         simulatorUpdate.affected_wells = {"test"};
         simulatorUpdate.welpi_wells.insert("I-45");
+        simulatorUpdate.new_frac_wconns.assign({
+                std::pair { "I-45"s, std::vector { std::size_t{11}, std::size_t{22}, std::size_t{33} } },
+                std::pair { "RA-MAN"s, std::vector { std::size_t{1}, std::size_t{7}, std::size_t{29} } },
+            });
+
         return simulatorUpdate;
     }
 
@@ -46,6 +57,7 @@ struct SimulatorUpdate
     {
         serializer(affected_wells);
         serializer(welpi_wells);
+        serializer(new_frac_wconns);
         serializer(tran_update);
         serializer(well_structure_changed);
     }
@@ -57,6 +69,15 @@ struct SimulatorUpdate
     /// Wells affected only by WELPI for which the simulator needs to update
     /// its internal notion of the connection transmissibility factors.
     std::unordered_set<std::string> welpi_wells{};
+
+    /// New well connections created as a result of a geomechanical
+    /// fracturing process.
+    ///
+    /// Collection of zero-based Cartesian cell IDs for each of a set of
+    /// named wells.  Passing these to the output layer enables the summary
+    /// vector engine to dynamically create new connection level summary
+    /// vectors if requested in the model input.
+    std::vector<std::pair<std::string, std::vector<std::size_t>>> new_frac_wconns{};
 
     /// Whether or not a transmissibility multiplier keyword was invoked in
     /// an ACTIONX block.
@@ -94,6 +115,10 @@ struct SimulatorUpdate
 
         this->welpi_wells.insert(otherSimUpdate.welpi_wells.begin(),
                                  otherSimUpdate.welpi_wells.end());
+
+        this->new_frac_wconns.insert(this->new_frac_wconns.end(),
+                                     otherSimUpdate.new_frac_wconns.begin(),
+                                     otherSimUpdate.new_frac_wconns.end());
     }
 
     void reset()
@@ -103,6 +128,7 @@ struct SimulatorUpdate
         this->well_structure_changed = false;
         this->affected_wells.clear();
         this->welpi_wells.clear();
+        this->new_frac_wconns.clear();
     }
 
     bool operator==(const SimulatorUpdate& that) const
@@ -111,6 +137,7 @@ struct SimulatorUpdate
             && (this->well_structure_changed == that.well_structure_changed)
             && (this->affected_wells == that.affected_wells)
             && (this->welpi_wells == that.welpi_wells)
+            && (this->new_frac_wconns == that.new_frac_wconns)
             ;
     }
 };

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1938,7 +1938,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
             auto& conns = this->snapshots[reportStep]
                 .wells.get(well).getConnections();
 
-            auto allConnsExist = true;
+            auto new_frac_wconns = std::vector<std::size_t>{};
             for (const auto& newConn : newConns) {
                 auto* existingConn = conns
                     .maybeGetFromGlobalIndex(newConn.global_index());
@@ -1953,7 +1953,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
                 else {
                     // 'newConn' does not already exist in 'conns'.  Add to
                     // collection.
-                    allConnsExist = false;
+                    new_frac_wconns.push_back(newConn.global_index());
 
                     const auto seqIndex = conns.size();
                     conns.addConnection(newConn.getI(),
@@ -1971,11 +1971,13 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
                 }
             }
 
-            if (allConnsExist) {
+            if (new_frac_wconns.empty()) {
                 sim_update.welpi_wells.insert(well);
             }
             else {
                 sim_update.well_structure_changed = true;
+                sim_update.new_frac_wconns
+                    .emplace_back(well, std::move(new_frac_wconns));
             }
         }
 

--- a/opm/io/eclipse/OutputStream.cpp
+++ b/opm/io/eclipse/OutputStream.cpp
@@ -788,6 +788,26 @@ Parameters::add(const std::string&                          keyword,
     // else: pure non-LGR run — nothing to do.
 }
 
+void
+Opm::EclIO::OutputStream::SummarySpecification::
+Parameters::setNumber(const std::size_t paramIx, const int num)
+{
+    if (paramIx >= this->nums.size()) {
+        std::ostringstream msgStr;
+
+        msgStr << "Parameter index "       << paramIx
+               << " for entity number "    << num
+               << " is out of bounds for " << this->nums.size()
+               << " registered parameter"
+               << ((this->nums.size() == 1) ? "" : "s")
+               << '.';
+
+        throw std::invalid_argument { msgStr.str() };
+    }
+
+    this->nums[paramIx] = num;
+}
+
 Opm::EclIO::OutputStream::SummarySpecification::
 SummarySpecification(const ResultSet&            rset,
                      const Formatted&            fmt,

--- a/opm/io/eclipse/OutputStream.hpp
+++ b/opm/io/eclipse/OutputStream.hpp
@@ -409,6 +409,18 @@ namespace Opm { namespace EclIO { namespace OutputStream {
                      const std::string&                          unit,
                      const std::optional<Opm::EclIO::lgr_info>& lgr);
 
+            /// Assign NUMBER value of a single summary vector.
+            ///
+            /// This is a special purpose modifier to support connection
+            /// level vectors that arise dynamically as a result of a
+            /// geomechanical fracturing process.
+            ///
+            /// \param[in] paramIx Vector index.
+            ///
+            /// \param[in] num Vector's new NUMBER value.
+            void setNumber(const std::size_t paramIx,
+                           const int         num);
+
             friend class SummarySpecification;
 
         private:

--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -21,8 +21,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "config.h"
-#include "opm/input/eclipse/EclipseState/Grid/NNC.hpp"
+#include <config.h>
 
 #include <opm/output/eclipse/EclipseIO.hpp>
 
@@ -32,6 +31,7 @@
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
@@ -70,7 +70,6 @@
 #include <optional>
 #include <sstream>
 #include <stdexcept>
-#include <unordered_map>
 #include <utility>    // move
 #include <vector>
 
@@ -343,6 +342,32 @@ public:
                       std::map<std::string, std::vector<int>> int_data,
                       const NNCCollection&                    nnc_col) const;
 
+    /// Activate pre-allocated summary vector slots for newly established
+    /// well connections arising from dynamic fracturing.
+    ///
+    /// During initialisation, a geomechanics run pre-allocates a fixed
+    /// number of placeholder output parameter slots for each well that
+    /// is configured to produce fracturing-related connection vectors.
+    /// When the simulator informs the output layer that new connections
+    /// have actually been created during the run, this function claims
+    /// those slots and assigns them to the concrete connection cell
+    /// indices supplied by the caller.
+    ///
+    /// For each (well name, connection IDs) pair in \p newConns the
+    /// function looks up the set of connection summary vectors that were
+    /// pre-allocated for that well.  For every such vector and every new
+    /// connection index it requests a new parameter slot from internal
+    /// storage so that the vector is evaluated and written from the next
+    /// time step onwards.
+    ///
+    /// \param[in] newConns Each element is a pair of
+    ///   - a well name, and
+    ///   - a list of zero-based connection cell global indices that have
+    ///     become active since the last report step as a result of
+    ///     fracturing.
+    ///   Wells that have no pre-allocated fracturing vectors are silently
+    ///   ignored.
+    void recordNewDynamicWellConns(const out::Summary::DynamicConns& newConns);
 
     /// Create summary file output.
     ///
@@ -836,6 +861,11 @@ void Opm::EclipseIO::Impl::writeInitial(std::vector<data::Solution>             
     }
 }
 
+void Opm::EclipseIO::Impl::
+recordNewDynamicWellConns(const out::Summary::DynamicConns& newConns)
+{
+    this->summary_.recordNewDynamicWellConns(newConns);
+}
 
 void Opm::EclipseIO::Impl::writeSummaryFile(const SummaryState&      st,
                                             const int                report_step,
@@ -1201,7 +1231,6 @@ void Opm::EclipseIO::writeTimeStep(const Action::State& action_state,
     this->impl->countTimeStep();
 }
 
-
 void Opm::EclipseIO::writeTimeStep(const Action::State&      action_state,
                                    const WellTestState&      wtest_state,
                                    const SummaryState&       st,
@@ -1244,6 +1273,11 @@ void Opm::EclipseIO::writeTimeStep(const Action::State&      action_state,
     this->impl->countTimeStep();
 }
 
+void Opm::EclipseIO::
+recordNewDynamicWellConns(const out::Summary::DynamicConns& newConns)
+{
+    this->impl->recordNewDynamicWellConns(newConns);
+}
 
 Opm::RestartValue
 Opm::EclipseIO::loadRestart(Action::State&                 action_state,

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -25,8 +25,11 @@
 #include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
 
 #include <opm/output/data/Solution.hpp>
-#include <opm/output/eclipse/RestartValue.hpp>
 
+#include <opm/output/eclipse/RestartValue.hpp>
+#include <opm/output/eclipse/Summary.hpp>
+
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <optional>
@@ -49,10 +52,6 @@ class WellTestState;
 namespace Opm::Action {
     class State;
 } // namespace Opm::Action
-
-namespace Opm::out {
-    class Summary;
-} // namespace Opm::out
 
 namespace Opm {
 
@@ -331,6 +330,32 @@ public:
                        std::optional<int>        time_step = std::nullopt,
                        const bool                isFinalWriteOut = false);
 
+    /// Activate pre-allocated summary vector slots for newly established
+    /// well connections arising from dynamic fracturing.
+    ///
+    /// During initialisation, a geomechanics run pre-allocates a fixed
+    /// number of placeholder output parameter slots for each well that
+    /// is configured to produce fracturing-related connection vectors.
+    /// When the simulator informs the output layer that new connections
+    /// have actually been created during the run, this function claims
+    /// those slots and assigns them to the concrete connection cell
+    /// indices supplied by the caller.
+    ///
+    /// For each (well name, connection IDs) pair in \p newConns the
+    /// function looks up the set of connection summary vectors that were
+    /// pre-allocated for that well.  For every such vector and every new
+    /// connection index it requests a new parameter slot from internal
+    /// storage so that the vector is evaluated and written from the next
+    /// time step onwards.
+    ///
+    /// \param[in] newConns Each element is a pair of
+    ///   - a well name, and
+    ///   - a list of zero-based connection cell global indices that have
+    ///     become active since the last report step as a result of
+    ///     fracturing.
+    ///   Wells that have no pre-allocated fracturing vectors are silently
+    ///   ignored.
+    void recordNewDynamicWellConns(const out::Summary::DynamicConns& newConns);
 
     /// Load per-cell solution data and wellstate from restart file.
     ///

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -85,10 +85,13 @@
 #include <limits>
 #include <memory>
 #include <numeric>
+#include <optional>
+#include <queue>
 #include <regex>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -4332,17 +4335,29 @@ namespace Evaluator {
                             Opm::SummaryState&      st) const = 0;
     };
 
+    bool useNumber(Opm::EclIO::SummaryNode::Category cat)
+    {
+        using Cat = Opm::EclIO::SummaryNode::Category;
+
+        return ! ((cat == Cat::Well) ||
+                  (cat == Cat::Group) ||
+                  (cat == Cat::Field) ||
+                  (cat == Cat::Node) ||
+                  (cat == Cat::Miscellaneous));
+    }
+
     class FunctionRelation : public Base
     {
     public:
+        enum class State { Complete, Deferred };
+
         explicit FunctionRelation(Opm::EclIO::SummaryNode node, ofun fcn)
-            : node_(std::move(node))
-            , fcn_ (std::move(fcn))
-        {
-            if (this->use_number()) {
-                this->number_ = std::max(0, this->node_.number);
-            }
-        }
+            : node_      (std::move(node))
+            , fcn_       (std::move(fcn))
+            , use_number_(useNumber(node_.category))
+            , state_     (use_number_ && (node_.number <= 0)
+                          ? State::Deferred : State::Complete)
+        {}
 
         void update(const std::size_t       sim_step,
                     const double            stepSize,
@@ -4350,6 +4365,10 @@ namespace Evaluator {
                     const SimulatorResults& simRes,
                     Opm::SummaryState&      st) const override
         {
+            if (! this->isComplete()) {
+                return;
+            }
+
             const auto wells = need_wells(this->node_)
                 ? find_wells(input.sched, this->node_,
                              static_cast<int>(sim_step), input.reg)
@@ -4361,7 +4380,7 @@ namespace Evaluator {
             const fn_args args {
                 wells, this->group_name(), this->node_.keyword,
                 stepSize, static_cast<int>(sim_step),
-                this->number_, this->node_.fip_region,
+                this->number(), this->node_.fip_region,
                 st,
                 simRes.wellSol, simRes.wbp, simRes.grpNwrkSol,
                 input.reg, input.grid, input.sched,
@@ -4377,10 +4396,31 @@ namespace Evaluator {
             updateValue(this->node_, usys.from_si(prm.unit, prm.value), st);
         }
 
+        void setNumber(const int numValue)
+        {
+            if (this->isComplete()) {
+                throw std::invalid_argument {
+                    "Cannot reset SMSPEC node number "
+                    "after it has been fully assigned"
+                };
+            }
+
+            if (numValue > 0) {
+                this->node_.number = numValue;
+                this->state_ = State::Complete;
+            }
+        }
+
+        std::string uniqueKey() const
+        {
+            return this->node_.unique_key();
+        }
+
     private:
         Opm::EclIO::SummaryNode node_;
         ofun                    fcn_;
-        int                     number_{0};
+        bool                    use_number_;
+        State                   state_;
 
         std::string group_name() const
         {
@@ -4397,16 +4437,16 @@ namespace Evaluator {
                 ? this->node_.wgname : def_gr_name;
         }
 
-        bool use_number() const
+        bool isComplete() const
         {
-            using Cat = ::Opm::EclIO::SummaryNode::Category;
-            const auto cat = this->node_.category;
+            return this->state_ == State::Complete;
+        }
 
-            return ! ((cat == Cat::Well) ||
-                      (cat == Cat::Group) ||
-                      (cat == Cat::Field) ||
-                      (cat == Cat::Node) ||
-                      (cat == Cat::Miscellaneous));
+        int number() const
+        {
+            return this->use_number_
+                ? this->node_.number
+                : -1;
         }
     };
 
@@ -5565,6 +5605,45 @@ std::string makeWGName(std::string name)
     return use_dflt ? std::string(":+:+:+:+") : std::move(name);
 }
 
+/// Owns SMSPEC parameter metadata and evaluator objects for summary output.
+///
+/// This helper centralises construction of summary vectors and keeps the
+/// vector metadata (\c smspec_) and runtime evaluators (\c evaluators_)
+/// index-aligned: the evaluator at index \c i computes the value for the
+/// SMSPEC parameter at index \c i.
+///
+/// It also manages a two-phase workflow for "extra" connection vectors used
+/// by dynamic fracturing:
+/// - Registration phase: \c recordExtraParameter(...) stores placeholder
+///   vectors (typically with NUMBER = -1, clamped to 0 in SMSPEC) and records
+///   their indices in \c extra_.
+/// - Activation phase: \c createExtraParameter(...) consumes one queued
+///   placeholder index, assigns the concrete connection number, and returns
+///   the corresponding SummaryState key and evaluator index.
+///
+/// The separation lets the output layer pre-allocate a bounded number of
+/// potential vectors during initialisation, then bind only the ones that are
+/// actually needed at runtime when new dynamic well connections appear.
+///
+/// \par Design Overview
+/// The class enforces one critical invariant: \c smspec_ and \c evaluators_
+/// are append-only and share identical indexing.  This keeps the runtime
+/// evaluation path simple because an evaluator index can always be reused as
+/// the SMSPEC parameter index.
+///
+/// Dynamic connection vectors are handled with an explicit reservation-and-
+/// activation protocol keyed by \c (WGNAME, keyword):
+/// - Reservation records indices in \c extra_ before insertion, so each queue
+///   element points to a specific future slot in the aligned
+///   \c smspec_/\c evaluators_ arrays.
+/// - Activation consumes queue entries FIFO to produce deterministic binding
+///   between discovered dynamic connections and pre-allocated slots.
+/// - Activation mutates both representations of the vector identity:
+///   \c FunctionRelation::setNumber(num) for runtime key generation and
+///   \c smspec_.setNumber(ix, num) for persisted metadata.
+///
+/// This protocol deliberately avoids structural edits (erase/reorder) after
+/// initial insertion, so existing indices remain stable across the run.
 class SummaryOutputParameters
 {
 public:
@@ -5584,6 +5663,19 @@ public:
     SummaryOutputParameters&
     operator=(SummaryOutputParameters&& rhs) = default;
 
+    /// Append one summary parameter/evaluator pair.
+    ///
+    /// This is the low-level insertion primitive.  It updates \c smspec_
+    /// and \c evaluators_ in lockstep so the new parameter gets index
+    /// \c evaluators_.size() before insertion.
+    ///
+    /// \param[in] keyword Summary keyword (e.g., "WBHP").
+    /// \param[in] name    WGNAME/entity identifier associated with the
+    ///   parameter.
+    /// \param[in] num     Parameter NUMBER.  Negative values are clamped to
+    ///   zero for SMSPEC storage.
+    /// \param[in] unit    Unit string for the parameter.
+    /// \param[in] evaluator Evaluator used to compute parameter values.
     void makeParameter(std::string keyword,
                        std::string name,
                        const int   num,
@@ -5602,6 +5694,88 @@ public:
         this->evaluators_.push_back(std::move(evaluator));
     }
 
+    /// Register one "extra" parameter slot and append its evaluator.
+    ///
+    /// This is the high-level entry point for pre-allocated dynamic
+    /// connection vectors.  It first records the index that the next
+    /// parameter will get (via the private \c recordExtraParameter(keyword,
+    /// name) helper), then appends the parameter/evaluator via
+    /// \c makeParameter(...).
+    ///
+    /// The queued indices can later be claimed by \c createExtraParameter()
+    /// when concrete dynamic connection numbers become known.
+    ///
+    /// \param[in] keyword Summary keyword for the extra vector.
+    /// \param[in] name    WGNAME/entity identifier.
+    /// \param[in] num     Initial NUMBER (often a placeholder value).
+    /// \param[in] unit    Unit string for the parameter.
+    /// \param[in] evaluator Evaluator used to compute parameter values.
+    void recordExtraParameter(std::string keyword,
+                              std::string name,
+                              const int   num,
+                              std::string unit,
+                              EvalPtr     evaluator)
+    {
+        this->recordExtraParameter(keyword, name);
+
+        this->makeParameter(std::move(keyword), std::move(name),
+                            num, std::move(unit), std::move(evaluator));
+    }
+
+    /// Activate one previously registered extra parameter slot.
+    ///
+    /// Looks up the queue of pre-registered indices for (\p name, \p keyword),
+    /// takes the oldest available slot, and assigns it the concrete
+    /// connection NUMBER \p num.  Activation currently requires the evaluator
+    /// at that slot to be \c Evaluator::FunctionRelation so both the evaluator
+    /// and SMSPEC metadata can be updated consistently.
+    ///
+    /// \param[in] keyword Summary keyword identifying an extra vector family.
+    /// \param[in] name    WGNAME/entity identifier.
+    /// \param[in] num     Concrete connection NUMBER to bind to the vector.
+    ///
+    /// \return \c std::nullopt if no unclaimed slot exists for
+    ///   (\p name, \p keyword), or if the corresponding evaluator is not a
+    ///   \c FunctionRelation.  Otherwise returns
+    ///   \c {uniqueSummaryStateKey, evaluatorIndex} for the activated slot.
+    std::optional<std::pair<std::string, std::vector<EvalPtr>::size_type>>
+    createExtraParameter(const std::string& keyword,
+                         const std::string& name,
+                         const int          num)
+    {
+        const auto paramPos = this->extra_.find(VectorID { name, keyword });
+        if ((paramPos == this->extra_.end()) || paramPos->second.empty()) {
+            // No extra vectors registered for (keyword,name), or all have
+            // already been allocated/consumed.
+            return {};
+        }
+
+        const auto ix = paramPos->second.front();
+
+        // Make sure evaluators_[ix] is ineligible for future allocation,
+        // whether it's a FunctionRelation or not.
+        paramPos->second.pop();
+
+        if (auto* func = dynamic_cast<Evaluator::FunctionRelation*>(this->evaluators_[ix].get());
+            func != nullptr)
+        {
+            // evaluators_[ix] is a FunctionRelation.  This is the expected case.
+
+            // Finalise summary node for this function by recording its "NUMBER".
+            func->setNumber(num);
+            this->smspec_.setNumber(ix, num);
+
+            // Inform caller about the exact SummaryState query key it needs
+            // to use for evaluators_[ix].
+            return { std::pair { func->uniqueKey(), ix } };
+        }
+
+        // Evaluators_[ix] is not a FunctionRelation.  This is unexpected,
+        // but we can't do anything in this case.  Let the caller know this
+        // by returning nullopt.
+        return {};
+    }
+
     const SMSpecPrm& summarySpecification() const
     {
         return this->smspec_;
@@ -5613,8 +5787,24 @@ public:
     }
 
 private:
+    using VectorID = std::pair<std::string, std::string>;
+    using VectorIdxQueue = std::queue<std::vector<EvalPtr>::size_type>;
+    using ExtraVectors = std::map<VectorID, VectorIdxQueue>;
+
     SMSpecPrm smspec_{};
     std::vector<EvalPtr> evaluators_{};
+    ExtraVectors extra_{};
+
+    /// Enqueue the index of the next parameter for later extra-slot
+    /// activation.
+    ///
+    /// Must be called immediately before \c makeParameter(...) so the queued
+    /// index matches the parameter/evaluator pair that is about to be
+    /// appended.
+    void recordExtraParameter(const std::string& keyword, const std::string& name)
+    {
+        this->extra_[ VectorID { name, keyword } ].push(this->evaluators_.size());
+    }
 };
 
 class SMSpecStreamDeferredCreation
@@ -5758,6 +5948,34 @@ public:
     SummaryImplementation& operator=(const SummaryImplementation& rhs) = delete;
     SummaryImplementation& operator=(SummaryImplementation&& rhs) = default;
 
+    /// Activate pre-allocated summary vector slots for newly established
+    /// well connections arising from dynamic fracturing.
+    ///
+    /// During initialisation, a geomechanics run pre-allocates a fixed
+    /// number of placeholder output parameter slots (with connection number
+    /// -1) for each well that is configured to produce fracturing-related
+    /// connection vectors.  When the simulator informs the output layer
+    /// that new connections have actually been created during the run, this
+    /// function claims those slots and assigns them to the concrete
+    /// connection cell indices supplied by the caller.
+    ///
+    /// For each (well name, connection IDs) pair in \p newConns the
+    /// function looks up the set of connection summary vectors that were
+    /// pre-allocated for that well (via \c extraConnVectors_).  For every
+    /// such vector and every new connection index it requests a concrete
+    /// parameter slot from \c outputParameters_, then records the
+    /// resulting unique key in \c valueKeys_ so that the vector is
+    /// evaluated and written from the next time step onwards.
+    ///
+    /// \param[in] newConns Each element is a pair of
+    ///   - a well name, and
+    ///   - a list of zero-based connection cell global indices that have
+    ///     become active since the last report step as a result of
+    ///     fracturing.
+    ///   Wells that have no pre-allocated fracturing vectors are silently
+    ///   ignored.
+    void recordNewDynamicWellConns(const DynamicConns& newConns);
+
     void eval(const int                    sim_step,
               const double                 secs_elapsed,
               const DynamicSimulatorState& values,
@@ -5807,10 +6025,21 @@ private:
 
     std::unique_ptr<Opm::EclIO::ExtSmryOutput> esmry_;
 
+    /// Extra connection level summary vectors that may be needed for dynamic fracturing.
+    ///
+    /// Keyed by well name.
+    ///
+    /// In particular, extraConnVectors_[wname] is the set of summary vector keywords
+    /// (e.g., "CPR") that are configured for dynamic connection reporting for well
+    /// 'wname'.  When new connections are reported for 'wname' during the run, each
+    /// of those vectors will need to be activated for the new connections.
+    std::unordered_map<std::string, std::unordered_set<std::string>> extraConnVectors_{};
+
     void configureTimeVector(const EclipseState& es, const std::string& kw);
     void configureTimeVectors(const EclipseState& es, const SummaryConfig& sumcfg);
 
     void configureSummaryInput(const SummaryConfig& sumcfg,
+                               const bool           enableDynamicVectors,
                                Evaluator::Factory&  evaluatorFactory);
 
     void configureRequiredRestartParameters(const SummaryConfig& sumcfg,
@@ -5860,8 +6089,19 @@ SummaryImplementation(SummaryConfig&      sumcfg,
         es, grid, sched, st, sched.getUDQConfig(sched.size() - 1)
     };
 
+    const auto isGeomechWithFracturingRun =
+        es.runspec().mech() && es.runspec().frac() &&
+        !sumcfg.extraFracturingVectors().empty();
+
+    if (isGeomechWithFracturingRun && writeEsmry) {
+        OpmLog::warning("ESMRY is incompatible with MECH/FRAC. "
+                        "Request for ESMRY output ignored.");
+    }
+
     this->configureTimeVectors(es, sumcfg);
-    this->configureSummaryInput(sumcfg, evaluatorFactory);
+    this->configureSummaryInput(sumcfg,
+                                isGeomechWithFracturingRun,
+                                evaluatorFactory);
     this->configureRequiredRestartParameters(sumcfg, es.aquifer(), es.tracer(),
                                              sched, evaluatorFactory);
 
@@ -5871,20 +6111,24 @@ SummaryImplementation(SummaryConfig&      sumcfg,
                                es.globalFieldProps(),
                                grid, sched);
 
-    const auto esmryFileName = EclIO::OutputStream::
-        outputFileName(this->rset_, "ESMRY");
-
-    if (std::filesystem::exists(esmryFileName)) {
+    if (const auto esmryFileName = EclIO::OutputStream::outputFileName(this->rset_, "ESMRY");
+        std::filesystem::exists(esmryFileName))
+    {
         std::filesystem::remove(esmryFileName);
     }
 
-    if (writeEsmry && !es.cfg().io().getFMTOUT()) {
-        this->esmry_ = std::make_unique<Opm::EclIO::ExtSmryOutput>
-            (this->valueKeys_, this->valueUnits_, es, sched.posixStartTime());
-    }
-
-    if (writeEsmry && es.cfg().io().getFMTOUT()) {
-        OpmLog::warning("ESMRY only supported for unformatted output. Request ignored.");
+    if (!isGeomechWithFracturingRun && writeEsmry) {
+        if (!es.cfg().io().getFMTOUT()) {
+            // Run requests unformatted output files.  Typical case.  Create
+            // an ESMRY file writing object for this run.  Constructor takes
+            // a snapshot of the configured nodes.
+            this->esmry_ = std::make_unique<Opm::EclIO::ExtSmryOutput>
+                (this->valueKeys_, this->valueUnits_, es, sched.posixStartTime());
+        }
+        else {
+            // We don't support formatted ESMRY files.
+            OpmLog::warning("ESMRY only supported for unformatted output. Request ignored.");
+        }
     }
 }
 
@@ -5905,6 +6149,50 @@ internal_store(const SummaryState& st,
             continue;
 
         ms.params[i] = st.get(this->valueKeys_[i]);
+    }
+}
+
+void Opm::out::Summary::SummaryImplementation::
+recordNewDynamicWellConns(const DynamicConns& newConns)
+{
+    for (const auto& [wname, dynConns] : newConns) {
+        const auto extraPos = this->extraConnVectors_.find(wname);
+        if (extraPos == this->extraConnVectors_.end()) {
+            // No dynamic vectors configured for this well ('wname').
+            continue;
+        }
+
+        for (const auto& vector : extraPos->second) {
+            for (const auto& connId : dynConns) {
+                if (connId > static_cast<std::size_t>(std::numeric_limits<int>::max() - 1)) {
+                    OpmLog::warning(
+                        fmt::format("Dynamic connection cell index {} for well '{}' is too large to be represented in SMSPEC NUMBER. "
+                                    "This connection summary vector will not be written.",
+                                    connId,
+                                    wname));
+                    continue;
+                }
+
+                const auto connNumber = static_cast<int>(connId) + 1;
+                const auto param =
+                    this->outputParameters_.createExtraParameter(vector, wname, connNumber);
+
+                if (param.has_value()) {
+                    const auto& [valueKey, ix] = *param;
+
+                    this->valueKeys_[ix] = valueKey;
+                }
+                else {
+                    OpmLog::warning(
+                        fmt::format("Failed to allocate dynamic connection summary vector '{}' "
+                                    "for well '{}' at connection number {}. "
+                                    "This summary vector will not be written.",
+                                    vector,
+                                    wname,
+                                    connNumber));
+                }
+            }
+        }
     }
 }
 
@@ -5978,9 +6266,8 @@ eval(const int                    sim_step,
         evalPtr->update(sim_step, duration, input, simRes, st);
     }
 
-    for (auto& [_, evalPtr] : this->extra_parameters) {
-        (void)_;
-        evalPtr->update(sim_step, duration, input, simRes, st);
+    for (const auto& paramPair : this->extra_parameters) {
+        paramPair.second->update(sim_step, duration, input, simRes, st);
     }
 
     st.update_elapsed(duration);
@@ -6118,6 +6405,7 @@ configureTimeVectors(const EclipseState&  es,
 void
 Opm::out::Summary::SummaryImplementation::
 configureSummaryInput(const SummaryConfig& sumcfg,
+                      const bool           enableDynamicVectors,
                       Evaluator::Factory&  evaluatorFactory)
 {
     auto unsuppkw = std::vector<SummaryConfigNode>{};
@@ -6148,6 +6436,30 @@ configureSummaryInput(const SummaryConfig& sumcfg,
                            std::move(prmDescr.unit),
                            std::move(prmDescr.evaluator),
                            std::move(lgr));
+    }
+
+    if (enableDynamicVectors) {
+        for (const auto& fracturingVector : sumcfg.extraFracturingVectors()) {
+            auto prmDescr = evaluatorFactory.create(fracturingVector);
+
+            if (! prmDescr.evaluator) {
+                unsuppkw.push_back(fracturingVector);
+                continue;
+            }
+
+            this->valueKeys_.push_back(std::move(prmDescr.uniquekey));
+            this->valueUnits_.push_back(prmDescr.unit);
+
+            const auto name = makeWGName(fracturingVector.namedEntity());
+
+            this->outputParameters_
+                .recordExtraParameter(fracturingVector.keyword(), name,
+                                      fracturingVector.number(), // Expected to be '-1'.
+                                      std::move(prmDescr.unit),
+                                      std::move(prmDescr.evaluator));
+
+            this->extraConnVectors_[name].insert(fracturingVector.keyword());
+        }
     }
 
     if (! unsuppkw.empty()) {
@@ -6431,6 +6743,11 @@ Summary::Summary(SummaryConfig&       sumcfg,
                  const bool           writeEsmry)
     : pImpl_ { std::make_unique<SummaryImplementation>(sumcfg, es, grid, sched, basename, writeEsmry) }
 {}
+
+void Summary::recordNewDynamicWellConns(const DynamicConns& newConns)
+{
+    this->pImpl_->recordNewDynamicWellConns(newConns);
+}
 
 void Summary::eval(const int                    report_step,
                    const double                 secs_elapsed,

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -175,6 +175,15 @@ public:
         const LgrBlockValues* lgr_block_values {nullptr};
     };
 
+    /// Set of well connections that have been created during the simulation run.
+    ///
+    /// This is only relevant for geomechanics runs with dynamic fracturing.
+    /// A set of connections is identified by a well name and a vector of
+    /// connection IDs.  The output layer needs to know about these
+    /// connections because it needs to activate the corresponding summary
+    /// vector slots for newly established connections.
+    using DynamicConns = std::vector<std::pair<std::string, std::vector<std::size_t>>>;
+
     /// Constructor
     ///
     /// \param[in,out] sumcfg On input, the full collection of summary
@@ -235,6 +244,33 @@ public:
                       const int           report_step,
                       const int           ministep_id,
                       const bool          isSubstep);
+
+    /// Activate pre-allocated summary vector slots for newly established
+    /// well connections arising from dynamic fracturing.
+    ///
+    /// During initialisation, a geomechanics run pre-allocates a fixed
+    /// number of placeholder output parameter slots for each well that
+    /// is configured to produce fracturing-related connection vectors.
+    /// When the simulator informs the output layer that new connections
+    /// have actually been created during the run, this function claims
+    /// those slots and assigns them to the concrete connection cell
+    /// indices supplied by the caller.
+    ///
+    /// For each (well name, connection IDs) pair in \p newConns the
+    /// function looks up the set of connection summary vectors that were
+    /// pre-allocated for that well.  For every such vector and every new
+    /// connection index it requests a new parameter slot from internal
+    /// storage so that the vector is evaluated and written from the next
+    /// time step onwards.
+    ///
+    /// \param[in] newConns Each element is a pair of
+    ///   - a well name, and
+    ///   - a list of zero-based connection cell global indices that have
+    ///     become active since the last report step as a result of
+    ///     fracturing.
+    ///   Wells that have no pre-allocated fracturing vectors are silently
+    ///   ignored.
+    void recordNewDynamicWellConns(const DynamicConns& newConns);
 
     /// Calculate summary vector values.
     ///

--- a/tests/test_SummaryDynamicConnectionVectors.cpp
+++ b/tests/test_SummaryDynamicConnectionVectors.cpp
@@ -1,0 +1,376 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE Summary_Dynamic_Connection_Vectors
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/output/data/Wells.hpp>
+#include <opm/output/eclipse/Summary.hpp>
+
+#include <opm/io/eclipse/ESmry.hpp>
+
+#include <opm/common/utility/TimeService.hpp>
+
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+#include <opm/input/eclipse/Python/Python.hpp>
+
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/SummaryState.hpp>
+
+#include <opm/input/eclipse/Units/Units.hpp>
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <tests/WorkArea.hpp>
+
+#include <cctype>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+
+using namespace Opm;
+using rt = data::Rates::opt;
+
+namespace {
+
+double sm3_pr_day()
+{
+    return unit::cubic(unit::meter) / unit::day;
+}
+
+double cp_rm3_per_db()
+{
+    return prefix::centi * unit::Poise * unit::cubic(unit::meter)
+        / (unit::day * unit::barsa);
+}
+
+double operator ""_degC(long double t)
+{
+    return UnitSystem{}
+        .to_si(UnitSystem::measure::temperature, static_cast<double>(t));
+}
+
+std::string toUpper(std::string input)
+{
+    for (auto& c : input) {
+        const auto uc = std::toupper(static_cast<unsigned char>(c));
+        c = static_cast<std::string::value_type>(uc);
+    }
+
+    return input;
+}
+
+std::string makeDeck(const bool geomech)
+{
+    const auto mech = geomech ? std::string{"MECH\nFRAC\n"} : std::string{};
+
+    return std::string { R"(RUNSPEC
+DIMENS
+ 4 1 1 /
+OIL
+GAS
+WATER
+)" } + mech + std::string { R"(TABDIMS
+/
+GRID
+DXV
+ 4*100 /
+DYV
+ 100 /
+DZV
+ 10 /
+TOPS
+ 4*2000 /
+EQUALS
+  PORO 0.30 /
+  PERMX 100 /
+  PERMY 100 /
+  PERMZ 10 /
+/
+PROPS
+DENSITY
+  800 1000 1.05 /
+SUMMARY
+CTFAC
+  W_3 /
+/
+CWIRFRAC
+  W_3 /
+/
+CFCFFVIR
+  W_3 /
+/
+CFCFVIR
+  W_3 /
+/
+SCHEDULE
+WELSPECS
+  'W_3' 'FIELD' 3 1 1* 'WATER' 7* /
+/
+COMPDAT
+  W_3 0 0 1 1 2* 1* 2* 0.7 /
+/
+WCONINJH
+  W_3 WATER OPEN 30.0 2.1 2.2 /
+/
+TSTEP
+ 2*1 /
+END
+)" };
+}
+
+data::Wells makeWells(const bool includeDynamicConn)
+{
+    auto wells = data::Wells {};
+
+    data::Rates wellRates{};
+    wellRates.set(rt::wat, 30.0 / unit::day)
+             .set(rt::oil,  0.0 / unit::day)
+             .set(rt::gas,  0.0 / unit::day);
+
+    data::Rates connRates{};
+    connRates.set(rt::wat, 30.0 / unit::day)
+             .set(rt::wat_frac, 0.618 / unit::day);
+
+    const auto baseFiltrate = data::ConnectionFiltrate {
+        .rate = 0.1 * sm3_pr_day(),
+        .total = 1.0 * unit::cubic(unit::meter),
+        .skin_factor = 1.0,
+        .thickness = 0.01 * unit::meter,
+        .perm = 1.0 * prefix::milli * unit::darcy,
+        .poro = 0.2,
+        .radius = 0.05 * unit::meter,
+        .area_of_flow = 10.0 * unit::square(unit::meter),
+        .flow_factor = 0.75,
+        .fracture_rate = 0.025 * sm3_pr_day()
+    };
+
+    const auto dynamicFiltrate = data::ConnectionFiltrate {
+        .rate = 0.2 * sm3_pr_day(),
+        .total = 1.0 * unit::cubic(unit::meter),
+        .skin_factor = 1.0,
+        .thickness = 0.01 * unit::meter,
+        .perm = 1.0 * prefix::milli * unit::darcy,
+        .poro = 0.2,
+        .radius = 0.05 * unit::meter,
+        .area_of_flow = 10.0 * unit::square(unit::meter),
+        .flow_factor = 0.75,
+        .fracture_rate = 0.05 * sm3_pr_day()
+    };
+
+    auto baseConn = data::Connection {
+        .index = 2,
+        .rates = connRates,
+        .pressure = 1.0 * unit::barsa,
+        .reservoir_rate = 100.0 * sm3_pr_day(),
+        .cell_pressure = 100.0,
+        .cell_saturation_water = 0.2,
+        .cell_saturation_gas = 0.1,
+        .effective_Kh = 10.0,
+        .trans_factor = 444.555 * cp_rm3_per_db(),
+        .d_factor = 0.0,
+        .compact_mult = 1.0,
+        .lgr_grid = 0,
+        .filtrate = baseFiltrate
+    };
+
+    auto dynamicConn = baseConn;
+    dynamicConn.index = 3; // (4,1,1) in a 4x1x1 grid
+    dynamicConn.trans_factor = 654.321 * cp_rm3_per_db();
+    dynamicConn.filtrate = dynamicFiltrate;
+
+    auto well = data::Well {
+        .rates = wellRates,
+        .bhp = 2.1 * unit::barsa,
+        .thp = 2.2 * unit::barsa,
+        .temperature = 10.11_degC,
+        .control = 3,
+        .efficiency_scaling_factor = 1.0,
+        .filtrate = {},
+        .dynamicStatus = ::Opm::Well::Status::OPEN,
+        .connections = { baseConn },
+        .segments = {},
+        .current_control = data::CurrentControl {},
+        .guide_rates = data::GuideRateValue {},
+        .limits = data::WellControlLimits {}
+    };
+
+    if (includeDynamicConn) {
+        well.connections.push_back(dynamicConn);
+    }
+
+    well.current_control.isProducer = false;
+    well.current_control.inj = ::Opm::Well::InjectorCMode::BHP;
+
+    wells.insert_or_assign("W_3", std::move(well));
+
+    return wells;
+}
+
+struct Setup
+{
+    explicit Setup(std::string caseName, const bool geomech)
+        : deck     { Parser{}.parseString(makeDeck(geomech)) }
+        , es       { deck }
+        , schedule { deck, es, std::make_shared<Python>() }
+        , config   { deck, schedule, es.fieldProps(), es.aquifer() }
+        , name     { toUpper(std::move(caseName)) }
+        , ta       { "summary_test" }
+    {}
+
+    Deck deck;
+    EclipseState es;
+    Schedule schedule;
+    SummaryConfig config;
+    std::string name;
+    WorkArea ta;
+};
+
+EclIO::ESmry runCase(const bool geomech)
+{
+    auto cfg = Setup { geomech ? "dynconn_geomech" : "dynconn_nongeomech", geomech };
+
+    auto writer = out::Summary {
+        cfg.config, cfg.es, cfg.es.getInputGrid(), cfg.schedule, cfg.name
+    };
+
+    auto st = SummaryState {
+        TimeService::now(), cfg.es.runspec().udqParams().undefinedValue()
+    };
+
+    auto values = out::Summary::DynamicSimulatorState {};
+    auto wells = makeWells(/* includeDynamicConn = */ geomech);
+    values.well_solution = &wells;
+
+    writer.eval(/* sim_step = */ 0, /* secs_elapsed = */ 0.0 * unit::day, values, st);
+    writer.add_timestep(st, /* report_step = */ 0, /* ministep_id = */ 0, /* isSubstep = */ false);
+
+    // Global index 3 => (4,1,1) in a 4x1x1 grid.
+    writer.recordNewDynamicWellConns({ { "W_3", { std::size_t {3} } } });
+
+    writer.eval(/* sim_step = */ 1, /* secs_elapsed = */ 1.0 * unit::day, values, st);
+    writer.add_timestep(st, /* report_step = */ 1, /* ministep_id = */ 1, /* isSubstep = */ false);
+
+    writer.write();
+
+    auto smry = EclIO::ESmry { cfg.name };
+
+    // Note: We load all vectors eagerly because the WorkArea and its
+    // associated output files will go away at the end of this function.
+    smry.loadData();
+
+    return smry;
+}
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Summary_Dynamic_Connection_Vectors)
+
+namespace {
+    std::string connVectorKey(std::string_view vector, const int I = 4)
+    {
+        return fmt::format("{}:W_3:{},1,1", vector, I);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Geomech_Activates_Dynamic_Connection_Vectors)
+{
+    const auto smry = runCase(/* geomech = */ true);
+
+    const auto ctfac_key = connVectorKey("CTFAC");
+    const auto cwirfrac_key = connVectorKey("CWIRFRAC");
+    const auto cfcffvir_key = connVectorKey("CFCFFVIR");
+    const auto cfcfvir_key = connVectorKey("CFCFVIR");
+
+    {
+        BOOST_REQUIRE_MESSAGE(smry.hasKey(ctfac_key),
+                              "Expected dynamic key " << ctfac_key);
+
+        const auto& ctfac = smry.get(ctfac_key);
+
+        BOOST_REQUIRE_EQUAL(ctfac.size(), std::size_t{2});
+
+        BOOST_CHECK_CLOSE(ctfac[0],   0.0f  , 1.0e-4f);
+        BOOST_CHECK_CLOSE(ctfac[1], 654.321f, 1.0e-4f);
+    }
+
+    {
+        BOOST_REQUIRE_MESSAGE(smry.hasKey(cwirfrac_key),
+                              "Expected dynamic key " << cwirfrac_key);
+
+        const auto& cwirfrac = smry.get(cwirfrac_key);
+
+        BOOST_REQUIRE_EQUAL(cwirfrac.size(), std::size_t{2});
+
+        BOOST_CHECK_CLOSE(cwirfrac[0], 0.0f  , 1.0e-4f);
+        BOOST_CHECK_CLOSE(cwirfrac[1], 0.618f, 1.0e-4f);
+    }
+
+    {
+        BOOST_REQUIRE_MESSAGE(smry.hasKey(cfcffvir_key),
+                              "Expected dynamic key " << cfcffvir_key);
+
+        const auto& cfcffvir = smry.get(cfcffvir_key);
+
+        BOOST_REQUIRE_EQUAL(cfcffvir.size(), std::size_t{2});
+
+        BOOST_CHECK_CLOSE(cfcffvir[0], 0.0f , 1.0e-4f);
+        BOOST_CHECK_CLOSE(cfcffvir[1], 0.05f, 1.0e-4f);
+    }
+
+    {
+        BOOST_REQUIRE_MESSAGE(smry.hasKey(cfcfvir_key),
+                              "Expected dynamic key " << cfcfvir_key);
+
+        const auto& cfcfvir = smry.get(cfcfvir_key);
+
+        BOOST_REQUIRE_EQUAL(cfcfvir.size(), std::size_t{2});
+
+        BOOST_CHECK_CLOSE(cfcfvir[0], 0.0f , 1.0e-4f);
+        BOOST_CHECK_CLOSE(cfcfvir[1], 0.25f, 1.0e-4f);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(NonGeomech_Does_Not_Activate_Dynamic_Connection_Vectors)
+{
+    const auto smry = runCase(/* geomech = */ false);
+
+    BOOST_CHECK(smry.hasKey(connVectorKey("CTFAC", 3)));
+
+    BOOST_CHECK(!smry.hasKey(connVectorKey("CTFAC")));
+    BOOST_CHECK(!smry.hasKey(connVectorKey("CWIRFRAC")));
+    BOOST_CHECK(!smry.hasKey(connVectorKey("CFCFFVIR")));
+    BOOST_CHECK(!smry.hasKey(connVectorKey("CFCFVIR")));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds support for registering new summary vectors at the connection level at runtime.  This is in support of fracturing processes which dynamically expose parts of the geometry to well flow as a fracture opens up.  We introduce the notion of "dynamic" connections, represented as a vector of pairs of well names and vectors of intersected cell IDs. We expect that these will be created by the simulator as needed and registered with the `Summary` object as they become available.

In this initial implementation, we allocate at most 20 dynamic connection vectors for each well connection that's defined with a wild card in the `SUMMARY` section.  This number is subject to change as we gain experience and may become user configurable.