### PR TITLE
Allow the simulator to force an output write to be the final one.

### DIFF
--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -229,16 +229,23 @@ public:
                            const bool         isSubstep,
                            std::optional<int> time_step) const;
 
-    /// Whether or not this is the run's final report step.
+    /// Whether or not this is the run's final write operation.
     ///
     /// Simplifies checking for whether or not to to create an RSM file.
     ///
     /// \param[in] report_step One-based report step index for which to
     /// create output.  Report_step=0 represents time zero.
     ///
+    /// \param[in] is_substep Whether this is just a sub step and not the
+    ///                       end of a full report step,
+    ///
+    /// \param[in] force_final_report_step If true then this is final write no
+    ///                                    matter what report_step actually is.
+    ///                                    Used if there was an EXIT in an ACTIONX
     /// \return Whether or not \p report_step is the run's final report
     /// step.
-    bool isFinalStep(const int report_step) const;
+    bool isFinalWrite(const int report_step, const bool is_substep,
+                      const bool force_final_report_step) const;
 
     /// Name of run's output directory.
     const std::string& outputDir() const { return this->outputDir_; }
@@ -362,7 +369,8 @@ public:
                           const int                report_step,
                           const std::optional<int> time_step,
                           const double             secs_elapsed,
-                          const bool               isSubstep);
+                          const bool               isSubstep,
+                          const bool               isFinalSummmary);
 
     /// Create restart file output.
     ///
@@ -697,9 +705,12 @@ Opm::EclipseIO::Impl::wantRFTOutput(const int  report_step,
     };
 }
 
-bool Opm::EclipseIO::Impl::isFinalStep(const int report_step) const
+bool Opm::EclipseIO::Impl::isFinalWrite(const int report_step, const bool is_substep,
+                                        const bool force_final_report_step) const
 {
-    return report_step == static_cast<int>(this->schedule_.get().size()) - 1;
+    return (force_final_report_step ||
+            report_step == static_cast<int>(this->schedule_.get().size()) - 1)
+        && !is_substep;
 }
 
 bool Opm::EclipseIO::Impl::wantSummaryOutput(const int          report_step,
@@ -828,14 +839,15 @@ void Opm::EclipseIO::Impl::writeSummaryFile(const SummaryState&      st,
                                             const int                report_step,
                                             const std::optional<int> time_step,
                                             const double             secs_elapsed,
-                                            const bool               isSubstep)
+                                            const bool               isSubstep,
+                                            const bool               forceFinalWrite)
 {
     this->summary_.add_timestep(st, this->reportIndex(report_step, time_step),
                                 this->miniStepId_,
                                 !time_step.has_value() || isSubstep);
 
     const auto is_final_summary =
-        this->isFinalStep(report_step) && !isSubstep;
+        this->isFinalWrite(report_step, isSubstep, forceFinalWrite);
 
     this->summary_.write(is_final_summary);
 
@@ -1147,7 +1159,8 @@ void Opm::EclipseIO::writeTimeStep(const Action::State& action_state,
                                    const double         secs_elapsed,
                                    RestartValue         value,
                                    const bool           write_double,
-                                   std::optional<int>   time_step)
+                                   std::optional<int>   time_step,
+                                   const bool           forceFinalWrite)
 {
     if (! this->impl->outputEnabled()) {
         // Run does not request any output.  Uncommon, but might be useful
@@ -1166,7 +1179,7 @@ void Opm::EclipseIO::writeTimeStep(const Action::State& action_state,
 
     if (this->impl->wantSummaryOutput(report_step, isSubstep, secs_elapsed, time_step)) {
         this->impl->writeSummaryFile(st, report_step, time_step,
-                                     secs_elapsed, isSubstep);
+                                     secs_elapsed, isSubstep, forceFinalWrite);
     }
 
     if (this->impl->wantRestartOutput(report_step, isSubstep, time_step)) {
@@ -1176,8 +1189,7 @@ void Opm::EclipseIO::writeTimeStep(const Action::State& action_state,
                                      write_double, std::move(value));
     }
 
-    if (! isSubstep &&
-        this->impl->isFinalStep(report_step) &&
+    if ( this->impl->isFinalWrite(report_step, isSubstep, forceFinalWrite)  &&
         this->impl->summaryConfig().createRunSummary())
     {
         // Write RSM file at end of simulation.
@@ -1197,7 +1209,8 @@ void Opm::EclipseIO::writeTimeStep(const Action::State&      action_state,
                                    const double              secs_elapsed,
                                    std::vector<RestartValue> value,
                                    const bool                write_double,
-                                   std::optional<int>        time_step)
+                                   std::optional<int>        time_step,
+                                   const bool                forceFinalWrite)
 {
     if (! this->impl->outputEnabled()) {
         // Run does not request any output.  Uncommon, but might be useful
@@ -1209,7 +1222,7 @@ void Opm::EclipseIO::writeTimeStep(const Action::State&      action_state,
 
     if (this->impl->wantSummaryOutput(report_step, isSubstep, secs_elapsed, time_step)) {
         this->impl->writeSummaryFile(st, report_step, time_step,
-                                     secs_elapsed, isSubstep);
+                                     secs_elapsed, isSubstep, forceFinalWrite);
     }
 
     if (this->impl->wantRestartOutput(report_step, isSubstep, time_step)) {
@@ -1219,8 +1232,7 @@ void Opm::EclipseIO::writeTimeStep(const Action::State&      action_state,
                                      write_double, std::move(value));
     }
 
-    if (! isSubstep &&
-        this->impl->isFinalStep(report_step) &&
+    if ( this->impl->isFinalWrite(report_step, isSubstep, forceFinalWrite) &&
         this->impl->summaryConfig().createRunSummary())
     {
         // Write RSM file at end of simulation.

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -253,7 +253,8 @@ public:
                        double               seconds_elapsed,
                        RestartValue         value,
                        const bool           write_double = false,
-                       std::optional<int>   time_step = std::nullopt);
+                       std::optional<int>   time_step = std::nullopt,
+                       const bool           isFinalWriteOut = false);
 
     /// Write reservoir state and summary information to disk for runs with
     /// local grid refinement.
@@ -323,7 +324,8 @@ public:
                        double                    seconds_elapsed,
                        std::vector<RestartValue> value,
                        const bool                write_double = false,
-                       std::optional<int>        time_step = std::nullopt);
+                       std::optional<int>        time_step = std::nullopt,
+                       const bool                isFinalWriteOut = false);
 
 
     /// Load per-cell solution data and wellstate from restart file.


### PR DESCRIPTION
The final write is special as it might create an RSM file. Up to now we created this file only for the last write of the last report step of a simulation.

This approach neglected that a simulation might finish before the last step if it encounters an EXIT keyword inside of an executed ACTIONX statement.

With this change we will also write an RSM file in this case. Such a file was missing before.