### PR TITLE
[bugfix] Make sure that an SMSPEC file is written at the last time step.

### DIFF
--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -5356,7 +5356,12 @@ void Opm::out::Summary::SummaryImplementation::write(const bool is_final_summary
 
     this->createSMSpecIfNecessary();
 
-    if (this->prevReportStepID_ < this->lastUnwritten().seq) {
+    // We are forcing a final write at the end of the last report step to get all changes
+    // to the SMSPEC file (WGNAMES, KEYWORDS) that might have changed due ACTIONX at an
+    // intermediate timestep.
+    // Because of adaptive time stepping there could have been previous writes for the same
+    // report step that missed information.
+    if (this->prevReportStepID_ < this->lastUnwritten().seq || is_final_summary) {
         this->smspec_->write(this->outputParameters_.summarySpecification());
     }
 


### PR DESCRIPTION
Before we would have written the file only after the first time step of the last report step.
Hence simulations that did adaptive time stepping would stay marked as not finished for upcoming RUNTIMEI support.

Previously, if output writing of arrays WGNAMES and KEYWORDS changed due to e.g. ACTIONX in one of the adaptive time steps then this was also not reflected in the in the SMSPEC file.