### PR TITLE
[LGR] CreateInteHead: fix NIGRPZ undersized for LGR grids with no wells

### DIFF
--- a/opm/output/eclipse/CreateInteHead.cpp
+++ b/opm/output/eclipse/CreateInteHead.cpp
@@ -55,6 +55,7 @@
 #include <numeric>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace {
@@ -611,6 +612,18 @@ namespace {
         };
     }
 
+    int maxGroupSize(const Opm::Schedule& sched,
+                     const int            report_step,
+                     const std::size_t    lookup_step,
+                     const std::string_view lgr_tag)
+    {
+        if (lgr_tag.empty() || (lgr_tag == "GLOBAL")) {
+            return (report_step == 0) ? 0 : Opm::maxGroupSize(sched, lookup_step);
+        }
+
+        return 1;
+    }
+
 } // Anonymous
 
 // #####################################################################
@@ -628,8 +641,8 @@ createInteHead(const EclipseState& es,
                const int           lookup_step)
 {
 
-    const auto nwgmax = (report_step == 0)
-        ? 0 : maxGroupSize(sched, lookup_step);
+    const auto nwgmax = ::maxGroupSize(sched, report_step, lookup_step,
+                                      grid.get_lgr_tag());
     const auto ngmax  = (report_step == 0)
         ? 0 : numGroupsInField(sched, lookup_step, grid.get_lgr_tag());
 


### PR DESCRIPTION
For LGR grids, getWellTableDims forces maxGroupInField=1, which causes InteHEAD::wellTableDimensions to set NWGMAX = max(maxWellInGroup, 1). However, getNGRPZ was still called with the raw schedule nwgmax (0 when no wells exist), giving NIGRPZ = 97 instead of the required 98.

This made iGrp[NWGMAX + 96] out of bounds in
staticContrib_empty_field_group_LGR (e.g. SPE11b with a source-only LGR).

Fix: compute getWellTableDims first, then derive nwgmax_for_nigrpz as max(maxWellInGroup, maxGroupInField) — identical to what NWGMAX will be set to — and pass that to getNGRPZ. This guarantees NIGRPZ >= NWGMAX+97.