### PR TITLE
Exclude REIN from Group::topup_phase()

### DIFF
--- a/opm/input/eclipse/Schedule/Group/Group.cpp
+++ b/opm/input/eclipse/Schedule/Group/Group.cpp
@@ -445,6 +445,34 @@ bool has_control(int controls, Group::ProductionCMode cmode)
     return (controls & static_cast<int>(cmode)) != 0;
 }
 
+// Determine the unique top-up phase for a group's injection properties.
+// Only RESV and VREP controls define a top-up phase (not REIN).
+// Returns the phase if exactly one phase has RESV/VREP controls,
+// or nullopt if no phase qualifies or multiple phases conflict.
+std::optional<Phase>
+topup_phase(const std::map<Phase, Group::GroupInjectionProperties>& injection_properties)
+{
+    std::optional<Phase> topup_phase;
+    for (const auto& [phase, injection] : injection_properties) {
+        if (!has_control(injection.injection_controls, Group::InjectionCMode::RESV) &&
+            !has_control(injection.injection_controls, Group::InjectionCMode::VREP))
+        {
+            continue;
+        }
+
+        if (topup_phase.has_value() && topup_phase.value() != phase) {
+            // Multiple phases have RESV/VREP controls — no unique top-up phase.
+            return {};
+        }
+
+        topup_phase = phase;
+    }
+
+    // Returns nullopt if no phase has RESV/VREP controls, including
+    // when injection_properties is empty (group has no injection config).
+    return topup_phase;
+}
+
 }} // namespace <anonymous>::detail
 
 bool Group::updateInjection(const GroupInjectionProperties& injection)
@@ -468,22 +496,10 @@ bool Group::updateInjection(const GroupInjectionProperties& injection)
         }
     }
 
-    if (detail::has_control(injection.injection_controls, Group::InjectionCMode::RESV) ||
-        detail::has_control(injection.injection_controls, Group::InjectionCMode::REIN) ||
-        detail::has_control(injection.injection_controls, Group::InjectionCMode::VREP))
-    {
-        auto topUp_phase = injection.phase;
-        if (topUp_phase != this->m_topup_phase) {
-            this->m_topup_phase = topUp_phase;
-            update = true;
-        }
-    }
-    else {
-        if (this->m_topup_phase.has_value()) {
-            update = true;
-        }
-
-        this->m_topup_phase = {};
+    const auto new_topup_phase = detail::topup_phase(this->injection_properties);
+    if (new_topup_phase != this->m_topup_phase) {
+        this->m_topup_phase = new_topup_phase;
+        update = true;
     }
 
     return update;
@@ -950,6 +966,12 @@ std::optional<std::string> Group::flow_group() const
     return this->parent();
 }
 
+// Returns the group's unique top-up phase, computed by detail::topup_phase()
+// and cached in m_topup_phase during updateInjection().
+//
+// - Returns a Phase if exactly one phase has RESV or VREP injection controls.
+// - Returns nullopt if no phase has RESV/VREP controls, or if multiple
+//   phases conflict (e.g., both WATER RESV and GAS RESV are active).
 const std::optional<Phase>& Group::topup_phase() const
 {
     return this->m_topup_phase;

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -963,6 +963,85 @@ GCONINJE
     }
 }
 
+BOOST_AUTO_TEST_CASE(GCONINJE_RESV_SETS_TOPUP_PHASE) {
+    const std::string input = R"(
+START             -- 0
+31 AUG 1993 /
+SCHEDULE
+
+GRUPTREE
+  'G1'  'FIELD' /
+/
+
+GCONINJE
+  'G1'   'GAS'     'RESV' 1* 1000 /
+/)";
+
+    auto schedule = create_schedule(input);
+    const auto& g1 = schedule.getGroup("G1", 0);
+    BOOST_CHECK(g1.topup_phase().has_value());
+    BOOST_CHECK(g1.topup_phase().value() == Phase::GAS);
+}
+
+BOOST_AUTO_TEST_CASE(GCONINJE_VREP_SETS_TOPUP_PHASE) {
+    const std::string input = R"(
+START             -- 0
+31 AUG 1993 /
+SCHEDULE
+
+GRUPTREE
+  'G1'  'FIELD' /
+/
+
+GCONINJE
+  'G1'   'WATER'   'VREP' 3* 1.0 /
+/)";
+
+    auto schedule = create_schedule(input);
+    const auto& g1 = schedule.getGroup("G1", 0);
+    BOOST_CHECK(g1.topup_phase().has_value());
+    BOOST_CHECK(g1.topup_phase().value() == Phase::WATER);
+}
+
+BOOST_AUTO_TEST_CASE(GCONINJE_REIN_DOES_NOT_SET_TOPUP_PHASE) {
+    const std::string input = R"(
+START             -- 0
+31 AUG 1993 /
+SCHEDULE
+
+GRUPTREE
+  'G1'  'FIELD' /
+/
+
+GCONINJE
+  'G1'   'GAS'     'REIN' 2* 0.8 /
+/)";
+
+    auto schedule = create_schedule(input);
+    const auto& g1 = schedule.getGroup("G1", 0);
+    BOOST_CHECK(!g1.topup_phase().has_value());
+}
+
+BOOST_AUTO_TEST_CASE(GCONINJE_MULTIPLE_TOPUP_PHASES_RETURNS_NULLOPT) {
+    const std::string input = R"(
+START             -- 0
+31 AUG 1993 /
+SCHEDULE
+
+GRUPTREE
+  'G1'  'FIELD' /
+/
+
+GCONINJE
+  'G1'   'WATER'   'RESV' 1* 1000 /
+  'G1'   'GAS'     'RESV' 1* 1000 /
+/)";
+
+    auto schedule = create_schedule(input);
+    const auto& g1 = schedule.getGroup("G1", 0);
+    BOOST_CHECK(!g1.topup_phase().has_value());
+}
+
 BOOST_AUTO_TEST_CASE(GCONINJE_GUIDERATE) {
     const std::string input = R"(
 START             -- 0


### PR DESCRIPTION
Used by companion PR https://github.com/OPM/opm-simulators/pull/6928

- **Fix `topup_phase()` semantics**: Only `RESV` and `VREP` injection control modes now define a top-up phase. Previously, `REIN` was also included, but REIN is a reinjection mode unrelated to the reservoir-rate subtraction logic that `topup_phase()` supports.
- **Recompute from all injection properties**: Instead of updating `m_topup_phase` based on a single `updateInjection()` call, the new `detail::topup_phase()` helper scans all active injection properties to determine the unique top-up phase. Returns `nullopt` when no phase qualifies or when multiple phases conflict (e.g., both WATER RESV and GAS RESV).
- **Add test**: Verify that a `GCONINJE` entry with `REIN` control does not set `topup_phase()`.

## Context

This is a companion PR for an opm-simulators change that adds cross-group validation of GCONINJE top-up phase consistency. The simulator-side validation relies on `Group::topup_phase()` returning meaningful values — only phases that participate in reservoir-rate subtraction (RESV, VREP), not reinjection (REIN).

