### PR TITLE
OpmLibMain: use prereqs file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,11 +523,6 @@ include (OpmInit)
 # HAVE_OPM_TESTS will be set to true.
 include(Findopm-tests)
 
-# list of prerequisites for this particular project; this is in a
-# separate file (in cmake/Modules sub-directory) because it is shared
-# with the find module
-include (${project}-prereqs)
-
 if(OPM_ENABLE_EMBEDDED_PYTHON AND NOT OPM_ENABLE_PYTHON)
   # This needs to be here to run before source_hook
   message(WARNING "Inconsistent settings: OPM_ENABLE_PYTHON=OFF and "

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -52,6 +52,9 @@ if(COMMAND ${project}_language_hook)
   cmake_language(CALL ${project}_language_hook)
 endif()
 
+# Setup prereqs
+include(${project}-prereqs)
+
 opm_add_library(
   TARGET
     ${${project}_TARGET}
@@ -59,20 +62,16 @@ opm_add_library(
     ${${project}_VERSION}
 )
 
-# callback hook to setup additional dependencies
+# set aliases to probed variables
+include (OpmAliases)
+
+# callback hook to link to dependencies
 if(COMMAND ${project}_prereqs_hook)
   cmake_language(CALL ${project}_prereqs_hook)
 endif()
 
-# macro to set standard variables (INCLUDE_DIRS, LIBRARIES etc.)
-include (OpmFind)
-find_and_append_package_list_to (${project} ${${project}_DEPS})
-
-# set aliases to probed variables
-include (OpmAliases)
-
 # find Boost::unit_test_framework and detect if Boost is in a shared library
-include (UseDynamicBoost)
+include(UseDynamicBoost)
 
 # Run conditional file hook
 if(COMMAND ${project}_files_hook)


### PR DESCRIPTION
No reason to do prereqs setup twice (though second call was mostly a dummy).