### PR TITLE
Diagnose and Skip Well Connections in Zero Perm Cells

### DIFF
--- a/opm/input/eclipse/Parser/ParseContext.cpp
+++ b/opm/input/eclipse/Parser/ParseContext.cpp
@@ -127,6 +127,7 @@ namespace Opm {
         this->addKey(SCHEDULE_COMPSEGS_INVALID, InputErrorAction::THROW_EXCEPTION);
         this->addKey(SCHEDULE_COMPSEGS_NOT_SUPPORTED, InputErrorAction::THROW_EXCEPTION);
         this->addKey(SCHEDULE_COMPDAT_INVALID, InputErrorAction::THROW_EXCEPTION);
+        this->addKey(SCHEDULE_COMPDAT_ZERO_PERM, InputErrorAction::WARN);
 
         this->addKey(SCHEDULE_ICD_MISSING_SEGMENT, InputErrorAction::WARN);
         this->addKey(SCHEDULE_ICD_INCOMPATIBLE_PDROP_MODEL, InputErrorAction::THROW_EXCEPTION);
@@ -406,6 +407,7 @@ namespace Opm {
     const std::string ParseContext::SCHEDULE_COMPSEGS_NOT_SUPPORTED = "SCHEDULE_COMPSEGS_NOT_SUPPORTED";
 
     const std::string ParseContext::SCHEDULE_COMPDAT_INVALID = "SCHEDULE_COMPDAT_INVALID";
+    const std::string ParseContext::SCHEDULE_COMPDAT_ZERO_PERM = "SCHEDULE_COMPDAT_ZERO_PERM";
 
     const std::string ParseContext::SCHEDULE_ICD_MISSING_SEGMENT = "SCHEDULE_ICD_MISSING_SEGMENT";
     const std::string ParseContext::SCHEDULE_ICD_INCOMPATIBLE_PDROP_MODEL = "SCHEDULE_ICD_INCOMPATIBLE_PDROP_MODEL";

--- a/opm/input/eclipse/Parser/ParseContext.hpp
+++ b/opm/input/eclipse/Parser/ParseContext.hpp
@@ -565,6 +565,9 @@ namespace Opm {
         /// Connection data (COMPDAT keyword) invalid in some way.
         const static std::string SCHEDULE_COMPDAT_INVALID;
 
+        /// Connection in zero-permeability cell (COMPDAT keyword).
+        const static std::string SCHEDULE_COMPDAT_ZERO_PERM;
+
         /// ICD keyword (WSEGAICD, WSEGSICD, WSEGVALV) references a missing
         /// well segment.
         ///

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -62,8 +62,10 @@
 #include <limits>
 #include <numbers>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -133,6 +135,48 @@ namespace {
                   extent[ p[2] ] }};
     }
 
+    void diagnoseZeroPermConnectionSkipped(const Opm::KeywordLocation&      location,
+                                           std::string_view                 wname,
+                                           std::span<const int, 3>          ijk_1based,
+                                           std::span<const double, 3>       perm,
+                                           const Opm::Connection::Direction direction,
+                                           const Opm::ParseContext&         parseContext,
+                                           Opm::ErrorGuard&                 errors)
+    {
+        constexpr auto dirs = std::array {
+            Opm::Connection::Direction::X,
+            Opm::Connection::Direction::Y,
+            Opm::Connection::Direction::Z,
+        };
+
+        const auto dirIdx = directionIndices(direction);
+
+        const auto toMD = [&perm](const std::size_t i)
+        {
+            constexpr auto md = Opm::prefix::milli*Opm::unit::darcy;
+
+            // 'perm' is already permuted according to 'direction', so index directly.
+            return Opm::unit::convert::to(perm[i], md);
+        };
+
+        const auto dirStr = [&dirs, &dirIdx](const std::size_t i)
+        {
+            return Opm::Connection::Direction2String(dirs[dirIdx[i]]);
+        };
+
+        const auto msg_fmt = fmt::format(R"(Problem with keyword {{keyword}}
+In {{file}} line {{line}}
+Connection ({},{},{}) (direction '{}') for well {} ignored because
+   PERM{}={:.3e} mD and PERM{}={:.3e} mD.)",
+                                         ijk_1based[0], ijk_1based[1], ijk_1based[2],
+                                         dirStr(2), wname,
+                                         dirStr(0), toMD(0),
+                                         dirStr(1), toMD(1));
+
+        parseContext.handleError(Opm::ParseContext::SCHEDULE_COMPDAT_ZERO_PERM,
+                                 msg_fmt, location, errors);
+    }
+
     // Compute Peaceman's effective radius of single completion.
     double effectiveRadius(const std::array<double,3>& K,
                            const std::array<double,3>& D)
@@ -168,6 +212,14 @@ namespace {
                                         const double                          porosity,
                                         const Opm::WDFAC&                     wdfac)
     {
+        if (const auto valid_input = (ctf_props.Ke > 0.0) &&
+            (ctf_props.connection_length * ctf_props.rw > 0.0);
+            ! valid_input)
+        {
+            // Not valid input--e.g., Ke=0 or connection_length=0.
+            return 0.0;
+        }
+
         // Reference/background permeability against which to scale cell
         // permeability for model evaluation.
         constexpr auto Kref = 1.0*Opm::prefix::milli*Opm::unit::darcy;
@@ -377,8 +429,8 @@ namespace Opm {
                                        const ScheduleGrid&               grid,
                                        const KeywordLocation&            location,
                                        const std::optional<std::string>& lgr_label,
-                                       [[maybe_unused]] const ParseContext& parseContext,
-                                       [[maybe_unused]] ErrorGuard&         errors)
+                                       const ParseContext&               parseContext,
+                                       ErrorGuard&                       errors)
     {
         const auto& itemI = record.getItem("I");
         const auto defaulted_I = itemI.defaultApplied(0) || (itemI.get<int>(0) == 0);
@@ -468,6 +520,12 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
 
             const auto D = effectiveExtent(direction, props->ntg, cell.dimensions);
             const auto K = permComponents(direction, { props->permx, props->permy, props->permz });
+
+            // Note: we could *arguably* skip the connection entirely if
+            // Ke=0, but that's a little presumptuous if both CF and Kh are
+            // provided as input values.  We'll nevertheless skip the
+            // connection if Ke=0 and we actually need to compute r0 from
+            // K[0] and K[1].
             ctf_props.Ke = std::sqrt(K[0] * K[1]);
 
             const auto ctf_kind = (ctf_props.CF < 0.0)
@@ -484,7 +542,16 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
             // We must calculate CF and Kh from the items in the COMPDAT
             // record and cell properties.
             if (ctf_props.r0 < 0.0) {
-                ctf_props.r0 = effectiveRadius(K, D);
+                if ((K[0] > 0.0) && (K[1] > 0.0)) {
+                    ctf_props.r0 = effectiveRadius(K, D);
+                }
+                else {
+                    // Zero permeability cell.  No connection.
+                    diagnoseZeroPermConnectionSkipped(location, wname,
+                                                      std::array {I + 1, J + 1, k + 1},
+                                                      K, direction, parseContext, errors);
+                    continue;
+                }
             }
 
             if (const auto peaceman_denom = peacemanDenominator(ctf_props);
@@ -528,7 +595,20 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
             }
 
             // Length of the well perforation interval.
-            ctf_props.connection_length = ctf_props.Kh / ctf_props.Ke;
+            //
+            // Note: Zero if Ke=0, as that's (most) compatible with the
+            // definition
+            //
+            //    Kh = Ke * D[2]
+            //
+            // when neither CF nor Kh are defined in the input (or for the
+            // special case COMPDAT(10)=0).  This is also the most
+            // reasonable definition for the Forchheimer D-factor
+            // correlation calculation as a zero effective permeability or
+            // connection length should give a zero-valued D-factor.
+            ctf_props.connection_length = (ctf_props.Ke > 0.0)
+                ? ctf_props.Kh / ctf_props.Ke
+                : 0.0;
 
             // Area equivalent radius of the grid block.  Used by the
             // PolymerMW module.

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -23,6 +23,7 @@
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
 
 #include <opm/common/utility/ActiveGridCells.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/Python/Python.hpp>
 
@@ -46,13 +47,19 @@
 #include <opm/input/eclipse/Deck/Deck.hpp>
 
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/input/eclipse/Parser/InputErrorAction.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
+#include <array>
 #include <cstddef>
-#include <stdexcept>
+#include <memory>
 #include <ostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace {
     double cp_rm3_per_db()
@@ -761,4 +768,557 @@ BOOST_AUTO_TEST_CASE(loadCOMPTRAJTESTSPE1_2) {
          BOOST_CHECK_CLOSE(connections[i].CF(), units.to_si(Opm::UnitSystem::measure::transmissibility, connection_factor[i]), 2e-2);
          BOOST_CHECK_EQUAL(connections[i].global_index(), global_index[i]);
     }
+}
+
+BOOST_AUTO_TEST_CASE(Compdat_Zero_Perm_Dflt_Action)
+{
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+START
+  18 MAR 2026 /
+OIL
+WATER
+DIMENS
+3 1 3 /
+TABDIMS
+/
+EQLDIMS
+/
+WELLDIMS
+ 1 3 1 1 /
+GRID
+DXV
+ 3*100 /
+DYV
+ 100 /
+DZV
+ 3*10 /
+DEPTHZ
+ 8*2000 /
+EQUALS
+ PERMX 100 /
+ PERMY 100 /
+ PERMZ  10 /
+ PORO    0.3 /
+/
+-- Kx(2,1,2) = Ky(2,1,2) = 0.
+EQUALS
+ PERMX 0  2 2  1 1  2 2 /
+ PERMY 0 /
+/
+PROPS
+DENSITY
+  800 1000 1 /
+SOLUTION
+EQUIL
+2010 200 2010 1.23 1995 0.0 1* 1* -5 /
+SCHEDULE
+WELSPECS
+  'P' 'G' 2 2 2005.0 LIQ /
+/
+COMPDAT
+  'P'  2  1  1  3  OPEN  1  1*  0.3048  /
+/
+TSTEP
+  5*10 /
+END
+)");
+
+    const auto ctx = Opm::ParseContext{};
+    auto errors = Opm::ErrorGuard{};
+
+    const auto es = Opm::EclipseState { deck };
+    const auto sched = Opm::Schedule {
+        deck, es, ctx, errors,
+        std::make_shared<Opm::Python>()
+    };
+
+    const auto& well_p = sched.back().wells("P");
+
+    BOOST_REQUIRE_MESSAGE(well_p.hasConnections(),
+                          R"(Well "P" must have connections at end of simulation)");
+
+    BOOST_REQUIRE_EQUAL(well_p.getConnections().size(), std::size_t{2});
+
+    {
+        const auto& c0 = well_p.getConnections()[0];
+
+        BOOST_CHECK_EQUAL(c0.getI(), 1);
+        BOOST_CHECK_EQUAL(c0.getJ(), 0);
+        BOOST_CHECK_EQUAL(c0.getK(), 0);
+    }
+
+    {
+        const auto& c1 = well_p.getConnections()[1];
+
+        BOOST_CHECK_EQUAL(c1.getI(), 1);
+        BOOST_CHECK_EQUAL(c1.getJ(), 0);
+        BOOST_CHECK_EQUAL(c1.getK(), 2);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Compdat_Zero_Perm_Throw)
+{
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+START
+  18 MAR 2026 /
+OIL
+WATER
+DIMENS
+3 1 3 /
+TABDIMS
+/
+EQLDIMS
+/
+WELLDIMS
+ 1 3 1 1 /
+GRID
+DXV
+ 3*100 /
+DYV
+ 100 /
+DZV
+ 3*10 /
+DEPTHZ
+ 8*2000 /
+EQUALS
+ PERMX 100 /
+ PERMY 100 /
+ PERMZ  10 /
+ PORO    0.3 /
+/
+-- Kx(2,1,2) = Ky(2,1,2) = 0.
+EQUALS
+ PERMX 0  2 2  1 1  2 2 /
+ PERMY 0 /
+/
+PROPS
+DENSITY
+  800 1000 1 /
+SOLUTION
+EQUIL
+2010 200 2010 1.23 1995 0.0 1* 1* -5 /
+SCHEDULE
+WELSPECS
+  'P' 'G' 2 2 2005.0 LIQ /
+/
+COMPDAT
+  'P'  2  1  1  3  OPEN  1  1*  0.3048  /
+/
+TSTEP
+  5*10 /
+END
+)");
+
+    const auto ctx = Opm::ParseContext {
+        std::vector {
+            std::pair { Opm::ParseContext::SCHEDULE_COMPDAT_ZERO_PERM,
+                        Opm::InputErrorAction::THROW_EXCEPTION },
+        }
+    };
+
+    auto errors = Opm::ErrorGuard{};
+
+    const auto es = Opm::EclipseState { deck };
+
+    BOOST_CHECK_THROW(Opm::Schedule(deck, es, ctx, errors, std::make_shared<Opm::Python>()),
+                      Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(Compdat_Zero_Perm_Diagnostic_Text)
+{
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+START
+  18 MAR 2026 /
+OIL
+WATER
+DIMENS
+3 1 3 /
+TABDIMS
+/
+EQLDIMS
+/
+WELLDIMS
+ 1 3 1 1 /
+GRID
+DXV
+ 3*100 /
+DYV
+ 100 /
+DZV
+ 3*10 /
+DEPTHZ
+ 8*2000 /
+EQUALS
+ PERMX 100 /
+ PERMY 100 /
+ PERMZ  10 /
+ PORO    0.3 /
+/
+-- Kx(2,1,2) = Ky(2,1,2) = 0.
+EQUALS
+ PERMX 0  2 2  1 1  2 2 /
+ PERMY 0 /
+/
+PROPS
+DENSITY
+  800 1000 1 /
+SOLUTION
+EQUIL
+2010 200 2010 1.23 1995 0.0 1* 1* -5 /
+SCHEDULE
+WELSPECS
+  'P' 'G' 2 2 2005.0 LIQ /
+/
+COMPDAT
+  'P'  2  1  1  3  OPEN  1  1*  0.3048  /
+/
+TSTEP
+  5*10 /
+END
+)");
+
+    const auto ctx = Opm::ParseContext {
+        std::vector {
+            std::pair { Opm::ParseContext::SCHEDULE_COMPDAT_ZERO_PERM,
+                        Opm::InputErrorAction::DELAYED_EXIT1 },
+        }
+    };
+
+    auto errors = Opm::ErrorGuard{};
+
+    const auto es = Opm::EclipseState { deck };
+    const auto sched = Opm::Schedule {
+        deck, es, ctx, errors,
+        std::make_shared<Opm::Python>()
+    };
+
+    const auto diagnostic = errors.formattedErrors();
+    errors.clear();
+
+    // Note: Leading newline ("R(\n)) added by ErrorGuard::formattedErrors().
+    BOOST_CHECK_EQUAL(diagnostic, R"(
+Problem with keyword COMPDAT
+In <memory string> line 44
+Connection (2,1,2) (direction 'Z') for well P ignored because
+   PERMX=0.000e+00 mD and PERMY=0.000e+00 mD.)");
+}
+
+BOOST_AUTO_TEST_CASE(Compdat_Zero_Perm_Diagnostic_Text_Kx10)
+{
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+START
+  18 MAR 2026 /
+OIL
+WATER
+DIMENS
+3 1 3 /
+TABDIMS
+/
+EQLDIMS
+/
+WELLDIMS
+ 1 3 1 1 /
+GRID
+DXV
+ 3*100 /
+DYV
+ 100 /
+DZV
+ 3*10 /
+DEPTHZ
+ 8*2000 /
+EQUALS
+ PERMX 100 /
+ PERMY 100 /
+ PERMZ  10 /
+ PORO    0.3 /
+/
+-- Kx(2,1,2) = Ky(2,1,2) = 0.
+EQUALS
+ PERMX 10  2 2  1 1  2 2 /
+ PERMY  0 /
+/
+PROPS
+DENSITY
+  800 1000 1 /
+SOLUTION
+EQUIL
+2010 200 2010 1.23 1995 0.0 1* 1* -5 /
+SCHEDULE
+WELSPECS
+  'P' 'G' 2 2 2005.0 LIQ /
+/
+COMPDAT
+  'P'  2  1  1  3  OPEN  1  1*  0.3048  /
+/
+TSTEP
+  5*10 /
+END
+)");
+
+    const auto ctx = Opm::ParseContext {
+        std::vector {
+            std::pair { Opm::ParseContext::SCHEDULE_COMPDAT_ZERO_PERM,
+                        Opm::InputErrorAction::DELAYED_EXIT1 },
+        }
+    };
+
+    auto errors = Opm::ErrorGuard{};
+
+    const auto es = Opm::EclipseState { deck };
+    const auto sched = Opm::Schedule {
+        deck, es, ctx, errors,
+        std::make_shared<Opm::Python>()
+    };
+
+    const auto diagnostic = errors.formattedErrors();
+    errors.clear();
+
+    // Note: Leading newline ("R(\n)) added by ErrorGuard::formattedErrors().
+    BOOST_CHECK_EQUAL(diagnostic, R"(
+Problem with keyword COMPDAT
+In <memory string> line 44
+Connection (2,1,2) (direction 'Z') for well P ignored because
+   PERMX=1.000e+01 mD and PERMY=0.000e+00 mD.)");
+}
+
+BOOST_AUTO_TEST_CASE(Compdat_Zero_Perm_Diagnostic_Text_Ky10)
+{
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+START
+  18 MAR 2026 /
+OIL
+WATER
+DIMENS
+3 1 3 /
+TABDIMS
+/
+EQLDIMS
+/
+WELLDIMS
+ 1 3 1 1 /
+GRID
+DXV
+ 3*100 /
+DYV
+ 100 /
+DZV
+ 3*10 /
+DEPTHZ
+ 8*2000 /
+EQUALS
+ PERMX 100 /
+ PERMY 100 /
+ PERMZ  10 /
+ PORO    0.3 /
+/
+-- Kx(2,1,2) = Ky(2,1,2) = 0.
+EQUALS
+ PERMX  0  2 2  1 1  2 2 /
+ PERMY 10 /
+/
+PROPS
+DENSITY
+  800 1000 1 /
+SOLUTION
+EQUIL
+2010 200 2010 1.23 1995 0.0 1* 1* -5 /
+SCHEDULE
+WELSPECS
+  'P' 'G' 2 2 2005.0 LIQ /
+/
+COMPDAT
+  'P'  2  1  1  3  OPEN  1  1*  0.3048  /
+/
+TSTEP
+  5*10 /
+END
+)");
+
+    const auto ctx = Opm::ParseContext {
+        std::vector {
+            std::pair { Opm::ParseContext::SCHEDULE_COMPDAT_ZERO_PERM,
+                        Opm::InputErrorAction::DELAYED_EXIT1 },
+        }
+    };
+
+    auto errors = Opm::ErrorGuard{};
+
+    const auto es = Opm::EclipseState { deck };
+    const auto sched = Opm::Schedule {
+        deck, es, ctx, errors,
+        std::make_shared<Opm::Python>()
+    };
+
+    const auto diagnostic = errors.formattedErrors();
+    errors.clear();
+
+    // Note: Leading newline ("R(\n)) added by ErrorGuard::formattedErrors().
+    BOOST_CHECK_EQUAL(diagnostic, R"(
+Problem with keyword COMPDAT
+In <memory string> line 44
+Connection (2,1,2) (direction 'Z') for well P ignored because
+   PERMX=0.000e+00 mD and PERMY=1.000e+01 mD.)");
+}
+
+BOOST_AUTO_TEST_CASE(Compdat_Zero_Perm_Diagnostic_Text_DirX)
+{
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+START
+  18 MAR 2026 /
+OIL
+WATER
+DIMENS
+3 1 3 /
+TABDIMS
+/
+EQLDIMS
+/
+WELLDIMS
+ 1 3 1 1 /
+GRID
+DXV
+ 3*100 /
+DYV
+ 100 /
+DZV
+ 3*10 /
+DEPTHZ
+ 8*2000 /
+EQUALS
+ PERMX 100 /
+ PERMY 100 /
+ PERMZ  10 /
+ PORO    0.3 /
+/
+-- Ky(2,1,2) = Kz(2,1,2) = 0.
+EQUALS
+ PERMY 0  2 2  1 1  2 2 /
+ PERMZ 0 /
+/
+PROPS
+DENSITY
+  800 1000 1 /
+SOLUTION
+EQUIL
+2010 200 2010 1.23 1995 0.0 1* 1* -5 /
+SCHEDULE
+WELSPECS
+  'P' 'G' 2 2 2005.0 LIQ /
+/
+COMPDAT
+  'P'  2  1  1  1  OPEN  1  1*  0.3048  /
+  'P'  2  1  2  2  OPEN  1  1*  0.3048 1* 1* 1* 'X' /
+  'P'  2  1  3  3  OPEN  1  1*  0.3048  /
+/
+TSTEP
+  5*10 /
+END
+)");
+
+    const auto ctx = Opm::ParseContext {
+        std::vector {
+            std::pair { Opm::ParseContext::SCHEDULE_COMPDAT_ZERO_PERM,
+                        Opm::InputErrorAction::DELAYED_EXIT1 },
+        }
+    };
+
+    auto errors = Opm::ErrorGuard{};
+
+    const auto es = Opm::EclipseState { deck };
+    const auto sched = Opm::Schedule {
+        deck, es, ctx, errors,
+        std::make_shared<Opm::Python>()
+    };
+
+    const auto diagnostic = errors.formattedErrors();
+    errors.clear();
+
+    // Note: Leading newline ("R(\n)) added by ErrorGuard::formattedErrors().
+    BOOST_CHECK_EQUAL(diagnostic, R"(
+Problem with keyword COMPDAT
+In <memory string> line 44
+Connection (2,1,2) (direction 'X') for well P ignored because
+   PERMY=0.000e+00 mD and PERMZ=0.000e+00 mD.)");
+}
+
+BOOST_AUTO_TEST_CASE(Compdat_Zero_Perm_Diagnostic_Text_DirY)
+{
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+START
+  18 MAR 2026 /
+OIL
+WATER
+DIMENS
+3 1 3 /
+TABDIMS
+/
+EQLDIMS
+/
+WELLDIMS
+ 1 3 1 1 /
+GRID
+DXV
+ 3*100 /
+DYV
+ 100 /
+DZV
+ 3*10 /
+DEPTHZ
+ 8*2000 /
+EQUALS
+ PERMX 100 /
+ PERMY 100 /
+ PERMZ  10 /
+ PORO    0.3 /
+/
+-- Kx(2,1,2) = Kz(2,1,2) = 0.
+EQUALS
+ PERMX 0  2 2  1 1  2 2 /
+ PERMZ 0 /
+/
+PROPS
+DENSITY
+  800 1000 1 /
+SOLUTION
+EQUIL
+2010 200 2010 1.23 1995 0.0 1* 1* -5 /
+SCHEDULE
+WELSPECS
+  'P' 'G' 2 2 2005.0 LIQ /
+/
+COMPDAT
+  'P'  2  1  1  1  OPEN  1  1*  0.3048  /
+  'P'  2  1  2  2  OPEN  1  1*  0.3048 1* 1* 1* 'Y' /
+  'P'  2  1  3  3  OPEN  1  1*  0.3048  /
+/
+TSTEP
+  5*10 /
+END
+)");
+
+    const auto ctx = Opm::ParseContext {
+        std::vector {
+            std::pair { Opm::ParseContext::SCHEDULE_COMPDAT_ZERO_PERM,
+                        Opm::InputErrorAction::DELAYED_EXIT1 },
+        }
+    };
+
+    auto errors = Opm::ErrorGuard{};
+
+    const auto es = Opm::EclipseState { deck };
+    const auto sched = Opm::Schedule {
+        deck, es, ctx, errors,
+        std::make_shared<Opm::Python>()
+    };
+
+    const auto diagnostic = errors.formattedErrors();
+    errors.clear();
+
+    // Note: Leading newline ("R(\n)) added by ErrorGuard::formattedErrors().
+    BOOST_CHECK_EQUAL(diagnostic, R"(
+Problem with keyword COMPDAT
+In <memory string> line 44
+Connection (2,1,2) (direction 'Y') for well P ignored because
+   PERMZ=0.000e+00 mD and PERMX=0.000e+00 mD.)");
 }


### PR DESCRIPTION
This PR adds diagnostics for well connections that happen to be in cells of zero permeability in the directions perpendicular to the perforation interval.  These connections are furthermore not added to the well.  At present, we support only the axis-aligned directions (i.e., `X`,`Y`,`Z`) for this kind of diagnostic.

Example diagnostics, by default a "warning" though this can be changed through the `ParseContext` key `SCHEDULE_COMPDAT_ZERO_PERM`, are as follows
```
Problem with keyword COMPDAT
In CASE.DATA line 1234
Connection (11,22,33) (direction 'Y') for well P-42 ignored because
   PERMX=0 and PERMZ=0.
```