### PR TITLE
DownloadFmt: don't use globals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,10 @@ macro(opm-common_prereqs_hook)
   endif()
 
   if(TARGET fmt::fmt)
-    # OpmSatellites will not add the library, do it here.
     list(APPEND opm-common_LIBRARIES fmt::fmt)
   else()
     include(DownloadFmt)
+    DownloadFmt(opmcommon)
   endif()
 
   # If opm-common is configured to embed the python interpreter we must make sure

--- a/cmake/Modules/DownloadFmt.cmake
+++ b/cmake/Modules/DownloadFmt.cmake
@@ -1,17 +1,22 @@
 include(FetchContent)
 
-if(NOT fmt_POPULATED)
-  FetchContent_Declare(fmt
-                       DOWNLOAD_EXTRACT_TIMESTAMP ON
-                       URL https://github.com/fmtlib/fmt/archive/refs/tags/10.1.1.tar.gz
-                       URL_HASH SHA512=288c349baac5f96f527d5b1bed0fa5f031aa509b4526560c684281388e91909a280c3262a2474d963b5d1bf7064b1c9930c6677fe54a0d8f86982d063296a54c)
-  FetchContent_Populate(fmt)
-endif()
+macro(DownloadFmt target)
+  if(NOT fmt_POPULATED)
+    FetchContent_Declare(fmt
+                         DOWNLOAD_EXTRACT_TIMESTAMP ON
+                         URL https://github.com/fmtlib/fmt/archive/refs/tags/10.1.1.tar.gz
+                         URL_HASH SHA512=288c349baac5f96f527d5b1bed0fa5f031aa509b4526560c684281388e91909a280c3262a2474d963b5d1bf7064b1c9930c6677fe54a0d8f86982d063296a54c)
+    FetchContent_Populate(fmt)
+  endif()
 
-# We do not want to use the target directly as that means it ends up
-# in our depends list for downstream modules and the installation list.
-# Instead, we just download and use header only mode.
-add_compile_definitions(FMT_HEADER_ONLY)
-include_directories(SYSTEM ${fmt_SOURCE_DIR}/include)
-set(fmt_POPULATED ${fmt_POPULATED} PARENT_SCOPE)
-set(fmt_SOURCE_DIR ${fmt_SOURCE_DIR} PARENT_SCOPE)
+  # We do not want to use the target directly as that means it ends up
+  # in our depends list for downstream modules and the installation list.
+  # Instead, we just download and use header only mode.
+  target_compile_definitions(${target} PUBLIC $<BUILD_INTERFACE:FMT_HEADER_ONLY>)
+  target_include_directories(${target} PUBLIC $<BUILD_INTERFACE:${fmt_SOURCE_DIR}/include>)
+
+  # Target used by binaries
+  add_library(fmt::fmt INTERFACE IMPORTED)
+  target_compile_definitions(fmt::fmt INTERFACE FMT_HEADER_ONLY)
+  target_include_directories(fmt::fmt INTERFACE ${fmt_SOURCE_DIR}/include)
+endmacro()


### PR DESCRIPTION
attach to the build interface for a given target.
this way the vendored sources are available while
using sibling builds, yet not leaking into the installed interface