### PR TITLE
Prefer Std::Numbers::PI

### DIFF
--- a/opm/common/utility/numeric/calculateCellVol.cpp
+++ b/opm/common/utility/numeric/calculateCellVol.cpp
@@ -24,6 +24,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <numbers>
 
 namespace {
 
@@ -146,5 +147,5 @@ double calculateCellVol(const std::array<double,8>& X,
 */
 double calculateCylindricalCellVol(const double r_inner, const double r_outer, const double delta_theta, const double delta_z)
 {
-    return M_PI * std::abs((std::pow(r_outer,2) - std::pow(r_inner,2)) * delta_theta * delta_z) / 360.0;
+    return std::numbers::pi * std::abs((std::pow(r_outer,2) - std::pow(r_inner,2)) * delta_theta * delta_z) / 360.0;
 }

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -58,8 +58,6 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/Z.hpp>
 
-#define _USE_MATH_DEFINES
-
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
@@ -68,6 +66,7 @@
 #include <cstring>
 #include <functional>
 #include <initializer_list>
+#include <numbers>
 #include <numeric>
 #include <optional>
 #include <stdexcept>
@@ -1189,7 +1188,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
                     /*
                       The theta value is supposed to go counterclockwise, starting at 'twelve o clock'.
                     */
-                    double t = M_PI * (90 - tj[j]) / 180;
+                    double t = std::numbers::pi * (90 - tj[j]) / 180;
                     double c = cos( t );
                     double s = sin( t );
                     for (std::size_t i = 0; i <= this->getNX(); i++) {

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -42,6 +42,7 @@
 #include <cstddef>
 #include <iterator>
 #include <map>
+#include <numbers>
 #include <numeric>
 #include <set>
 #include <stdexcept>
@@ -50,11 +51,6 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
-
-#ifdef _WIN32
-#define _USE_MATH_DEFINES
-#include <math.h>
-#endif
 
 #include <fmt/format.h>
 
@@ -223,7 +219,7 @@ namespace Opm {
         const int branchID = 1;  // Only main branch for now.
 
         const double roughness = 0.0;  // Defaulted: ROUGHNESS in WELSEGS.
-        const double area = M_PI * diameter * diameter / 4.0;
+        const double area = std::numbers::pi * diameter * diameter / 4.0;
         const double volume = Segment::invalidValue();
 
         // Add segments:
@@ -332,7 +328,7 @@ namespace Opm {
             }
 
             const double diameter = record.getItem("DIAMETER").getSIDouble(0);
-            double area = M_PI * diameter * diameter / 4.0;
+            double area = std::numbers::pi * diameter * diameter / 4.0;
             {
                 const auto& itemArea = record.getItem("AREA");
                 if (itemArea.hasValue(0)) {

--- a/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -35,6 +35,7 @@
 #include <cassert>
 #include <cstddef>
 #include <exception>
+#include <numbers>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -661,8 +662,7 @@ double Connection::getFilterCakeArea() const
         return *flow_area;
     }
     else {
-        constexpr double two_pi = 2 * 3.14159265358979323846264;
-        return two_pi * this->getFilterCakeRadius() * this->connectionLength();
+        return 2*std::numbers::pi * this->getFilterCakeRadius() * this->connectionLength();
     }
 }
 

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -57,6 +57,7 @@
 #include <cmath>
 #include <cstddef>
 #include <limits>
+#include <numbers>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -219,7 +220,7 @@ namespace {
             Opm::Connection::Direction::Z,
         };
 
-        const double angle = 6.2831853071795864769252867665590057683943387987502116419498;
+        const double angle = 2 * std::numbers::pi;
 
         for (size_t i = 0; i < 3; ++i) {
             const auto K = permComponents(direction[i], cell_perm);
@@ -410,7 +411,7 @@ namespace Opm {
 
         // Angle of completion exposed to flow.  We assume centre
         // placement so there's complete exposure (= 2\pi).
-        const auto angle = 6.2831853071795864769252867665590057683943387987502116419498;
+        const auto angle = 2 * std::numbers::pi;
 
         for (int k = K1; k <= K2; ++k) {
             const auto& cell = grid.get_cell(I, J, k, lgr_label);

--- a/opm/io/eclipse/EGrid.cpp
+++ b/opm/io/eclipse/EGrid.cpp
@@ -28,9 +28,10 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <numbers>
 #include <numeric>
-#include <string>
 #include <stdexcept>
+#include <string>
 
 #include <fmt/format.h>
 
@@ -412,10 +413,10 @@ void EGrid::getCellCorners(const std::array<int, 3>& ijk,
         double zb = coord_array[pind[n] + 5];
 
         if (m_radial) {
-            xt = coord_array[pind[n]] * cos(coord_array[pind[n] + 1] / 180.0 * M_PI);
-            yt = coord_array[pind[n]] * sin(coord_array[pind[n] + 1] / 180.0 * M_PI);
-            xb = coord_array[pind[n] + 3] * cos(coord_array[pind[n] + 4] / 180.0 * M_PI);
-            yb = coord_array[pind[n] + 3] * sin(coord_array[pind[n] + 4] / 180.0 * M_PI);
+            xt = coord_array[pind[n]] * cos(coord_array[pind[n] + 1] / 180.0 * std::numbers::pi);
+            yt = coord_array[pind[n]] * sin(coord_array[pind[n] + 1] / 180.0 * std::numbers::pi);
+            xb = coord_array[pind[n] + 3] * cos(coord_array[pind[n] + 4] / 180.0 * std::numbers::pi);
+            yb = coord_array[pind[n] + 3] * sin(coord_array[pind[n] + 4] / 180.0 * std::numbers::pi);
         } else {
             xt = coord_array[pind[n]];
             yt = coord_array[pind[n] + 1];

--- a/opm/io/eclipse/rst/connection.cpp
+++ b/opm/io/eclipse/rst/connection.cpp
@@ -25,6 +25,7 @@
 
 #include <array>
 #include <cmath>
+#include <numbers>
 #include <cstddef>
 #include <stdexcept>
 #include <string>
@@ -103,7 +104,7 @@ double pressEquivRadius(const Opm::UnitSystem& usys,
 
 double Opm::RestartIO::RstConnection::inverse_peaceman(double cf, double kh, double rw, double skin)
 {
-    auto alpha = 3.14159265 * 2 * kh / cf - skin;
+    const auto alpha = 2*std::numbers::pi * kh / cf - skin;
     return rw * std::exp(alpha);
 }
 

--- a/opm/material/Constants.hpp
+++ b/opm/material/Constants.hpp
@@ -27,10 +27,12 @@
 #ifndef OPM_CONSTANTS_HPP
 #define OPM_CONSTANTS_HPP
 
-#include <cmath>
 #if HAVE_QUAD
 #include <opm/material/common/quad.hpp>
 #endif
+
+#include <cmath>
+#include <numbers>
 
 namespace Opm
 {
@@ -72,7 +74,7 @@ public:
     /*!
      * \brief Reduced Planck constant [J s]
      */
-    static constexpr Scalar hRed = h / (2 * M_PI);
+    static constexpr Scalar hRed = h / (2 * std::numbers::pi_v<Scalar>);
 };
 
 } // namespace Opm

--- a/opm/material/binarycoefficients/Brine_CO2.hpp
+++ b/opm/material/binarycoefficients/Brine_CO2.hpp
@@ -35,6 +35,7 @@
 #include <opm/common/utility/gpuDecorators.hpp>
 
 #include <array>
+#include <numbers>
 
 namespace Opm {
 namespace BinaryCoeff {
@@ -71,7 +72,7 @@ public:
         Scalar c = 4; // slip parameter, can vary between 4 (slip condition) and 6 (stick condition)
         Scalar R_h = 1.72e-10; // hydrodynamic radius of the solute
         const Evaluation& mu = CO2::gasViscosity(params, temperature, pressure, extrapolate); // CO2 viscosity
-        return k / (c * M_PI * R_h) * (temperature / mu);
+        return k / (c * std::numbers::pi * R_h) * (temperature / mu);
     }
 
     /*!

--- a/opm/material/common/PolynomialUtils.hpp
+++ b/opm/material/common/PolynomialUtils.hpp
@@ -27,10 +27,11 @@
 #ifndef OPM_POLYNOMIAL_UTILS_HH
 #define OPM_POLYNOMIAL_UTILS_HH
 
-#include <cmath>
-#include <algorithm>
-
 #include <opm/material/common/MathToolbox.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
 
 namespace Opm {
 /*!
@@ -260,7 +261,7 @@ unsigned invertCubicPolynomial(SolContainer* sol,
             // calculate the three real roots of the polynomial:
             for (int i = 0; i < 3; ++i) {
                 sol[i] = cos(phi)*(uAbs - p/(3*uAbs)) - b/3;
-                phi += 2*M_PI/3;
+                phi += 2*std::numbers::pi/3;
             }
 
             // post process the obtained solution to increase numerical
@@ -355,8 +356,8 @@ unsigned cubicRoots(SolContainer* sol,
 
         // Calculate the three roots
         sol[0] = 2.0 * sqrt(-p / 3.0) * cos( theta ) - b / (3.0 * a);
-        sol[1] = 2.0 * sqrt(-p / 3.0) * cos( theta - ((2.0 * M_PI) / 3.0) ) - b / (3.0 * a);
-        sol[2] = 2.0 * sqrt(-p / 3.0) * cos( theta - ((4.0 * M_PI) / 3.0) ) - b / (3.0 * a);
+        sol[1] = 2.0 * sqrt(-p / 3.0) * cos( theta - ((2.0 * std::numbers::pi) / 3.0) ) - b / (3.0 * a);
+        sol[2] = 2.0 * sqrt(-p / 3.0) * cos( theta - ((4.0 * std::numbers::pi) / 3.0) ) - b / (3.0 * a);
 
         // Sort in ascending order
         std::sort(sol, sol + 3);

--- a/opm/material/common/quad.hpp
+++ b/opm/material/common/quad.hpp
@@ -31,10 +31,11 @@
 
 #include <cmath>
 #include <complex>
-#include <string>
-#include <stdexcept>
-#include <limits>
 #include <iostream>
+#include <limits>
+#include <numbers>
+#include <stdexcept>
+#include <string>
 #include <type_traits>
 
 extern "C" {
@@ -347,6 +348,11 @@ inline bool isinf(quad val)
 #endif // QUADMATH_HAS_MATH_OPERATORS
 
 } // namespace std
+
+namespace std::numbers {
+    template <>
+    inline constexpr quad pi_v<quad> = M_PIq;
+} // namespace std::numbers
 
 #if HAVE_DUNE_COMMON
 

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -47,6 +47,7 @@
 #include <ctime>
 #include <math.h>
 #include <memory>
+#include <numbers>
 #include <optional>
 #include <numeric>
 #include <stdexcept>
@@ -2009,8 +2010,8 @@ BOOST_AUTO_TEST_CASE(RadialDetails) {
     Opm::Deck deck = radial_details();
     Opm::EclipseGrid grid( deck );
 
-    BOOST_CHECK_CLOSE( grid.getCellVolume( 0 , 0 , 0 ) , 0.75 * M_PI, 0.0001);
-    BOOST_CHECK_CLOSE( grid.getCellVolume( 0 , 3 , 0 ) , 0.5 * M_PI , 0.0001);
+    BOOST_CHECK_CLOSE( grid.getCellVolume( 0 , 0 , 0 ) , 0.75 * std::numbers::pi, 0.0001);
+    BOOST_CHECK_CLOSE( grid.getCellVolume( 0 , 3 , 0 ) , 0.5 * std::numbers::pi , 0.0001);
     auto pos0 = grid.getCellCenter(0,0,0);
     auto pos2 = grid.getCellCenter(0,2,0);
 
@@ -2066,8 +2067,8 @@ BOOST_AUTO_TEST_CASE(RadialDetailsDZ) {
     Opm::Deck deck = radial_details_dz();
     Opm::EclipseGrid grid( deck );
 
-    BOOST_CHECK_CLOSE( grid.getCellVolume( 0 , 0 , 0 ) , 0.75 * M_PI, 0.0001);
-    BOOST_CHECK_CLOSE( grid.getCellVolume( 0 , 3 , 0 ) , 0.5 * M_PI , 0.0001);
+    BOOST_CHECK_CLOSE( grid.getCellVolume( 0 , 0 , 0 ) , 0.75 * std::numbers::pi, 0.0001);
+    BOOST_CHECK_CLOSE( grid.getCellVolume( 0 , 3 , 0 ) , 0.5 * std::numbers::pi , 0.0001);
     auto pos0 = grid.getCellCenter(0,0,0);
     auto pos2 = grid.getCellCenter(0,2,0);
 

--- a/tests/test_calculateCellVol.cpp
+++ b/tests/test_calculateCellVol.cpp
@@ -29,6 +29,7 @@
 
 #include <array>
 #include <cmath>
+#include <numbers>
 
 BOOST_AUTO_TEST_SUITE (CalculateCellVolume)
 
@@ -63,19 +64,19 @@ BOOST_AUTO_TEST_CASE (calc_cellvol_cylindric)
 {
   {
     double r_inner = 0.0, r_outer = 1.0, delta_theta = 360.0, delta_z = 1.0;
-    BOOST_REQUIRE_CLOSE(calculateCylindricalCellVol(r_inner, r_outer, delta_theta, delta_z), M_PI, 1e-9);
+    BOOST_REQUIRE_CLOSE(calculateCylindricalCellVol(r_inner, r_outer, delta_theta, delta_z), std::numbers::pi, 1e-9);
   }
   {
     double r_inner = 1.0, r_outer = 2.0, delta_theta = 360.0, delta_z = 1.0;
-    BOOST_REQUIRE_CLOSE(calculateCylindricalCellVol(r_inner, r_outer, delta_theta, delta_z), 3.0 * M_PI, 1e-9);
+    BOOST_REQUIRE_CLOSE(calculateCylindricalCellVol(r_inner, r_outer, delta_theta, delta_z), 3.0 * std::numbers::pi, 1e-9);
   }
   {
     double r_inner = 1.0, r_outer = 2.0, delta_theta = 120.0, delta_z = 1.0;
-    BOOST_REQUIRE_CLOSE(calculateCylindricalCellVol(r_inner, r_outer, delta_theta, delta_z), M_PI, 1e-9);
+    BOOST_REQUIRE_CLOSE(calculateCylindricalCellVol(r_inner, r_outer, delta_theta, delta_z), std::numbers::pi, 1e-9);
   }
   {
     double r_inner = 1.0, r_outer = 2.0, delta_theta = 120.0, delta_z = 1.5;
-    BOOST_REQUIRE_CLOSE(calculateCylindricalCellVol(r_inner, r_outer, delta_theta, delta_z), 1.5 * M_PI, 1e-9);
+    BOOST_REQUIRE_CLOSE(calculateCylindricalCellVol(r_inner, r_outer, delta_theta, delta_z), 1.5 * std::numbers::pi, 1e-9);
   }
 }
 

--- a/tests/test_densead.cpp
+++ b/tests/test_densead.cpp
@@ -37,10 +37,11 @@
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/densead/Math.hpp>
 
-#include <iostream>
-#include <cmath>
 #include <algorithm>
 #include <cassert>
+#include <cmath>
+#include <iostream>
+#include <numbers>
 #include <stdexcept>
 #include <tuple>
 
@@ -528,7 +529,7 @@ struct TestEnvBase
         std::cout << "  Testing sin()\n";
         test1DFunction(Opm::DenseAd::sin<Scalar, numVars, staticSize>,
                        static_cast<Scalar (*)(Scalar)>(std::sin),
-                       0, 2*M_PI);
+                       0, 2*std::numbers::pi);
 
         std::cout << "  Testing asin()\n";
         test1DFunction(Opm::DenseAd::asin<Scalar, numVars, staticSize>,
@@ -538,7 +539,7 @@ struct TestEnvBase
         std::cout << "  Testing cos()\n";
         test1DFunction(Opm::DenseAd::cos<Scalar, numVars, staticSize>,
                        static_cast<Scalar (*)(Scalar)>(std::cos),
-                       0, 2*M_PI);
+                       0, 2*std::numbers::pi);
 
         std::cout << "  Testing acos()\n";
         test1DFunction(Opm::DenseAd::acos<Scalar, numVars, staticSize>,
@@ -548,7 +549,7 @@ struct TestEnvBase
         std::cout << "  Testing tan()\n";
         test1DFunction(Opm::DenseAd::tan<Scalar, numVars, staticSize>,
                        static_cast<Scalar (*)(Scalar)>(std::tan),
-                       -M_PI / 2 * 0.95, M_PI / 2 * 0.95);
+                       -std::numbers::pi / 2 * 0.95, std::numbers::pi / 2 * 0.95);
 
         std::cout << "  Testing atan()\n";
         test1DFunction(Opm::DenseAd::atan<Scalar, numVars, staticSize>,


### PR DESCRIPTION
We have C++20 now so use the portable alternative to spelling out the value or using the Posix-only `M_PI` macro.