### PR TITLE
Addzcorn

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -396,6 +396,9 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         switch (found.front()) {
         case GridType::COORD:
             this->initCornerPointGrid(deck);
+            // Apply ADDZCORN if active
+            // Only for corner point grids
+            this->addZCORN(deck);
             break;
         case GridType::DEPTHZ:
         case GridType::TOPS:
@@ -507,9 +510,10 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
                 units.to_si(length, m_zcorn);
             }
             else {
-                std::string message = "gridunit '" + gridunit[0] + "' doesn't correspong to a valid unit system";
+                std::string message = "gridunit '" + gridunit[0] + "' doesn't correspond to a valid unit system";
                 throw std::invalid_argument(message);
             }
+
         }
 
         if (egridfile.hasKey("ACTNUM") && m_useActnumFromGdfile) {
@@ -1857,6 +1861,182 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
         return mapper.fixupZCORN( m_zcorn );
     }
 
+    void EclipseGrid::addZCORN(const Deck& deck) {
+        using ADDZCORN = Opm::ParserKeywords::ADDZCORN;
+        using AddZCornInput = ZcornMapper::AddZCornInput;
+        ZcornMapper mapper(getNX(), getNY(), getNZ());
+        std::vector<AddZCornInput> addzcorns;
+
+        const int nx = static_cast<int>(getNX());
+        const int ny = static_cast<int>(getNY());
+        const int nz = static_cast<int>(getNZ());
+
+        // Adds top (0..3), bottom (4..7), or both corners for one logical corner.
+        auto add_corner = [&addzcorns, &mapper, nx, ny, nz]
+            (double value, int i, int j, int k, int c, bool move_top, bool move_bottom) {
+            if (i < 0 || j < 0 || k < 0 || i >= nx || j >= ny || k >= nz) {
+                return;
+            }
+
+            if (move_top && c >= 0 && c < 4) {
+                addzcorns.push_back(AddZCornInput{
+                    value,
+                    mapper.index(i,j,k,c)
+                });
+            }
+
+            if (move_bottom && c >= 0 && c < 4) {
+                addzcorns.push_back(AddZCornInput{
+                    value,
+                    mapper.index(i,j,k,c+4)
+                });
+            }
+        };
+
+        for (const auto& input : deck.get<ADDZCORN>()) {
+            for (const auto& record : input) {
+
+                std::string flag = record.getItem<ADDZCORN::ACTION>().get<std::string>(0);
+                if (flag == "ALL") {
+                    flag = "BOTH";
+                }
+                const bool move_top = (flag == "TOP" || flag == "BOTH");
+                const bool move_bottom = (flag == "BOTTOM" || flag == "BOTH");
+                if (!move_top && !move_bottom) {
+                    throw std::invalid_argument("ADDZCORN: ACTION must be TOP, BOTTOM, BOTH/ALL");
+                } 
+
+                const double value = record.getItem<ADDZCORN::ADDED_VALUE>().getSIDouble(0);
+                const int ix1 = record.getItem<ADDZCORN::IX1>().get<int>(0);
+                const int ix2 = record.getItem<ADDZCORN::IX2>().get<int>(0);
+                const int jy1 = record.getItem<ADDZCORN::JY1>().get<int>(0);
+                const int jy2 = record.getItem<ADDZCORN::JY2>().get<int>(0);
+                const int kz1 = record.getItem<ADDZCORN::KZ1>().get<int>(0);
+                const int kz2 = record.getItem<ADDZCORN::KZ2>().get<int>(0);
+
+                int ix1a = record.getItem<ADDZCORN::IX1A>().get<int>(0);
+                int ix2a = record.getItem<ADDZCORN::IX2A>().get<int>(0);
+                int jy1a = record.getItem<ADDZCORN::JY1A>().get<int>(0);
+                int jy2a = record.getItem<ADDZCORN::JY2A>().get<int>(0);
+
+                // Default continuity: include neighboring pillars around the box.
+                if (ix1a == -1) {
+                    ix1a = std::max(0, ix1 - 1);
+                }
+                if (ix2a == -1) {
+                    ix2a = std::min(nx, ix2 + 1);
+                }
+                if (jy1a == -1) {
+                    jy1a = std::max(0, jy1 - 1);
+                }
+                if (jy2a == -1) {
+                    jy2a = std::min(ny, jy2 + 1);
+                }
+
+                const bool single_cell_mode = (ix1 == 0 || ix2 == 0 || jy1 == 0 || jy2 == 0);
+
+                if (!single_cell_mode && ix2 < ix1) {
+                    throw std::invalid_argument("ADDZCORN: ix2 >= ix1");
+                }
+                if (!single_cell_mode && jy2 < jy1) {
+                    throw std::invalid_argument("ADDZCORN: jy2 >= jy1");
+                }
+                if (kz2 < kz1) {
+                    throw std::invalid_argument("ADDZCORN: kz2 >= kz1");
+                }
+
+                for (int k = kz1 - 1; k < kz2; ++k) {
+                    if (single_cell_mode) {
+                        const int i = std::max(ix1, ix2) - 1;
+                        const int j = std::max(jy1, jy2) - 1;
+
+                        if (ix1 > 0 && jy2 > 0) {
+                            add_corner(value, i, j, k, 0, move_top, move_bottom);
+                        }
+                        if (ix2 > 0 && jy2 > 0) {
+                            add_corner(value, i, j, k, 1, move_top, move_bottom);
+                        }
+                        if (ix1 > 0 && jy1 > 0) {
+                            add_corner(value, i, j, k, 2, move_top, move_bottom);
+                        }
+                        if (ix2 > 0 && jy1 > 0) {
+                            add_corner(value, i, j, k, 3, move_top, move_bottom);
+                        }
+                        continue;
+                    }
+
+                    // 1) Move all corners in selected box.
+                    for (int j = jy1 - 1; j <= jy2 - 1; ++j) {
+                        for (int i = ix1 - 1; i <= ix2 - 1; ++i) {
+                            for (int c = 0; c < 4; ++c) {
+                                add_corner(value, i, j, k, c, move_top, move_bottom);
+                            }
+                        }
+                    }
+
+                    // 2) Optional continuity propagation to neighboring cells.
+                    const bool cont_left  = (ix1a == ix1 - 1);
+                    const bool cont_right = (ix2a == ix2 + 1);
+                    const bool cont_low_j = (jy1a == jy1 - 1);
+                    const bool cont_high_j = (jy2a == jy2 + 1);
+
+                    if (cont_left) {
+                        const int i = ix1 - 2;
+                        for (int j = jy1 - 1; j <= jy2 - 1; ++j) {
+                            add_corner(value, i, j, k, 1, move_top, move_bottom);
+                            add_corner(value, i, j, k, 3, move_top, move_bottom);
+                        }
+                    }
+
+                    if (cont_right) {
+                        const int i = ix2;
+                        for (int j = jy1 - 1; j <= jy2 - 1; ++j) {
+                            add_corner(value, i, j, k, 0, move_top, move_bottom);
+                            add_corner(value, i, j, k, 2, move_top, move_bottom);
+                        }
+                    }
+
+                    if (cont_low_j) {
+                        const int j = jy1 - 2;
+                        for (int i = ix1 - 1; i <= ix2 - 1; ++i) {
+                            add_corner(value, i, j, k, 2, move_top, move_bottom);
+                            add_corner(value, i, j, k, 3, move_top, move_bottom);
+                        }
+                    }
+
+                    if (cont_high_j) {
+                        const int j = jy2;
+                        for (int i = ix1 - 1; i <= ix2 - 1; ++i) {
+                            add_corner(value, i, j, k, 0, move_top, move_bottom);
+                            add_corner(value, i, j, k, 1, move_top, move_bottom);
+                        }
+                    }
+
+                    if (cont_left && cont_low_j) {
+                        add_corner(value, ix1 - 2, jy1 - 2, k, 3, move_top, move_bottom);
+                    }
+                    if (cont_left && cont_high_j) {
+                        add_corner(value, ix1 - 2, jy2,     k, 1, move_top, move_bottom);
+                    }
+                    if (cont_right && cont_low_j) {
+                        add_corner(value, ix2,     jy1 - 2, k, 2, move_top, move_bottom);
+                    }
+                    if (cont_right && cont_high_j) {
+                        add_corner(value, ix2,     jy2,     k, 0, move_top, move_bottom);
+                    }
+                }
+            }
+        }
+
+        
+        mapper.addZCORN(m_zcorn, addzcorns);
+
+        // Keep original-input representation in sync for save().
+        if (m_input_zcorn) {
+            mapper.addZCORN(m_input_zcorn.value(), addzcorns);
+        }
+    }
+
     const std::vector<double>& EclipseGrid::getZCORN( ) const {
 
         return m_zcorn;
@@ -2646,6 +2826,13 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
                     }
         return cells_adjusted;
     }
+
+    void ZcornMapper::addZCORN( std::vector<double>& zcorn, const std::vector<AddZCornInput>& addzcorns) const {
+        for (const auto& addzcorn : addzcorns) {
+            zcorn[addzcorn.index] += addzcorn.value;
+        }
+    }
+
 
     CoordMapper::CoordMapper(std::size_t nx_, std::size_t ny_) :
         nx(nx_),

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -442,6 +442,7 @@ namespace Opm {
         void save_nna(Opm::EclIO::EclOutput& egridfile, const std::vector<Opm::NNCdata>& nnc, std::size_t grid1, std::size_t grid2) const;
         void save_core(Opm::EclIO::EclOutput& egridfile, const Opm::UnitSystem& units) const;
 
+        void addZCORN(const Deck& deck);
     };
 
     /// Specialized Class to describe LGR refined cells.
@@ -554,6 +555,10 @@ namespace Opm {
 
     class ZcornMapper {
     public:
+        struct AddZCornInput {
+            double value;
+            std::size_t index;
+        };
         ZcornMapper(size_t nx, size_t ny, size_t nz);
         size_t index(size_t i, size_t j, size_t k, int c) const;
         size_t index(size_t g, int c) const;
@@ -576,6 +581,8 @@ namespace Opm {
         */
         size_t fixupZCORN( std::vector<double>& zcorn);
         bool validZCORN( const std::vector<double>& zcorn) const;
+        void addZCORN( std::vector<double>& zcorn, const std::vector<AddZCornInput>& addzcorns) const;
+
     private:
         std::array<size_t,3> dims;
         std::array<size_t,3> stride;

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/A/ADDZCORN
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/A/ADDZCORN
@@ -35,23 +35,28 @@
     },
     {
       "name": "IX1A",
-      "value_type": "INT"
+      "value_type": "INT",
+      "default": -1
     },
     {
       "name": "IX2A",
-      "value_type": "INT"
+      "value_type": "INT",
+      "default": -1
     },
     {
       "name": "JY1A",
-      "value_type": "INT"
+      "value_type": "INT",
+      "default": -1
     },
     {
       "name": "JY2A",
-      "value_type": "INT"
+      "value_type": "INT",
+      "default": -1
     },
     {
       "name": "ACTION",
-      "value_type": "STRING"
+      "value_type": "STRING",
+      "default": "BOTH"
     }
   ]
 }

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -3532,3 +3532,305 @@ PORO
     SPIDER with DR/DRV, DTHETA/DTHETAV, DZ/DZV and TOPS creates a spider grid)");
     });
 }
+
+
+BOOST_AUTO_TEST_CASE(TEST_GDFILE_1_ADDZCORN) {
+
+    const auto deckDataBase = std::string { R"(RUNSPEC
+
+    DIMENS
+    2 2 2 /
+    GRID
+    SPECGRID
+    2 2 2 1 F /
+    COORD
+    2002.0000  2002.0000   100.0000   1999.8255  1999.9127   108.4935
+    2011.9939  2000.0000   100.3490   2009.8194  1999.9127   108.8425
+    2015.9878  2000.0000   100.6980   2019.8133  1999.9127   109.1915
+    2000.0000  2009.9985   100.1745   1999.8255  2009.9112   108.6681 
+    2010.9939  2011.9985   100.5235   2009.8194  2009.9112   109.0170
+    2019.9878  2009.9985   100.8725   2019.8133  2009.9112   109.3660
+    2005.0000  2019.9970   100.3490   1999.8255  2019.9097   108.8426
+    2009.9939  2019.9970   100.6980   2009.8194  2019.9097   109.1916
+    2016.9878  2019.9970   101.0470   2019.8133  2019.9097   109.5406 /
+    ZCORN
+    98.0000   100.3490    97.3490   100.6980   100.1745   100.5235
+    100.5235   100.8725   100.1745   100.5235   100.5235   100.8725
+    100.3490   101.6980   101.6980   102.5470   102.4973   102.1463
+    103.2463   104.1953   103.6719   104.0209   104.0209   104.3698
+    103.6719   104.0209   104.0209   104.3698   103.8464   104.1954
+    104.1954   104.5444   103.4973   103.8463   103.8463   104.1953
+    103.6719   104.0209   104.0209   104.3698   103.6719   104.0209
+    104.0209   104.3698   103.8464   104.1954   104.1954   104.5444
+    108.4935   108.8425   108.8425   109.1915   108.6681   109.0170
+    109.0170   109.3660   108.6681   109.0170   109.0170   109.3660
+    108.8426   109.1916   109.1916   109.5406  /
+
+    ACTNUM
+    1 1 1 1 0 1 0 1 /
+    )" };
+
+    Opm::Parser parser;
+    auto deck_base = parser.parseString(deckDataBase);
+    Opm::EclipseGrid grid_base(deck_base);
+    auto zcorn_base = grid_base.getZCORN();
+    {
+        const auto test1 = std::string {
+            R"(ADDZCORN
+            1.0 1 2 1 2 1 2 1 2 1 2/
+            /
+            )"
+        };
+
+        const auto deckData1 = deckDataBase + test1;
+        auto deck1 = parser.parseString(deckData1);
+        Opm::EclipseGrid grid1(deck1);
+        auto zcorn = grid1.getZCORN();
+        // all zcorns are moved 1.0
+        for (int i = 0; i < 64; i++) {
+            BOOST_CHECK_CLOSE( zcorn_base[i] + 1.0, zcorn[i], 1e-8);
+        }
+    }
+
+    {
+        const auto test1 = std::string {
+            R"(ADDZCORN
+            1.0 0 1 0 1 1 1 0 1 0 1/
+            -1.0 1 0 1 0 2 2 1 0 1 0/
+            /
+            )"
+        };
+
+        const auto deckData1 = deckDataBase + test1;
+        auto deck1 = parser.parseString(deckData1);
+        Opm::EclipseGrid grid1(deck1);
+        const auto zcorn = grid1.getZCORN();
+        for (int i = 0; i < 64; i++) {
+            if (i == 1 || i == 17) { // move right front corner of cell 1, 1 m
+                BOOST_CHECK_CLOSE(zcorn_base[i] + 1.0, zcorn[i], 1e-8);
+            } else if (i == 36 || i == 52) { // move left back corner of cell 2, -1m
+                BOOST_CHECK_CLOSE(zcorn_base[i] - 1.0, zcorn[i], 1e-8);
+            } else {
+                BOOST_CHECK_CLOSE(zcorn_base[i], zcorn[i], 1e-8);
+            }
+        }
+    }
+    {
+        // Move one full cell box (cell i=1,j=1,k=1) with explicit discontinuity flags.
+        // This should only move that cell's 8 ZCORN entries.
+        const auto test1 = std::string {
+            R"(ADDZCORN
+            2.0 1 1 1 1 1 1 1 1 1 1 /
+            /
+            )"
+        };
+
+        const auto deckData1 = deckDataBase + test1;
+        auto deck1 = parser.parseString(deckData1);
+        Opm::EclipseGrid grid1(deck1);
+
+        const auto zcorn = grid1.getZCORN();
+
+        auto zmap = grid1.zcornMapper();
+        std::vector<char> moved(64, 0);
+        for (int c = 0; c < 8; ++c) {
+            moved[zmap.index(0, 0, 0, c)] = 1;
+        }
+
+        for (int i = 0; i < 64; ++i) {
+            if (moved[i]) {
+                BOOST_CHECK_CLOSE(zcorn_base[i] + 2.0, zcorn[i], 1e-8);
+            } else {
+                BOOST_CHECK_CLOSE(zcorn_base[i], zcorn[i], 1e-8);
+            }
+        }
+    }
+
+    {
+        // Same single-corner operation repeated twice -> cumulative effect.
+        const auto test1 = std::string {
+            R"(ADDZCORN
+            1.0 0 1 0 1 1 1 0 1 0 1 /
+            0.5 0 1 0 1 1 1 0 1 0 1 /
+            /
+            )"
+        };
+
+        const auto deckData1 = deckDataBase + test1;
+        auto deck1 = parser.parseString(deckData1);
+        Opm::EclipseGrid grid1(deck1);
+
+        const auto zcorn = grid1.getZCORN();
+
+        for (int i = 0; i < 64; ++i) {
+            if (i == 1 || i == 17) { // same corner as in your existing test
+                BOOST_CHECK_CLOSE(zcorn_base[i] + 1.5, zcorn[i], 1e-8);
+            } else {
+                BOOST_CHECK_CLOSE(zcorn_base[i], zcorn[i], 1e-8);
+            }
+        }
+    }
+
+    {
+        // Whole-grid move in two records -> cumulative everywhere.
+        const auto test1 = std::string {
+            R"(ADDZCORN
+            1.0 1 2 1 2 1 2 1 2 1 2 /
+            -0.25 1 2 1 2 1 2 1 2 1 2 /
+            /
+            )"
+        };
+
+        const auto deckData1 = deckDataBase + test1;
+        auto deck1 = parser.parseString(deckData1);
+        Opm::EclipseGrid grid1(deck1);
+
+        const auto zcorn = grid1.getZCORN();
+
+        for (int i = 0; i < 64; ++i) {
+            BOOST_CHECK_CLOSE(zcorn_base[i] + 0.75, zcorn[i], 1e-8);
+        }
+    }
+
+    {
+        // TOP action should only move the top four corners of the selected cell.
+        const auto test1 = std::string {
+            R"(ADDZCORN
+            2.0 1 1 1 1 1 1 1 1 1 1 TOP /
+            /
+            )"
+        };
+
+        const auto deckData1 = deckDataBase + test1;
+        auto deck1 = parser.parseString(deckData1);
+        Opm::EclipseGrid grid1(deck1);
+
+        const auto zcorn = grid1.getZCORN();
+
+        auto zmap = grid1.zcornMapper();
+        std::vector<char> moved(zcorn.size(), 0);
+        for (int c = 0; c < 4; ++c) {
+            moved[zmap.index(0, 0, 0, c)] = 1;
+        }
+
+        for (std::size_t i = 0; i < zcorn.size(); ++i) {
+            if (moved[i]) {
+                BOOST_CHECK_CLOSE(zcorn_base[i] + 2.0, zcorn[i], 1e-8);
+            } else {
+                BOOST_CHECK_CLOSE(zcorn_base[i], zcorn[i], 1e-8);
+            }
+        }
+    }
+
+    {
+        // BOTTOM action should only move the bottom four corners of the selected cell.
+        const auto test1 = std::string {
+            R"(ADDZCORN
+            2.0 1 1 1 1 1 1 1 1 1 1 BOTTOM /
+            /
+            )"
+        };
+
+        const auto deckData1 = deckDataBase + test1;
+        auto deck1 = parser.parseString(deckData1);
+        Opm::EclipseGrid grid1(deck1);
+
+        const auto zcorn = grid1.getZCORN();
+
+        auto zmap = grid1.zcornMapper();
+        std::vector<char> moved(zcorn.size(), 0);
+        for (int c = 4; c < 8; ++c) {
+            moved[zmap.index(0, 0, 0, c)] = 1;
+        }
+
+        for (std::size_t i = 0; i < zcorn.size(); ++i) {
+            if (moved[i]) {
+                BOOST_CHECK_CLOSE(zcorn_base[i] + 2.0, zcorn[i], 1e-8);
+            } else {
+                BOOST_CHECK_CLOSE(zcorn_base[i], zcorn[i], 1e-8);
+            }
+        }
+    }
+
+    {
+        // Compare discontinuous vs continuous move on the same single-cell box.
+        // Continuity on +I and +J should move additional shared corners.
+        const auto test_discont = std::string { R"(ADDZCORN
+            1.0 1 1 1 1 1 1 1 1 1 1 /
+            /
+            )"
+        };
+
+        const auto test_cont = std::string { R"(ADDZCORN
+            1.0 1 1 1 1 1 1 1 2 1 2 /
+            /
+            )"
+        };
+
+        // Discontinuous case
+        auto deck_discont = parser.parseString(deckDataBase + test_discont);
+        Opm::EclipseGrid grid_discont(deck_discont);
+        const auto z1_discont = grid_discont.getZCORN();
+
+        // Continuous case
+        auto deck_cont = parser.parseString(deckDataBase + test_cont);
+        Opm::EclipseGrid grid_cont(deck_cont);
+        const auto z1_cont = grid_cont.getZCORN();
+
+        BOOST_REQUIRE_EQUAL(zcorn_base.size(), z1_discont.size());
+        BOOST_REQUIRE_EQUAL(zcorn_base.size(), z1_cont.size());
+        BOOST_REQUIRE_EQUAL(z1_discont.size(), z1_cont.size());
+
+        std::vector<char> changed_discont(z1_discont.size(), 0);
+        std::vector<char> changed_cont(z1_cont.size(), 0);
+
+        std::size_t n_changed_discont = 0;
+        std::size_t n_changed_cont = 0;
+        constexpr double eps = 1e-12;
+
+        for (std::size_t i = 0; i < z1_discont.size(); ++i) {
+            if (std::abs(z1_discont[i] - zcorn_base[i]) > eps) {
+                changed_discont[i] = 1;
+                ++n_changed_discont;
+            }
+            if (std::abs(z1_cont[i] - zcorn_base[i]) > eps) {
+                changed_cont[i] = 1;
+                ++n_changed_cont;
+            }
+        }
+
+        // Continuous move must affect strictly more corners than discontinuous.
+        BOOST_CHECK_GT(n_changed_cont, n_changed_discont);
+
+        // Everything moved in discontinuous case must also move in continuous case.
+        for (std::size_t i = 0; i < changed_discont.size(); ++i) {
+            if (changed_discont[i]) {
+                BOOST_CHECK(changed_cont[i]);
+            }
+        }
+
+        // And continuity should move at least one corner in each neighbor (+I and +J).
+        auto zmap = grid_cont.zcornMapper();
+
+        bool moved_in_i_neighbor = false;
+        for (int c = 0; c < 8; ++c) {
+            const auto idx = zmap.index(1, 0, 0, c); // cell (i=2,j=1,k=1) in 1-based terms
+            if (changed_cont[idx] && !changed_discont[idx]) {
+                moved_in_i_neighbor = true;
+                break;
+            }
+        }
+
+        bool moved_in_j_neighbor = false;
+        for (int c = 0; c < 8; ++c) {
+            const auto idx = zmap.index(0, 1, 0, c); // cell (i=1,j=2,k=1) in 1-based terms
+            if (changed_cont[idx] && !changed_discont[idx]) {
+                moved_in_j_neighbor = true;
+                break;
+            }
+        }
+
+        BOOST_CHECK(moved_in_i_neighbor);
+        BOOST_CHECK(moved_in_j_neighbor);
+    }
+}


### PR DESCRIPTION
The Volve model uses ADDZCORN. This PR contains a minimum support of ADDZCORN to support https://www.equinor.com/energy/volve-data-sharing

In particular, this PR does not yet implement support for moving neighbouring corners (i.e., ix1a == ix1, etc.), which is the default. 
 
Needs further testing, cleanup, and discussion.  