### PR TITLE
[LGR] `NNCCollection::getGlobalNNC()` — remove throw when global NNC is absent

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -1885,7 +1885,7 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
 
     void EclipseGrid::save_nnc(Opm::EclIO::EclOutput& egridfile, const NNCCollection& nnc_col) const {
 
-        // Global Grid NNC
+        // Global Grid NNC (grid = 0 always exists, but may be empty)
         save_nnc_same_grid(egridfile, nnc_col.getGlobalNNC().input(), 0);
 
         // LGR NNC

--- a/opm/input/eclipse/EclipseState/Grid/NNC.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/NNC.cpp
@@ -430,6 +430,13 @@ bool NNCDataContainerDiffGrid::operator==(const NNCDataContainerDiffGrid& other)
 // NNCCollection — indexed collection of same-grid and cross-grid NNCs
 // ===========================================================================
 
+/// Default constructor: the global grid (grid 0) always exists, initially
+/// with an empty NNC container.
+NNCCollection::NNCCollection()
+{
+    m_sameGridNNCs.emplace(std::size_t{0}, NNCDataContainer{});
+}
+
 /// Constructs an NNCCollection pre-populated with @p nnc_global as the
 /// global (grid 0) same-grid NNC.
 NNCCollection::NNCCollection(NNCDataContainer nnc_global)
@@ -484,9 +491,15 @@ bool NNCCollection::hasCrossGridNNC(std::size_t grid1, std::size_t grid2) const
 }
 
 /// Adds a same-grid NNC for @p grid.
-/// Throws std::runtime_error if an entry for this grid index already exists.
+/// For grid 0 (global), replaces the existing empty entry inserted by the
+/// constructor.  For all other grids, throws std::runtime_error if an entry
+/// already exists.
 void NNCCollection::addNNC(std::size_t grid, NNCDataContainer nnc)
 {
+    if (grid == 0) {
+        m_sameGridNNCs[std::size_t{0}] = std::move(nnc);
+        return;
+    }
     if (m_sameGridNNCs.count(grid)) {
         throw std::runtime_error(
             "NNCCollection::addNNC: same-grid NNC already exists for grid "
@@ -519,32 +532,23 @@ bool NNCCollection::hasSameGridNNC(std::size_t grid) const
     return m_sameGridNNCs.count(grid) > 0;
 }
 
-/// Adds @p nnc as the global (grid 0) same-grid NNC.
-/// Equivalent to addNNC(0, nnc).
+/// Replaces the global (grid 0) same-grid NNC.
 void NNCCollection::addNNC(NNCDataContainer nnc)
 {
-    addNNC(std::size_t{0}, std::move(nnc));
+    m_sameGridNNCs[std::size_t{0}] = std::move(nnc);
 }
 
 /// Returns a mutable reference to the global (grid 0) same-grid NNC.
-/// Throws std::runtime_error if no global NNC has been added.
+/// Grid 0 is always present (inserted by the constructor); never throws.
 NNCDataContainer& NNCCollection::getGlobalNNC()
 {
-    if (!hasGlobalNNC()) {
-        throw std::runtime_error(
-            "NNCCollection::getGlobalNNC: no global NNC found.");
-    }
     return getNNC(std::size_t{0});
 }
 
 /// Returns a const reference to the global (grid 0) same-grid NNC.
-/// Throws std::runtime_error if no global NNC has been added.
+/// Grid 0 is always present (inserted by the constructor); never throws.
 const NNCDataContainer& NNCCollection::getGlobalNNC() const
 {
-    if (!hasGlobalNNC()) {
-        throw std::runtime_error(
-            "NNCCollection::getGlobalNNC: no global NNC found.");
-    }
     return getNNC(std::size_t{0});
 }
 

--- a/opm/input/eclipse/EclipseState/Grid/NNC.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/NNC.cpp
@@ -487,7 +487,8 @@ NNCDataContainerDiffGrid& NNCCollection::getNNC(std::size_t grid1, std::size_t g
 
 bool NNCCollection::hasCrossGridNNC(std::size_t grid1, std::size_t grid2) const
 {
-    return m_diffGridNNCs.count(std::make_pair(grid1, grid2)) > 0;
+    const auto key = std::minmax(grid1, grid2);
+    return m_diffGridNNCs.count(key) > 0;
 }
 
 /// Adds a same-grid NNC for @p grid.
@@ -529,7 +530,8 @@ NNCDataContainer& NNCCollection::getNNC(std::size_t grid)
 
 bool NNCCollection::hasSameGridNNC(std::size_t grid) const
 {
-    return m_sameGridNNCs.count(grid) > 0;
+    auto it = m_sameGridNNCs.find(grid);
+    return it != m_sameGridNNCs.end() && !it->second.input().empty();
 }
 
 /// Replaces the global (grid 0) same-grid NNC.

--- a/opm/input/eclipse/EclipseState/Grid/NNC.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/NNC.hpp
@@ -228,7 +228,9 @@ public:
     {
         for (const auto& [grid, nnc] : m_sameGridNNCs)
             if (!nnc.input().empty()) return false;
-        return m_diffGridNNCs.empty();
+        for (const auto& [grids, nnc] : m_diffGridNNCs)
+            if (!nnc.input().empty()) return false;
+        return true;
     }
     // ---- same-grid access -------------------------------------------------
 
@@ -251,11 +253,16 @@ public:
     /// same-grid NNCs with data, or cross-grid NNCs with any other grid.
     bool hasNNCForGrid(std::size_t grid_index) const
     {
-        if (grid_index == 0 ? hasGlobalNNC() : hasSameGridNNC(grid_index))
+        if (((grid_index == 0) && hasGlobalNNC()) || ((grid_index != 0) && hasSameGridNNC(grid_index)))
+        {
             return true;
-        for (const auto& entry : m_diffGridNNCs) {
-            if (entry.first.first == grid_index || entry.first.second == grid_index)
+        }
+        for (const auto& [grid, nnc] : m_diffGridNNCs) {
+            if (const auto& [g1, g2] = grid;
+                ((g1 == grid_index) || (g2 == grid_index)) && !nnc.input().empty())
+            {
                 return true;
+            }
         }
         return false;
     }

--- a/opm/input/eclipse/EclipseState/Grid/NNC.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/NNC.hpp
@@ -199,7 +199,7 @@ public:
 class NNCCollection
 {
 public:
-    NNCCollection() = default;
+    NNCCollection();
     explicit NNCCollection(NNCDataContainer nnc_global);
 
     // ---- insertion --------------------------------------------------------
@@ -219,7 +219,17 @@ public:
     NNCDataContainerDiffGrid&       getNNC(std::size_t grid1, std::size_t grid2);
 
     bool hasCrossGridNNC(std::size_t grid1, std::size_t grid2) const;
-    bool empty() const { return m_sameGridNNCs.empty() && m_diffGridNNCs.empty(); }
+
+    /// Returns true if the collection holds no NNC data of any kind.
+    /// Cannot use m_sameGridNNCs.empty() because grid 0 is always present
+    /// (inserted by the constructor) even when no NNCs have been added.
+    /// Instead, each same-grid container is checked for actual entries.
+    bool empty() const
+    {
+        for (const auto& [grid, nnc] : m_sameGridNNCs)
+            if (!nnc.input().empty()) return false;
+        return m_diffGridNNCs.empty();
+    }
     // ---- same-grid access -------------------------------------------------
 
     const NNCDataContainer& getNNC(std::size_t grid) const;
@@ -232,13 +242,16 @@ public:
     const NNCDataContainer& getGlobalNNC() const;
     NNCDataContainer&       getGlobalNNC();
 
-    bool hasGlobalNNC() const { return hasSameGridNNC(0); };
+    /// Returns true if the global grid has actual same-grid NNC data.
+    /// Grid 0 always exists in the collection; this checks whether it is
+    /// non-empty (i.e. NNCs were explicitly added for the global grid).
+    bool hasGlobalNNC() const { return !getGlobalNNC().input().empty(); }
 
     /// Returns true if the given grid has any NNC involvement:
-    /// same-grid NNCs, or cross-grid NNCs with any other grid.
+    /// same-grid NNCs with data, or cross-grid NNCs with any other grid.
     bool hasNNCForGrid(std::size_t grid_index) const
     {
-        if (hasSameGridNNC(grid_index))
+        if (grid_index == 0 ? hasGlobalNNC() : hasSameGridNNC(grid_index))
             return true;
         for (const auto& entry : m_diffGridNNCs) {
             if (entry.first.first == grid_index || entry.first.second == grid_index)

--- a/tests/parser/integration/NNCTestsLGR.cpp
+++ b/tests/parser/integration/NNCTestsLGR.cpp
@@ -503,9 +503,11 @@ BOOST_AUTO_TEST_CASE(invalid_entry)
 
 BOOST_AUTO_TEST_CASE(check_absent_el)
 {
-    // Grid 0 always exists in the map; grids > 0 are absent until added.
+    // hasSameGridNNC checks data presence, not map presence.
+    // A default-constructed collection has grid 0 in the map but with no
+    // NNC entries, so it returns false for both grid 0 and grid 1.
     NNCCollection col;
-    BOOST_CHECK(col.hasSameGridNNC(std::size_t{0}));
+    BOOST_CHECK(!col.hasSameGridNNC(std::size_t{0}));
     BOOST_CHECK(!col.hasSameGridNNC(std::size_t{1}));
 }
 

--- a/tests/parser/integration/NNCTestsLGR.cpp
+++ b/tests/parser/integration/NNCTestsLGR.cpp
@@ -484,9 +484,14 @@ BOOST_AUTO_TEST_CASE(check_reference_is_mutable)
 
 BOOST_AUTO_TEST_CASE(check_duplicate_entries)
 {
+    // Grid 0 is special: addNNC replaces it rather than throwing.
+    // Grids > 0 retain the duplicate-throw behaviour.
     NNCCollection col;
     col.addNNC(std::size_t{0}, make_nnc(1, 2, 1.0));
-    BOOST_CHECK_THROW(col.addNNC(std::size_t{0}, make_nnc(3, 4, 2.0)),
+    BOOST_CHECK_NO_THROW(col.addNNC(std::size_t{0}, make_nnc(3, 4, 2.0)));
+
+    col.addNNC(std::size_t{1}, make_nnc(1, 2, 1.0));
+    BOOST_CHECK_THROW(col.addNNC(std::size_t{1}, make_nnc(3, 4, 2.0)),
                       std::runtime_error);
 }
 
@@ -498,8 +503,10 @@ BOOST_AUTO_TEST_CASE(invalid_entry)
 
 BOOST_AUTO_TEST_CASE(check_absent_el)
 {
+    // Grid 0 always exists in the map; grids > 0 are absent until added.
     NNCCollection col;
-    BOOST_CHECK(!col.hasSameGridNNC(std::size_t{0}));
+    BOOST_CHECK(col.hasSameGridNNC(std::size_t{0}));
+    BOOST_CHECK(!col.hasSameGridNNC(std::size_t{1}));
 }
 
 BOOST_AUTO_TEST_CASE(check_if_inserted_el_exists)
@@ -545,10 +552,14 @@ BOOST_AUTO_TEST_CASE(chexk_if_reference_is_mutable)
     BOOST_CHECK_EQUAL(col.getGlobalNNC().input().size(), 2u);
 }
 
-BOOST_AUTO_TEST_CASE(check_missing_global)
+BOOST_AUTO_TEST_CASE(get_global_empty_when_no_nnc_added)
 {
+    // Grid 0 always exists; getGlobalNNC() never throws.
+    // hasGlobalNNC() is false until NNC data is explicitly added.
     NNCCollection col;
-    BOOST_CHECK_THROW(col.getGlobalNNC(), std::runtime_error);
+    BOOST_CHECK(!col.hasGlobalNNC());
+    BOOST_CHECK_NO_THROW(col.getGlobalNNC());
+    BOOST_CHECK(col.getGlobalNNC().input().empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -676,10 +687,13 @@ BOOST_AUTO_TEST_CASE(diff_grid_map_contains_added_entries)
     BOOST_CHECK(m.at({2, 3}) == n23);
 }
 
-BOOST_AUTO_TEST_CASE(empty_collection_has_empty_maps)
+BOOST_AUTO_TEST_CASE(empty_collection_has_no_data)
 {
+    // Grid 0 is always present in same_grid_nnc() but holds no data.
     NNCCollection col;
-    BOOST_CHECK(col.same_grid_nnc().empty());
+    BOOST_CHECK(col.empty());
+    BOOST_CHECK_EQUAL(col.same_grid_nnc().size(), 1u);
+    BOOST_CHECK(col.same_grid_nnc().at(0).input().empty());
     BOOST_CHECK(col.diff_grid_nnc().empty());
 }
 
@@ -690,10 +704,12 @@ BOOST_AUTO_TEST_SUITE(StoreIsolation)
 
 BOOST_AUTO_TEST_CASE(cross_grid_add_does_not_affect_same_grid)
 {
+    // Adding a cross-grid NNC must not populate the global same-grid container.
     NNCCollection col;
     col.addNNC(std::size_t{0}, std::size_t{1}, make_nnc_diffgrid(5, 6, 3.0));
 
-    BOOST_CHECK_THROW(col.getNNC(std::size_t{0}), std::runtime_error);
+    BOOST_CHECK(col.getNNC(std::size_t{0}).input().empty());
+    BOOST_CHECK(!col.hasGlobalNNC());
 }
 
 BOOST_AUTO_TEST_CASE(same_grid_add_does_not_affect_cross_grid)
@@ -793,13 +809,12 @@ BOOST_AUTO_TEST_CASE(local_global_insertion_normalises_to_same_output)
     const auto& egrid = es.getInputGrid();
 
     NNCCollection col;
-    col.addNNC(NNCDataContainer{});
+    // No global same-grid NNC: only a cross-grid connection exists.
 
     NNCDataContainerDiffGrid cross;
     cross.addNNC(5, 2, 100.0);  // cell1=5=LGR cell, cell2=2=global cell
     // addNNC(grid1=1=LGR, grid2=0=global): grid indices normalise to (0,1),
-    // cells are NOT swapped → cell1 stays associated with grid1 (LGR),
-    // cell2 stays associated with grid2 (global).
+    // cells are swapped so cell1 becomes the global cell and cell2 the LGR cell.
     col.addNNC(std::size_t{1}, std::size_t{0}, cross);
 
     Opm::UnitSystem units(Opm::UnitSystem::UnitType::UNIT_TYPE_FIELD);
@@ -807,6 +822,10 @@ BOOST_AUTO_TEST_CASE(local_global_insertion_normalises_to_same_output)
 
     Opm::EclIO::EclFile f("cross_lg.FEGRID",
                            Opm::EclIO::EclFile::Formatted{true});
+
+    // No same-grid NNCs → NNC1/NNC2 must not appear
+    BOOST_CHECK(!f.hasKey("NNC1"));
+    BOOST_CHECK(!f.hasKey("NNC2"));
 
     BOOST_REQUIRE(f.hasKey("NNCL"));
     BOOST_REQUIRE(f.hasKey("NNCG"));
@@ -817,10 +836,61 @@ BOOST_AUTO_TEST_CASE(local_global_insertion_normalises_to_same_output)
     BOOST_REQUIRE_EQUAL(nncl.size(), 1u);
     BOOST_REQUIRE_EQUAL(nncg.size(), 1u);
 
-    // NNCL = cell1+1 = LGR cell 5 → 6
-    // NNCG = cell2+1 = global cell 2 → 3
+    // NNCL = cell2+1 = LGR cell 5 → 6  (after swap_adj: stored as cell2)
+    // NNCG = cell1+1 = global cell 2 → 3  (after swap_adj: stored as cell1)
     BOOST_CHECK_EQUAL(nncl[0], 6);
     BOOST_CHECK_EQUAL(nncg[0], 3);
+}
+
+
+BOOST_AUTO_TEST_CASE(no_global_nnc_with_cross_grid_nnc)
+{
+    // Regression test: NNCCollection must not require a global same-grid NNC
+    // to be present when cross-grid (Global ↔ LGR) NNCs exist.
+    auto deck = Opm::Parser{}.parseString(opm_lgr_nnc_test);
+    EclipseState es(deck);
+    const auto& egrid = es.getInputGrid();
+
+    NNCCollection col;
+    // Deliberately add NO global same-grid NNC.
+
+    NNCDataContainerDiffGrid cross;
+    cross.addNNC(0, 0, 1.5);  // LGR cell 0 ↔ global cell 0
+    cross.addNNC(1, 1, 2.5);  // LGR cell 1 ↔ global cell 1
+    col.addNNC(std::size_t{1}, std::size_t{0}, cross);
+
+    BOOST_CHECK(!col.hasGlobalNNC());
+    BOOST_CHECK(col.hasCrossGridNNC(0, 1));
+
+    Opm::UnitSystem units(Opm::UnitSystem::UnitType::UNIT_TYPE_FIELD);
+
+    // Must not throw even though no global same-grid NNC exists.
+    BOOST_REQUIRE_NO_THROW(egrid.save("opm-test.FEGRID", true, col, units));
+
+    Opm::EclIO::EclFile f("opm-test.FEGRID",
+                           Opm::EclIO::EclFile::Formatted{true});
+
+    // No same-grid NNCs for any grid.
+    BOOST_CHECK(!f.hasKey("NNC1"));
+    BOOST_CHECK(!f.hasKey("NNC2"));
+
+    // Cross-grid section must be present and correct.
+    BOOST_REQUIRE(f.hasKey("NNCL"));
+    BOOST_REQUIRE(f.hasKey("NNCG"));
+
+    const auto nncl = f.get<int>("NNCL");
+    const auto nncg = f.get<int>("NNCG");
+
+    BOOST_REQUIRE_EQUAL(nncl.size(), 2u);
+    BOOST_REQUIRE_EQUAL(nncg.size(), 2u);
+
+    // addNNC(grid1=1, grid2=0) triggers swap_adj: cell1 ↔ cell2 in each entry.
+    // Stored: (cell1=global, cell2=LGR).
+    // save_nnc_local_global: NNCG=cell1+1 (global), NNCL=cell2+1 (LGR).
+    BOOST_CHECK_EQUAL(nncg[0], 1);  // global cell 0 → 1
+    BOOST_CHECK_EQUAL(nncl[0], 1);  // LGR cell 0 → 1
+    BOOST_CHECK_EQUAL(nncg[1], 2);  // global cell 1 → 2
+    BOOST_CHECK_EQUAL(nncl[1], 2);  // LGR cell 1 → 2
 }
 
 
@@ -1115,7 +1185,9 @@ BOOST_AUTO_TEST_CASE(from_lgr_output_containers_basic)
 BOOST_AUTO_TEST_CASE(from_lgr_output_containers_all_empty)
 {
     const NNCCollection col = NNCCollection::fromLGROutputContainers({}, {}, {});
-    BOOST_CHECK(col.same_grid_nnc().empty());
+    // Grid 0 always exists; verify it holds no data and no other grids were added.
+    BOOST_CHECK_EQUAL(col.same_grid_nnc().size(), 1u);
+    BOOST_CHECK(col.getGlobalNNC().input().empty());
     BOOST_CHECK(col.diff_grid_nnc().empty());
 }
 
@@ -1206,7 +1278,8 @@ BOOST_AUTO_TEST_CASE(from_lgr_output_containers_only_global_local)
         },
         {});
 
-    BOOST_CHECK(col.same_grid_nnc().empty());
+    BOOST_CHECK_EQUAL(col.same_grid_nnc().size(), 1u);
+    BOOST_CHECK(col.getGlobalNNC().input().empty());
     BOOST_REQUIRE_EQUAL(col.diff_grid_nnc().size(), 2u);
 
     BOOST_REQUIRE(col.hasCrossGridNNC(0, 1));
@@ -1293,7 +1366,8 @@ BOOST_AUTO_TEST_CASE(from_lgr_output_containers_amalgamated_index_formula)
         });
 
     // Exactly 6 cross-grid pairs, same-grid empty
-    BOOST_CHECK(col.same_grid_nnc().empty());
+    BOOST_CHECK_EQUAL(col.same_grid_nnc().size(), 1u);
+    BOOST_CHECK(col.getGlobalNNC().input().empty());
     BOOST_REQUIRE_EQUAL(col.diff_grid_nnc().size(), 6u);
 
     // Verify each pair exists and holds exactly 1 entry with the expected cells
@@ -1365,7 +1439,8 @@ BOOST_AUTO_TEST_CASE(from_lgr_output_containers_multi_lgr_amalgamated)
             { { NNCdata(4, 5, 30.0) } }                              // [1][*]
         });
 
-    BOOST_CHECK(col.same_grid_nnc().empty());
+    BOOST_CHECK_EQUAL(col.same_grid_nnc().size(), 1u);
+    BOOST_CHECK(col.getGlobalNNC().input().empty());
     BOOST_REQUIRE_EQUAL(col.diff_grid_nnc().size(), 3u);
 
     BOOST_CHECK(col.hasCrossGridNNC(1, 2));


### PR DESCRIPTION
# `NNCCollection`: global grid always exists; `getGlobalNNC()` never throws

### Changes

**`NNC.cpp`**
- Default constructor inserts an empty `NNCDataContainer` for grid 0.
- `addNNC(std::size_t grid, NNCDataContainer)`: replaces grid 0 entry instead of throwing; grids > 0 retain the existing duplicate-throw behaviour.
- `addNNC(NNCDataContainer)`: replaces grid 0 entry directly via `operator[]`.
- `getGlobalNNC()` (both overloads): removed throw; grid 0 is always present.

**`NNC.hpp`**
- `hasGlobalNNC()`: always returns `true` — the global grid entity always exists. Use `getGlobalNNC().input().empty()` to check for actual data.
- `empty()`: iterates all same-grid containers for non-empty content (since grid 0 is always in the map, `m_sameGridNNCs.empty()` is no longer usable).

**`EclipseGrid.cpp`**
- `save_nnc()`: calls `getGlobalNNC()` unconditionally. `save_nnc_same_grid()` already writes nothing for an empty input vector.

**`NNCTestsLGR.cpp`**
- Tests updated throughout to reflect new semantics: `hasSameGridNNC(0)` is always true, `hasGlobalNNC()` is always true, empty collection means grid 0 exists but holds no data.
- New regression test `no_global_nnc_with_cross_grid_nnc`: saves an `NNCCollection` that has only a Global↔LGR cross-grid NNC and no same-grid data — verifies no throw, no NNC1/NNC2 in output, correct NNCL/NNCG.