### PR TITLE
adding solvent to BlackOilFluidState

### DIFF
--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -106,6 +106,18 @@ OPM_HOST_DEVICE auto getSaltSaturation_(typename std::enable_if<!HasMember_saltS
                                                     const FluidState&>::type)
 { return 0.0; }
 
+OPM_GENERATE_HAS_MEMBER(solventSaturation, ) // Creates 'HasMember_solventSaturation<T>'.
+
+template <class FluidState>
+OPM_HOST_DEVICE auto getSolventSaturation_(typename std::enable_if<HasMember_solventSaturation<FluidState>::value,
+                                                    const FluidState&>::type fluidState)
+{ return fluidState.solventSaturation(); }
+
+template <class FluidState>
+OPM_HOST_DEVICE auto getSolventSaturation_(typename std::enable_if<!HasMember_solventSaturation<FluidState>::value,
+                                                    const FluidState&>::type)
+{ return 0.0; }
+
 /*!
  * \brief Implements a "tailor-made" fluid state class for the black-oil model.
  *
@@ -122,6 +134,7 @@ template <class ScalarT,
           bool enableBrine = false,
           bool enableSaltPrecipitation = false,
           bool enableDissolutionInWater = false,
+          bool enableSolvent = false,
           unsigned numStoragePhases = FluidSystemT::numPhases>
 class BlackOilFluidState
 {
@@ -168,6 +181,7 @@ public:
                                   enableBrine,
                                   enableSaltPrecipitation,
                                   enableDissolutionInWater,
+                                  enableSolvent,
                                   numStoragePhases>(other);
         bfstate.assign(*this);
         return bfstate;
@@ -227,6 +241,13 @@ public:
             Valgrind::CheckDefined(*saltSaturation_);
         }
 
+        if constexpr (enableSolvent) {
+            Valgrind::CheckDefined(*solventSaturation_);
+            Valgrind::CheckDefined(*solventDensity_);
+            Valgrind::CheckDefined(*solventInvB_);
+            Valgrind::CheckDefined(*rsSolw_);
+        }
+
         if constexpr (storeTemperature)
             Valgrind::CheckDefined(*temperature_);
 #endif // NDEBUG
@@ -262,6 +283,12 @@ public:
         }
         if constexpr (enableSaltPrecipitation){
             setSaltSaturation(BlackOil::getSaltSaturation_<FluidSystem, FluidState, Scalar>(fs, pvtRegionIdx));
+        }
+        if constexpr (enableSolvent) {
+            setSolventSaturation(BlackOil::getSolventSaturation_<FluidState, Scalar>(fs, pvtRegionIdx));
+            setSolventDensity(BlackOil::getSolventDensity_<FluidState, Scalar>(fs, pvtRegionIdx));
+            setSolventInvB(BlackOil::getSolventInvB_<FluidState, Scalar>(fs, pvtRegionIdx));
+            setRsSolw(BlackOil::getRsSolw_<FluidState, Scalar>(fs, pvtRegionIdx));
         }
         for (unsigned storagePhaseIdx = 0; storagePhaseIdx < numStoragePhases; ++storagePhaseIdx) {
             unsigned phaseIdx = storageToCanonicalPhaseIndex_(storagePhaseIdx, fluidSystem());
@@ -388,6 +415,30 @@ public:
     { *saltSaturation_ = newSaltSaturation; }
 
     /*!
+     * \brief Set the solvent saturation.
+     */
+    OPM_HOST_DEVICE void setSolventSaturation(const Scalar& newSolventSaturation)
+    { *solventSaturation_ = newSolventSaturation; }
+
+    /*!
+     * \brief Set the solvent density [kg/m^3].
+     */
+    OPM_HOST_DEVICE void setSolventDensity(const Scalar& newSolventDensity)
+    { *solventDensity_ = newSolventDensity; }
+
+    /*!
+     * \brief Set the solvent inverse formation volume factor [-].
+     */
+    OPM_HOST_DEVICE void setSolventInvB(const Scalar& newSolventInvB)
+    { *solventInvB_ = newSolventInvB; }
+
+    /*!
+     * \brief Set the solvent dissolution factor in water [m^3/m^3].
+     */
+    OPM_HOST_DEVICE void setRsSolw(const Scalar& newRsSolw)
+    { *rsSolw_ = newRsSolw; }
+
+    /*!
      * \brief Return the pressure of a fluid phase [Pa]
      */
     OPM_HOST_DEVICE const Scalar& pressure(unsigned phaseIdx) const
@@ -511,6 +562,54 @@ public:
     {
         if constexpr (enableSaltPrecipitation) {
             return *saltSaturation_;
+        } else {
+            return Scalar(0.0);
+        }
+    }
+
+    /*!
+     * \brief Return the solvent saturation [-]
+     */
+    OPM_HOST_DEVICE Scalar solventSaturation() const
+    {
+        if constexpr (enableSolvent) {
+            return *solventSaturation_;
+        } else {
+            return Scalar(0.0);
+        }
+    }
+
+    /*!
+     * \brief Return the solvent density [kg/m^3]
+     */
+    OPM_HOST_DEVICE Scalar solventDensity() const
+    {
+        if constexpr (enableSolvent) {
+            return *solventDensity_;
+        } else {
+            return Scalar(0.0);
+        }
+    }
+
+    /*!
+     * \brief Return the solvent inverse formation volume factor [-]
+     */
+    OPM_HOST_DEVICE Scalar solventInvB() const
+    {
+        if constexpr (enableSolvent) {
+            return *solventInvB_;
+        } else {
+            return Scalar(0.0);
+        }
+    }
+
+    /*!
+     * \brief Return the solvent dissolution factor in water [m^3/m^3]
+     */
+    OPM_HOST_DEVICE Scalar rsSolw() const
+    {
+        if constexpr (enableSolvent) {
+            return *rsSolw_;
         } else {
             return Scalar(0.0);
         }
@@ -757,6 +856,10 @@ private:
     ConditionalStorage<enableDissolutionInWater,Scalar> Rsw_{};
     ConditionalStorage<enableBrine, Scalar> saltConcentration_{};
     ConditionalStorage<enableSaltPrecipitation, Scalar> saltSaturation_{};
+    ConditionalStorage<enableSolvent, Scalar> solventSaturation_{};
+    ConditionalStorage<enableSolvent, Scalar> solventDensity_{};
+    ConditionalStorage<enableSolvent, Scalar> solventInvB_{};
+    ConditionalStorage<enableSolvent, Scalar> rsSolw_{};
 
     unsigned short pvtRegionIdx_{};
 

--- a/opm/material/fluidsystems/BlackOilFunctions.hpp
+++ b/opm/material/fluidsystems/BlackOilFunctions.hpp
@@ -55,6 +55,10 @@ OPM_GENERATE_HAS_MEMBER(Rvw, ) // Creates 'HasMember_Rvw<T>'.
 OPM_GENERATE_HAS_MEMBER(Rsw, ) // Creates 'HasMember_Rsw<T>'.
 OPM_GENERATE_HAS_MEMBER(saltConcentration, )
 OPM_GENERATE_HAS_MEMBER(saltSaturation, )
+OPM_GENERATE_HAS_MEMBER(solventSaturation, )
+OPM_GENERATE_HAS_MEMBER(solventDensity, )
+OPM_GENERATE_HAS_MEMBER(solventInvB, )
+OPM_GENERATE_HAS_MEMBER(rsSolw, )
 
 template <class FluidSystem, class FluidState, class LhsEval>
 OPM_HOST_DEVICE LhsEval
@@ -156,6 +160,74 @@ getSaltSaturation_(
     -> decltype(decay<LhsEval>(fluidState.saltSaturation()))
 {
     return decay<LhsEval>(fluidState.saltSaturation());
+}
+
+template <class FluidState, class LhsEval>
+OPM_HOST_DEVICE LhsEval
+getSolventSaturation_(typename std::enable_if<!HasMember_solventSaturation<FluidState>::value, const FluidState&>::type,
+                      unsigned)
+{
+    return 0.0;
+}
+
+template <class FluidState, class LhsEval>
+OPM_HOST_DEVICE auto
+getSolventSaturation_(
+    typename std::enable_if<HasMember_solventSaturation<FluidState>::value, const FluidState&>::type fluidState,
+    unsigned) -> decltype(decay<LhsEval>(fluidState.solventSaturation()))
+{
+    return decay<LhsEval>(fluidState.solventSaturation());
+}
+
+template <class FluidState, class LhsEval>
+OPM_HOST_DEVICE LhsEval
+getSolventDensity_(typename std::enable_if<!HasMember_solventDensity<FluidState>::value, const FluidState&>::type,
+                   unsigned)
+{
+    return 0.0;
+}
+
+template <class FluidState, class LhsEval>
+OPM_HOST_DEVICE auto
+getSolventDensity_(
+    typename std::enable_if<HasMember_solventDensity<FluidState>::value, const FluidState&>::type fluidState,
+    unsigned) -> decltype(decay<LhsEval>(fluidState.solventDensity()))
+{
+    return decay<LhsEval>(fluidState.solventDensity());
+}
+
+template <class FluidState, class LhsEval>
+OPM_HOST_DEVICE LhsEval
+getSolventInvB_(typename std::enable_if<!HasMember_solventInvB<FluidState>::value, const FluidState&>::type,
+                unsigned)
+{
+    return 0.0;
+}
+
+template <class FluidState, class LhsEval>
+OPM_HOST_DEVICE auto
+getSolventInvB_(
+    typename std::enable_if<HasMember_solventInvB<FluidState>::value, const FluidState&>::type fluidState,
+    unsigned) -> decltype(decay<LhsEval>(fluidState.solventInvB()))
+{
+    return decay<LhsEval>(fluidState.solventInvB());
+}
+
+template <class FluidState, class LhsEval>
+OPM_HOST_DEVICE LhsEval
+getRsSolw_(typename std::enable_if<!HasMember_rsSolw<FluidState>::value, const FluidState&>::type,
+           unsigned)
+{
+    return 0.0;
+}
+
+template <class FluidState, class LhsEval>
+OPM_HOST_DEVICE auto
+getRsSolw_(
+    typename std::enable_if<HasMember_rsSolw<FluidState>::value, const FluidState&>::type fluidState,
+    unsigned) -> decltype(decay<LhsEval>(fluidState.rsSolw()))
+{
+    return decay<LhsEval>(fluidState.rsSolw());
 }
 
 } // namespace Opm::BlackOil

--- a/tests/material/test_blackoilfluidstate.cpp
+++ b/tests/material/test_blackoilfluidstate.cpp
@@ -53,3 +53,75 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ApiConformance, Scalar, Types)
     FluidState fs{};
     checkFluidState<Evaluation>(fs);
 }
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(SolventSupport, Scalar, Types)
+{
+    using FluidSystem = Opm::BlackOilFluidSystem<Scalar>;
+
+    // BlackOilFluidState with solvent enabled
+    //   template params: Scalar, FluidSystem, storeTemp, storeEnthalpy,
+    //                    enableDissolution, enableVapwat, enableBrine,
+    //                    enableSaltPrecipitation, enableDissolutionInWater,
+    //                    enableSolvent
+    using SolventFluidState = Opm::BlackOilFluidState<Scalar, FluidSystem,
+                                                      false, false, true, false, false, false, false,
+                                                      true>;
+
+    // When solvent is disabled (default), getters should return 0
+    using NoSolventFluidState = Opm::BlackOilFluidState<Scalar, FluidSystem>;
+
+    // Test solvent-enabled fluid state
+    {
+        SolventFluidState fs{};
+
+        // Initially solvent properties should be value-initialized (zero)
+        BOOST_CHECK_EQUAL(fs.solventSaturation(), Scalar(0.0));
+        BOOST_CHECK_EQUAL(fs.solventDensity(), Scalar(0.0));
+        BOOST_CHECK_EQUAL(fs.solventInvB(), Scalar(0.0));
+        BOOST_CHECK_EQUAL(fs.rsSolw(), Scalar(0.0));
+
+        // Set and retrieve solvent saturation
+        fs.setSolventSaturation(Scalar(0.15));
+        BOOST_CHECK_EQUAL(fs.solventSaturation(), Scalar(0.15));
+
+        // Set and retrieve solvent density
+        fs.setSolventDensity(Scalar(250.0));
+        BOOST_CHECK_EQUAL(fs.solventDensity(), Scalar(250.0));
+
+        // Set and retrieve solvent inverse formation volume factor
+        fs.setSolventInvB(Scalar(1.5));
+        BOOST_CHECK_EQUAL(fs.solventInvB(), Scalar(1.5));
+
+        // Set and retrieve rsSolw (solvent dissolution factor in water)
+        fs.setRsSolw(Scalar(0.05));
+        BOOST_CHECK_EQUAL(fs.rsSolw(), Scalar(0.05));
+    }
+
+    // Test solvent-disabled fluid state: getters should return 0
+    {
+        NoSolventFluidState fs{};
+
+        BOOST_CHECK_EQUAL(fs.solventSaturation(), Scalar(0.0));
+        BOOST_CHECK_EQUAL(fs.solventDensity(), Scalar(0.0));
+        BOOST_CHECK_EQUAL(fs.solventInvB(), Scalar(0.0));
+        BOOST_CHECK_EQUAL(fs.rsSolw(), Scalar(0.0));
+    }
+
+    // Test assign between solvent-enabled fluid states
+    {
+        SolventFluidState fs1{};
+        fs1.setSolventSaturation(Scalar(0.2));
+        fs1.setSolventDensity(Scalar(300.0));
+        fs1.setSolventInvB(Scalar(1.8));
+        fs1.setRsSolw(Scalar(0.1));
+        fs1.setPvtRegionIndex(0);
+
+        SolventFluidState fs2{};
+        fs2.assign(fs1);
+
+        BOOST_CHECK_EQUAL(fs2.solventSaturation(), Scalar(0.2));
+        BOOST_CHECK_EQUAL(fs2.solventDensity(), Scalar(300.0));
+        BOOST_CHECK_EQUAL(fs2.solventInvB(), Scalar(1.8));
+        BOOST_CHECK_EQUAL(fs2.rsSolw(), Scalar(0.1));
+    }
+}


### PR DESCRIPTION
The main motivation is to support other development which requires that we can create FluidState for the wellbore. 

Under certain circumstances, there might be only be Solvent in side the wellbore.  With the master branch, solvent saturation is stored in blackoilsolventmodules.hh .

With the new design, some implementation might be able to be done in different ways, but this PR is mostly moving things around. 


