### PR TITLE
Implement explicit handling of trajectory segment depths

### DIFF
--- a/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
@@ -410,7 +410,6 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
         for (const auto& trajectory_point : trajectory_segments) {
             // Defaulted values:
             const auto direction = Opm::Connection::Direction::X;
-            const auto center_depth = 0.0;
             const auto segment_number = 0;
             const auto branch = 1;
 
@@ -422,7 +421,7 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
                                   branch,
                                   trajectory_point.startMD, trajectory_point.endMD,
                                   direction,
-                                  center_depth,
+                                  trajectory_point.centerTVD,
                                   segment_number, seqIndex);
         }
 

--- a/opm/input/eclipse/Schedule/MSW/Compsegs.hpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.hpp
@@ -95,6 +95,9 @@ namespace Opm::Compsegs {
         /// Measured depth along well bore at the end of the segment.
         double endMD{};
 
+        /// True depth at the measured center depth of the segment.
+        double centerTVD{};
+
         /// Cartesian IJK tuple of the cell intersected by this segment.
         std::array<int, 3> ijk{};
     };

--- a/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
@@ -71,16 +71,17 @@ namespace
         const auto& ecl_grid = handlerContext.grid.get_grid();
 
         for (const auto& intersection : intersections) {
-            trajectory_segments.push_back({
-                    intersection.startMD,
-                    intersection.endMD,
-                    ecl_grid->getIJK(intersection.globCellIndex)
-                });
-
             const double cell_md = 0.5 * (intersection.startMD + intersection.endMD);
             const double cell_tvd = wellPathGeometry->interpolatedPointAlongWellPath(cell_md)[2];
 
             cell_md_and_tvd.emplace_back(cell_md, cell_tvd);
+            
+            trajectory_segments.push_back({
+                    intersection.startMD,
+                    intersection.endMD,
+                    cell_tvd,
+                    ecl_grid->getIJK(intersection.globCellIndex)
+                });
         }
 
         return { std::move(trajectory_segments), std::move(cell_md_and_tvd) };


### PR DESCRIPTION
@GitPaean and @bska : Could you maybe give me some feedback on this PR, as I am not fully sure if I am reasoning correctly?

Here is the rationale for the change:

Currently the WELTRAJ/COMPTRAJ combination of keywords generates a multi-segmented well by generating a segment for each cell. Segments that normally are specified by the WELSEGS keyword are derived from the intersections of the trajectory with the cell faces, yielding one segment per cell. The information normally provided by COMPSEGS is also derived in a similar way.

COMPSEGS also requires a DEPTH parameter that defines the depth of the well. If defaulted, this point is set as the mid-point of the perforations associated with the cell. The true vertical depth is then calculated from the depths of the associated segments by linear interpolation. In COMPTRAJ this is used to find the depths by always defaulting.

However, this depth can also be calculated by directly interpolating between the measured depths of the intersection points that are derived from the trajectory provided by WELTRAJ. This has the advantage that this is independent of the segment information. At this moment this does not matter: the segments are also derived from those intersection points and the result is the same.

However, this may be different if it becomes possible to specify the segments of grid-independent wells manually with the WELSEGS keyword. In this case we would only want to generate the COMPSEGS information from the WELTRAJ/COMPTRAJ keywords. In this case it would be more reliable to derive the depths directly from the trajectory, in particular if only a few large segments are specified and linearly interpolating them might be inaccurate.

I have implemented the change to calculate the depths from the trajectory in this small PR. If possible, I would like some feedback on it:

1. Is my reasoning correct? Can I indeed derive the cell true depths at the midpoints in this way instead of deriving them from the segments? Or am I maybe missing something?
2. If it is correct, I would like to implement this PR as a first step towards allowing segments manually defined with WELSEGS in combination with WELTRAJ/COMPTRAJ. This would provide also a way forward to implement grid-independent multilateral wells by leveraging the existing WELSEGS keyword. Does this sound reasonable?
3. Note that this PR is a bit of a prototype: it duplicates cell depth data in different structures, that could be optimized.