### PR TITLE
use vector instead of array

### DIFF
--- a/opm/material/eos/PengRobinson.hpp
+++ b/opm/material/eos/PengRobinson.hpp
@@ -465,7 +465,9 @@ protected:
         Evaluation b4 = a4 + V*b3;
 
         // invert resulting cubic polynomial analytically
-        std::array<Evaluation,4> allV;
+        // a vector is used instead of an array due to faulty
+        // compiler diagnostics with gcc 14.2
+        std::vector<Evaluation> allV(4);
         allV[0] = V;
         const decltype(allV.size()) numSol = 1 + invertCubicPolynomial<Evaluation>(allV.data() + 1, b1, b2, b3, b4);
 


### PR DESCRIPTION
quells (broken) compiler warnings

Again this looks like broken diagnostics in gcc,
```
In file included from /usr/include/c++/14/bits/stl_algobase.h:71,
                 from /usr/include/c++/14/array:43,
                 from /build/opm/material/densead/Evaluation.hpp:39,
                 from /build/tests/material/test_pengrobinson.cpp:31:
In member function 'constexpr bool __gnu_cxx::__ops::_Iter_less_iter::operator()(_Iterator1, _Iterator2) const [with _Iterator1 = double*; _Iterator2 = double*]',
    inlined from 'constexpr void std::__move_median_to_first(_Iterator, _Iterator, _Iterator, _Iterator, _Compare) [with _Iterator = double*; _Compare = __gnu_cxx::__ops::_Iter_less_iter]' at /usr/include/c++/14/bits/stl_algo.h:88:17,
    inlined from 'constexpr _RandomAccessIterator std::__unguarded_partition_pivot(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = double*; _Compare = __gnu_cxx::__ops::_Iter_less_iter]' at /usr/include/c++/14/bits/stl_algo.h:1855:34,
    inlined from 'constexpr void std::__introsort_loop(_RandomAccessIterator, _RandomAccessIterator, _Size, _Compare) [with _RandomAccessIterator = double*; _Size = long int; _Compare = __gnu_cxx::__ops::_Iter_less_iter]' at /usr/include/c++/14/bits/stl_algo.h:1889:38,
    inlined from 'constexpr void std::__sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = double*; _Compare = __gnu_cxx::__ops::_Iter_less_iter]' at /usr/include/c++/14/bits/stl_algo.h:1905:25,
    inlined from 'constexpr void std::sort(_RAIter, _RAIter) [with _RAIter = double*]' at /usr/include/c++/14/bits/stl_algo.h:4771:18,
    inlined from 'static bool Opm::PengRobinson<Scalar, UseLegacy>::findExtrema_(Evaluation&, Evaluation&, Evaluation&, Evaluation&, const Evaluation&, const Evaluation&, const Evaluation&) [with Evaluation = double; Scalar = double; bool UseLegacy = true]' at /build/opm/material/eos/PengRobinson.hpp:475:18:
/usr/include/c++/14/bits/predefined_ops.h:45:23: warning: array subscript [8, 576460752303423487] is outside array bounds of 'std::array<double, 4> [1]' [-Warray-bounds=]
   45 |       { return *__it1 < *__it2; }
```
and many similar statements. Using a vector shuts it up. Seems worth it to me.