### PR TITLE
OpmPolicies: reorganize to get appropriate scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,13 +460,17 @@ include(GNUInstallDirs)
 set(OPM_PROJECT_EXTRA_CODE_INSTALLED
   "set(OPM_MACROS_ROOT ${CMAKE_INSTALL_FULL_DATADIR}/opm)
   list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)
-  include(OpmPackage)"
+  include(OpmPackage)
+  include(OpmPolicies)
+  OpmSetPolicies()"
 )
 
 set(OPM_PROJECT_EXTRA_CODE_INTREE
   "set(OPM_MACROS_ROOT ${OPM_MACROS_ROOT})
   list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)
-  include(OpmPackage)"
+  include(OpmPackage)
+  include(OpmPolicies)
+  OpmSetPolicies()"
 )
 
 # project information is in dune.module. Read this file and set variables.

--- a/cmake/Modules/OpmInit.cmake
+++ b/cmake/Modules/OpmInit.cmake
@@ -13,43 +13,6 @@
 # This module should be the first to be included in the project,
 # because most of the others (OpmXxx.cmake) use these variables.
 
-# for CMake >= 3.0, we need to change a few policies:
-#
-#   - CMP0026 to allow access to the LOCATION target property
-#   - CMP0048 to indicate that we want to deal with the *VERSION*
-#     variables ourselves
-#   - CMP0064 to indicate that we want TEST if conditions to be evaluated
-#   - CMP0074 to indicate that <PackageName>_ROOT can be used to find package
-#             config files
-macro(OpmSetPolicies)
-  if (POLICY CMP0048)
-    # We do not set version. Hence NEW should work and this can be removed later
-    cmake_policy(SET CMP0048 NEW)
-  endif()
-
-  if(POLICY CMP0064)
-    cmake_policy(SET CMP0064 NEW)
-  endif()
-
-  # set the behavior of the policy 0054 to NEW. (i.e. do not implicitly
-  # expand variables in if statements)
-  if (POLICY CMP0054)
-    cmake_policy(SET CMP0054 NEW)
-  endif()
-
-  # set the behavior of policy 0074 to new as we always used <PackageName>_ROOT as the
-  # root of the installation
-  if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-  endif()
-
-  # de-duplicates libraries for capable linkers (Apple ld64, lld, MSVC)
-  if(POLICY CMP0156)
-    cmake_policy(SET CMP0156 NEW)
-  endif()
-endmacro()
-
-
 # helper macro to retrieve a single field of a dune.module file
 macro(OpmGetDuneModuleDirective field variable contents)
   string (REGEX MATCH ".*${field}:[ ]*([^\n]+).*" ${variable} "${contents}")
@@ -100,7 +63,6 @@ if("${CMAKE_SIZEOF_VOID_P}" LESS 8)
   message(FATAL_ERROR "OPM will only work correctly on 64bit (or higher) systems!")
 endif()
 
-OpmSetPolicies()
 OpmInitProjVars ()
 OpmInitDirVars ()
 

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -17,6 +17,7 @@
 # ${project}_targets_hook     Add additional targets, set additional target properties
 
 include(OpmCompile)
+include(OpmPolicies)
 include(OpmTargets)
 include(MPIChecks)
 
@@ -38,6 +39,8 @@ vcs_info ()
 include (UseCompVer)
 compiler_info ()
 linker_info ()
+
+OpmSetPolicies()
 
 # default settings: build static debug library
 include (OpmDefaults)

--- a/cmake/Modules/OpmPolicies.cmake
+++ b/cmake/Modules/OpmPolicies.cmake
@@ -1,0 +1,40 @@
+# for CMake >= 3.0, we need to change a few policies:
+#
+#   - CMP0026 to allow access to the LOCATION target property
+#   - CMP0048 to indicate that we want to deal with the *VERSION*
+#     variables ourselves
+#   - CMP0064 to indicate that we want TEST if conditions to be evaluated
+#   - CMP0074 to indicate that <PackageName>_ROOT can be used to find package
+#             config files
+macro(OpmSetPolicies)
+  if (POLICY CMP0048)
+    # We do not set version. Hence NEW should work and this can be removed later
+    cmake_policy(SET CMP0048 NEW)
+  endif()
+
+  if(POLICY CMP0064)
+    cmake_policy(SET CMP0064 NEW)
+  endif()
+
+  # set the behavior of the policy 0054 to NEW. (i.e. do not implicitly
+  # expand variables in if statements)
+  if (POLICY CMP0054)
+    cmake_policy(SET CMP0054 NEW)
+  endif()
+
+  # set the behavior of policy 0074 to new as we always used <PackageName>_ROOT as the
+  # root of the installation
+  if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+  endif()
+
+  # de-duplicates libraries for capable linkers (Apple ld64, lld, MSVC)
+  if(POLICY CMP0156)
+    cmake_policy(SET CMP0156 NEW)
+  endif()
+
+  # use boost config mode
+  if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+  endif()
+endmacro()

--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -1,12 +1,7 @@
 # -*- mode: cmake; tab-width: 2; indent-tabs-mode: nil; truncate-lines: t; compile-command: "cmake -Wdev" -*-
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 expandtab softtabstop=2 nowrap:
 
-# CMake 3.30.0 requires to find Boost in CONFIG mode
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30.0)
-  set(_Boost_CONFIG_MODE CONFIG)
-endif()
-
-find_package(Boost REQUIRED ${_Boost_CONFIG_MODE})
+find_package(Boost REQUIRED)
 find_package(cJSON)
 find_package(fmt)
 find_package(QuadMath)


### PR DESCRIPTION
in particular we need to include it in the opm-common config file.

now we can use the policy for using boost config mode instead of having a manual check in all the prereqs files