### PR TITLE
Remove warnings ranlib: warning: 'libopmcommon.a(*.cpp.o)' has no symbols

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -69,8 +69,6 @@ list(APPEND MAIN_SOURCE_FILES
   opm/common/utility/parameters/ParameterRequirement.cpp
   opm/common/utility/parameters/ParameterTools.cpp
   opm/common/utility/numeric/calculateCellVol.cpp
-  opm/common/utility/numeric/GeometryUtil.cpp
-  opm/common/utility/numeric/VectorUtil.cpp
   opm/common/utility/numeric/GridUtil.cpp
   opm/common/utility/numeric/MonotCubicInterpolator.cpp
   opm/common/utility/numeric/RootFinders.cpp

--- a/opm/common/utility/numeric/GeometryUtil.cpp
+++ b/opm/common/utility/numeric/GeometryUtil.cpp
@@ -1,5 +1,0 @@
-#include <opm/common/utility/numeric/GeometryUtil.hpp>
-
-namespace GeometryUtil {
-
-} // namespace GeometryUtils

--- a/opm/common/utility/numeric/VectorUtil.cpp
+++ b/opm/common/utility/numeric/VectorUtil.cpp
@@ -1,6 +1,0 @@
-#include <opm/common/utility/numeric/VectorUtil.hpp>
-
-namespace VectorUtil {
-
-
-} // namespace VectorUtil


### PR DESCRIPTION
Remove warnings
```
ranlib: warning: 'libopmcommon.a(GeometryUtil/VectorUtil.cpp.o)' has no symbols
```