### PR TITLE
Fix CO2STORE/H2STORE salinity handling in diffusion coefficients and PVT conversion

### DIFF
--- a/opm/material/fluidsystems/BlackOilFluidSystem.cpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.cpp
@@ -181,23 +181,28 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
                 && eclState.runspec().phases().active(Phase::GAS)
                 && eclState.runspec().phases().active(Phase::WATER))
         {
-            diffusionCoefficients_.resize(num_regions, {0,0,0,0,0,0,0,0,0});
             // diffusion coefficients can be set using DIFFCGAS and DIFFCWAT
-            // for CO2STORE and H2STORE cases with gas + water
+            // for CO2STORE and H2STORE cases with gas + water.
+            // Only populate diffusionCoefficients_ when at least one table exists;
+            // otherwise leave it empty so the PVT model's diffusionCoefficient()
+            // is used at runtime (which includes salinity-dependent corrections).
             const auto& diffCoeffWatTables = eclState.getTableManager().getDiffusionCoefficientWaterTable();
-            if (!diffCoeffWatTables.empty()) {
-                for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
-                    const auto& diffCoeffWatTable = diffCoeffWatTables[regionIdx];
-                    setDiffusionCoefficient(diffCoeffWatTable.co2_in_water, gasCompIdx, waterPhaseIdx, regionIdx);
-                    setDiffusionCoefficient(diffCoeffWatTable.h2o_in_water, waterCompIdx, waterPhaseIdx, regionIdx);
-                }
-            }
             const auto& diffCoeffGasTables = eclState.getTableManager().getDiffusionCoefficientGasTable();
-            if (!diffCoeffGasTables.empty()) {
-                for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
-                    const auto& diffCoeffGasTable = diffCoeffGasTables[regionIdx];
-                    setDiffusionCoefficient(diffCoeffGasTable.co2_in_gas, gasCompIdx, gasPhaseIdx, regionIdx);
-                    setDiffusionCoefficient(diffCoeffGasTable.h2o_in_gas, waterCompIdx, gasPhaseIdx, regionIdx);
+            if (!diffCoeffWatTables.empty() || !diffCoeffGasTables.empty()) {
+                diffusionCoefficients_.resize(num_regions, {0,0,0,0,0,0,0,0,0});
+                if (!diffCoeffWatTables.empty()) {
+                    for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
+                        const auto& diffCoeffWatTable = diffCoeffWatTables[regionIdx];
+                        setDiffusionCoefficient(diffCoeffWatTable.co2_in_water, gasCompIdx, waterPhaseIdx, regionIdx);
+                        setDiffusionCoefficient(diffCoeffWatTable.h2o_in_water, waterCompIdx, waterPhaseIdx, regionIdx);
+                    }
+                }
+                if (!diffCoeffGasTables.empty()) {
+                    for (unsigned regionIdx = 0; regionIdx < num_regions; ++regionIdx) {
+                        const auto& diffCoeffGasTable = diffCoeffGasTables[regionIdx];
+                        setDiffusionCoefficient(diffCoeffGasTable.co2_in_gas, gasCompIdx, gasPhaseIdx, regionIdx);
+                        setDiffusionCoefficient(diffCoeffGasTable.h2o_in_gas, waterCompIdx, gasPhaseIdx, regionIdx);
+                    }
                 }
             }
         }

--- a/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
@@ -1762,11 +1762,12 @@ public:
 
         const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
         const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const unsigned regionIdx = paramCache.regionIndex();
 
         switch (phaseIdx) {
         case oilPhaseIdx: return oilPvt().diffusionCoefficient(T, p, compIdx);
         case gasPhaseIdx: return gasPvt().diffusionCoefficient(T, p, compIdx);
-        case waterPhaseIdx: return waterPvt().diffusionCoefficient(T, p, compIdx);
+        case waterPhaseIdx: return waterPvt().diffusionCoefficient(T, p, compIdx, regionIdx);
         default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
         }
     }

--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -812,7 +812,13 @@ private:
                                             const LhsEval& saltConcentration) const
     {
         if (enableSaltConcentration_) {
-            return saltConcentration/H2O::liquidDensity(T, P, true);
+            // Convert concentration [kg/m³] to mass fraction [kg_salt/kg_solution].
+            // First approximation using pure water density
+            const LhsEval rho_w = H2O::liquidDensity(T, P, true);
+            const LhsEval S_approx = saltConcentration / rho_w;
+            // Improved estimate using Batzle-Wang brine density
+            const LhsEval rho_brine = Brine::liquidDensity(T, P, S_approx, rho_w);
+            return saltConcentration / rho_brine;
         }
 
         return salinity(regionIdx);

--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -504,7 +504,8 @@ public:
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation diffusionCoefficient(const Evaluation& temperature,
                                     const Evaluation& pressure,
-                                    unsigned /*compIdx*/) const
+                                    unsigned /*compIdx*/,
+                                    unsigned regionIdx = 0) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         // Diffusion coefficient of CO2 in pure water according to
@@ -521,11 +522,11 @@ public:
         if (enableEzrokhiViscosity_) {
             const Evaluation& nacl_exponent = ezrokhiExponent_(temperature,
                                                                ezrokhiViscNaClCoeff_);
-            mu_Brine = mu_H20 * pow(10.0, nacl_exponent * Evaluation(salinity_[0]));
+            mu_Brine = mu_H20 * pow(10.0, nacl_exponent * Evaluation(salinity_[regionIdx]));
         }
         else {
             // Brine viscosity
-            mu_Brine = Brine::liquidViscosity(temperature, pressure, Evaluation(salinity_[0]));
+            mu_Brine = Brine::liquidViscosity(temperature, pressure, Evaluation(salinity_[regionIdx]));
         }
         const Evaluation log_D_Brine = log_D_H20 - 0.87*log10(mu_Brine / mu_H20);
 

--- a/opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.hpp
@@ -684,7 +684,13 @@ private:
                                             const LhsEval& saltConcentration) const
     {
         if (enableSaltConcentration_) {
-            return saltConcentration/H2O::liquidDensity(T, P, true);
+            // Convert concentration [kg/m³] to mass fraction [kg_salt/kg_solution].
+            // First approximation using pure water density
+            const LhsEval rho_w = H2O::liquidDensity(T, P, true);
+            const LhsEval S_approx = saltConcentration / rho_w;
+            // Improved estimate using Batzle-Wang brine density
+            const LhsEval rho_brine = Brine::liquidDensity(T, P, S_approx, rho_w);
+            return saltConcentration / rho_brine;
         }
 
         return salinity(regionIdx);

--- a/opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.hpp
@@ -384,7 +384,8 @@ public:
     template <class Evaluation>
     Evaluation diffusionCoefficient(const Evaluation& temperature,
                                     const Evaluation& pressure,
-                                    unsigned /*compIdx*/) const
+                                    unsigned /*compIdx*/,
+                                    unsigned regionIdx = 0) const
     {
         // Diffusion coefficient of H2 in pure water according to
         // Ferrell & Himmelbau, AIChE Journal, 13(4), 1967 (Eq. 23)
@@ -398,7 +399,7 @@ public:
         const Scalar lambda = 1.729; // quantum parameter [-]
         const Evaluation mu_pure = H2O::liquidViscosity(temperature, pressure, extrapolate) * 1e3;  // [cP]
         const Evaluation mu_brine = Brine::liquidViscosity(temperature, pressure,
-                                                           Evaluation(salinity_[0])) * 1e3;
+                                                           Evaluation(salinity_[regionIdx])) * 1e3;
 
         // Diffusion coeff in pure water in cm2/s
         const Evaluation D_pure = ((4.8e-7 * temperature) / pow(mu_pure, alpha)) *

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp
@@ -235,7 +235,8 @@ public:
     template <class Evaluation>
     Evaluation diffusionCoefficient(const Evaluation& /*temperature*/,
                                     const Evaluation& /*pressure*/,
-                                    unsigned /*compIdx*/) const
+                                    unsigned /*compIdx*/,
+                                    unsigned /*regionIdx*/ = 0) const
     {
         throw std::runtime_error("Not implemented: The PVT model does not provide "
                                  "a diffusionCoefficient()");

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -272,7 +272,8 @@ public:
     template <class Evaluation>
     Evaluation diffusionCoefficient(const Evaluation& /*temperature*/,
                                     const Evaluation& /*pressure*/,
-                                    unsigned /*compIdx*/) const
+                                    unsigned /*compIdx*/,
+                                    unsigned /*regionIdx*/ = 0) const
     {
         throw std::runtime_error("Not implemented: The PVT model does not provide "
                                  "a diffusionCoefficient()");

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -239,9 +239,10 @@ public:
     template <class Evaluation>
     Evaluation diffusionCoefficient(const Evaluation& temperature,
                                     const Evaluation& pressure,
-                                    unsigned compIdx) const
+                                    unsigned compIdx,
+                                    unsigned regionIdx = 0) const
     {
-      OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.diffusionCoefficient(temperature, pressure, compIdx));
+      OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.diffusionCoefficient(temperature, pressure, compIdx, regionIdx));
     }
 
     void setApproach(WaterPvtApproach appr);

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -367,7 +367,8 @@ public:
     template <class Evaluation>
     Evaluation diffusionCoefficient(const Evaluation& /*temperature*/,
                                     const Evaluation& /*pressure*/,
-                                    unsigned /*compIdx*/) const
+                                    unsigned /*compIdx*/,
+                                    unsigned /*regionIdx*/ = 0) const
     {
         throw std::runtime_error("Not implemented: The PVT model does not provide "
                                  "a diffusionCoefficient()");


### PR DESCRIPTION
  ## Summary

  Two bug fixes for salinity handling in CO2STORE/H2STORE WATER+GAS simulations:

  - **Diffusion coefficient initialization**: `diffusionCoefficients_` was unconditionally
    resized to zeros in the WATER+GAS path, even without DIFFCGAS/DIFFCWAT tables. This
    prevented the PVT model's salinity-aware `diffusionCoefficient()` from being called
    at runtime (the `!diffusionCoefficients_.empty()` guard always returned true).
    The OIL+GAS path did not have this issue. Fix: only resize when tables exist.

  - **Region-dependent salinity in diffusion**: `BrineCo2Pvt::diffusionCoefficient()` and
    `BrineH2Pvt::diffusionCoefficient()` used hard-coded `salinity_[0]` instead of
    `salinity_[regionIdx]`. Every other method in these classes (rsSat, density, viscosity,
    internalEnergy) already uses `salinity_[regionIdx]`. Added `regionIdx` parameter with
    default=0 for backward compatibility, propagated through WaterPvtMultiplexer.

  - **Salt concentration to mass fraction conversion**: `salinityFromConcentration()` divided
    by pure water density instead of brine density. Since salt concentration is defined as
    kg/m³ of brine solution, this overestimates mass fraction by ~2% at 32k ppm and ~7%
    at 100k ppm. Fix: one-iteration Batzle-Wang correction via `Brine::liquidDensity()`.
    Note: `Co2GasPvt` has the same first-order approximation but is not changed here.

  ## Files changed (opm-common only)

  | File | Change |
  |------|--------|
  | `BlackOilFluidSystem.cpp` | Conditional resize of `diffusionCoefficients_` |
  | `BlackOilFluidSystem_macrotemplate.hpp` | Extract `regionIdx` from `paramCache`, pass to water PVT |
  | `BrineCo2Pvt.hpp` | `diffusionCoefficient()`: regionIdx + salinity fix; `salinityFromConcentration()`: Batzle-Wang |
  | `BrineH2Pvt.hpp` | Same two fixes |
  | `WaterPvtMultiplexer.hpp` | Pass-through regionIdx |
  | `WaterPvtThermal.hpp` | Interface compatibility (default parameter) |
  | `ConstantCompressibilityBrinePvt.hpp` | Interface compatibility (default parameter) |
  | `ConstantCompressibilityWaterPvt.hpp` | Interface compatibility (default parameter) |

  ## Backward compatibility

  - Default `regionIdx = 0` preserves existing single-region behavior
  - Decks with explicit DIFFCWAT/DIFFCGAS tables are unaffected
  - The OIL+GAS (Framework 1) code path is not modified

  ## Test plan

  - [ ] Existing OPM test suite passes
  - [ ] CO2STORE WATER+GAS simulation with DIFFUSE (no DIFFCWAT/DIFFCGAS) uses PVT model diffusion (not zeros)
  - [ ] Multi-region CO2STORE model uses correct per-region salinity for diffusion
