### PR TITLE
Support Formalised Error Handling in COMPDAT

### DIFF
--- a/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
@@ -153,7 +153,7 @@ namespace
                 wellTraj.wellPathGeometry = new external::RigWellPath;
 
                 auto connections = std::make_shared<WellConnections>(well.getConnections());
-                connections->loadCOMPTRAJ(record, handlerContext.grid, name,
+                connections->loadCOMPTRAJ(record, name, handlerContext.grid,
                                           handlerContext.keyword.location(),
                                           wellTraj);
 
@@ -204,7 +204,7 @@ Well {} has no connections to the grid. The well will remain SHUT)", name);
                 auto well = handlerContext.state().wells.get(name);
 
                 auto connections = std::make_shared<WellConnections>(well.getConnections());
-                connections->loadWELTRAJ(record, handlerContext.grid, name,
+                connections->loadWELTRAJ(record, name, handlerContext.grid,
                                          handlerContext.keyword.location());
 
                 if (const auto& md = connections->getMD(); md.size() > 1) {

--- a/opm/input/eclipse/Schedule/Well/WellCompletionKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellCompletionKeywordHandlers.cpp
@@ -32,41 +32,58 @@
 
 #include <fmt/format.h>
 
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
 #include <unordered_set>
-
-namespace Opm {
+#include <utility>
+#include <vector>
 
 namespace {
 
-using LoadConnectionMethod = void (WellConnections::*)(
-    const DeckRecord&,
-    const ScheduleGrid&,
-    const std::string&,
-    const WDFAC&,
-    const KeywordLocation&
-);
+using namespace Opm;
 
-void handleCOMPDATX(HandlerContext& handlerContext, LoadConnectionMethod loadMethod)
+template <typename CompdatKwHandler>
+void handleCOMPDATX(HandlerContext&    handlerContext,
+                    CompdatKwHandler&& compdatKwHandler)
 {
-    std::unordered_set<std::string> wells;
-    std::unordered_map<std::string, bool> well_connected;
+    auto wells = std::unordered_set<std::string> {};
+    auto well_connected = std::unordered_map<std::string, bool> {};
+
     for (const auto& record : handlerContext.keyword) {
         const auto wellNamePattern = record.getItem("WELL").getTrimmedString(0);
         const auto wellnames = handlerContext.wellNames(wellNamePattern);
 
         for (const auto& name : wellnames) {
-            auto well2 = handlerContext.state().wells.get(name);
+            auto well2 = handlerContext.state().wells(name);
 
             auto connections = std::make_shared<WellConnections>(well2.getConnections());
             const auto origWellConnSetIsEmpty = connections->empty();
-            std::invoke(loadMethod, connections, record, handlerContext.grid,
-                             name, well2.getWDFAC(), handlerContext.keyword.location());
+
+            std::invoke(compdatKwHandler, connections,
+                        record, name, well2.getWDFAC(),
+                        handlerContext.grid,
+                        handlerContext.keyword.location(),
+                        handlerContext.parseContext,
+                        handlerContext.errors);
 
             const auto isConnected = !origWellConnSetIsEmpty || !connections->empty();
-            if (well_connected.count(name))
-                well_connected[name] = (isConnected || well_connected[name]);
-            else
-                well_connected[name] = isConnected;
+
+            const auto& [connectedPos, inserted] =
+                well_connected.emplace(name, isConnected);
+
+            if ((! inserted) && isConnected) {
+                // Note condition here.  If we inserted a new well, then
+                // ->second is "isConnected".  Otherwise, we leave ->second
+                // unchanged if "isConnected" is false and unconditionally
+                // set it to true if "isConnected" is true.
+                //
+                // This block achieves the same effect as
+                //
+                //   ->second = ->second || isConnected
+                connectedPos->second = true;
+            }
 
             if (well2.updateConnections(std::move(connections), handlerContext.grid)) {
                 auto wdfac = std::make_shared<WDFAC>(well2.getWDFAC());
@@ -82,15 +99,17 @@ void handleCOMPDATX(HandlerContext& handlerContext, LoadConnectionMethod loadMet
                 .addEvent(name, ScheduleEvents::COMPLETION_CHANGE);
         }
     }
+
     // Output warning messages per well/keyword (not per COMPDAT record..)
     for (const auto& [wname, connected] : well_connected) {
         if (!connected) {
             const auto& location = handlerContext.keyword.location();
 
-            const auto msg = fmt::format(R"(Potential problem with COMPDAT/{}
+            const auto msg = fmt::format(R"(Potential problem with {}/{}
 In {} line {}
 Well {} is not connected to grid - will remain SHUT)",
-                                         wname, location.filename,
+                                         location.keyword, wname,
+                                         location.filename,
                                          location.lineno, wname);
 
             OpmLog::warning(msg);
@@ -125,8 +144,6 @@ void handleCOMPDATL(HandlerContext& handlerContext)
     handleCOMPDATX(handlerContext, &WellConnections::loadCOMPDATL);
 }
 
-
-
 void handleCOMPLUMP(HandlerContext& handlerContext)
 {
     for (const auto& record : handlerContext.keyword) {
@@ -148,7 +165,6 @@ void handleCOMPLUMP(HandlerContext& handlerContext)
 // handleWELSPECS() function.
 void handleCOMPORD(HandlerContext&)
 {}
-
 
 void handleCSKIN(HandlerContext& handlerContext)
 {
@@ -174,6 +190,8 @@ void handleCSKIN(HandlerContext& handlerContext)
 }
 
 } // Anonymous namespace
+
+namespace Opm {
 
 std::vector<std::pair<std::string,KeywordHandlers::handler_function>>
 getWellCompletionHandlers()

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -39,6 +39,9 @@
 
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
+#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+
 #include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 
@@ -195,10 +198,14 @@ namespace {
             Opm::Connection::Direction::Z,
         };
 
-        for (auto i = 0*direction.size(); i < direction.size(); ++i) {
-            const auto K = permComponents(direction[i], cell_perm);
-            perm_thickness[i] *= std::sqrt(K[0] * K[1]);
-        }
+        std::ranges::transform(direction, perm_thickness, perm_thickness.begin(),
+                               [&cell_perm](const Opm::Connection::Direction d,
+                                            const double                     h)
+                               {
+                                   const auto K = permComponents(d, cell_perm);
+
+                                   return std::sqrt(K[0] * K[1]) * h;
+                               });
 
         return perm_thickness;
     }
@@ -220,16 +227,19 @@ namespace {
             Opm::Connection::Direction::Z,
         };
 
-        constexpr auto angle = 2 * std::numbers::pi;
+        std::ranges::transform(direction, Kh, connection_factor.begin(),
+                               [&cell_perm, &cell_size, ntg, rw, skin_factor]
+                               (const Opm::Connection::Direction d,
+                                const double                     kh)
+                               {
+                                   constexpr auto angle = 2 * std::numbers::pi;
 
-        for (auto i = 0*direction.size(); i < direction.size(); ++i) {
-            const auto K = permComponents(direction[i], cell_perm);
-            const auto D = effectiveExtent(direction[i], ntg, cell_size);
-            const auto r0 = effectiveRadius(K, D);
+                                   const auto K = permComponents(d, cell_perm);
+                                   const auto D = effectiveExtent(d, ntg, cell_size);
+                                   const auto r0 = effectiveRadius(K, D);
 
-            connection_factor[i] = angle * Kh[i]
-                / peacemanDenominator(r0, rw, skin_factor);
-        }
+                                   return angle * kh / peacemanDenominator(r0, rw, skin_factor);
+                               });
 
         return connection_factor;
     }
@@ -362,11 +372,13 @@ namespace Opm {
     }
 
     void WellConnections::loadCOMPDATX(const DeckRecord&                 record,
-                                       const ScheduleGrid&               grid,
                                        const std::string&                wname,
                                        const WDFAC&                      wdfac,
+                                       const ScheduleGrid&               grid,
                                        const KeywordLocation&            location,
-                                       const std::optional<std::string>& lgr_label)
+                                       const std::optional<std::string>& lgr_label,
+                                       [[maybe_unused]] const ParseContext& parseContext,
+                                       [[maybe_unused]] ErrorGuard&         errors)
     {
         const auto& itemI = record.getItem("I");
         const auto defaulted_I = itemI.defaultApplied(0) || (itemI.get<int>(0) == 0);
@@ -555,22 +567,27 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
     }
 
     void WellConnections::loadCOMPDAT(const DeckRecord&      record,
-                                      const ScheduleGrid&    grid,
                                       const std::string&     wname,
                                       const WDFAC&           wdfac,
-                                      const KeywordLocation& location)
+                                      const ScheduleGrid&    grid,
+                                      const KeywordLocation& location,
+                                      const ParseContext&    parseContext,
+                                      ErrorGuard&            errors)
     {
         // No LGR tag when processing the main grid COMPDAT keyword.
         const auto lgr_tag = std::optional<std::string>{}; // == nullopt.
 
-        this->loadCOMPDATX(record, grid, wname, wdfac, location, lgr_tag);
+        this->loadCOMPDATX(record, wname, wdfac, grid, location,
+                           lgr_tag, parseContext, errors);
     }
 
     void WellConnections::loadCOMPDATL(const DeckRecord&      record,
-                                       const ScheduleGrid&    grid,
                                        const std::string&     wname,
                                        const WDFAC&           wdfac,
-                                       const KeywordLocation& location)
+                                       const ScheduleGrid&    grid,
+                                       const KeywordLocation& location,
+                                       const ParseContext&    parseContext,
+                                       ErrorGuard&            errors)
     {
         // We're processing a local grid's connection data (COMPDATL or
         // COMPDATM keyword).  Convey this information to the keyword
@@ -578,13 +595,14 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
         const auto lgr_tag = std::make_optional
             (record.getItem<ParserKeywords::COMPDATX::LGR>().getTrimmedString(0));
 
-        this->loadCOMPDATX(record, grid, wname, wdfac, location, lgr_tag);
+        this->loadCOMPDATX(record, wname, wdfac, grid, location,
+                           lgr_tag, parseContext, errors);
     }
 
     void
     WellConnections::loadCOMPTRAJ(const DeckRecord&      record,
-                                  const ScheduleGrid&    grid,
                                   const std::string&     wname,
+                                  const ScheduleGrid&    grid,
                                   const KeywordLocation& location,
                                   WellTrajInfo&          wellTraj)
     {
@@ -802,8 +820,8 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
     }
 
     void WellConnections::loadWELTRAJ(const DeckRecord& record,
-                                      [[maybe_unused]] const ScheduleGrid&    grid,
                                       [[maybe_unused]] const std::string&     wname,
+                                      [[maybe_unused]] const ScheduleGrid&    grid,
                                       [[maybe_unused]] const KeywordLocation& location)
     {
         double x = record.getItem("X").getSIDouble(0);

--- a/opm/input/eclipse/Schedule/Well/WellConnections.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.hpp
@@ -34,8 +34,10 @@ namespace Opm {
     class ActiveGridCells;
     class DeckRecord;
     class EclipseGrid;
+    class ErrorGuard;
     class FieldPropsManager;
     class KeywordLocation;
+    class ParseContext;
     class ScheduleGrid;
     class WDFAC;
     struct WellTrajInfo;
@@ -87,26 +89,30 @@ namespace Opm {
                            const bool defaultSatTabId = true);
 
         void loadCOMPDAT(const DeckRecord&      record,
-                         const ScheduleGrid&    grid,
                          const std::string&     wname,
                          const WDFAC&           wdfac,
-                         const KeywordLocation& location);
+                         const ScheduleGrid&    grid,
+                         const KeywordLocation& location,
+                         const ParseContext&    parseContext,
+                         ErrorGuard&            errors);
 
         void loadCOMPDATL(const DeckRecord&      record,
-                          const ScheduleGrid&    grid,
                           const std::string&     wname,
                           const WDFAC&           wdfac,
-                          const KeywordLocation& location);
+                          const ScheduleGrid&    grid,
+                          const KeywordLocation& location,
+                          const ParseContext&    parseContext,
+                          ErrorGuard&            errors);
 
         void loadCOMPTRAJ(const DeckRecord&      record,
-                          const ScheduleGrid&    grid,
                           const std::string&     wname,
+                          const ScheduleGrid&    grid,
                           const KeywordLocation& location,
-                          WellTrajInfo&         wellTraj);
+                          WellTrajInfo&          wellTraj);
 
         void loadWELTRAJ(const DeckRecord&      record,
-                         const ScheduleGrid&    grid,
                          const std::string&     wname,
+                         const ScheduleGrid&    grid,
                          const KeywordLocation& location);
 
         void applyDFactorCorrelation(const ScheduleGrid& grid,
@@ -212,11 +218,13 @@ namespace Opm {
         void orderDEPTH();
 
         void loadCOMPDATX(const DeckRecord&                 record,
-                          const ScheduleGrid&               grid,
                           const std::string&                wname,
                           const WDFAC&                      wdfac,
+                          const ScheduleGrid&               grid,
                           const KeywordLocation&            location,
-                          const std::optional<std::string>& lgr_label);
+                          const std::optional<std::string>& lgr_label,
+                          const ParseContext&               parseContext,
+                          ErrorGuard&                       errors);
     };
 
     std::optional<int>

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -45,6 +45,9 @@
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 
+#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
 #include <cstddef>
@@ -74,12 +77,15 @@ namespace {
             deck, Opm::Phases{true, true, true}, grid, Opm::TableManager{}
         };
 
+        const auto ctx = Opm::ParseContext{};
+        auto errors = Opm::ErrorGuard{};
+
         // Must be mutable.
         Opm::CompletedCells completed_cells(grid);
         const auto sg = Opm::ScheduleGrid { grid, field_props, completed_cells };
 
         for (const auto& rec : deck["COMPDAT"][0]) {
-            connections.loadCOMPDAT(rec, sg, "WELL", wdfac, loc);
+            connections.loadCOMPDAT(rec, "WELL", wdfac, sg, loc, ctx, errors);
         }
 
         return connections;


### PR DESCRIPTION
This PR extends the `handleCOMPDAT*()` function family to support the `ParseContext`/`ErrorGuard` protocol for reporting failure conditions.  This change is, however, a pure API change as the objects are currently unused.  Follow-up work will employ these to diagnose well connections in zero-permeability cells.

While here, move the `ScheduleGrid` parameter further out in the argument list as that is less important than the well name and the D-factor parameters.