### PR TITLE
Clarify the error message of the parser.

### DIFF
--- a/opm/input/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/input/eclipse/Parser/ParserKeyword.cpp
@@ -756,15 +756,22 @@ void set_dimensions( ParserItem& item,
                Each block of records is separated by an empty DeckRecord.
             */
             size_t record_nr = 0;
-            for (auto& rawRecord : rawKeyword) {
-                if (rawRecord.size() == 0) {
-                     keyword.addRecord( DeckRecord() );
-                     record_nr = 0;
+            try {
+                for (auto& rawRecord : rawKeyword) {
+                    if (rawRecord.size() == 0) {
+                         keyword.addRecord( DeckRecord() );
+                         record_nr = 0;
+                    }
+                    else {
+                        keyword.addRecord( this->getRecord( record_nr ).parse( parseContext, errors, rawRecord, active_unitsystem, default_unitsystem, rawKeyword.location() ) );
+                        record_nr++;
+                    }
                 }
-                else {
-                    keyword.addRecord( this->getRecord( record_nr ).parse( parseContext, errors, rawRecord, active_unitsystem, default_unitsystem, rawKeyword.location() ) );
-                    record_nr++;
-                }
+            }
+            catch (const std::invalid_argument& e) {
+                throw std::invalid_argument(
+                    fmt::format("Failed to parse the record {} out of {} of the keyword {}\n{}",
+                                record_nr + 1, rawKeyword.size(), keyword.name(), e.what()));
             }
         }
         else {
@@ -777,10 +784,11 @@ void set_dimensions( ParserItem& item,
                     keyword.addRecord( this->getRecord( record_nr ).parse( parseContext, errors, rawRecord, active_unitsystem, default_unitsystem, rawKeyword.location() ) );
                     record_nr++;
                 }
-            } catch (const std::invalid_argument& e) {
-                std::string msg = "Failed to process entry " + std::to_string(record_nr+1) + " out of " + std::to_string(rawKeyword.size())
-                                  + " of the keyword " + keyword.name() + "\n" + e.what();
-                throw std::invalid_argument(msg);
+            }
+            catch (const std::invalid_argument& e) {
+                throw std::invalid_argument(
+                    fmt::format("Failed to parse the record {} out of {} of the keyword {}\n{}",
+                                record_nr+1, rawKeyword.size(), keyword.name(), e.what()));
             }
         }
 


### PR DESCRIPTION
Clarify the error message of the parser by adding information about which entry of the keyword could not be processed.

The change was motivated by a complaint that putting too high EQLDIMS number leads to a confusing message "Malformed floating point number _FOLLOWINGKEYWORD_". This PR prepends the message with a new line "Failed to process entry X out of Y of the keyword KEYWORDNAME".