### PR TITLE
Replace Global Namespace Type Aliases with STD:: Prefixed Equivalents

### DIFF
--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -78,6 +78,7 @@ specializationTemplate = \
 #endif
 {% if numDerivs < 0 %}\
 #include <opm/material/common/FastSmallVector.hpp>
+#include <cstddef>
 
 {% else %}\
 
@@ -1094,7 +1095,7 @@ private:
 {% if numDerivs < 0 %}\
     FastSmallVector<ValueT, staticSize> data_;
 
-    void appendDerivativesToConstant(size_t numDer) {
+    void appendDerivativesToConstant(std::size_t numDer) {
         assert(size() == 0); // we only append derivatives to a constant
         if (numDer > 0) {
             data_.resize(1 + numDer);

--- a/opm/common/OpmLog/CounterLog.cpp
+++ b/opm/common/OpmLog/CounterLog.cpp
@@ -21,18 +21,19 @@
 #include <opm/common/OpmLog/LogUtil.hpp>
 #include <opm/common/OpmLog/CounterLog.hpp>
 
+#include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 
 namespace Opm {
 
-CounterLog::CounterLog(int64_t messageTypes) : LogBackend(messageTypes)
+CounterLog::CounterLog(std::int64_t messageTypes) : LogBackend(messageTypes)
 { }
 
 CounterLog::CounterLog() : LogBackend(Log::DefaultMessageTypes)
 { }
 
-
-size_t CounterLog::numMessages(int64_t messageType) const {
+std::size_t CounterLog::numMessages(std::int64_t messageType) const {
     if (Log::isPower2( messageType )) {
         auto iter = m_count.find( messageType );
         if (iter == m_count.end())
@@ -43,18 +44,13 @@ size_t CounterLog::numMessages(int64_t messageType) const {
         throw std::invalid_argument("The messageType ID must be 2^n");
 }
 
-
-
-void CounterLog::addMessageUnconditionally(int64_t messageType, const std::string& ) {
+void CounterLog::addMessageUnconditionally(std::int64_t messageType, const std::string& ) {
     m_count[messageType]++;
 }
-
 
 void CounterLog::clear()
 {
     m_count.clear();
 }
-
-
 
 } // namespace Opm

--- a/opm/common/OpmLog/CounterLog.hpp
+++ b/opm/common/OpmLog/CounterLog.hpp
@@ -16,14 +16,17 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #ifndef OPM_COUNTERLOG_HPP
 #define OPM_COUNTERLOG_HPP
 
-#include <string>
-#include <memory>
-#include <map>
-
 #include <opm/common/OpmLog/LogBackend.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
 
 namespace Opm {
 /*!
@@ -33,18 +36,18 @@ namespace Opm {
     class CounterLog : public LogBackend
     {
     public:
-        explicit CounterLog(int64_t messageMask);
+        explicit CounterLog(std::int64_t messageMask);
         CounterLog();
 
-        size_t numMessages(int64_t messageType) const;
+        std::size_t numMessages(std::int64_t messageType) const;
 
         void clear();
 
     protected:
-        void addMessageUnconditionally(int64_t messageFlag,
+        void addMessageUnconditionally(std::int64_t messageFlag,
                                        const std::string& message) override;
     private:
-        std::map<int64_t , size_t> m_count;
+        std::map<std::int64_t , std::size_t> m_count;
     };
 
 } // namespace Opm

--- a/opm/common/OpmLog/EclipsePRTLog.cpp
+++ b/opm/common/OpmLog/EclipsePRTLog.cpp
@@ -20,17 +20,18 @@
 #include <opm/common/OpmLog/EclipsePRTLog.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
 
+#include <cstddef>
+#include <cstdint>
+
 namespace Opm {
 
-
-    void EclipsePRTLog::addMessageUnconditionally(int64_t messageType, const std::string& message)
+    void EclipsePRTLog::addMessageUnconditionally(std::int64_t messageType, const std::string& message)
     {
         StreamLog::addMessageUnconditionally(messageType, message);
         m_count[messageType]++;
     }
 
-
-    size_t EclipsePRTLog::numMessages(int64_t messageType) const
+    std::size_t EclipsePRTLog::numMessages(std::int64_t messageType) const
     {
         if (Log::isPower2( messageType )) {
             auto iter = m_count.find( messageType );
@@ -41,7 +42,6 @@ namespace Opm {
         } else
             throw std::invalid_argument("The messageType ID must be 2^n");
     }
-
 
     EclipsePRTLog::~EclipsePRTLog()
     {
@@ -62,7 +62,7 @@ namespace Opm {
     }
 
     EclipsePRTLog::EclipsePRTLog(const std::string& logFile,
-                                 int64_t messageMask,
+                                 std::int64_t messageMask,
                                  bool append,
                                  bool print_summary)
         : StreamLog(logFile, messageMask, append),
@@ -70,7 +70,7 @@ namespace Opm {
     {}
 
     EclipsePRTLog::EclipsePRTLog(std::ostream& os,
-                                 int64_t messageMask,
+                                 std::int64_t messageMask,
                                  bool print_summary)
         : StreamLog(os, messageMask), print_summary_(print_summary)
     {}

--- a/opm/common/OpmLog/EclipsePRTLog.hpp
+++ b/opm/common/OpmLog/EclipsePRTLog.hpp
@@ -20,9 +20,12 @@
 #ifndef ECLIPSEPRTLOG_H
 #define ECLIPSEPRTLOG_H
 
+#include <opm/common/OpmLog/StreamLog.hpp>
+
+#include <cstddef>
+#include <cstdint>
 #include <map>
 #include <string>
-#include <opm/common/OpmLog/StreamLog.hpp>
 
 namespace Opm {
 
@@ -31,7 +34,7 @@ class EclipsePRTLog : public StreamLog {
 public:
     using StreamLog::StreamLog;
 
-    size_t numMessages(int64_t messageType) const;
+    std::size_t numMessages(std::int64_t messageType) const;
 
     ~EclipsePRTLog() override;
 
@@ -41,21 +44,21 @@ public:
     /// \param append If true then we append messages to the file.
     ///               Otherwise a new file is created.
     /// \param print_summary If true print a summary to the PRT file.
-    EclipsePRTLog(const std::string& logFile , int64_t messageMask,
+    EclipsePRTLog(const std::string& logFile , std::int64_t messageMask,
                   bool append, bool print_summary);
 
     /// \brief Construct a logger to the <MODEL>.PRT file
     /// \param os The stream to write the log to.
     /// \param messageMask Mask for logging of messages
     /// \param print_summary If true print a summary to the PRT file.
-    EclipsePRTLog(std::ostream& os, int64_t messageMask,
+    EclipsePRTLog(std::ostream& os, std::int64_t messageMask,
                   bool print_summary);
 
 protected:
-    void addMessageUnconditionally(int64_t messageType, const std::string& message) override;
+    void addMessageUnconditionally(std::int64_t messageType, const std::string& message) override;
 
 private:
-    std::map<int64_t, size_t> m_count;
+    std::map<std::int64_t, std::size_t> m_count;
     /// \brief Whether to print a summary to the log file.
     bool print_summary_ = true;
 };

--- a/opm/common/OpmLog/LogBackend.cpp
+++ b/opm/common/OpmLog/LogBackend.cpp
@@ -20,9 +20,11 @@
 #include <opm/common/OpmLog/LogBackend.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
 
+#include <cstdint>
+
 namespace Opm {
 
-    LogBackend::LogBackend( int64_t mask ) :
+    LogBackend::LogBackend( std::int64_t mask ) :
         m_mask(mask)
     {
     }
@@ -41,24 +43,24 @@ namespace Opm {
         m_limiter = limiter;
     }
 
-    void LogBackend::addMessage(int64_t messageFlag, const std::string& message)
+    void LogBackend::addMessage(std::int64_t messageFlag, const std::string& message)
     {
         // Forward the call to the tagged version.
         addTaggedMessage(messageFlag, "", message);
     }
 
-    void LogBackend::addTaggedMessage(int64_t messageType, const std::string& messageTag, const std::string& message) {
+    void LogBackend::addTaggedMessage(std::int64_t messageType, const std::string& messageTag, const std::string& message) {
         if (includeMessage( messageType, messageTag )) {
             addMessageUnconditionally(messageType, message);
         }
     }
 
-    int64_t LogBackend::getMask() const
+    std::int64_t LogBackend::getMask() const
     {
         return m_mask;
     }
 
-    bool LogBackend::includeMessage(int64_t messageFlag, const std::string& messageTag)
+    bool LogBackend::includeMessage(std::int64_t messageFlag, const std::string& messageTag)
     {
         // Check mask.
         const bool included = ((messageFlag & m_mask) == messageFlag) && (messageFlag > 0);
@@ -85,7 +87,7 @@ namespace Opm {
         return res == MessageLimiter::Response::PrintMessage;
     }
 
-    std::string LogBackend::formatMessage(int64_t messageFlag, const std::string& message)
+    std::string LogBackend::formatMessage(std::int64_t messageFlag, const std::string& message)
     {
         if (m_formatter) {
             return m_formatter->format(messageFlag, message);
@@ -93,6 +95,5 @@ namespace Opm {
             return message;
         }
     }
-
 
 }

--- a/opm/common/OpmLog/LogBackend.hpp
+++ b/opm/common/OpmLog/LogBackend.hpp
@@ -24,9 +24,10 @@
 
 #include <opm/common/OpmLog/MessageFormatter.hpp>
 #include <opm/common/OpmLog/MessageLimiter.hpp>
+
 #include <cstdint>
-#include <string>
 #include <memory>
+#include <string>
 
 namespace Opm
 {
@@ -36,7 +37,7 @@ namespace Opm
     {
     public:
         /// Construct with given message mask.
-        explicit LogBackend(int64_t mask);
+        explicit LogBackend(std::int64_t mask);
 
         /// Virtual destructor to enable inheritance.
         virtual ~LogBackend();
@@ -48,34 +49,34 @@ namespace Opm
         void setMessageLimiter(std::shared_ptr<MessageLimiter> limiter);
 
         /// Add a message to the backend if accepted by the message limiter.
-        void addMessage(int64_t messageFlag, const std::string& message);
+        void addMessage(std::int64_t messageFlag, const std::string& message);
 
         /// Add a tagged message to the backend if accepted by the message limiter.
-        void addTaggedMessage(int64_t messageFlag,
+        void addTaggedMessage(std::int64_t messageFlag,
                               const std::string& messageTag,
                               const std::string& message);
 
         /// The message mask types are specified in the
         /// Opm::Log::MessageType namespace, in file LogUtils.hpp.
-        int64_t getMask() const;
+        std::int64_t getMask() const;
 
     protected:
         /// This is the method subclasses should override.
         ///
         /// Typically a subclass may filter, change, and output
         /// messages based on configuration and the messageFlag.
-        virtual void addMessageUnconditionally(int64_t messageFlag,
+        virtual void addMessageUnconditionally(std::int64_t messageFlag,
                                                const std::string& message) = 0;
 
         /// Return decorated version of message depending on configureDecoration() arguments.
-        std::string formatMessage(int64_t messageFlag, const std::string& message);
+        std::string formatMessage(std::int64_t messageFlag, const std::string& message);
 
     private:
         /// Return true if all bits of messageFlag are also set in our mask,
         /// and the message limiter returns a PrintMessage response.
-        bool includeMessage(int64_t messageFlag, const std::string& messageTag);
+        bool includeMessage(std::int64_t messageFlag, const std::string& messageTag);
 
-        int64_t m_mask;
+        std::int64_t m_mask;
         std::shared_ptr<MessageFormatterInterface> m_formatter;
         std::shared_ptr<MessageLimiter> m_limiter;
     };

--- a/opm/common/OpmLog/LogUtil.cpp
+++ b/opm/common/OpmLog/LogUtil.cpp
@@ -17,21 +17,20 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <sstream>
-#include <stdexcept>
 #include <opm/common/OpmLog/LogUtil.hpp>
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 
+#include <cstdint>
+#include <sstream>
+#include <stdexcept>
 
 namespace Opm {
 
 namespace Log {
 
-    bool isPower2(int64_t x) {
+    bool isPower2(std::int64_t x) {
         return ((x != 0) && !(x & (x - 1)));
     }
-
-
 
     std::string fileMessage(const KeywordLocation& location, const std::string& message) {
         std::ostringstream oss;
@@ -41,12 +40,11 @@ namespace Log {
         return oss.str();
     }
 
-    std::string fileMessage(int64_t messageType , const KeywordLocation& location, const std::string& message) {
+    std::string fileMessage(std::int64_t messageType , const KeywordLocation& location, const std::string& message) {
         return fileMessage( location , prefixMessage( messageType , message ));
     }
 
-
-    std::string prefixMessage(int64_t messageType, const std::string& message) {
+    std::string prefixMessage(std::int64_t messageType, const std::string& message) {
         std::string prefix;
         switch (messageType) {
         case MessageType::Debug:
@@ -77,8 +75,7 @@ namespace Log {
         return prefix + ": " + message;
     }
 
-
-    std::string colorCodeMessage(int64_t messageType, const std::string& message) {
+    std::string colorCodeMessage(std::int64_t messageType, const std::string& message) {
         switch (messageType) {
         case MessageType::Debug:
         case MessageType::Note:

--- a/opm/common/OpmLog/LogUtil.hpp
+++ b/opm/common/OpmLog/LogUtil.hpp
@@ -29,18 +29,18 @@ class KeywordLocation;
 
 namespace Log {
     namespace MessageType {
-        const int64_t Debug     =  1;   /* Excessive information */
-        const int64_t Note      =  2;  /* Information that should only go into print file.*/
-        const int64_t Info      =  4;   /* Normal status information */
-        const int64_t Warning   =  8;   /* Input anomaly - possible error */
-        const int64_t Error     = 16;   /* Error in the input data - should probably exit. */
-        const int64_t Problem   = 32;   /* Calculation problems - e.g. convergence failure. */
-        const int64_t Bug       = 64;   /* An inconsistent state has been encountered in the simulator - should probably exit. */
+        const std::int64_t Debug     =  1;   /* Excessive information */
+        const std::int64_t Note      =  2;  /* Information that should only go into print file.*/
+        const std::int64_t Info      =  4;   /* Normal status information */
+        const std::int64_t Warning   =  8;   /* Input anomaly - possible error */
+        const std::int64_t Error     = 16;   /* Error in the input data - should probably exit. */
+        const std::int64_t Problem   = 32;   /* Calculation problems - e.g. convergence failure. */
+        const std::int64_t Bug       = 64;   /* An inconsistent state has been encountered in the simulator - should probably exit. */
     }
 
-    const int64_t DefaultMessageTypes = MessageType::Debug + MessageType::Note + MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
-    const int64_t NoDebugMessageTypes = MessageType::Info + MessageType::Note + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
-    const int64_t StdoutMessageTypes = MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
+    const std::int64_t DefaultMessageTypes = MessageType::Debug + MessageType::Note + MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
+    const std::int64_t NoDebugMessageTypes = MessageType::Info + MessageType::Note + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
+    const std::int64_t StdoutMessageTypes = MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
 
     /// Terminal codes for ANSI/vt100 compatible terminals.
     /// See for example http://ascii-table.com/ansi-escape-sequences.php
@@ -58,11 +58,11 @@ namespace Log {
     }
 
 
-    bool isPower2(int64_t x);
+    bool isPower2(std::int64_t x);
     std::string fileMessage(const KeywordLocation& location, const std::string& msg);
-    std::string fileMessage(int64_t messageType , const KeywordLocation& location , const std::string& msg);
-    std::string prefixMessage(int64_t messageType , const std::string& msg);
-    std::string colorCodeMessage(int64_t messageType , const std::string& msg);
+    std::string fileMessage(std::int64_t messageType , const KeywordLocation& location , const std::string& msg);
+    std::string prefixMessage(std::int64_t messageType , const std::string& msg);
+    std::string colorCodeMessage(std::int64_t messageType , const std::string& msg);
 
 }
 }

--- a/opm/common/OpmLog/Logger.cpp
+++ b/opm/common/OpmLog/Logger.cpp
@@ -18,12 +18,15 @@
 */
 
 #include <config.h>
-#include <opm/common/OpmLog/Logger.hpp>
 
-#include <stdexcept>
+#include <opm/common/OpmLog/Logger.hpp>
 
 #include <opm/common/OpmLog/LogBackend.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
 
 namespace Opm {
 
@@ -40,7 +43,7 @@ namespace Opm {
         addMessageType( Log::MessageType::Note , "note");
     }
 
-    void Logger::addTaggedMessage(int64_t messageType, const std::string& tag, const std::string& message) const {
+    void Logger::addTaggedMessage(std::int64_t messageType, const std::string& tag, const std::string& message) const {
         if ((m_enabledTypes & messageType) == 0)
             throw std::invalid_argument("Tried to issue message with unrecognized message ID");
 
@@ -52,15 +55,13 @@ namespace Opm {
         }
     }
 
-    void Logger::addMessage(int64_t messageType , const std::string& message) const {
+    void Logger::addMessage(std::int64_t messageType , const std::string& message) const {
         addTaggedMessage(messageType, "", message);
     }
 
-
-    void Logger::updateGlobalMask( int64_t mask ) {
+    void Logger::updateGlobalMask( std::int64_t mask ) {
         m_globalMask |= mask;
     }
-
 
     bool Logger::hasBackend(const std::string& name) {
         if (m_backends.find( name ) == m_backends.end())
@@ -75,26 +76,24 @@ namespace Opm {
     }
 
     bool Logger::removeBackend(const std::string& name) {
-        size_t eraseCount = m_backends.erase( name );
+        std::size_t eraseCount = m_backends.erase( name );
         if (eraseCount == 1)
             return true;
         else
             return false;
     }
 
-
     void Logger::addBackend(const std::string& name , std::shared_ptr<LogBackend> backend) {
         updateGlobalMask( backend->getMask() );
         m_backends[ name ] = backend;
     }
 
-
-    int64_t Logger::enabledMessageTypes() const {
+    std::int64_t Logger::enabledMessageTypes() const {
         return m_enabledTypes;
     }
 
     //static:
-    bool Logger::enabledMessageType( int64_t enabledTypes , int64_t messageType) {
+    bool Logger::enabledMessageType( std::int64_t enabledTypes , std::int64_t messageType) {
         if (Log::isPower2( messageType)) {
             if ((messageType & enabledTypes) == 0)
                 return false;
@@ -104,18 +103,16 @@ namespace Opm {
             throw std::invalid_argument("The message type id must be ~ 2^n");
     }
 
-
     //static:
-    bool Logger::enabledDefaultMessageType( int64_t messageType) {
+    bool Logger::enabledDefaultMessageType( std::int64_t messageType) {
         return enabledMessageType( Log::DefaultMessageTypes , messageType );
     }
 
-    bool Logger::enabledMessageType( int64_t messageType) const {
+    bool Logger::enabledMessageType( std::int64_t messageType) const {
         return enabledMessageType( m_enabledTypes , messageType );
     }
 
-
-    void Logger::addMessageType( int64_t messageType , const std::string& /* prefix */) {
+    void Logger::addMessageType( std::int64_t messageType , const std::string& /* prefix */) {
         if (Log::isPower2( messageType)) {
             m_enabledTypes |= messageType;
         } else

--- a/opm/common/OpmLog/Logger.hpp
+++ b/opm/common/OpmLog/Logger.hpp
@@ -20,10 +20,10 @@
 #ifndef OPM_LOGGER_HPP
 #define OPM_LOGGER_HPP
 
-#include <stdexcept>
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
 
 namespace Opm {
@@ -34,13 +34,13 @@ class Logger {
 
 public:
     Logger();
-    void addMessage(int64_t messageType , const std::string& message) const;
-    void addTaggedMessage(int64_t messageType, const std::string& tag, const std::string& message) const;
+    void addMessage(std::int64_t messageType , const std::string& message) const;
+    void addTaggedMessage(std::int64_t messageType, const std::string& tag, const std::string& message) const;
 
-    static bool enabledDefaultMessageType( int64_t messageType);
-    bool enabledMessageType( int64_t messageType) const;
-    void addMessageType( int64_t messageType , const std::string& prefix);
-    int64_t enabledMessageTypes() const;
+    static bool enabledDefaultMessageType( std::int64_t messageType);
+    bool enabledMessageType( std::int64_t messageType) const;
+    void addMessageType( std::int64_t messageType , const std::string& prefix);
+    std::int64_t enabledMessageTypes() const;
 
     void addBackend(const std::string& name , std::shared_ptr<LogBackend> backend);
     bool hasBackend(const std::string& name);
@@ -70,11 +70,11 @@ public:
 
 
 private:
-    void updateGlobalMask( int64_t mask );
-    static bool enabledMessageType( int64_t enabledTypes , int64_t messageType);
+    void updateGlobalMask( std::int64_t mask );
+    static bool enabledMessageType( std::int64_t enabledTypes , std::int64_t messageType);
 
-    int64_t m_globalMask;
-    int64_t m_enabledTypes;
+    std::int64_t m_globalMask;
+    std::int64_t m_enabledTypes;
     std::map<std::string , std::shared_ptr<LogBackend> > m_backends;
 };
 

--- a/opm/common/OpmLog/MessageFormatter.hpp
+++ b/opm/common/OpmLog/MessageFormatter.hpp
@@ -21,11 +21,12 @@
 #define OPM_MESSAGEFORMATTER_HEADER_INCLUDED
 
 #include <opm/common/OpmLog/LogUtil.hpp>
+
+#include <cstdint>
 #include <string>
 
 namespace Opm
 {
-
 
     /// Abstract interface for message formatting classes.
     class MessageFormatterInterface
@@ -36,12 +37,8 @@ namespace Opm
         /// Should return a possibly modified/decorated version of the
         /// input string, the formatting applied depending on the
         /// message_flag.
-        virtual std::string format(const int64_t message_flag, const std::string& message) = 0;
+        virtual std::string format(const std::int64_t message_flag, const std::string& message) = 0;
     };
-
-
-
-
 
     /// A simple formatter capable of adding message prefixes and colors.
     class SimpleMessageFormatter : public MessageFormatterInterface
@@ -56,13 +53,11 @@ namespace Opm
             }
         }
 
-
-        SimpleMessageFormatter(const int64_t prefix_flag, const bool use_color_coding)
+        SimpleMessageFormatter(const std::int64_t prefix_flag, const bool use_color_coding)
             : use_color_coding_(use_color_coding),
               prefix_flag_(prefix_flag)
         {
         }
-
 
         explicit SimpleMessageFormatter(const bool use_color_coding)
             : use_color_coding_(use_color_coding)
@@ -73,7 +68,7 @@ namespace Opm
         /// Returns a copy of the input string with a flag-dependant
         /// prefix (if use_prefix) and the entire message in a
         /// flag-dependent color (if use_color_coding).
-        virtual std::string format(const int64_t message_flag, const std::string& message) override
+        virtual std::string format(const std::int64_t message_flag, const std::string& message) override
         {
             std::string msg = message;
             if (message_flag & prefix_flag_) {
@@ -86,9 +81,8 @@ namespace Opm
         }
     private:
         bool use_color_coding_ = false;
-        int64_t prefix_flag_ = 0;
+        std::int64_t prefix_flag_ = 0;
     };
-
 
 } // namespace Opm
 

--- a/opm/common/OpmLog/OpmLog.cpp
+++ b/opm/common/OpmLog/OpmLog.cpp
@@ -20,7 +20,10 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/Logger.hpp>
 #include <opm/common/OpmLog/StreamLog.hpp>
+
+#include <cstdint>
 #include <iostream>
+
 #include <errno.h>  // For errno
 #include <stdio.h>  // For fileno() and stdout
 
@@ -72,48 +75,40 @@ namespace Opm {
         return m_logger;
     }
 
-
-    void OpmLog::addMessage(int64_t messageFlag , const std::string& message) {
+    void OpmLog::addMessage(std::int64_t messageFlag , const std::string& message) {
         if (m_logger)
             m_logger->addMessage( messageFlag , message );
     }
 
-
-    void OpmLog::addTaggedMessage(int64_t messageFlag, const std::string& tag, const std::string& message) {
+    void OpmLog::addTaggedMessage(std::int64_t messageFlag, const std::string& tag, const std::string& message) {
         if (m_logger)
             m_logger->addTaggedMessage( messageFlag, tag, message );
     }
-
 
     void OpmLog::info(const std::string& message)
     {
         addMessage(Log::MessageType::Info, message);
     }
 
-
     void OpmLog::warning(const std::string& message)
     {
         addMessage(Log::MessageType::Warning, message);
     }
-
 
     void OpmLog::problem(const std::string& message)
     {
         addMessage(Log::MessageType::Problem, message);
     }
 
-
     void OpmLog::error(const std::string& message)
     {
         addMessage(Log::MessageType::Error, message);
     }
 
-
     void OpmLog::bug(const std::string& message)
     {
         addMessage(Log::MessageType::Bug, message);
     }
-
 
     void OpmLog::debug(const std::string& message, const int verbosity_level)
     {
@@ -122,60 +117,47 @@ namespace Opm {
         }
     }
 
-
     void OpmLog::note(const std::string& message)
     {
         addMessage(Log::MessageType::Note, message);
     }
-
-
 
     void OpmLog::info(const std::string& tag, const std::string& message)
     {
         addTaggedMessage(Log::MessageType::Info, tag, message);
     }
 
-
     void OpmLog::warning(const std::string& tag, const std::string& message)
     {
         addTaggedMessage(Log::MessageType::Warning, tag, message);
     }
-
 
     void OpmLog::problem(const std::string& tag, const std::string& message)
     {
         addTaggedMessage(Log::MessageType::Problem, tag, message);
     }
 
-
     void OpmLog::error(const std::string& tag, const std::string& message)
     {
         addTaggedMessage(Log::MessageType::Error, tag, message);
     }
-
 
     void OpmLog::bug(const std::string& tag, const std::string& message)
     {
         addTaggedMessage(Log::MessageType::Bug, tag, message);
     }
 
-
     void OpmLog::debug(const std::string& tag, const std::string& message)
     {
         addTaggedMessage(Log::MessageType::Debug, tag, message);
     }
-
-
 
     void OpmLog::note(const std::string& tag, const std::string& message)
     {
         addTaggedMessage(Log::MessageType::Note, tag, message);
     }
 
-
-
-
-    bool OpmLog::enabledMessageType( int64_t messageType ) {
+    bool OpmLog::enabledMessageType( std::int64_t messageType ) {
         if (m_logger)
             return m_logger->enabledMessageType( messageType );
         else
@@ -189,7 +171,6 @@ namespace Opm {
             return false;
     }
 
-
     bool OpmLog::removeBackend(const std::string& name) {
         if (m_logger)
             return m_logger->removeBackend( name );
@@ -197,26 +178,21 @@ namespace Opm {
             return false;
     }
 
-
     void OpmLog::removeAllBackends() {
         if (m_logger) {
             m_logger->removeAllBackends();
         }
     }
 
-
-    void OpmLog::addMessageType( int64_t messageType , const std::string& prefix) {
+    void OpmLog::addMessageType( std::int64_t messageType , const std::string& prefix) {
         auto logger = OpmLog::getLogger();
         logger->addMessageType( messageType , prefix );
     }
-
 
     void OpmLog::addBackend(const std::string& name , std::shared_ptr<LogBackend> backend) {
         auto logger = OpmLog::getLogger();
         return logger->addBackend( name , backend );
     }
-
-
 
     void OpmLog::setupSimpleDefaultLogging(const bool use_prefix,
                                            const bool use_color_coding,

--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -20,11 +20,11 @@
 #ifndef OPMLOG_HPP
 #define OPMLOG_HPP
 
-#include <memory>
-#include <cstdint>
-
 #include <opm/common/OpmLog/Logger.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
+
+#include <cstdint>
+#include <memory>
 
 namespace Opm {
 
@@ -38,14 +38,13 @@ namespace Opm {
   Logger instance.
 */
 
-
 class OpmLog {
 
 public:
     constexpr static int defaultDebugVerbosityLevel = 1;
 
-    static void addMessage(int64_t messageFlag , const std::string& message);
-    static void addTaggedMessage(int64_t messageFlag, const std::string& tag, const std::string& message);
+    static void addMessage(std::int64_t messageFlag , const std::string& message);
+    static void addTaggedMessage(std::int64_t messageFlag, const std::string& tag, const std::string& message);
 
     static void info(const std::string& message);
     static void warning(const std::string& message);
@@ -67,9 +66,8 @@ public:
     static void addBackend(const std::string& name , std::shared_ptr<LogBackend> backend);
     static bool removeBackend(const std::string& name);
     static void removeAllBackends();
-    static bool enabledMessageType( int64_t messageType );
-    static void addMessageType( int64_t messageType , const std::string& prefix);
-
+    static bool enabledMessageType( std::int64_t messageType );
+    static void addMessageType( std::int64_t messageType , const std::string& prefix);
 
     static int getDebugVerbosityLevel() { return debug_verbosity_level_; }
     static void setDebugVerbosityLevel(const int verbosity_level) { debug_verbosity_level_ = verbosity_level; }
@@ -95,7 +93,6 @@ public:
         auto logger = getLogger();
         return logger->popBackend<BackendType>(name);
     }
-
 
     static bool stdoutIsTerminal();
 
@@ -124,10 +121,6 @@ private:
     static std::shared_ptr<Logger> m_logger;
 };
 
-
 }
-
-
-
 
 #endif

--- a/opm/common/OpmLog/StreamLog.cpp
+++ b/opm/common/OpmLog/StreamLog.cpp
@@ -16,13 +16,15 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdexcept>
+
 #include <opm/common/OpmLog/StreamLog.hpp>
+
+#include <cstdint>
+#include <stdexcept>
 
 namespace Opm {
 
-
-StreamLog::StreamLog(const std::string& logFile , int64_t messageMask, bool append) : LogBackend(messageMask)
+StreamLog::StreamLog(const std::string& logFile , std::int64_t messageMask, bool append) : LogBackend(messageMask)
 {
     if (append) {
         m_ofstream.open( logFile.c_str() ,  std::ofstream::app );
@@ -36,13 +38,11 @@ StreamLog::StreamLog(const std::string& logFile , int64_t messageMask, bool appe
     m_ostream = &m_ofstream;
 }
 
-
-StreamLog::StreamLog(std::ostream& os , int64_t messageMask) : LogBackend(messageMask)
+StreamLog::StreamLog(std::ostream& os , std::int64_t messageMask) : LogBackend(messageMask)
 {
     m_ostream = &os;
     m_streamOwner = false;
 }
-
 
 void StreamLog::close() {
     if (m_streamOwner && m_ofstream.is_open()) {
@@ -51,14 +51,13 @@ void StreamLog::close() {
     }
 }
 
-void StreamLog::addMessageUnconditionally(int64_t messageType, const std::string& message)
+void StreamLog::addMessageUnconditionally(std::int64_t messageType, const std::string& message)
 {
     (*m_ostream) << formatMessage(messageType, message) << std::endl;
     if (m_ofstream.is_open()) {
         m_ofstream.flush();
     }
 }
-
 
 StreamLog::~StreamLog() {
     close();

--- a/opm/common/OpmLog/StreamLog.hpp
+++ b/opm/common/OpmLog/StreamLog.hpp
@@ -20,22 +20,22 @@
 #ifndef STREAMLOG_H
 #define STREAMLOG_H
 
-#include <fstream>
-#include <cstdint>
-
 #include <opm/common/OpmLog/LogBackend.hpp>
+
+#include <cstdint>
+#include <fstream>
 
 namespace Opm {
 
 class StreamLog : public LogBackend {
 
 public:
-    StreamLog(const std::string& logFile , int64_t messageMask, bool append = false);
-    StreamLog(std::ostream& os , int64_t messageMask);
+    StreamLog(const std::string& logFile , std::int64_t messageMask, bool append = false);
+    StreamLog(std::ostream& os , std::int64_t messageMask);
     ~StreamLog() override;
 
 protected:
-    void addMessageUnconditionally(int64_t messageType, const std::string& message) override;
+    void addMessageUnconditionally(std::int64_t messageType, const std::string& message) override;
 
 private:
     void close();

--- a/opm/common/OpmLog/TimerLog.cpp
+++ b/opm/common/OpmLog/TimerLog.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <config.h>
+
 #include <opm/common/OpmLog/TimerLog.hpp>
 
 #include <opm/common/OpmLog/LogUtil.hpp>
@@ -25,6 +26,7 @@
 #include <opm/common/OpmLog/StreamLog.hpp>
 
 #include <cassert>
+#include <cstdint>
 #include <ios>
 #include <sstream>
 
@@ -44,7 +46,7 @@ TimerLog::TimerLog(std::ostream& os)
 
 
 
-void TimerLog::addMessageUnconditionally(int64_t messageType, const std::string& msg ) {
+void TimerLog::addMessageUnconditionally(std::int64_t messageType, const std::string& msg ) {
     if (messageType == StopTimer) {
         clock_t stop = clock();
         double secondsElapsed = 1.0 * (m_start - stop) / CLOCKS_PER_SEC ;

--- a/opm/common/OpmLog/TimerLog.hpp
+++ b/opm/common/OpmLog/TimerLog.hpp
@@ -19,13 +19,14 @@
 #ifndef OPM_TIMERLOG_HPP
 #define OPM_TIMERLOG_HPP
 
-#include <time.h>
+#include <opm/common/OpmLog/StreamLog.hpp>
 
-#include <memory>
+#include <cstdint>
 #include <iosfwd>
+#include <memory>
 #include <string>
 
-#include <opm/common/OpmLog/StreamLog.hpp>
+#include <time.h>
 
 /*
   This class is a simple demonstration of how the logging framework
@@ -36,8 +37,8 @@ namespace Opm {
 
 class TimerLog : public StreamLog {
 public:
-    static const int64_t StartTimer = 4096;
-    static const int64_t StopTimer  = 8192;
+    static const std::int64_t StartTimer = 4096;
+    static const std::int64_t StopTimer  = 8192;
 
     explicit TimerLog(const std::string& logFile);
     explicit TimerLog(std::ostream& os);
@@ -45,7 +46,7 @@ public:
     void clear();
 
 protected:
-    void addMessageUnconditionally(int64_t messageFlag,
+    void addMessageUnconditionally(std::int64_t messageFlag,
                                    const std::string& message) override;
 private:
     clock_t m_start;

--- a/opm/common/utility/CSRGraphFromCoordinates_impl.hpp
+++ b/opm/common/utility/CSRGraphFromCoordinates_impl.hpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <exception>
 #include <iterator>
 #include <optional>
@@ -684,7 +685,7 @@ addVertexGroup(const std::vector<VertexID>& vertices)
 
     // Union all vertices in the group
     if (vertices.size() > 1) {
-        for (size_t i = 1; i < vertices.size(); ++i) {
+        for (std::size_t i = 1; i < vertices.size(); ++i) {
             unionSets(vertices[0], vertices[i]);
         }
     }

--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -22,6 +22,7 @@
 #define SERIALIZER_HPP
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <map>
@@ -30,9 +31,9 @@
 #include <set>
 #include <stdexcept>
 #include <type_traits>
-#include <utility>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -198,7 +199,7 @@ public:
     }
 
     //! \brief Returns current position in buffer.
-    size_t position() const
+    std::size_t position() const
     {
         return m_position;
     }
@@ -260,7 +261,7 @@ protected:
             auto& data_mut = const_cast<std::vector<bool>&>(data);
             data_mut.clear();
             data_mut.reserve(size);
-            for (size_t i = 0; i < size; ++i) {
+            for (std::size_t i = 0; i < size; ++i) {
                 bool entry = false;
                 (*this)(entry);
                 data_mut.push_back(entry);
@@ -354,7 +355,7 @@ protected:
             std::size_t size = 0;
             (*this)(size);
             auto& data_mut = const_cast<Map&>(data);
-            for (size_t i = 0; i < size; ++i) {
+            for (std::size_t i = 0; i < size; ++i) {
                 typename Map::value_type entry;
                 (*this)(entry);
                 data_mut.insert(std::move(entry));
@@ -375,7 +376,7 @@ protected:
             std::size_t size = 0;
             (*this)(size);
             auto& data_mut = const_cast<Set&>(data);
-            for (size_t i = 0; i < size; ++i) {
+            for (std::size_t i = 0; i < size; ++i) {
                 typename Set::value_type entry{};
                 (*this)(entry);
                 data_mut.insert(entry);
@@ -600,8 +601,8 @@ protected:
 
     const Packer& m_packer; //!< Packer to use
     Operation m_op = Operation::PACKSIZE; //!< Current operation
-    size_t m_packSize = 0; //!< Required buffer size after PACKSIZE has been done
-    size_t m_position = 0; //!< Current position in buffer
+    std::size_t m_packSize = 0; //!< Required buffer size after PACKSIZE has been done
+    std::size_t m_position = 0; //!< Current position in buffer
     std::vector<char> m_buffer; //!< Buffer for serialized data
     std::map<std::uintptr_t, std::shared_ptr<void>> m_ptrmap; //!< Map to keep track of which pointer data has been serialized and actual pointers during unpacking
 };

--- a/opm/common/utility/String.cpp
+++ b/opm/common/utility/String.cpp
@@ -18,13 +18,15 @@
 */
 
 #include <config.h>
+
 #include <opm/common/utility/String.hpp>
 
 #include <opm/io/eclipse/PaddedOutputString.hpp>
 
 #include <algorithm>
-#include <cmath>
 #include <cctype>
+#include <cmath>
+#include <cstddef>
 #include <cstdlib>
 #include <cstring>
 #include <sstream>
@@ -127,7 +129,7 @@ template<typename T>
 void replaceAll(T& data, const T& toSearch, const T& replace)
 {
     // Get the first occurrence
-    size_t pos = data.find(toSearch);
+    std::size_t pos = data.find(toSearch);
 
     // Repeat till end is reached
     while (pos != std::string::npos)

--- a/opm/common/utility/TimeService.hpp
+++ b/opm/common/utility/TimeService.hpp
@@ -21,6 +21,7 @@
 #define OPM_TIMESERVICE_HEADER_INCLUDED
 
 #include <chrono>
+#include <cstdint>
 #include <ctime>
 #include <string>
 #include <unordered_map>
@@ -29,7 +30,7 @@ namespace Opm {
 
     class DeckRecord;
 
-    using time_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<int64_t, std::ratio<1,1000>>>;
+    using time_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<std::int64_t, std::ratio<1,1000>>>;
 
     namespace TimeService {
     std::time_t to_time_t(const time_point& tp);

--- a/opm/common/utility/numeric/GeometryUtil.hpp
+++ b/opm/common/utility/numeric/GeometryUtil.hpp
@@ -1,10 +1,13 @@
 #ifndef GEOMETRYUTIL_H
 #define GEOMETRYUTIL_H
 
-#include <vector>
 #include <opm/common/utility/numeric/VectorUtil.hpp>
-#include <numeric>
+
 #include <cmath>
+#include <cstddef>
+#include <numeric>
+#include <vector>
+
 namespace GeometryUtil {
 
 constexpr double epslon = 1e-6;
@@ -59,7 +62,7 @@ T calcHexaVol(const std::array<T,8>& x, const std::array<T,8>& y, const std::arr
     // the hexadron is subdivided in terahedrons.
     // calculating the volume of the pyramid with F0 as base and pc as center
     T totalVolume = 0.0;
-    for (size_t i = 0; i < faceConfigurations.size(); i += 2) {
+    for (std::size_t i = 0; i < faceConfigurations.size(); i += 2) {
         auto [fX0, fY0, fZ0] = getNodes(x, y, z, faceConfigurations[i]);
         totalVolume += std::apply(calcTetraVol<T>, VectorUtil::appendNode<double>(fX0, fY0, fZ0, cx, cy, cz));
 
@@ -90,7 +93,7 @@ std::vector<int> isInsideElement(const std::vector<T>& tpX, const std::vector<T>
         pcY = std::accumulate(Y[outerIndex].begin(), Y[outerIndex].end(), 0.0)/8;
         pcZ = std::accumulate(Z[outerIndex].begin(), Z[outerIndex].end(), 0.0)/8;
         element_volume = calcHexaVol(X[outerIndex],Y[outerIndex],Z[outerIndex], pcX, pcY,pcZ);
-        for (size_t innerIndex  = 0; innerIndex < tpX.size(); innerIndex++){
+        for (std::size_t innerIndex  = 0; innerIndex < tpX.size(); innerIndex++){
             // check if center of refined volume is outside the boundary box of a coarse volume.
             // Only computes volumed base test is this condition is met.
             flag  = (minX < tpX[innerIndex]) && (maxX > tpX[innerIndex]) &&

--- a/opm/common/utility/numeric/cmp.hpp
+++ b/opm/common/utility/numeric/cmp.hpp
@@ -94,7 +94,7 @@ namespace Opm {
                 return false;
             }
 
-            for (size_t i = 0; i < v1.size(); i++) {
+            for (std::size_t i = 0; i < v1.size(); i++) {
                 if (!scalar_equal<T>( v1[i], v2[i], abs_eps, rel_eps ))
                     return false;
             }
@@ -109,11 +109,11 @@ namespace Opm {
 
 
         template<typename T>
-        bool array_equal(const T* p1, const T* p2, size_t num_elements, T abs_eps, T rel_eps) {
+        bool array_equal(const T* p1, const T* p2, std::size_t num_elements, T abs_eps, T rel_eps) {
             if (std::memcmp(p1 , p2 , num_elements * sizeof * p1) == 0)
                 return true;
             else {
-                size_t index;
+                std::size_t index;
                 for (index = 0; index < num_elements; index++) {
                     if (!scalar_equal<T>( p1[index] , p2[index] , abs_eps , rel_eps)) {
                         return false;
@@ -125,7 +125,7 @@ namespace Opm {
 
 
         template<typename T>
-        bool array_equal(const T* p1, const T* p2, size_t num_elements) {
+        bool array_equal(const T* p1, const T* p2, std::size_t num_elements) {
              return array_equal<T>(p1, p2, num_elements , default_abs_epsilon, default_rel_epsilon);
         }
     }

--- a/opm/common/utility/pointerArithmetic.hpp
+++ b/opm/common/utility/pointerArithmetic.hpp
@@ -20,12 +20,15 @@
 #ifndef OPM_POINTERARITHMETIC_HPP
 #define OPM_POINTERARITHMETIC_HPP
 
+#include <cstddef>
+#include <stdexcept>
+
 namespace Opm {
 
     // Utility function motivated by for instance computing GPU pointers from the cpu without entering a kernel
     // Given a Buffer A with a starting pointer and a pointer into the buffer, compute the pointer with the same offset from the start of a buffer B
     template <class PtrType>
-    PtrType* ComputePtrBasedOnOffsetInOtherBuffer(PtrType* bufBStart, size_t bufBLength, PtrType* bufAStart, size_t bufALength, PtrType* ptrInA)
+    PtrType* ComputePtrBasedOnOffsetInOtherBuffer(PtrType* bufBStart, std::size_t bufBLength, PtrType* bufAStart, std::size_t bufALength, PtrType* ptrInA)
     {
         if (bufAStart == nullptr || bufBStart == nullptr || ptrInA == nullptr) {
             throw std::invalid_argument("ComputePtrBasedOnOffsetInOtherBuffer: One or more input pointers are null.");
@@ -33,7 +36,10 @@ namespace Opm {
 
         auto offset = ptrInA - bufAStart;
 
-        if (offset < 0 || static_cast<size_t>(offset) >= bufALength || static_cast<size_t>(offset) >= bufBLength) {
+        if ((offset < 0) ||
+            (static_cast<std::size_t>(offset) >= bufALength) ||
+            (static_cast<std::size_t>(offset) >= bufBLength))
+        {
             throw std::out_of_range("ComputePtrBasedOnOffsetInOtherBuffer: Pointer into A is out of range.");
         }
 

--- a/opm/input/eclipse/Deck/Deck.cpp
+++ b/opm/input/eclipse/Deck/Deck.cpp
@@ -17,12 +17,15 @@
  */
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
+
 #include <opm/input/eclipse/Deck/DeckOutput.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckSection.hpp>
+
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <iterator>
 #include <stdexcept>
 #include <utility>
@@ -211,7 +214,7 @@ const DeckView& Deck::global_view() const {
 
 
     void Deck::write( DeckOutput& output ) const {
-        size_t kw_index = 1;
+        std::size_t kw_index = 1;
         for (const auto& keyword: *this) {
             keyword.write( output );
             kw_index++;

--- a/opm/input/eclipse/Deck/Deck.hpp
+++ b/opm/input/eclipse/Deck/Deck.hpp
@@ -23,8 +23,10 @@
 #include <opm/input/eclipse/Deck/DeckView.hpp>
 #include <opm/input/eclipse/Deck/DeckTree.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <cstddef>
 #include <iosfwd>
 #include <memory>
 #include <optional>
@@ -40,8 +42,6 @@ namespace Opm {
      * use-after-free.
      */
     class DeckOutput;
-
-
 
     class Deck {
         public:
@@ -114,8 +114,6 @@ namespace Opm {
                 return this->hasKeyword( Keyword::keywordName );
             }
 
-
-
             const std::vector<std::size_t> index(const std::string& keyword) const {
                 return this->global_view().index(keyword);
             }
@@ -124,7 +122,7 @@ namespace Opm {
             std::size_t count() const {
                 return count( Keyword::keywordName );
             }
-            size_t count(const std::string& keyword) const;
+            std::size_t count(const std::string& keyword) const;
 
             void remove_keywords(int from, int to) { keywordList.erase(keywordList.begin() +from, keywordList.begin() + to); };
 

--- a/opm/input/eclipse/Deck/DeckItem.cpp
+++ b/opm/input/eclipse/Deck/DeckItem.cpp
@@ -17,16 +17,20 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <opm/input/eclipse/Deck/DeckOutput.hpp>
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
-#include <opm/input/eclipse/Units/Dimension.hpp>
+
 #include <opm/common/utility/String.hpp>
+
+#include <opm/input/eclipse/Deck/DeckOutput.hpp>
+
+#include <opm/input/eclipse/Units/Dimension.hpp>
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <ostream>
-#include <string>
 #include <stdexcept>
+#include <string>
 
 namespace Opm {
 
@@ -150,7 +154,7 @@ const std::string& DeckItem::name() const {
     return this->item_name;
 }
 
-bool DeckItem::defaultApplied( size_t index ) const {
+bool DeckItem::defaultApplied( std::size_t index ) const {
     return value::defaulted( this->value_status.at(index));
 }
 
@@ -158,20 +162,20 @@ const std::vector<value::status>& DeckItem::getValueStatus() const {
     return this->value_status;
 }
 
-bool DeckItem::hasValue( size_t index ) const {
+bool DeckItem::hasValue( std::size_t index ) const {
     if (index >= this->value_status.size())
         return false;
 
     return value::has_value( this->value_status[index] );
 }
 
-size_t DeckItem::data_size() const {
+std::size_t DeckItem::data_size() const {
     return this->value_status.size();
 }
 
 
 template< typename T >
-T DeckItem::get( size_t index ) const {
+T DeckItem::get( std::size_t index ) const {
     if (index >= this->value_status.size())
         throw std::out_of_range("Invalid index");
 
@@ -182,7 +186,7 @@ T DeckItem::get( size_t index ) const {
 }
 
 template<>
-UDAValue DeckItem::get( size_t index ) const {
+UDAValue DeckItem::get( std::size_t index ) const {
     auto value = this->value_ref<UDAValue>().at(index);
     if (this->active_dimensions.empty())
         return value;
@@ -256,26 +260,26 @@ void DeckItem::push_back( UDAValue x ) {
 }
 
 template< typename T >
-void DeckItem::push( T x, size_t n ) {
+void DeckItem::push( T x, std::size_t n ) {
     auto& val = this->value_ref< T >();
 
     val.insert( val.end(), n, x );
     this->value_status.insert( this->value_status.end(), n, value::status::deck_value );
 }
 
-void DeckItem::push_back( int x, size_t n ) {
+void DeckItem::push_back( int x, std::size_t n ) {
     this->push( x, n );
 }
 
-void DeckItem::push_back( double x, size_t n ) {
+void DeckItem::push_back( double x, std::size_t n ) {
     this->push( x, n );
 }
 
-void DeckItem::push_back( std::string x, size_t n ) {
+void DeckItem::push_back( std::string x, std::size_t n ) {
     this->push( std::move( x ), n );
 }
 
-void DeckItem::push_back( UDAValue x, size_t n ) {
+void DeckItem::push_back( UDAValue x, std::size_t n ) {
     this->push( std::move( x ), n );
 }
 
@@ -318,11 +322,11 @@ void DeckItem::push_backDummyDefault( std::size_t n ) {
     this->value_status.insert( this->value_status.end(), n, value::status::empty_default );
 }
 
-std::string DeckItem::getTrimmedString( size_t index ) const {
+std::string DeckItem::getTrimmedString( std::size_t index ) const {
     return trim_copy(this->value_ref< std::string >().at(index));
 }
 
-double DeckItem::getSIDouble( size_t index ) const {
+double DeckItem::getSIDouble( std::size_t index ) const {
     return this->getSIDoubleData().at( index );
 }
 
@@ -333,7 +337,7 @@ const std::vector<double>& DeckItem::getData() const {
         return data;
 
     const auto dim_size = this->active_dimensions.size();
-    for( size_t index = 0; index < data.size(); index++ ) {
+    for( std::size_t index = 0; index < data.size(); index++ ) {
         const auto dimIndex = index % dim_size;
         if (value::defaulted(this->value_status[index])) {
             const auto& dim = this->default_dimensions[dimIndex];
@@ -389,7 +393,7 @@ type_tag DeckItem::getType() const {
 
 template< typename T >
 void DeckItem::write_vector(DeckOutput& stream, const std::vector<T>& data) const {
-    for (size_t index = 0; index < this->data_size(); index++) {
+    for (std::size_t index = 0; index < this->data_size(); index++) {
         if (this->defaultApplied(index))
             stream.stash_default( );
         else
@@ -475,7 +479,7 @@ bool DeckItem::equal(const DeckItem& other, bool cmp_default, bool cmp_numeric) 
             constexpr double abs_eps = 1e-4;
             const auto& this_data = this->getData<double>();
             const auto& other_data = other.getData<double>();
-            for (size_t i=0; i < this_data.size(); i++) {
+            for (std::size_t i=0; i < this_data.size(); i++) {
                 if (!double_equal( this_data[i] , other_data[i], rel_eps, abs_eps))
                     return false;
             }
@@ -553,10 +557,10 @@ void DeckItem::reserve_additionalRawString(std::size_t n)
  * updated with changes in DeckItem so that code is emitted.
  */
 
-template int DeckItem::get< int >( size_t ) const;
-template double DeckItem::get< double >( size_t ) const;
-template std::string DeckItem::get< std::string >( size_t ) const;
-template RawString DeckItem::get< RawString >( size_t ) const;
+template int DeckItem::get< int >( std::size_t ) const;
+template double DeckItem::get< double >( std::size_t ) const;
+template std::string DeckItem::get< std::string >( std::size_t ) const;
+template RawString DeckItem::get< RawString >( std::size_t ) const;
 
 template void DeckItem::push_backDummyDefault<int>( std::size_t );
 template void DeckItem::push_backDummyDefault<double>( std::size_t );

--- a/opm/input/eclipse/Deck/DeckItem.hpp
+++ b/opm/input/eclipse/Deck/DeckItem.hpp
@@ -20,14 +20,17 @@
 #ifndef DECKITEM_HPP
 #define DECKITEM_HPP
 
-#include <opm/input/eclipse/Units/Dimension.hpp>
-#include <opm/input/eclipse/Utility/Typetools.hpp>
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 #include <opm/input/eclipse/Deck/value_status.hpp>
 
+#include <opm/input/eclipse/Utility/Typetools.hpp>
+
+#include <opm/input/eclipse/Units/Dimension.hpp>
+
+#include <cstddef>
+#include <iosfwd>
 #include <string>
 #include <vector>
-#include <iosfwd>
 
 namespace Opm {
     class DeckOutput;
@@ -50,12 +53,12 @@ namespace Opm {
         const std::string& name() const;
 
         // return true if the default value was used for a given data point
-        bool defaultApplied( size_t ) const;
+        bool defaultApplied( std::size_t ) const;
 
         // Return true if the item has a value for the current index;
         // does not differentiate between default values from the
         // config and values which have been set in the deck.
-        bool hasValue( size_t ) const;
+        bool hasValue( std::size_t ) const;
 
         // if the number returned by this method is less than what is semantically
         // expected (e.g. size() is less than the number of cells in the grid for
@@ -63,14 +66,13 @@ namespace Opm {
         // creates the defaulted items if all their sizes are fully specified by the
         // keyword, though...
 
-        size_t data_size() const;
+        std::size_t data_size() const;
 
         template<typename T>
-        T get( size_t index ) const;
+        T get( std::size_t index ) const;
 
-
-        double getSIDouble( size_t ) const;
-        std::string getTrimmedString( size_t ) const;
+        double getSIDouble( std::size_t ) const;
+        std::string getTrimmedString( std::size_t ) const;
 
         template <typename T> std::vector<T>& getData();
         template <typename T> const std::vector<T>& getData() const;
@@ -85,16 +87,15 @@ namespace Opm {
         template< typename T>
         void shrink_to_fit();
 
-
         void push_back( UDAValue );
         void push_back( int );
         void push_back( double );
         void push_back( std::string );
         void push_back( RawString );
-        void push_back( UDAValue, size_t );
-        void push_back( int, size_t );
-        void push_back( double, size_t );
-        void push_back( std::string, size_t );
+        void push_back( UDAValue, std::size_t );
+        void push_back( int, std::size_t );
+        void push_back( double, std::size_t );
+        void push_back( std::string, std::size_t );
         void push_backDefault( UDAValue, std::size_t n = 1 );
         void push_backDefault( int, std::size_t n = 1 );
         void push_backDefault( double, std::size_t n = 1 );
@@ -109,7 +110,6 @@ namespace Opm {
 
         void write(DeckOutput& writer) const;
         friend std::ostream& operator<<(std::ostream& os, const DeckItem& item);
-
 
         /*
           The comparison can be adjusted with the cmp_default and
@@ -180,7 +180,7 @@ namespace Opm {
         template< typename T > std::vector< T >& value_ref();
         template< typename T > const std::vector< T >& value_ref() const;
         template< typename T > void push( T );
-        template< typename T > void push( T, size_t );
+        template< typename T > void push( T, std::size_t );
         template< typename T > void push_default( T, std::size_t n );
         template< typename T > void write_vector(DeckOutput& writer, const std::vector<T>& data) const;
     };

--- a/opm/input/eclipse/Deck/DeckKeyword.cpp
+++ b/opm/input/eclipse/Deck/DeckKeyword.cpp
@@ -16,17 +16,21 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+
 #include <opm/input/eclipse/Utility/Typetools.hpp>
+
+#include <opm/input/eclipse/Deck/DeckItem.hpp>
+#include <opm/input/eclipse/Deck/DeckOutput.hpp>
+#include <opm/input/eclipse/Deck/DeckValue.hpp>
+
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/input/eclipse/Parser/ParserKeyword.hpp>
 
-#include <opm/input/eclipse/Units/UnitSystem.hpp>
-#include <opm/input/eclipse/Deck/DeckOutput.hpp>
-#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/input/eclipse/Deck/DeckValue.hpp>
-#include <opm/input/eclipse/Deck/DeckItem.hpp>
-
 #include <algorithm>
+#include <cstddef>
 #include <ostream>
 
 namespace Opm {
@@ -84,7 +88,7 @@ namespace Opm {
 
     namespace {
     template <typename T>
-    void add_deckvalue( DeckItem deck_item, DeckRecord& deck_record, const ParserItem& parser_item, const std::vector<DeckValue>& input_record, size_t j) {
+    void add_deckvalue( DeckItem deck_item, DeckRecord& deck_record, const ParserItem& parser_item, const std::vector<DeckValue>& input_record, std::size_t j) {
          if (j >= input_record.size() || input_record[j].is_default()) {
               if (parser_item.hasDefault())
                   deck_item.push_backDefault( parser_item.getDefault<T>() );
@@ -108,13 +112,13 @@ namespace Opm {
         if (parserKeyword.hasFixedSize() && (record_list.size() != parserKeyword.getFixedSize()))
              throw std::invalid_argument("Wrong number of records added to constructor for deckkeyword '" + name() + "'.");
 
-        for (size_t i = 0; i < record_list.size(); i++) {
+        for (std::size_t i = 0; i < record_list.size(); i++) {
 
              const ParserRecord& parser_record = parserKeyword.getRecord(i);
              const std::vector<DeckValue>& input_record = record_list[i];
              DeckRecord deck_record;
 
-             for (size_t j = 0; j < parser_record.size(); j++) {
+             for (std::size_t j = 0; j < parser_record.size(); j++) {
                   const ParserItem& parser_item = parser_record.get(j);
                   if (parser_item.sizeType() == ParserItem::item_size::ALL)
                       throw std::invalid_argument("constructor  DeckKeyword::DeckKeyword(const ParserKeyword&,  const std::vector<std::vector<DeckValue>>&) does not handle sizetype ALL.");
@@ -251,7 +255,7 @@ namespace Opm {
         return m_keywordName;
     }
 
-    size_t DeckKeyword::size() const {
+    std::size_t DeckKeyword::size() const {
         return m_recordList.size();
     }
 
@@ -279,11 +283,11 @@ namespace Opm {
         return this->m_recordList.at( index );
     }
 
-    const DeckRecord& DeckKeyword::getRecord(size_t index) const {
+    const DeckRecord& DeckKeyword::getRecord(std::size_t index) const {
         return this->operator[](index);
     }
 
-    DeckRecord& DeckKeyword::getRecord(size_t index) {
+    DeckRecord& DeckKeyword::getRecord(std::size_t index) {
         return this->operator[](index);
     }
 
@@ -295,7 +299,7 @@ namespace Opm {
     }
 
 
-    size_t DeckKeyword::getDataSize() const {
+    std::size_t DeckKeyword::getDataSize() const {
         return this->getDataRecord().getDataItem().data_size();
     }
 
@@ -370,7 +374,7 @@ namespace Opm {
         if (this->size() != other.size())
             return false;
 
-        for (size_t index = 0; index < this->size(); index++) {
+        for (std::size_t index = 0; index < this->size(); index++) {
             const auto& this_record = this->getRecord( index );
             const auto& other_record = other.getRecord( index );
             if (!this_record.equal( other_record , cmp_default, cmp_numeric))

--- a/opm/input/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/input/eclipse/Deck/DeckKeyword.hpp
@@ -20,12 +20,14 @@
 #ifndef DECKKEYWORD_HPP
 #define DECKKEYWORD_HPP
 
-#include <string>
-#include <vector>
+#include <opm/common/OpmLog/KeywordLocation.hpp>
 
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/value_status.hpp>
-#include <opm/common/OpmLog/KeywordLocation.hpp>
+
+#include <cstddef>
+#include <string>
+#include <vector>
 
 namespace Opm {
     class DeckOutput;
@@ -35,7 +37,6 @@ namespace Opm {
 
     class DeckKeyword {
     public:
-
 
         typedef std::vector< DeckRecord >::const_iterator const_iterator;
 
@@ -54,11 +55,11 @@ namespace Opm {
         const KeywordLocation& location() const;
         DeckKeyword emptyStructuralCopy() const;
 
-        size_t size() const;
+        std::size_t size() const;
         bool empty() const;
         void addRecord(DeckRecord&& record);
-        const DeckRecord& getRecord(size_t index) const;
-        DeckRecord& getRecord(size_t index);
+        const DeckRecord& getRecord(std::size_t index) const;
+        DeckRecord& getRecord(std::size_t index);
         const DeckRecord& getDataRecord() const;
         const DeckRecord& operator[](std::size_t index) const;
         DeckRecord& operator[](std::size_t index);
@@ -75,7 +76,7 @@ namespace Opm {
         const std::vector<double>& getSIDoubleData() const;
         const std::vector<std::string>& getStringData() const;
         const std::vector<value::status>& getValueStatus() const;
-        size_t getDataSize() const;
+        std::size_t getDataSize() const;
         void write( DeckOutput& output ) const;
         void write_data( DeckOutput& output ) const;
         void write_TITLE( DeckOutput& output ) const;

--- a/opm/input/eclipse/Deck/DeckOutput.hpp
+++ b/opm/input/eclipse/Deck/DeckOutput.hpp
@@ -20,9 +20,9 @@
 #ifndef DECK_OUTPUT_HPP
 #define DECK_OUTPUT_HPP
 
+#include <cstddef>
 #include <iosfwd>
 #include <string>
-#include <cstddef>
 
 namespace Opm {
 
@@ -30,7 +30,7 @@ namespace Opm {
     public:
         struct format {
             std::string item_sep = " ";        // Separator between items on a row.
-            size_t      columns = 7;          // The maximum number of columns on a record.
+            std::size_t      columns = 7;          // The maximum number of columns on a record.
             std::string record_indent = " "; // The indentation when starting a new line.
             std::string keyword_sep = "";  // The separation between keywords;
         };
@@ -51,8 +51,8 @@ namespace Opm {
         format fmt;
     private:
         std::ostream& os;
-        size_t default_count;
-        size_t row_count;
+        std::size_t default_count;
+        std::size_t row_count;
         bool record_on;
         int org_precision;
         bool split_line;

--- a/opm/input/eclipse/Deck/DeckRecord.cpp
+++ b/opm/input/eclipse/Deck/DeckRecord.cpp
@@ -17,19 +17,18 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#include <unordered_set>
-#include <stdexcept>
-#include <string>
-#include <algorithm>
-
-#include <opm/input/eclipse/Deck/DeckOutput.hpp>
-#include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
+#include <opm/input/eclipse/Deck/DeckItem.hpp>
+#include <opm/input/eclipse/Deck/DeckOutput.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
 
 namespace Opm {
-
 
     DeckRecord::DeckRecord( std::vector< DeckItem >&& items, const bool check_for_duplicate_names ) :
         m_items( std::move( items ) ) {
@@ -63,7 +62,7 @@ namespace Opm {
         return result;
     }
 
-    size_t DeckRecord::size() const {
+    std::size_t DeckRecord::size() const {
         return m_items.size();
     }
 
@@ -77,7 +76,7 @@ namespace Opm {
         m_items.push_back( std::move( deckItem ) );
     }
 
-    DeckItem& DeckRecord::getItem( size_t index ) {
+    DeckItem& DeckRecord::getItem( std::size_t index ) {
         return this->m_items.at( index );
     }
 
@@ -101,7 +100,7 @@ namespace Opm {
             throw std::range_error("Not a data keyword ?");
     }
 
-    const DeckItem& DeckRecord::getItem( size_t index ) const {
+    const DeckItem& DeckRecord::getItem( std::size_t index ) const {
         return this->m_items.at( index );
     }
 
@@ -141,7 +140,6 @@ namespace Opm {
         return this->m_items.end();
     }
 
-
     void DeckRecord::write_data(DeckOutput& writer, std::size_t item_offset) const {
         for (std::size_t item_index = item_offset; item_index < this->size(); item_index++) {
             const auto& item = this->getItem(item_index);
@@ -156,7 +154,6 @@ namespace Opm {
         writer.end_record( );
     }
 
-
     std::ostream& operator<<(std::ostream& os, const DeckRecord& record) {
         DeckOutput output(os);
         record.write( output );
@@ -167,7 +164,7 @@ namespace Opm {
         if (this->size() != other.size())
             return false;
 
-        for (size_t index = 0; index < this->size(); index++) {
+        for (std::size_t index = 0; index < this->size(); index++) {
             const auto& this_item = this->getItem( index );
             const auto& other_item = other.getItem( index );
             if (!this_item.equal( other_item , cmp_default, cmp_numeric))

--- a/opm/input/eclipse/Deck/DeckRecord.hpp
+++ b/opm/input/eclipse/Deck/DeckRecord.hpp
@@ -20,12 +20,13 @@
 #ifndef DECKRECORD_HPP
 #define DECKRECORD_HPP
 
+#include <opm/input/eclipse/Deck/DeckItem.hpp>
+
+#include <cstddef>
+#include <iosfwd>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
-#include <iosfwd>
-
-#include <opm/input/eclipse/Deck/DeckItem.hpp>
 
 namespace Opm {
 
@@ -38,14 +39,14 @@ namespace Opm {
 
         static DeckRecord serializationTestObject();
 
-        size_t size() const;
+        std::size_t size() const;
         void addItem( DeckItem deckItem );
 
-        DeckItem& getItem( size_t index );
+        DeckItem& getItem( std::size_t index );
         DeckItem& getItem( const std::string& name );
         DeckItem& getDataItem();
 
-        const DeckItem& getItem( size_t index ) const;
+        const DeckItem& getItem( std::size_t index ) const;
         const DeckItem& getItem( const std::string& name ) const;
         const DeckItem& getDataItem() const;
 

--- a/opm/input/eclipse/EclipseState/Aquifer/AquiferFlux.cpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/AquiferFlux.cpp
@@ -18,10 +18,13 @@
  */
 
 #include <opm/input/eclipse/EclipseState/Aquifer/AquiferFlux.hpp>
-#include <opm/input/eclipse/Parser/ParserKeywords/A.hpp>
 
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/input/eclipse/Parser/ParserKeywords/A.hpp>
+
+#include <cstddef>
 
 namespace Opm {
     SingleAquiferFlux::SingleAquiferFlux(const DeckRecord& record)
@@ -103,7 +106,7 @@ namespace Opm {
         return this->m_aquifers.count(id) > 0;
     }
 
-    size_t AquiferFlux::size() const {
+    std::size_t AquiferFlux::size() const {
         return this->m_aquifers.size();
     }
 

--- a/opm/input/eclipse/EclipseState/Aquifer/AquiferFlux.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/AquiferFlux.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_AQUIFERFLUX_HPP
 #define OPM_AQUIFERFLUX_HPP
 
+#include <cstddef>
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
@@ -84,7 +85,7 @@ namespace  Opm {
 
         bool operator==(const AquiferFlux& other) const;
 
-        size_t size() const;
+        std::size_t size() const;
 
         AquFluxs::const_iterator begin() const;
         AquFluxs::const_iterator end() const;

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.cpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.cpp
@@ -13,31 +13,34 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-#include <opm/input/eclipse/Parser/ParserKeywords/A.hpp>
-
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.hpp>
-
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
-#include <opm/common/utility/OpmInputError.hpp>
-#include <opm/common/OpmLog/OpmLog.hpp>
-#include <fmt/format.h>
 
 #include "../AquiferHelpers.hpp"
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
+
+#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/input/eclipse/Parser/ParserKeywords/A.hpp>
+
+#include <cstddef>
 #include <string>
+
+#include <fmt/format.h>
 
 namespace Opm {
 
-    std::map<size_t, std::map<size_t, NumericalAquiferConnection>>
+    std::map<std::size_t, std::map<std::size_t, NumericalAquiferConnection>>
     NumericalAquiferConnection::generateConnections(const Deck &deck, const EclipseGrid &grid)
     {
         using AQUCON=ParserKeywords::AQUCON;
         if ( !deck.hasKeyword<AQUCON>() ) return {};
 
-        std::map<size_t, std::map<size_t, NumericalAquiferConnection>> connections;
+        std::map<std::size_t, std::map<std::size_t, NumericalAquiferConnection>> connections;
 
         const auto& aqucon_keywords = deck.getKeywordList<AQUCON>();
         for (const auto& keyword : aqucon_keywords) {
@@ -45,8 +48,8 @@ namespace Opm {
             for (const auto& record : *keyword) {
                 const auto cons_from_record = NumericalAquiferConnection::connectionsFromSingleRecord(grid, record);
                 for (auto con : cons_from_record) {
-                    const size_t aqu_id = con.aquifer_id;
-                    const size_t global_index = con.global_index;
+                    const std::size_t aqu_id = con.aquifer_id;
+                    const std::size_t global_index = con.global_index;
                     auto& aqu_cons = connections[aqu_id];
                     if (aqu_cons.find(global_index) == aqu_cons.end()) {
                         aqu_cons.insert({global_index, con});
@@ -64,8 +67,8 @@ namespace Opm {
 
     // TODO: we should not need all following the information here
     using AQUCON = ParserKeywords::AQUCON;
-    NumericalAquiferConnection::NumericalAquiferConnection(const size_t i, const size_t j, const size_t k,
-                                                           const size_t global_index_in, const bool allow_connection_active, const DeckRecord& record)
+    NumericalAquiferConnection::NumericalAquiferConnection(const std::size_t i, const std::size_t j, const std::size_t k,
+                                                           const std::size_t global_index_in, const bool allow_connection_active, const DeckRecord& record)
     : aquifer_id(record.getItem<AQUCON::ID>().get<int>(0))
     , I(i)
     , J(j)
@@ -85,19 +88,19 @@ namespace Opm {
     connectionsFromSingleRecord(const EclipseGrid& grid, const DeckRecord& record) {
         std::vector<NumericalAquiferConnection> cons;
 
-        const size_t i1 = record.getItem<AQUCON::I1>().get<int>(0) - 1;
-        const size_t j1 = record.getItem<AQUCON::J1>().get<int>(0) - 1;
-        const size_t k1 = record.getItem<AQUCON::K1>().get<int>(0) - 1;
-        const size_t i2 = record.getItem<AQUCON::I2>().get<int>(0) - 1;
-        const size_t j2 = record.getItem<AQUCON::J2>().get<int>(0) - 1;
-        const size_t k2 = record.getItem<AQUCON::K2>().get<int>(0) - 1;
+        const std::size_t i1 = record.getItem<AQUCON::I1>().get<int>(0) - 1;
+        const std::size_t j1 = record.getItem<AQUCON::J1>().get<int>(0) - 1;
+        const std::size_t k1 = record.getItem<AQUCON::K1>().get<int>(0) - 1;
+        const std::size_t i2 = record.getItem<AQUCON::I2>().get<int>(0) - 1;
+        const std::size_t j2 = record.getItem<AQUCON::J2>().get<int>(0) - 1;
+        const std::size_t k2 = record.getItem<AQUCON::K2>().get<int>(0) - 1;
 
         const bool allow_internal_cells = DeckItem::to_bool( record.getItem<AQUCON::ALLOW_INTERNAL_CELLS>().getTrimmedString(0) );
 
-        for (size_t k = k1; k <= k2; ++k) {
-            for (size_t j = j1; j <=j2; ++j) {
-                for (size_t i = i1; i <= i2; ++i) {
-                    const size_t global_index = grid.getGlobalIndex(i, j, k);
+        for (std::size_t k = k1; k <= k2; ++k) {
+            for (std::size_t j = j1; j <=j2; ++j) {
+                for (std::size_t i = i1; i <= i2; ++i) {
+                    const std::size_t global_index = grid.getGlobalIndex(i, j, k);
                     cons.emplace_back(i, j, k, global_index, allow_internal_cells, record);
                 }
             }

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.hpp
@@ -21,8 +21,10 @@
 #define OPM_NUMERICALAQUIFERCONNECTION_HPP
 
 #include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
-#include <map>
+
 #include <array>
+#include <cstddef>
+#include <map>
 #include <vector>
 
 namespace Opm {
@@ -34,9 +36,9 @@ namespace Opm {
     struct NumericalAquiferConnection
     {
         // TODO: I do not think we need all the values here
-        size_t aquifer_id{};
-        size_t I{}, J{}, K{};
-        size_t global_index{};
+        std::size_t aquifer_id{};
+        std::size_t I{}, J{}, K{};
+        std::size_t global_index{};
         FaceDir::DirEnum face_dir{FaceDir::Unknown};
         double trans_multipler{};
         int trans_option{};
@@ -46,7 +48,7 @@ namespace Opm {
         double ve_frac_relperm{};
         double ve_frac_cappress{};
 
-        NumericalAquiferConnection(size_t i, size_t j, size_t k, size_t global_index, bool allow_connect_active, const DeckRecord& record);
+        NumericalAquiferConnection(std::size_t i, std::size_t j, std::size_t k, std::size_t global_index, bool allow_connect_active, const DeckRecord& record);
         NumericalAquiferConnection() = default;
 
         bool operator==(const NumericalAquiferConnection& other) const;
@@ -66,7 +68,7 @@ namespace Opm {
             serializer(this->ve_frac_cappress);
         }
 
-        static std::map<size_t, std::map<size_t, NumericalAquiferConnection>>
+        static std::map<std::size_t, std::map<std::size_t, NumericalAquiferConnection>>
                 generateConnections(const Deck& deck, const EclipseGrid& grid);
 
     private:

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
@@ -38,9 +38,9 @@
 #include <algorithm>
 #include <cstddef>
 #include <limits>
+#include <stdexcept>
 #include <unordered_set>
 #include <utility>
-#include <stdexcept>
 #include <vector>
 
 namespace Opm {
@@ -84,12 +84,12 @@ namespace Opm {
 
 
     void NumericalAquifers::addAquiferCell(const NumericalAquiferCell& aqu_cell) {
-        const size_t id = aqu_cell.aquifer_id;
+        const std::size_t id = aqu_cell.aquifer_id;
         auto& aquifer = this->m_aquifers.at(id);
         aquifer.addAquiferCell(aqu_cell);
     }
 
-    bool NumericalAquifers::hasAquifer(const size_t aquifer_id) const {
+    bool NumericalAquifers::hasAquifer(const std::size_t aquifer_id) const {
         return (this->m_aquifers.find(aquifer_id) != this->m_aquifers.end());
     }
 
@@ -98,7 +98,7 @@ namespace Opm {
         const auto aquifer_connections = NumericalAquiferConnection::generateConnections(deck, grid);
 
         for (auto& pair : this->m_aquifers) {
-            const size_t aqu_id = pair.first;
+            const std::size_t aqu_id = pair.first;
             const auto& aqu_cons = aquifer_connections.find(aqu_id);
             if (aqu_cons == aquifer_connections.end()) {
                 const auto msg = fmt::format("Numerical aquifer {} does not have any connections\n", aqu_id);
@@ -113,10 +113,10 @@ namespace Opm {
             // aquifer can not connect to aquifer cells
             for (const auto& con : cons) {
                 const auto& aqu_con = con.second;
-                const size_t con_global_index = aqu_con.global_index;
+                const std::size_t con_global_index = aqu_con.global_index;
                 const auto cell_iter = all_aquifer_cells.find(con_global_index);
                 if (cell_iter != all_aquifer_cells.end()) {
-                    const size_t cell_aquifer_id = cell_iter->second->aquifer_id;
+                    const std::size_t cell_aquifer_id = cell_iter->second->aquifer_id;
                     auto msg = fmt::format("Problem with keyword AQUCON \n"
                                            "Aquifer connection declared at grid cell ({}, {}, {}), is a aquifer cell "
                                            "of Aquifer {}, and will be removed",
@@ -141,7 +141,7 @@ namespace Opm {
             && (this->m_num_records == other.m_num_records);
     }
 
-    size_t NumericalAquifers::size() const {
+    std::size_t NumericalAquifers::size() const {
         return this->m_aquifers.size();
     }
 
@@ -151,7 +151,7 @@ namespace Opm {
         return result;
     }
 
-    const SingleNumericalAquifer& NumericalAquifers::getAquifer(const size_t aquifer_id) const {
+    const SingleNumericalAquifer& NumericalAquifers::getAquifer(const std::size_t aquifer_id) const {
         const auto iter = this->m_aquifers.find(aquifer_id);
         if ( iter != this->m_aquifers.end() ) {
             return iter->second;
@@ -161,10 +161,10 @@ namespace Opm {
         }
     }
 
-    std::unordered_map<size_t, const NumericalAquiferCell*> NumericalAquifers::allAquiferCells() const {
-        std::unordered_map<size_t, const NumericalAquiferCell*> cells;
+    std::unordered_map<std::size_t, const NumericalAquiferCell*> NumericalAquifers::allAquiferCells() const {
+        std::unordered_map<std::size_t, const NumericalAquiferCell*> cells;
         for (const auto& [id, aquifer] : this->m_aquifers) {
-            for (size_t i = 0; i < aquifer.numCells(); ++i) {
+            for (std::size_t i = 0; i < aquifer.numCells(); ++i) {
                 const NumericalAquiferCell* cell_ptr = aquifer.getCellPrt(i);
                 cells.insert(std::make_pair(cell_ptr->global_index, cell_ptr));
             }
@@ -188,12 +188,12 @@ namespace Opm {
         return cellIds;
     }
 
-    const std::map<size_t, SingleNumericalAquifer>& NumericalAquifers::aquifers() const {
+    const std::map<std::size_t, SingleNumericalAquifer>& NumericalAquifers::aquifers() const {
         return this->m_aquifers;
     }
 
-    std::unordered_map<size_t, AquiferCellProps> NumericalAquifers::aquiferCellProps() const {
-        std::unordered_map<size_t, AquiferCellProps> cell_props;
+    std::unordered_map<std::size_t, AquiferCellProps> NumericalAquifers::aquiferCellProps() const {
+        std::unordered_map<std::size_t, AquiferCellProps> cell_props;
         for ([[maybe_unused]]const auto& [id, aquifer] : this->m_aquifers ) {
             auto aqu_cell_props = aquifer.aquiferCellProps();
             cell_props.insert(aqu_cell_props.begin(), aqu_cell_props.end());
@@ -201,8 +201,8 @@ namespace Opm {
         return cell_props;
     }
 
-    std::unordered_map<size_t, double> NumericalAquifers::aquiferCellVolumes() const {
-        std::unordered_map<size_t, double> cell_volumes;
+    std::unordered_map<std::size_t, double> NumericalAquifers::aquiferCellVolumes() const {
+        std::unordered_map<std::size_t, double> cell_volumes;
         const auto aquifer_cells = this->allAquiferCells();
         for (const auto& [global_index, cell] : aquifer_cells) {
             cell_volumes.insert(std::make_pair(global_index, cell->cellVolume()));

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
@@ -27,8 +27,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <stddef.h>
-
 namespace Opm {
     class Deck;
     class EclipseGrid;
@@ -41,21 +39,21 @@ namespace Opm {
         NumericalAquifers(const Deck& deck, const EclipseGrid& grid, const FieldPropsManager& field_props);
 
         int numRecords() const { return static_cast<int>(this->m_num_records); }
-        size_t size() const;
-        bool hasAquifer(size_t aquifer_id) const;
-        const SingleNumericalAquifer& getAquifer(size_t aquifer_id) const;
-        const std::map<size_t, SingleNumericalAquifer>& aquifers() const;
+        std::size_t size() const;
+        bool hasAquifer(std::size_t aquifer_id) const;
+        const SingleNumericalAquifer& getAquifer(std::size_t aquifer_id) const;
+        const std::map<std::size_t, SingleNumericalAquifer>& aquifers() const;
         bool operator==(const NumericalAquifers& other) const;
 
-        std::unordered_map<size_t, const NumericalAquiferCell*> allAquiferCells() const;
+        std::unordered_map<std::size_t, const NumericalAquiferCell*> allAquiferCells() const;
         std::vector<std::size_t> allAquiferCellIds() const;
 
-        std::unordered_map<size_t, double> aquiferCellVolumes() const;
+        std::unordered_map<std::size_t, double> aquiferCellVolumes() const;
 
         std::vector<NNCdata> aquiferCellNNCs() const;
         std::vector<NNCdata> aquiferConnectionNNCs(const EclipseGrid& grid, const FieldPropsManager& fp) const;
 
-        std::unordered_map<size_t, AquiferCellProps> aquiferCellProps() const;
+        std::unordered_map<std::size_t, AquiferCellProps> aquiferCellProps() const;
 
         void applyMinPV(const EclipseGrid& grid);
 
@@ -71,8 +69,8 @@ namespace Opm {
         }
 
     private:
-        std::map<size_t, SingleNumericalAquifer> m_aquifers{};
-        size_t m_num_records{0};
+        std::map<std::size_t, SingleNumericalAquifer> m_aquifers{};
+        std::size_t m_num_records{0};
 
         void addAquiferCell(const NumericalAquiferCell& aqu_cell);
     };

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
@@ -17,22 +17,25 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
-
-#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.hpp>
-#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.hpp>
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp>
-#include "../AquiferHelpers.hpp"
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 
-#include <fmt/format.h>
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.hpp>
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
+
+#include "../AquiferHelpers.hpp"
+
+#include <cstddef>
 #include <unordered_set>
 
+#include <fmt/format.h>
+
 namespace Opm {
-    SingleNumericalAquifer::SingleNumericalAquifer(const size_t aqu_id)
+    SingleNumericalAquifer::SingleNumericalAquifer(const std::size_t aqu_id)
             : id_(aqu_id)
     {
     }
@@ -41,11 +44,11 @@ namespace Opm {
         cells_.push_back(aqu_cell);
     }
 
-    size_t SingleNumericalAquifer::numCells() const {
+    std::size_t SingleNumericalAquifer::numCells() const {
         return this->cells_.size();
     }
 
-    const NumericalAquiferCell* SingleNumericalAquifer::getCellPrt(const size_t index) const {
+    const NumericalAquiferCell* SingleNumericalAquifer::getCellPrt(const std::size_t index) const {
         return &this->cells_[index];
     }
 
@@ -59,11 +62,11 @@ namespace Opm {
                 this->id_ == other.id_;
     }
 
-    size_t SingleNumericalAquifer::numConnections() const {
+    std::size_t SingleNumericalAquifer::numConnections() const {
         return this->connections_.size();
     }
 
-    size_t SingleNumericalAquifer::id() const {
+    std::size_t SingleNumericalAquifer::id() const {
         return this->id_;
     }
 
@@ -84,8 +87,8 @@ namespace Opm {
         }
     }
 
-    std::unordered_map<size_t, AquiferCellProps> SingleNumericalAquifer::aquiferCellProps() const {
-        std::unordered_map<size_t, AquiferCellProps> aqucellprops;
+    std::unordered_map<std::size_t, AquiferCellProps> SingleNumericalAquifer::aquiferCellProps() const {
+        std::unordered_map<std::size_t, AquiferCellProps> aqucellprops;
         for (const auto& cell : this->cells_) {
             aqucellprops.emplace(std::make_pair(cell.global_index,
                                AquiferCellProps{cell.cellVolume(), cell.poreVolume(), cell.depth,
@@ -100,12 +103,12 @@ namespace Opm {
             return nncs;
 
         // aquifer cells are connected to each other through NNCs to form the aquifer
-        for (size_t i = 0; i < this->cells_.size() - 1; ++i) {
+        for (std::size_t i = 0; i < this->cells_.size() - 1; ++i) {
             const double trans1 = this->cells_[i].transmissiblity();
             const double trans2 = this->cells_[i + 1].transmissiblity();
             const double tran = 1. / (1. / trans1 + 1. / trans2);
-            const size_t gc1 = this->cells_[i].global_index;
-            const size_t gc2 = this->cells_[i + 1].global_index;
+            const std::size_t gc1 = this->cells_[i].global_index;
+            const std::size_t gc2 = this->cells_[i + 1].global_index;
             if (gc1 < gc2) {
                 nncs.emplace_back(gc1, gc2, tran);
             } else {
@@ -124,9 +127,9 @@ namespace Opm {
         const std::vector<double>& ntg = fp.get_double("NTG");
         const auto& cell1 = this->cells_[0];
         // all the connections connect to the first numerical aquifer cell
-        const size_t gc1 = cell1.global_index;
+        const std::size_t gc1 = cell1.global_index;
         for (const auto& con : this->connections_) {
-            const size_t gc2 = con.global_index;
+            const std::size_t gc2 = con.global_index;
             // TODO: the following is based on Cartesian grids, it turns out working for more general grids.
             //  We should keep in mind this can be something causing problems for specific grids
             const auto& cell_dims = grid.getCellDims(gc2);
@@ -185,16 +188,16 @@ namespace Opm {
     }
 
     void SingleNumericalAquifer::postProcessConnections(const EclipseGrid& grid, const std::vector<int>& actnum) {
-        std::unordered_set<size_t> cell_global_indices;
+        std::unordered_set<std::size_t> cell_global_indices;
         for (const auto& cell : this->cells_) {
             cell_global_indices.insert(cell.global_index);
         }
 
         std::vector<NumericalAquiferConnection> conns;
         for (const auto& con : this->connections_) {
-            const size_t i = con.I;
-            const size_t j = con.J;
-            const size_t k = con.K;
+            const std::size_t i = con.I;
+            const std::size_t j = con.J;
+            const std::size_t k = con.K;
             // Need to check for out-of-bounds access (eventually gives throw in aquiferConnectionNNCs also).
             if (! (i < grid.getNX() && j < grid.getNY() && k < grid.getNZ()) ) {
                 OpmLog::warning(

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
@@ -23,6 +23,7 @@
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.hpp>
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.hpp>
 
+#include <cstddef>
 #include <set>
 #include <unordered_map>
 #include <vector>
@@ -44,7 +45,7 @@ namespace Opm {
     class SingleNumericalAquifer
     {
     public:
-        explicit SingleNumericalAquifer(const size_t aqu_id);
+        explicit SingleNumericalAquifer(const std::size_t aqu_id);
         SingleNumericalAquifer() = default;
 
         void addAquiferCell(const NumericalAquiferCell& aqu_cell);
@@ -54,14 +55,14 @@ namespace Opm {
 
         // TODO: the following two can be made one function. Let us see
         // how we use them at the end
-        size_t numCells() const;
-        size_t id() const;
-        size_t numConnections() const;
-        const NumericalAquiferCell* getCellPrt(size_t index) const;
+        std::size_t numCells() const;
+        std::size_t id() const;
+        std::size_t numConnections() const;
+        const NumericalAquiferCell* getCellPrt(std::size_t index) const;
 
         void applyMinPV(const EclipseGrid& grid);
 
-        std::unordered_map<size_t, AquiferCellProps> aquiferCellProps() const;
+        std::unordered_map<std::size_t, AquiferCellProps> aquiferCellProps() const;
 
         std::vector<NNCdata> aquiferCellNNCs() const;
         std::vector<NNCdata> aquiferConnectionNNCs(const EclipseGrid &grid, const FieldPropsManager &fp) const;
@@ -82,11 +83,10 @@ namespace Opm {
             // Because if it is a map, the id will be there
             // Then adding aquifer cells will be much easier with the
             // default constructor
-            size_t id_{};
+            std::size_t id_{};
             std::vector<NumericalAquiferCell> cells_{};
             std::vector<NumericalAquiferConnection> connections_{};
         };
 }
-
 
 #endif //OPM_SINGLENUMERICALAQUIFER_HPP

--- a/opm/input/eclipse/EclipseState/Co2StoreConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Co2StoreConfig.cpp
@@ -16,19 +16,24 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <opm/input/eclipse/EclipseState/Co2StoreConfig.hpp>
 
 #include <opm/common/utility/OpmInputError.hpp>
 
+#include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
+
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckSection.hpp>
+
 #include <opm/input/eclipse/Parser/ParserKeywords/A.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/D.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/V.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
+
+#include <cstddef>
 
 namespace {
     template <class EzrokhiTable>
@@ -108,7 +113,7 @@ namespace Opm {
             const auto& item = keyword.getRecord(0).getItem<ParserKeywords::CNAMES::data>();
             const auto num_comp = item.getData<std::string>().size();
             cnames.insert({{"H2O", -1}, {"CO2", -1}, {"NACL", -1}});
-            for (size_t c = 0; c < num_comp; ++c) {
+            for (std::size_t c = 0; c < num_comp; ++c) {
                 const auto name = item.getTrimmedString(c);
                 auto it = cnames.find(name);
                 if (it != cnames.end()) {
@@ -119,7 +124,7 @@ namespace Opm {
 
         // DENAQA and VISCAQA
         const Tabdims tabdims{deck};
-        const size_t num_eos_res = tabdims.getNumEosRes();
+        const std::size_t num_eos_res = tabdims.getNumEosRes();
         if (props_section.hasKeyword<ParserKeywords::DENAQA>()) {
             initEzrokhiTable(deck, "DENAQA", num_eos_res, cnames, denaqa_tables);
         }
@@ -211,6 +216,5 @@ namespace Opm {
             throw std::invalid_argument(input + " is not a valid Salte mixing type. See THCO2MIX item 3");
         }
     }
-
 
 } // namespace Opm

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -192,7 +192,7 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
         for (const auto& kw : keywords) {
             const auto& item = kw.getRecord(0).getItem<ParserKeywords::NCOMPS::NUM_COMPS>();
             const auto ncomps = item.get<int>(0);
-            if (size_t(ncomps) != this->num_comps) {
+            if (std::size_t(ncomps) != this->num_comps) {
                 const std::string msg = fmt::format("NCOMPS is specified with {}, which is different from the number specified in COMPS {}",
                                                     ncomps, this->num_comps);
                 throw OpmInputError(msg, kw.location());
@@ -216,7 +216,7 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
                                          names_size, num_comps);
             throw OpmInputError(msg, kw.location());
         }
-        for (size_t c = 0; c < num_comps; ++c) {
+        for (std::size_t c = 0; c < num_comps; ++c) {
             comp_names[c] = item.getTrimmedString(c);
         }
     }
@@ -235,7 +235,7 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
     }
 
     const Tabdims tabdims{deck};
-    const size_t num_eos_res = tabdims.getNumEosRes();
+    const std::size_t num_eos_res = tabdims.getNumEosRes();
     // EOS keyword can also be in RUNSPEC section, we also parse the EOS in the RUNSPEC section here for simplicity
     // might be suggested to handle in the RUNSPEC section though
     eos_types.resize(num_eos_res, EOSType::PR);
@@ -260,7 +260,7 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
                                              " of equation of state regions of {}.", kw.size(), num_eos_res);
                 throw OpmInputError(msg, kw.location());
             }
-            for (size_t i = 0; i < kw.size(); ++i) {
+            for (std::size_t i = 0; i < kw.size(); ++i) {
                 const auto& item = kw.getRecord(i).getItem<KWEOS::EQUATION>();
                 const auto& equ_str = item.getTrimmedString(0);
                 eos_types[i] = eosTypeFromString(equ_str);
@@ -385,7 +385,7 @@ const std::vector<std::string>& CompositionalConfig::compName() const {
     return this->comp_names;
 }
 
-CompositionalConfig::EOSType CompositionalConfig::eosType(size_t eos_region) const {
+CompositionalConfig::EOSType CompositionalConfig::eosType(std::size_t eos_region) const {
     return this->eos_types[eos_region];
 }
 
@@ -393,27 +393,27 @@ const std::vector<double>& CompositionalConfig::molecularWeights(std::size_t eos
     return this->molecular_weights[eos_region];
 }
 
-const std::vector<double>& CompositionalConfig::acentricFactors(size_t eos_region) const {
+const std::vector<double>& CompositionalConfig::acentricFactors(std::size_t eos_region) const {
     return this->acentric_factors[eos_region];
 }
 
-const std::vector<double>& CompositionalConfig::criticalPressure(size_t eos_region) const {
+const std::vector<double>& CompositionalConfig::criticalPressure(std::size_t eos_region) const {
     return this->critical_pressure[eos_region];
 }
 
-const std::vector<double>& CompositionalConfig::criticalTemperature(size_t eos_region) const {
+const std::vector<double>& CompositionalConfig::criticalTemperature(std::size_t eos_region) const {
     return this->critical_temperature[eos_region];
 }
 
-const std::vector<double>& CompositionalConfig::criticalVolume(size_t eos_region) const {
+const std::vector<double>& CompositionalConfig::criticalVolume(std::size_t eos_region) const {
     return this->critical_volume[eos_region];
 }
 
-const std::vector<double>& CompositionalConfig::volumeShifts(size_t eos_region) const {
+const std::vector<double>& CompositionalConfig::volumeShifts(std::size_t eos_region) const {
     return this->volume_shifts[eos_region];
 }
 
-const std::vector<double>& CompositionalConfig::binaryInteractionCoefficient(size_t eos_region) const {
+const std::vector<double>& CompositionalConfig::binaryInteractionCoefficient(std::size_t eos_region) const {
     return this->binary_interaction_coefficient[eos_region];
 }
 

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
@@ -57,14 +57,14 @@ public:
     double standardTemperature() const;
     double standardPressure() const;
     const std::vector<std::string>& compName() const;
-    EOSType eosType(size_t eos_region) const;
+    EOSType eosType(std::size_t eos_region) const;
     const std::vector<double>& molecularWeights(std::size_t eos_region) const;
     const std::vector<double>& acentricFactors(std::size_t eos_region) const;
     const std::vector<double>& criticalPressure(std::size_t eos_region) const;
     const std::vector<double>& criticalTemperature(std::size_t eos_region) const;
     const std::vector<double>& criticalVolume(std::size_t eos_region) const;
     const std::vector<double>& volumeShifts(std::size_t eos_region) const;
-    const std::vector<double>& binaryInteractionCoefficient(size_t eos_region) const;
+    const std::vector<double>& binaryInteractionCoefficient(std::size_t eos_region) const;
     std::size_t numComps() const;
 
     template<class Serializer>

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -673,10 +673,10 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         auto ny = this->getNY();
         auto nz = this->getNZ();
 
-        assertVectorSize( DEPTHZ , static_cast<size_t>( (nx + 1)*(ny +1 )) , "DEPTHZ");
-        assertVectorSize( DXV    , static_cast<size_t>( nx ) , "DXV");
-        assertVectorSize( DYV    , static_cast<size_t>( ny ) , "DYV");
-        assertVectorSize( DZV    , static_cast<size_t>( nz ) , "DZV");
+        assertVectorSize( DEPTHZ , static_cast<std::size_t>( (nx + 1)*(ny +1 )) , "DEPTHZ");
+        assertVectorSize( DXV    , static_cast<std::size_t>( nx ) , "DXV");
+        assertVectorSize( DYV    , static_cast<std::size_t>( ny ) , "DYV");
+        assertVectorSize( DZV    , static_cast<std::size_t>( nz ) , "DZV");
 
         m_coord = makeCoordDxvDyvDzvDepthz(DXV, DYV, DZV, DEPTHZ);
         m_zcorn = makeZcornDzvDepthz(DZV, DEPTHZ);
@@ -1271,7 +1271,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         {
             const auto& ZCORNKeyWord = deck.get<ParserKeywords::ZCORN>().back();
 
-            if (ZCORNKeyWord.getDataSize() != static_cast<size_t>(8*nx*ny*nz)) {
+            if (ZCORNKeyWord.getDataSize() != static_cast<std::size_t>(8*nx*ny*nz)) {
                 const std::string msg =
                     "Wrong size of the ZCORN keyword: Expected 8*nx*ny*nz = "
                     + std::to_string(static_cast<long long>(8*nx*ny*nz)) + " is "
@@ -1283,7 +1283,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
 
         {
             const auto& COORDKeyWord = deck.get<ParserKeywords::COORD>().back();
-            if (COORDKeyWord.getDataSize() != static_cast<size_t>(6*(nx + 1)*(ny + 1))) {
+            if (COORDKeyWord.getDataSize() != static_cast<std::size_t>(6*(nx + 1)*(ny + 1))) {
                 const std::string msg =
                     "Wrong size of the COORD keyword: Expected 6*(nx + 1)*(ny + 1) = "
                     + std::to_string(static_cast<long long>(6*(nx + 1)*(ny + 1))) + " is "
@@ -2372,7 +2372,7 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
         std::vector<double> element_centerX, element_centerY, element_centerZ;
         for (EclipseGridLGR& lgr_cell : lgr_children_cells) {
             std::tie(element_centerX, element_centerY,element_centerZ) =
-                VectorUtil::callMethodForEachInputOnObjectXYZ<EclipseGridLGR, std::array<double,3>, int,std::array<double, 3> (EclipseGridLGR::*)(size_t) const>
+                VectorUtil::callMethodForEachInputOnObjectXYZ<EclipseGridLGR, std::array<double,3>, int,std::array<double, 3> (EclipseGridLGR::*)(std::size_t) const>
                 (lgr_cell, &EclipseGridLGR::getCellCenter, lgr_cell.getActiveMap());
             auto [host_cellX, host_cellY, host_cellZ]  =  getAllCellCorners(lgr_cell.get_father_global());
             auto inside_el = GeometryUtil::isInsideElement(element_centerX, element_centerY, element_centerZ, host_cellX, host_cellY, host_cellZ);

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -28,13 +28,14 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
+#include <map>
 #include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <vector>
-#include <map>
 
 namespace Opm {
 
@@ -71,7 +72,7 @@ namespace Opm {
         EclipseGrid(const EclipseGrid& src, const std::vector<int>& actnum);
         EclipseGrid(const EclipseGrid& src, const double* zcorn, const std::vector<int>& actnum);
 
-        EclipseGrid(size_t nx, size_t ny, size_t nz,
+        EclipseGrid(std::size_t nx, std::size_t ny, std::size_t nz,
                     double dx = 1.0, double dy = 1.0, double dz = 1.0,
                     double top = 0.0);
         explicit EclipseGrid(const GridDims& gd);
@@ -93,20 +94,20 @@ namespace Opm {
         static bool hasCylindricalKeywords(const Deck& deck);
         static bool hasCornerPointKeywords(const Deck&);
         static bool hasCartesianKeywords(const Deck&);
-        size_t  getNumActive( ) const;
+        std::size_t  getNumActive( ) const;
         bool allActive() const;
 
-        size_t activeIndex(size_t i, size_t j, size_t k) const;
-        size_t activeIndex(size_t globalIndex) const;
+        std::size_t activeIndex(std::size_t i, std::size_t j, std::size_t k) const;
+        std::size_t activeIndex(std::size_t globalIndex) const;
 
-        size_t getTotalActiveLGR() const;
-        size_t getActiveIndexLGR(const std::string& label, size_t i, size_t j, size_t k) const;
-        size_t getActiveIndexLGR(const std::string& label, size_t localIndex) const;
+        std::size_t getTotalActiveLGR() const;
+        std::size_t getActiveIndexLGR(const std::string& label, std::size_t i, std::size_t j, std::size_t k) const;
+        std::size_t getActiveIndexLGR(const std::string& label, std::size_t localIndex) const;
 
-        size_t activeIndexLGR(const std::string& label, size_t i, size_t j, size_t k) const;
-        size_t activeIndexLGR(const std::string& label, size_t localIndex) const;
+        std::size_t activeIndexLGR(const std::string& label, std::size_t i, std::size_t j, std::size_t k) const;
+        std::size_t activeIndexLGR(const std::string& label, std::size_t localIndex) const;
 
-        size_t getActiveIndex(size_t i, size_t j, size_t k) const {
+        std::size_t getActiveIndex(std::size_t i, std::size_t j, std::size_t k) const {
             return activeIndex(i, j, k);
         }
         const std::vector<std::size_t>& get_print_order_lgr () const {
@@ -126,10 +127,10 @@ namespace Opm {
                 throw std::runtime_error("LGR tag not found: " + lgr_tag);
             }
 
-            return static_cast<size_t>(std::distance(labels.begin(), it));
+            return static_cast<std::size_t>(std::distance(labels.begin(), it));
         }
 
-        size_t getActiveIndex(size_t globalIndex) const {
+        std::size_t getActiveIndex(std::size_t globalIndex) const {
             return activeIndex(globalIndex);
         }
 
@@ -159,7 +160,7 @@ namespace Opm {
         std::vector<GridDims> get_lgr_children_gridim() const;
 
 
-        void assertIndexLGR(size_t localIndex) const;
+        void assertIndexLGR(std::size_t localIndex) const;
 
         void assertLabelLGR(const std::string& label) const;
 
@@ -181,7 +182,7 @@ namespace Opm {
         void perform_refinement();
 
         using GridDims::getGlobalIndex;
-        size_t getGlobalIndex(size_t active_index) const;
+        std::size_t getGlobalIndex(std::size_t active_index) const;
 
         /*
           For RADIAL grids you can *optionally* use the keyword
@@ -225,7 +226,7 @@ namespace Opm {
                 std::vector<T> compressed_vector( this->getNumActive() );
                 const auto& active_map = this->getActiveMap( );
 
-                for (size_t i = 0; i < this->getNumActive(); ++i)
+                for (std::size_t i = 0; i < this->getNumActive(); ++i)
                     compressed_vector[i] = input_vector[ active_map[i] ];
 
                 return compressed_vector;
@@ -241,27 +242,27 @@ namespace Opm {
         void create_lgr_cells_tree(const LgrCollection& );
         /// \brief get cell center, and center and normal of bottom face
         std::tuple<std::array<double, 3>,std::array<double, 3>,std::array<double, 3>>
-        getCellAndBottomCenterNormal(size_t globalIndex) const;
-        std::array<double, 3> getCellCenter(size_t i,size_t j, size_t k) const;
-        std::array<double, 3> getCellCenter(size_t globalIndex) const;
-        std::array<double, 3> getCornerPos(size_t i,size_t j, size_t k, size_t corner_index) const;
+        getCellAndBottomCenterNormal(std::size_t globalIndex) const;
+        std::array<double, 3> getCellCenter(std::size_t i,std::size_t j, std::size_t k) const;
+        std::array<double, 3> getCellCenter(std::size_t globalIndex) const;
+        std::array<double, 3> getCornerPos(std::size_t i,std::size_t j, std::size_t k, std::size_t corner_index) const;
         const std::vector<double>& activeVolume() const;
-        double getCellVolume(size_t globalIndex) const;
-        double getCellVolume(size_t i , size_t j , size_t k) const;
-        double getCellThickness(size_t globalIndex) const;
-        double getCellThickness(size_t i , size_t j , size_t k) const;
-        std::array<double, 3> getCellDims(size_t i,size_t j, size_t k) const;
-        std::array<double, 3> getCellDims(size_t globalIndex) const;
-        bool cellActive( size_t globalIndex ) const;
-        bool cellActive( size_t i , size_t j, size_t k ) const;
-        bool cellActiveAfterMINPV( size_t i , size_t j , size_t k, double cell_porv ) const;
+        double getCellVolume(std::size_t globalIndex) const;
+        double getCellVolume(std::size_t i , std::size_t j , std::size_t k) const;
+        double getCellThickness(std::size_t globalIndex) const;
+        double getCellThickness(std::size_t i , std::size_t j , std::size_t k) const;
+        std::array<double, 3> getCellDims(std::size_t i,std::size_t j, std::size_t k) const;
+        std::array<double, 3> getCellDims(std::size_t globalIndex) const;
+        bool cellActive( std::size_t globalIndex ) const;
+        bool cellActive( std::size_t i , std::size_t j, std::size_t k ) const;
+        bool cellActiveAfterMINPV( std::size_t i , std::size_t j , std::size_t k, double cell_porv ) const;
         bool is_lgr() const {return lgr_grid;};
-        std::array<double, 3> getCellDimensions(size_t i, size_t j, size_t k) const {
+        std::array<double, 3> getCellDimensions(std::size_t i, std::size_t j, std::size_t k) const {
             return getCellDims(i, j, k);
         }
 
 
-        bool isCellActive(size_t i, size_t j, size_t k) const {
+        bool isCellActive(std::size_t i, std::size_t j, std::size_t k) const {
             return cellActive(i, j, k);
         }
 
@@ -273,8 +274,8 @@ namespace Opm {
         bool isValidCellGeomtry(const std::size_t globalIndex,
                                 const UnitSystem& usys) const;
 
-        double getCellDepth(size_t i,size_t j, size_t k) const;
-        double getCellDepth(size_t globalIndex) const;
+        double getCellDepth(std::size_t i,std::size_t j, std::size_t k) const;
+        double getCellDepth(std::size_t globalIndex) const;
         ZcornMapper zcornMapper() const;
 
         const std::vector<double>& getCOORD() const;
@@ -283,7 +284,7 @@ namespace Opm {
 
         const std::optional<MapAxes>& getMapAxes() const;
 
-        const std::map<size_t, std::array<int,2>>& getAquiferCellTabnums() const;
+        const std::map<std::size_t, std::array<int,2>>& getAquiferCellTabnums() const;
 
         /*
           The fixupZCORN method is run as part of constructiong the grid. This will adjust the
@@ -292,8 +293,8 @@ namespace Opm {
           stored in private member zcorn_fixed.
         */
 
-        size_t fixupZCORN();
-        size_t getZcornFixed() { return zcorn_fixed; };
+        std::size_t fixupZCORN();
+        std::size_t getZcornFixed() { return zcorn_fixed; };
 
         // resetACTNUM with no arguments will make all cells in the grid active.
 
@@ -370,7 +371,7 @@ namespace Opm {
         mutable std::optional<std::vector<double>> active_volume;
 
         bool m_circle = false;
-        size_t zcorn_fixed = 0;
+        std::size_t zcorn_fixed = 0;
         bool m_useActnumFromGdfile = false;
 
         std::optional<MapAxes> m_mapaxes;
@@ -380,10 +381,10 @@ namespace Opm {
         std::vector<int> m_active_to_global;
         std::vector<int> m_global_to_active;
         // Numerical aquifer cells, needs to be active
-        std::unordered_set<size_t> m_aquifer_cells;
+        std::unordered_set<std::size_t> m_aquifer_cells;
         // Keep track of aquifer cell depths and (pvtnum,satnum)
-        std::map<size_t, double> m_aquifer_cell_depths;
-        std::map<size_t, std::array<int,2>> m_aquifer_cell_tabnums;
+        std::map<std::size_t, double> m_aquifer_cell_depths;
+        std::map<std::size_t, std::array<int,2>> m_aquifer_cell_tabnums;
         std::optional<std::vector<double>> m_depth;
 
         // Radial grids need this for volume calculations.
@@ -394,7 +395,7 @@ namespace Opm {
         void initializeLGRTreeIndices(void);
         void propagateParentIndicesToLGRChildren(int);
         void updateNumericalAquiferCells(const Deck&);
-        double computeCellGeometricDepth(size_t globalIndex) const;
+        double computeCellGeometricDepth(std::size_t globalIndex) const;
 
         void initGridFromEGridFile(Opm::EclIO::EclFile& egridfile,
                                    const std::string& fileName);
@@ -419,11 +420,11 @@ namespace Opm {
         void assertCornerPointKeywords(const Deck&);
         void save_all_lgr_labels(const LgrCollection& );
         static bool hasDTOPSKeywords(const Deck&);
-        static void assertVectorSize(const std::vector<double>& vector, size_t expectedSize, const std::string& msg);
+        static void assertVectorSize(const std::vector<double>& vector, std::size_t expectedSize, const std::string& msg);
 
         static std::vector<double> createTOPSVector(const std::array<int, 3>& dims, const std::vector<double>& DZ, const Deck&);
         static std::vector<double> createDVector(const std::array<int, 3>& dims, std::size_t dim, const std::string& DKey, const std::string& DVKey, const Deck&);
-        static void scatterDim(const std::array<int, 3>& dims , size_t dim , const std::vector<double>& DV , std::vector<double>& D);
+        static void scatterDim(const std::array<int, 3>& dims , std::size_t dim , const std::vector<double>& DV , std::vector<double>& D);
 
 
         std::vector<double> makeCoordDxDyDzTops(const std::vector<double>& dx, const std::vector<double>& dy, const std::vector<double>& dz, const std::vector<double>& tops) const;
@@ -539,8 +540,8 @@ namespace Opm {
 
     class CoordMapper {
     public:
-        CoordMapper(size_t nx, size_t ny);
-        size_t size() const;
+        CoordMapper(std::size_t nx, std::size_t ny);
+        std::size_t size() const;
 
 
         /*
@@ -548,10 +549,10 @@ namespace Opm {
           layer = 0,1 for k=0 and k=nz layers respectively.
         */
 
-        size_t index(size_t i, size_t j, size_t dim, size_t layer) const;
+        std::size_t index(std::size_t i, std::size_t j, std::size_t dim, std::size_t layer) const;
     private:
-        size_t nx;
-        size_t ny;
+        std::size_t nx;
+        std::size_t ny;
     };
 
 
@@ -562,10 +563,10 @@ namespace Opm {
             double value;
             std::size_t index;
         };
-        ZcornMapper(size_t nx, size_t ny, size_t nz);
-        size_t index(size_t i, size_t j, size_t k, int c) const;
-        size_t index(size_t g, int c) const;
-        size_t size() const;
+        ZcornMapper(std::size_t nx, std::size_t ny, std::size_t nz);
+        std::size_t index(std::size_t i, std::size_t j, std::size_t k, int c) const;
+        std::size_t index(std::size_t g, int c) const;
+        std::size_t size() const;
 
         /*
           The fixupZCORN method will take a zcorn vector as input and
@@ -582,14 +583,14 @@ namespace Opm {
              |/
 
         */
-        size_t fixupZCORN( std::vector<double>& zcorn);
+        std::size_t fixupZCORN( std::vector<double>& zcorn);
         bool validZCORN( const std::vector<double>& zcorn) const;
         void addZCORN( std::vector<double>& zcorn, const std::vector<AddZCornInput>& addzcorns) const;
 
     private:
-        std::array<size_t,3> dims;
-        std::array<size_t,3> stride;
-        std::array<size_t,8> cell_shift;
+        std::array<std::size_t,3> dims;
+        std::array<std::size_t,3> stride;
+        std::array<std::size_t,8> cell_shift;
     };
 }
 #endif // OPM_PARSER_ECLIPSE_GRID_HPP

--- a/opm/input/eclipse/EclipseState/Grid/FaultCollection.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FaultCollection.cpp
@@ -33,11 +33,11 @@
 
 #include <opm/input/eclipse/Parser/ParserKeywords/F.hpp>
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
 namespace Opm {
-
 
     FaultCollection::FaultCollection()
     {}
@@ -79,9 +79,9 @@ namespace Opm {
         int K2 = faultRecord.getItem(6).get<int>(0) - 1;
         FaceDir::DirEnum faceDir = FaceDir::FromString(faultRecord.getItem(7).get<std::string>(0));
         FaultFace face { grid.getNX(), grid.getNY(), grid.getNZ(),
-                         size_t(I1), size_t(I2),
-                         size_t(J1), size_t(J2),
-                         size_t(K1), size_t(K2),
+                         std::size_t(I1), std::size_t(I2),
+                         std::size_t(J1), std::size_t(J2),
+                         std::size_t(K1), std::size_t(K2),
                          faceDir };
 
         if (!hasFault(faultName))
@@ -90,7 +90,7 @@ namespace Opm {
         getFault( faultName ).addFace( face );
     }
 
-    size_t FaultCollection::size() const {
+    std::size_t FaultCollection::size() const {
         return m_faults.size();
     }
 
@@ -106,11 +106,11 @@ namespace Opm {
         return m_faults.get( faultName );
     }
 
-    Fault& FaultCollection::getFault(size_t faultIndex) {
+    Fault& FaultCollection::getFault(std::size_t faultIndex) {
         return m_faults.iget( faultIndex );
     }
 
-    const Fault& FaultCollection::getFault(size_t faultIndex) const {
+    const Fault& FaultCollection::getFault(std::size_t faultIndex) const {
         return m_faults.iget( faultIndex );
     }
 

--- a/opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp
@@ -19,18 +19,17 @@
 #ifndef OPM_PARSER_FAULT_COLLECTION_HPP
 #define OPM_PARSER_FAULT_COLLECTION_HPP
 
+#include <opm/input/eclipse/EclipseState/Grid/Fault.hpp>
+#include <opm/input/eclipse/EclipseState/Util/OrderedMap.hpp>
+
 #include <cstddef>
 #include <string>
-
-#include <opm/input/eclipse/EclipseState/Util/OrderedMap.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/Fault.hpp>
 
 namespace Opm {
 
     class DeckRecord;
     class GridDims;
     class GRIDSection;
-
 
 class FaultCollection {
 public:
@@ -39,12 +38,12 @@ public:
 
     static FaultCollection serializationTestObject();
 
-    size_t size() const;
+    std::size_t size() const;
     bool hasFault(const std::string& faultName) const;
     Fault& getFault(const std::string& faultName);
     const Fault& getFault(const std::string& faultName) const;
-    Fault& getFault(size_t faultIndex);
-    const Fault& getFault(size_t faultIndex) const;
+    Fault& getFault(std::size_t faultIndex);
+    const Fault& getFault(std::size_t faultIndex) const;
     std::vector<std::string> getFaults(const std::string& pattern) const;
 
     /// we construct the fault based on faultName.  To get the fault: getFault

--- a/opm/input/eclipse/EclipseState/Grid/FaultFace.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FaultFace.cpp
@@ -16,17 +16,19 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <opm/input/eclipse/EclipseState/Grid/FaultFace.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <stdexcept>
 
 namespace Opm {
 
-    FaultFace::FaultFace(size_t nx , size_t ny , size_t nz,
-                         size_t I1 , size_t I2,
-                         size_t J1 , size_t J2,
-                         size_t K1 , size_t K2,
+    FaultFace::FaultFace(std::size_t nx , std::size_t ny , std::size_t nz,
+                         std::size_t I1 , std::size_t I2,
+                         std::size_t J1 , std::size_t J2,
+                         std::size_t K1 , std::size_t K2,
                          FaceDir::DirEnum faceDir)
         : m_faceDir( faceDir )
     {
@@ -48,10 +50,10 @@ namespace Opm {
                 throw std::invalid_argument("When the face is in Z direction we must have K1 == K2");
 
 
-        for (size_t k=K1; k <= K2; k++)
-            for (size_t j=J1; j <= J2; j++)
-                for (size_t i=I1; i <= I2; i++) {
-                    size_t globalIndex = i + j*nx + k*nx*ny;
+        for (std::size_t k=K1; k <= K2; k++)
+            for (std::size_t j=J1; j <= J2; j++)
+                for (std::size_t i=I1; i <= I2; i++) {
+                    std::size_t globalIndex = i + j*nx + k*nx*ny;
                     m_indexList.push_back( globalIndex );
                 }
     }
@@ -65,7 +67,7 @@ namespace Opm {
         return result;
     }
 
-    void FaultFace::checkCoord(size_t dim , size_t l1 , size_t l2) {
+    void FaultFace::checkCoord(std::size_t dim , std::size_t l1 , std::size_t l2) {
         if (l1 > l2)
             throw std::invalid_argument("Invalid coordinates");
 
@@ -74,11 +76,11 @@ namespace Opm {
     }
 
 
-    std::vector<size_t>::const_iterator FaultFace::begin() const {
+    std::vector<std::size_t>::const_iterator FaultFace::begin() const {
         return m_indexList.begin();
     }
 
-    std::vector<size_t>::const_iterator FaultFace::end() const {
+    std::vector<std::size_t>::const_iterator FaultFace::end() const {
         return m_indexList.end();
     }
 

--- a/opm/input/eclipse/EclipseState/Grid/FaultFace.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FaultFace.hpp
@@ -19,27 +19,26 @@
 #ifndef OPM_PARSER_FAULT_FACE_HPP
 #define OPM_PARSER_FAULT_FACE_HPP
 
+#include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
+
 #include <cstddef>
 #include <vector>
 
-#include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
-
 namespace Opm {
-
 
 class FaultFace {
 public:
     FaultFace() = default;
-    FaultFace(size_t nx , size_t ny , size_t nz,
-              size_t I1 , size_t I2,
-              size_t J1 , size_t J2,
-              size_t K1 , size_t K2,
+    FaultFace(std::size_t nx , std::size_t ny , std::size_t nz,
+              std::size_t I1 , std::size_t I2,
+              std::size_t J1 , std::size_t J2,
+              std::size_t K1 , std::size_t K2,
               FaceDir::DirEnum faceDir);
 
     static FaultFace serializationTestObject();
 
-    std::vector<size_t>::const_iterator begin() const;
-    std::vector<size_t>::const_iterator end() const;
+    std::vector<std::size_t>::const_iterator begin() const;
+    std::vector<std::size_t>::const_iterator end() const;
     FaceDir::DirEnum getDir() const;
 
     bool operator==( const FaultFace& rhs ) const;
@@ -53,11 +52,10 @@ public:
     }
 
 private:
-    static void checkCoord(size_t dim , size_t l1 , size_t l2);
+    static void checkCoord(std::size_t dim , std::size_t l1 , std::size_t l2);
     FaceDir::DirEnum m_faceDir = FaceDir::XPlus;
-    std::vector<size_t> m_indexList;
+    std::vector<std::size_t> m_indexList;
 };
-
 
 }
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -341,7 +341,7 @@ void assign_deck(const Fieldprops::keywords::keyword_info<T>& kw_info,
     for (const auto& cell_index : box.index_list()) {
         auto active_index = cell_index.active_index;
         auto data_index = cell_index.data_index;
-        for (size_t i = 0; i < kw_info.num_value; ++i) {
+        for (std::size_t i = 0; i < kw_info.num_value; ++i) {
             auto deck_data_index = i* box.size() + data_index;
             if (value::has_value(deck_status[deck_data_index])) {
                 auto data_active_index = i * box.size() + active_index;
@@ -1926,7 +1926,7 @@ void FieldProps::init_tempi(Fieldprops::FieldData<double>& tempi)
         const auto& depth = this->init_get<double>("DEPTH").data;
         std::vector< double > tempi_values( this->active_size, 0 );
 
-        for (size_t active_index = 0; active_index < this->active_size; active_index++) {
+        for (std::size_t active_index = 0; active_index < this->active_size; active_index++) {
             const auto& table = rtempvd.getTable<RtempvdTable>(eqlnum[active_index] - 1);
             tempi_values[active_index] = table.evaluate("Temperature", depth[active_index]);
         }
@@ -2343,7 +2343,7 @@ void FieldProps::apply_tran(const std::string& keyword, std::vector<double>& dat
 }
 
 
-void FieldProps::apply_tranz_global(const std::vector<size_t>& indices, std::vector<double>& data) const
+void FieldProps::apply_tranz_global(const std::vector<std::size_t>& indices, std::vector<double>& data) const
 {
     ::Opm::apply_tran(this->tran.at("TRANZ"), this->double_data, indices, data);
 }
@@ -2368,7 +2368,7 @@ void FieldProps::apply_numerical_aquifers(const NumericalAquifers& numerical_aqu
 
     const auto& aqu_cell_props = numerical_aquifers.aquiferCellProps();
     for (const auto& [global_index, cellprop] : aqu_cell_props) {
-        const size_t active_index = this->grid_ptr->activeIndex(global_index);
+        const std::size_t active_index = this->grid_ptr->activeIndex(global_index);
         this->cell_volume[active_index] = cellprop.volume;
         depth_data[active_index] = cellprop.depth;
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -691,7 +691,7 @@ public:
     void handle_schedule_keywords(const std::vector<DeckKeyword>& keywords);
     bool tran_active(const std::string& keyword) const;
     void apply_tran(const std::string& keyword, std::vector<double>& data);
-    void apply_tranz_global(const std::vector<size_t>& indices, std::vector<double>& data) const;
+    void apply_tranz_global(const std::vector<std::size_t>& indices, std::vector<double>& data) const;
     bool operator==(const FieldProps& other) const;
     static bool rst_cmp(const FieldProps& full_arg, const FieldProps& rst_arg);
 

--- a/opm/input/eclipse/EclipseState/Grid/LgrCollection.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/LgrCollection.cpp
@@ -13,19 +13,24 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <opm/input/eclipse/EclipseState/Grid/LgrCollection.hpp>
+
 #include <opm/common/utility/OpmInputError.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
-#include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/Deck/DeckSection.hpp>
+
+#include <opm/input/eclipse/EclipseState/Grid/Carfin.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/CarfinManager.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/LgrCollection.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/CarfinManager.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/Carfin.hpp>
+
+#include <opm/input/eclipse/Deck/DeckRecord.hpp>
+#include <opm/input/eclipse/Deck/DeckSection.hpp>
+
 #include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
 
-namespace Opm {
+#include <cstddef>
 
+namespace Opm {
 
     LgrCollection::LgrCollection()
     {}
@@ -47,7 +52,7 @@ namespace Opm {
         }
     }
 
-    size_t LgrCollection::size() const {
+    std::size_t LgrCollection::size() const {
         return m_lgrs.size();
     }
 
@@ -63,14 +68,13 @@ namespace Opm {
         return m_lgrs.get( lgrName );
     }
 
-    const Carfin& LgrCollection::getLgr(size_t lgrIndex) const {
+    const Carfin& LgrCollection::getLgr(std::size_t lgrIndex) const {
         return m_lgrs.iget( lgrIndex );
     }
 
-    Carfin& LgrCollection::getLgr(size_t lgrIndex) {
+    Carfin& LgrCollection::getLgr(std::size_t lgrIndex) {
         return m_lgrs.iget( lgrIndex );
     }
-
 
     void LgrCollection::addLgr(const EclipseGrid& grid, const DeckRecord&  lgrRecord) {
        Carfin lgr(grid,

--- a/opm/input/eclipse/EclipseState/Grid/LgrCollection.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/LgrCollection.hpp
@@ -16,19 +16,20 @@
 #ifndef OPM_PARSER_LGR_COLLECTION_HPP
 #define OPM_PARSER_LGR_COLLECTION_HPP
 
-#include <string>
-
 #include <opm/input/eclipse/EclipseState/Util/OrderedMap.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/CarfinManager.hpp>
+
 #include <opm/input/eclipse/EclipseState/Grid/Carfin.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/CarfinManager.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+
+#include <cstddef>
+#include <string>
 
 namespace Opm {
 
     class DeckRecord;
     class GridDims;
     class GRIDSection;
-
 
 class LgrCollection {
 public:
@@ -39,12 +40,12 @@ public:
 
    explicit LgrCollection(const Deck& deck);
 
-    size_t size() const;
+    std::size_t size() const;
     bool hasLgr(const std::string& lgrName) const;
     Carfin& getLgr(const std::string& lgrName);
     const Carfin& getLgr(const std::string& lgrName) const;
-    Carfin& getLgr(size_t lgrIndex);
-    const Carfin& getLgr(size_t lgrIndex) const;
+    Carfin& getLgr(std::size_t lgrIndex);
+    const Carfin& getLgr(std::size_t lgrIndex) const;
 
     void addLgr(const EclipseGrid& grid, const DeckRecord& lgrRecord);
 

--- a/opm/input/eclipse/EclipseState/Grid/NNC.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/NNC.cpp
@@ -17,6 +17,19 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
+
+#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Deck/DeckItem.hpp>
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/input/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/N.hpp>
+
 #include <algorithm>
 #include <cstddef>
 #include <deque>
@@ -24,24 +37,15 @@
 #include <string>
 #include <utility>
 
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Deck/DeckItem.hpp>
-#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
-#include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
-#include <opm/input/eclipse/Parser/ParserKeywords/N.hpp>
-
 namespace Opm
 {
 
 namespace {
 
 std::optional<std::size_t> global_index(const EclipseGrid& grid, const DeckRecord& record, std::size_t item_offset) {
-    std::size_t i = static_cast<size_t>(record.getItem(0 + item_offset).get< int >(0)-1);
-    std::size_t j = static_cast<size_t>(record.getItem(1 + item_offset).get< int >(0)-1);
-    std::size_t k = static_cast<size_t>(record.getItem(2 + item_offset).get< int >(0)-1);
+    std::size_t i = static_cast<std::size_t>(record.getItem(0 + item_offset).get< int >(0)-1);
+    std::size_t j = static_cast<std::size_t>(record.getItem(1 + item_offset).get< int >(0)-1);
+    std::size_t k = static_cast<std::size_t>(record.getItem(2 + item_offset).get< int >(0)-1);
 
     if (i >= grid.getNX())
         return {};
@@ -57,7 +61,6 @@ std::optional<std::size_t> global_index(const EclipseGrid& grid, const DeckRecor
 
     return grid.getGlobalIndex(i,j,k);
 }
-
 
 std::optional<std::pair<std::size_t, std::size_t>> make_index_pair(const EclipseGrid& grid, const DeckRecord& record) {
     auto g1 = global_index(grid, record, 0);
@@ -99,7 +102,6 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
         this->load_editr(grid, deck);
     }
 
-
     void NNC::load_input(const EclipseGrid& grid, const Deck& deck) {
         for (const auto& keyword_ptr : deck.getKeywordList<ParserKeywords::NNC>()) {
             for (const auto& record : *keyword_ptr) {
@@ -118,7 +120,6 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
 
         std::sort(this->m_input.begin(), this->m_input.end());
     }
-
 
     void NNC::load_edit(const EclipseGrid& grid, const Deck& deck) {
         std::vector<NNCdata> nnc_edit;
@@ -276,7 +277,7 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
         return result;
     }
 
-    bool NNC::addNNC(const size_t cell1, const size_t cell2, const double trans) {
+    bool NNC::addNNC(const std::size_t cell1, const std::size_t cell2, const double trans) {
         if (cell1 > cell2)
             return this->addNNC(cell2, cell1, trans);
 
@@ -320,8 +321,6 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
         this->m_edit.push_back(edit_node);
     }
 
-
-
    /*
      In principle we can have multiple NNC keywords, and to provide a good error
      message we should be able to return the location of the offending NNC. That
@@ -336,7 +335,6 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
         else
             return {};
     }
-
 
     KeywordLocation NNC::edit_location(const NNCdata& /* nnc */) const {
         if (this->m_edit_location)
@@ -376,7 +374,7 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
 
 /// Inserts an NNC entry (cell1, cell2, trans) into the container, enforcing
 /// cell1 <= cell2.
-bool NNCDataContainer::addNNC(const size_t cell1, const size_t cell2, const double trans) {
+bool NNCDataContainer::addNNC(const std::size_t cell1, const std::size_t cell2, const double trans) {
     if (cell1 > cell2)
         return this->addNNC(cell2, cell1, trans);
     this->nnc_container.emplace_back(cell1,cell2, trans);
@@ -395,7 +393,6 @@ bool NNCDataContainer::operator==(const NNCDataContainer& other) const
     return nnc_container == other.nnc_container;
 }
 
-
 // ===========================================================================
 // NNCDataContainerDiffGrid — NNC storage for connections between two grids
 // ===========================================================================
@@ -403,7 +400,7 @@ bool NNCDataContainer::operator==(const NNCDataContainer& other) const
 /// Inserts a cross-grid NNC entry without enforcing any cell ordering, since
 /// cell1 and cell2 belong to different grids and swapping them would lose
 /// the grid-association information.
-bool NNCDataContainerDiffGrid::addNNC(const size_t cell1, const size_t cell2, const double trans)
+bool NNCDataContainerDiffGrid::addNNC(const std::size_t cell1, const std::size_t cell2, const double trans)
 {
     nnc_container.emplace_back(cell1, cell2, trans);
     return true;
@@ -424,7 +421,6 @@ bool NNCDataContainerDiffGrid::operator==(const NNCDataContainerDiffGrid& other)
 {
     return NNCDataContainer::operator==(other);
 }
-
 
 // ===========================================================================
 // NNCCollection — indexed collection of same-grid and cross-grid NNCs

--- a/opm/input/eclipse/EclipseState/Grid/NNC.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/NNC.hpp
@@ -20,13 +20,13 @@
 #ifndef OPM_PARSER_NNC_HPP
 #define OPM_PARSER_NNC_HPP
 
+#include <opm/common/OpmLog/KeywordLocation.hpp>
+
 #include <cstddef>
+#include <map>
 #include <optional>
 #include <tuple>
-#include <map>
 #include <vector>
-
-#include <opm/common/OpmLog/KeywordLocation.hpp>
 
 namespace Opm
 {
@@ -34,7 +34,7 @@ namespace Opm
 class GridDims;
 
 struct NNCdata {
-    NNCdata(size_t c1, size_t c2, double t)
+    NNCdata(std::size_t c1, std::size_t c2, double t)
         : cell1(c1), cell2(c2), trans(t)
     {}
     NNCdata() = default;
@@ -61,12 +61,10 @@ struct NNCdata {
         return std::tie(this->cell1, this->cell2) < std::tie(other.cell1, other.cell2);
     }
 
-    size_t cell1{};
-    size_t cell2{};
+    std::size_t cell1{};
+    std::size_t cell2{};
     double trans{};
 };
-
-
 
 class Deck;
 class EclipseGrid;
@@ -109,7 +107,7 @@ public:
 
     static NNC serializationTestObject();
 
-    virtual bool addNNC(const size_t cell1, const size_t cell2, const double trans);
+    virtual bool addNNC(const std::size_t cell1, const std::size_t cell2, const double trans);
 
     /// \brief Merge additional NNCs into sorted NNCs
     virtual void merge(const std::vector<NNCdata>& nncs);
@@ -122,7 +120,6 @@ public:
     KeywordLocation input_location(const NNCdata& nnc) const;
     KeywordLocation edit_location(const NNCdata& nnc) const;
     KeywordLocation editr_location(const NNCdata& nnc) const;
-
 
     bool operator==(const NNC& data) const;
 
@@ -157,14 +154,13 @@ private:
     friend class NNCDiffGrid;
 };
 
-
 class NNCDataContainer
 {
     public:
     NNCDataContainer() = default;
     virtual ~NNCDataContainer() = default;
 
-    virtual bool addNNC(const size_t cell1, const size_t cell2, const double trans);
+    virtual bool addNNC(const std::size_t cell1, const std::size_t cell2, const double trans);
     bool addNNC(const NNCdata nnc_data);
 
     const std::vector<NNCdata>& input() const { return nnc_container; }
@@ -174,8 +170,6 @@ class NNCDataContainer
     protected:
     std::vector<NNCdata> nnc_container;
 };
-
-
 
 /*
   NNCDiffGrid is derived class of NNC.  NNC Class as it does not preserve the
@@ -187,14 +181,13 @@ public:
     NNCDataContainerDiffGrid() = default;
     ~NNCDataContainerDiffGrid() override = default;
 
-    bool addNNC(const size_t cell1, const size_t cell2,
+    bool addNNC(const std::size_t cell1, const std::size_t cell2,
                 const double trans) override;
 
     void swap_adj(std::size_t grid1, std::size_t grid2);
 
     bool operator==(const NNCDataContainerDiffGrid& other) const;
 };
-
 
 class NNCCollection
 {
@@ -267,7 +260,6 @@ public:
         return false;
     }
 
-
     /// Returns a view of all same-grid NNCs as (grid_index, NNC) pairs.
     const std::map<std::size_t, NNCDataContainer>& same_grid_nnc() const
     {
@@ -321,6 +313,5 @@ private:
 };
 
 } // namespace Opm
-
 
 #endif // OPM_PARSER_NNC_HPP

--- a/opm/input/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cstddef>
 #include <exception>
 #include <functional>
 #include <iterator>
@@ -48,8 +49,6 @@
 #include <string>
 #include <type_traits>
 #include <utility>
-
-#include <stddef.h>
 
 // Note on deriving critical saturations: All table scanners are implemented
 // in terms of std::lower_bound(begin, end, tolcrit, predicate) which returns
@@ -1467,7 +1466,7 @@ namespace {
     }
 
     std::vector<double>
-    satnumApply(size_t size,
+    satnumApply(std::size_t size,
                 const std::string& columnName,
                 const std::vector< double >& fallbackValues,
                 const Opm::TableManager& tableManager,
@@ -1485,7 +1484,7 @@ namespace {
         // assign a NaN in this case...
         const bool useEnptvd = tableManager.useEnptvd();
         const auto& enptvdTables = tableManager.getEnptvdTables();
-        for( size_t cellIdx = 0; cellIdx < values.size(); cellIdx++ ) {
+        for( std::size_t cellIdx = 0; cellIdx < values.size(); cellIdx++ ) {
             int satTableIdx = satnum_data[cellIdx] - 1;
             int endNum = endnum_data[cellIdx] - 1;
 
@@ -1504,7 +1503,7 @@ namespace {
     }
 
     std::vector<double>
-    imbnumApply(size_t size,
+    imbnumApply(std::size_t size,
                 const std::string& columnName,
                 const std::vector< double >& fallBackValues,
                 const Opm::TableManager& tableManager,
@@ -1522,7 +1521,7 @@ namespace {
         // assign a NaN in this case...
         const bool useImptvd = tableManager.useImptvd();
         const Opm::TableContainer& imptvdTables = tableManager.getImptvdTables();
-        for( size_t cellIdx = 0; cellIdx < values.size(); cellIdx++ ) {
+        for( std::size_t cellIdx = 0; cellIdx < values.size(); cellIdx++ ) {
             int imbTableIdx = imbnum_data[ cellIdx ] - 1;
             int endNum = endnum_data[ cellIdx ] - 1;
 

--- a/opm/input/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/TransMult.cpp
@@ -17,29 +17,35 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdexcept>
-
-#include <fmt/format.h>
+#include <opm/input/eclipse/EclipseState/Grid/TransMult.hpp>
 
 #include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
+
 #include <opm/common/utility/OpmInputError.hpp>
 
-#include <opm/common/OpmLog/OpmLog.hpp>
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/input/eclipse/Deck/DeckSection.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/Fault.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/FaultFace.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/TransMult.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
-#include <opm/input/eclipse/Parser/ParserKeywords/M.hpp>
-#include <opm/input/eclipse/Units/UnitSystem.hpp>
 #include <opm/output/data/Cells.hpp>
 #include <opm/output/data/Solution.hpp>
 
+#include <opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FaultFace.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/Fault.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
+
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/input/eclipse/Deck/DeckSection.hpp>
+
+#include <opm/input/eclipse/Parser/ParserKeywords/M.hpp>
+
+#include <stdexcept>
+#include <cstddef>
+
+#include <fmt/format.h>
 
 namespace Opm {
 
@@ -78,26 +84,24 @@ namespace Opm {
         return result;
     }
 
-    void TransMult::assertIJK(size_t i , size_t j , size_t k) const {
+    void TransMult::assertIJK(std::size_t i , std::size_t j , std::size_t k) const {
         if ((i >= m_nx) || (j >= m_ny) || (k >= m_nz))
             throw std::invalid_argument("Invalid ijk");
     }
 
-
-    size_t TransMult::getGlobalIndex(size_t i , size_t j , size_t k) const {
+    std::size_t TransMult::getGlobalIndex(std::size_t i , std::size_t j , std::size_t k) const {
         assertIJK(i,j,k);
         return i + j*m_nx + k*m_nx*m_ny;
     }
 
-
-    double TransMult::getMultiplier(size_t globalIndex,  FaceDir::DirEnum faceDir) const {
+    double TransMult::getMultiplier(std::size_t globalIndex,  FaceDir::DirEnum faceDir) const {
         if (globalIndex < m_nx * m_ny * m_nz)
             return this->getMultiplier__(globalIndex , faceDir);
         else
             throw std::invalid_argument("Invalid global index");
     }
 
-    double TransMult::getMultiplier__(size_t globalIndex,  FaceDir::DirEnum faceDir) const {
+    double TransMult::getMultiplier__(std::size_t globalIndex,  FaceDir::DirEnum faceDir) const {
         if (hasDirectionProperty( faceDir )) {
             const auto& data = m_trans.at(faceDir);
             return data[globalIndex];
@@ -105,15 +109,12 @@ namespace Opm {
             return 1.0;
     }
 
-
-
-
-    double TransMult::getMultiplier(size_t i , size_t j , size_t k, FaceDir::DirEnum faceDir) const {
-        size_t globalIndex = this->getGlobalIndex(i,j,k);
+    double TransMult::getMultiplier(std::size_t i , std::size_t j , std::size_t k, FaceDir::DirEnum faceDir) const {
+        std::size_t globalIndex = this->getGlobalIndex(i,j,k);
         return getMultiplier__( globalIndex , faceDir );
     }
 
-    double TransMult::getRegionMultiplier(size_t globalCellIndex1,  size_t globalCellIndex2, FaceDir::DirEnum faceDir) const {
+    double TransMult::getRegionMultiplier(std::size_t globalCellIndex1,  std::size_t globalCellIndex2, FaceDir::DirEnum faceDir) const {
         return m_multregtScanner.getRegionMultiplier(globalCellIndex1, globalCellIndex2, faceDir);
     }
 
@@ -124,7 +125,6 @@ namespace Opm {
     bool TransMult::hasDirectionProperty(FaceDir::DirEnum faceDir) const {
         return m_trans.count(faceDir) == 1;
     }
-
 
     std::vector<double>& TransMult::getDirectionProperty(FaceDir::DirEnum faceDir) {
         if (m_trans.count(faceDir) == 0) {
@@ -138,10 +138,9 @@ namespace Opm {
     void TransMult::applyMULT(const std::vector<double>& srcData, FaceDir::DirEnum faceDir)
     {
         auto& dstProp = this->getDirectionProperty(faceDir);
-        for (size_t i = 0; i < srcData.size(); ++i)
+        for (std::size_t i = 0; i < srcData.size(); ++i)
             dstProp[i] *= srcData[i];
     }
-
 
     void TransMult::applyMULTFLT(const Fault& fault) {
         double transMult = fault.getTransMult();
@@ -155,9 +154,8 @@ namespace Opm {
         }
     }
 
-
     void TransMult::applyMULTFLT(const FaultCollection& faults) {
-        for (size_t faultIndex = 0; faultIndex < faults.size(); faultIndex++) {
+        for (std::size_t faultIndex = 0; faultIndex < faults.size(); faultIndex++) {
             auto& fault = faults.getFault(faultIndex);
             this->applyMULTFLT(fault);
         }

--- a/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
@@ -29,13 +29,12 @@
 #ifndef OPM_PARSER_TRANSMULT_HPP
 #define OPM_PARSER_TRANSMULT_HPP
 
+#include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
 
 #include <cstddef>
 #include <map>
 #include <memory>
-
-#include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
 
 namespace Opm {
     namespace data {
@@ -57,9 +56,9 @@ namespace Opm {
 
         static TransMult serializationTestObject();
 
-        double getMultiplier(size_t globalIndex, FaceDir::DirEnum faceDir) const;
-        double getMultiplier(size_t i , size_t j , size_t k, FaceDir::DirEnum faceDir) const;
-        double getRegionMultiplier( size_t globalCellIndex1, size_t globalCellIndex2, FaceDir::DirEnum faceDir) const;
+        double getMultiplier(std::size_t globalIndex, FaceDir::DirEnum faceDir) const;
+        double getMultiplier(std::size_t i , std::size_t j , std::size_t k, FaceDir::DirEnum faceDir) const;
+        double getRegionMultiplier( std::size_t globalCellIndex1, std::size_t globalCellIndex2, FaceDir::DirEnum faceDir) const;
         double getRegionMultiplierNNC(std::size_t globalCellIndex1, std::size_t globalCellIndex2) const;
         void applyMULT(const std::vector<double>& srcMultProp, FaceDir::DirEnum faceDir);
         void applyMULTFLT(const FaultCollection& faults);
@@ -88,13 +87,13 @@ namespace Opm {
         }
 
     private:
-        size_t getGlobalIndex(size_t i , size_t j , size_t k) const;
-        void assertIJK(size_t i , size_t j , size_t k) const;
-        double getMultiplier__(size_t globalIndex , FaceDir::DirEnum faceDir) const;
+        std::size_t getGlobalIndex(std::size_t i , std::size_t j , std::size_t k) const;
+        void assertIJK(std::size_t i , std::size_t j , std::size_t k) const;
+        double getMultiplier__(std::size_t globalIndex , FaceDir::DirEnum faceDir) const;
         bool hasDirectionProperty(FaceDir::DirEnum faceDir) const;
         std::vector<double>& getDirectionProperty(FaceDir::DirEnum faceDir);
 
-        size_t m_nx = 0, m_ny = 0, m_nz = 0;
+        std::size_t m_nx = 0, m_ny = 0, m_nz = 0;
         std::map<FaceDir::DirEnum , std::vector<double> > m_trans;
         std::map<FaceDir::DirEnum , std::string> m_names;
         MULTREGTScanner m_multregtScanner;

--- a/opm/input/eclipse/EclipseState/IOConfig/FIPConfig.cpp
+++ b/opm/input/eclipse/EclipseState/IOConfig/FIPConfig.cpp
@@ -19,12 +19,13 @@
 
 #include <opm/input/eclipse/EclipseState/IOConfig/FIPConfig.hpp>
 
+#include <opm/input/eclipse/Schedule/RPTConfig.hpp>
+
 #include <opm/input/eclipse/Deck/DeckSection.hpp>
 
 #include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
 
-#include <opm/input/eclipse/Schedule/RPTConfig.hpp>
-
+#include <cstddef>
 #include <vector>
 
 namespace Opm {
@@ -52,7 +53,7 @@ void FIPConfig::parseRPT(const RPTConfig& rptConfig)
     auto parseFlags = [this](const std::vector<int>& flags,
                              const unsigned value)
     {
-        for (size_t i = 0; i < flags.size(); ++i) {
+        for (std::size_t i = 0; i < flags.size(); ++i) {
             if (value > i) {
                 m_flags.set(flags[i]);
             }

--- a/opm/input/eclipse/EclipseState/InitConfig/Equil.hpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/Equil.hpp
@@ -154,7 +154,7 @@ namespace Opm {
 
             const RecordType& getRecord(std::size_t id) const;
 
-            size_t size() const;
+            std::size_t size() const;
             bool empty() const;
 
             const_iterator begin() const;

--- a/opm/input/eclipse/EclipseState/Runspec.cpp
+++ b/opm/input/eclipse/EclipseState/Runspec.cpp
@@ -43,6 +43,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <ctime>
 #include <stdexcept>
 #include <string>
@@ -175,7 +176,7 @@ bool Phases::active( Phase p ) const noexcept {
     return this->bits[ static_cast< int >( p ) ];
 }
 
-size_t Phases::size() const noexcept {
+std::size_t Phases::size() const noexcept {
     return this->bits.count();
 }
 
@@ -1064,7 +1065,7 @@ bool Runspec::compositionalMode() const
     return this->m_comps > 0;
 }
 
-size_t Runspec::numComps() const
+std::size_t Runspec::numComps() const
 {
     return this->m_comps;
 }

--- a/opm/input/eclipse/EclipseState/Runspec.hpp
+++ b/opm/input/eclipse/EclipseState/Runspec.hpp
@@ -58,7 +58,7 @@ public:
     static Phases serializationTestObject();
 
     bool active( Phase ) const noexcept;
-    size_t size() const noexcept;
+    std::size_t size() const noexcept;
 
     bool operator==(const Phases& data) const;
 
@@ -633,7 +633,7 @@ public:
     const Tracers& tracers() const;
     const Geochem& geochem() const;
     bool compositionalMode() const;
-    size_t numComps() const;
+    std::size_t numComps() const;
     bool co2Storage() const noexcept;
     bool co2Sol() const noexcept;
     bool h2Sol() const noexcept;
@@ -698,7 +698,7 @@ private:
     MechSolver m_mechsolver{};
     Tracers m_tracers{};
     Geochem m_geochem{};
-    size_t m_comps = 0;
+    std::size_t m_comps = 0;
     bool m_co2storage{false};
     bool m_co2sol{false};
     bool m_h2sol{false};

--- a/opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -17,16 +17,22 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
+
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/shmatch.hpp>
-#include <opm/input/eclipse/Deck/DeckSection.hpp>
+
 #include <opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
-#include <opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
+
+#include <opm/input/eclipse/Deck/DeckSection.hpp>
+
 #include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/V.hpp>
+
+#include <cstddef>
 
 namespace Opm {
 
@@ -105,7 +111,6 @@ namespace Opm {
                 throw std::runtime_error("Error in EQLNUM data: all values are 0");
             }
 
-
             // Fill threshold pressure table.
             const auto& thpres = solutionSection.get<ParserKeywords::THPRES>().back();
 
@@ -147,13 +152,13 @@ namespace Opm {
         // extract the multipliers from the deck keyword
         m_thresholdFaultTable.resize(faults.size(), -1.0);
         for (const auto& thpresft : gridSection.get<ParserKeywords::THPRESFT>()) {
-            for (size_t recordIdx = 0; recordIdx < thpresft.size(); ++ recordIdx) {
+            for (std::size_t recordIdx = 0; recordIdx < thpresft.size(); ++ recordIdx) {
                 const DeckRecord& record = thpresft.getRecord(recordIdx);
 
                 const std::string& faultName = record.getItem("FAULT_NAME").getTrimmedString(0);
                 double thpresValue = record.getItem("VALUE").getSIDouble(0);
 
-                for (size_t faultIdx = 0; faultIdx < faults.size(); faultIdx++) {
+                for (std::size_t faultIdx = 0; faultIdx < faults.size(); faultIdx++) {
                     auto& fault = faults.getFault(faultIdx);
                     if (!shmatch(faultName, fault.getName()))
                         continue;
@@ -182,7 +187,6 @@ namespace Opm {
         else
             return true;
     }
-
 
     double ThresholdPressure::getThresholdPressure(int r1 , int r2) const {
         std::pair<int,int> indexPair = this->makeIndex(r1,r2);
@@ -231,11 +235,11 @@ namespace Opm {
         addPair( r1,r2, valuePair );
     }
 
-    size_t ThresholdPressure::size() const {
+    std::size_t ThresholdPressure::size() const {
         return m_pressureTable.size();
     }
 
-    size_t ThresholdPressure::ftSize() const {
+    std::size_t ThresholdPressure::ftSize() const {
         return m_thresholdFaultTable.size();
     }
 
@@ -269,7 +273,6 @@ namespace Opm {
                this->m_thresholdPressureTable == data.m_thresholdPressureTable &&
                this->m_pressureTable == data.m_pressureTable;
     }
-
 
     bool ThresholdPressure::rst_cmp(const ThresholdPressure& full_arg, const ThresholdPressure& rst_arg) {
         return full_arg.active() == rst_arg.active() &&

--- a/opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
@@ -84,8 +84,8 @@ namespace Opm {
         //! \brief Returns threshold pressure for a fault.
         double getThresholdPressureFault(int idx) const;
 
-        size_t ftSize() const;
-        size_t size() const;
+        std::size_t ftSize() const;
+        std::size_t size() const;
         bool active() const;
         bool restart() const;
         bool irreversible() const;

--- a/opm/input/eclipse/EclipseState/Tables/Aqudims.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/Aqudims.hpp
@@ -53,42 +53,42 @@ namespace Opm {
             return result;
         }
 
-        size_t getNumAqunum() const
+        std::size_t getNumAqunum() const
         {
             return m_mxnaqn;
         }
 
-        size_t getNumConnectionNumericalAquifer() const
+        std::size_t getNumConnectionNumericalAquifer() const
         {
             return m_mxnaqc;
         }
 
-        size_t getNumInfluenceTablesCT() const
+        std::size_t getNumInfluenceTablesCT() const
         {
             return m_niftbl;
         }
 
-        size_t getNumRowsInfluenceTable() const
+        std::size_t getNumRowsInfluenceTable() const
         {
             return m_nriftb;
         }
 
-        size_t getNumAnalyticAquifers() const
+        std::size_t getNumAnalyticAquifers() const
         {
             return m_nanaqu;
         }
 
-        size_t getNumRowsAquancon() const
+        std::size_t getNumRowsAquancon() const
         {
             return m_ncamax;
         }
 
-        size_t getNumAquiferLists() const
+        std::size_t getNumAquiferLists() const
         {
             return m_mxnali;
         }
 
-        size_t getNumAnalyticAquifersSingleList() const
+        std::size_t getNumAnalyticAquifersSingleList() const
         {
             return m_mxaaql;
         }
@@ -119,7 +119,7 @@ namespace Opm {
         }
 
     private:
-        size_t m_mxnaqn , m_mxnaqc , m_niftbl , m_nriftb , m_nanaqu , m_ncamax , m_mxnali , m_mxaaql;
+        std::size_t m_mxnaqn , m_mxnaqc , m_niftbl , m_nriftb , m_nanaqu , m_ncamax , m_mxnali , m_mxaaql;
 
     };
 }

--- a/opm/input/eclipse/EclipseState/Tables/Bdensity.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Bdensity.cpp
@@ -17,15 +17,18 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <vector>
+#include <opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.hpp>
+
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.hpp>
+
+#include <cstddef>
+#include <vector>
 
 namespace Opm {
 
-        static const size_t numEntries = 5;
+        static const std::size_t numEntries = 5;
         PvtwsaltTable::PvtwsaltTable()
         {
         }
@@ -38,7 +41,7 @@ namespace Opm {
             m_tableValues = record1.getItem("DATA").getSIDoubleData();
         }
 
-        size_t PvtwsaltTable::size() const
+        std::size_t PvtwsaltTable::size() const
         {
             return m_tableValues.size()/numEntries;
         }
@@ -55,9 +58,9 @@ namespace Opm {
 
         std::vector<double> PvtwsaltTable::getSaltConcentrationColumn() const
         {
-            size_t tableindex = 0;
+            std::size_t tableindex = 0;
             std::vector<double> saltCons(this->size());
-            for(size_t i=0; i<this->size(); ++i){
+            for(std::size_t i=0; i<this->size(); ++i){
                 saltCons[i] = m_tableValues[tableindex];
                 tableindex = tableindex+numEntries;
             }
@@ -67,9 +70,9 @@ namespace Opm {
 
         std::vector<double> PvtwsaltTable::getFormationVolumeFactorColumn() const
         {
-            size_t tableindex = 1;
+            std::size_t tableindex = 1;
             std::vector<double> formationvolumefactor(this->size());
-            for(size_t i=0; i<this->size(); ++i){
+            for(std::size_t i=0; i<this->size(); ++i){
                 formationvolumefactor[i] = m_tableValues[tableindex];
                 tableindex = tableindex+numEntries;
             }
@@ -79,9 +82,9 @@ namespace Opm {
 
         std::vector<double> PvtwsaltTable::getCompressibilityColumn() const
         {
-            size_t tableindex = 2;
+            std::size_t tableindex = 2;
             std::vector<double> compresibility(this->size());
-            for(size_t i=0; i<this->size(); ++i){
+            for(std::size_t i=0; i<this->size(); ++i){
                 compresibility[i] = m_tableValues[tableindex];
                 tableindex = tableindex+numEntries;
             }
@@ -91,9 +94,9 @@ namespace Opm {
 
         std::vector<double> PvtwsaltTable::getViscosityColumn() const
         {
-            size_t tableindex = 3;
+            std::size_t tableindex = 3;
             std::vector<double> viscosity(this->size());
-            for(size_t i=0; i<this->size(); ++i){
+            for(std::size_t i=0; i<this->size(); ++i){
                 viscosity[i] = m_tableValues[tableindex];
                 tableindex = tableindex+numEntries;
             }
@@ -103,9 +106,9 @@ namespace Opm {
 
         std::vector<double> PvtwsaltTable::getViscosibilityColumn() const
         {
-            size_t tableindex = 4;
+            std::size_t tableindex = 4;
             std::vector<double> viscosibility(this->size());
-            for(size_t i=0; i<this->size(); ++i){
+            for(std::size_t i=0; i<this->size(); ++i){
                 viscosibility[i] = m_tableValues[tableindex];
                 tableindex = tableindex+numEntries;
             }

--- a/opm/input/eclipse/EclipseState/Tables/BrineDensityTable.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/BrineDensityTable.cpp
@@ -17,11 +17,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <vector>
+#include <opm/input/eclipse/EclipseState/Tables/BrineDensityTable.hpp>
+
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/BrineDensityTable.hpp>
+
+#include <vector>
 
 namespace Opm {
         BrineDensityTable BrineDensityTable::serializationTestObject()

--- a/opm/input/eclipse/EclipseState/Tables/BrineDensityTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/BrineDensityTable.hpp
@@ -20,9 +20,16 @@
 #ifndef OPM_PARSER_BRINEDENSITY_TABLE_HPP
 #define	OPM_PARSER_BRINEDENSITY_TABLE_HPP
 
+#include <cstddef>
+#include <vector>
+
 namespace Opm {
 
-    class DeckItem;
+    class DeckRecord;
+
+} // namespace Opm
+
+namespace Opm {
 
     class BrineDensityTable {
     public:

--- a/opm/input/eclipse/EclipseState/Tables/Eqldims.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/Eqldims.hpp
@@ -34,7 +34,7 @@ namespace Opm {
 
         Eqldims();
 
-        Eqldims( size_t ntequl , size_t depth_nodes_p , size_t depth_nodes_tab , size_t nttrvd , size_t nstrvd) :
+        Eqldims( std::size_t ntequl , std::size_t depth_nodes_p , std::size_t depth_nodes_tab , std::size_t nttrvd , std::size_t nstrvd) :
             m_ntequl( ntequl ),
             m_depth_nodes_p( depth_nodes_p ),
             m_depth_nodes_tab( depth_nodes_tab ),
@@ -47,28 +47,28 @@ namespace Opm {
             return Eqldims(1, 2, 3, 4, 5);
         }
 
-        size_t getNumEquilRegions() const
+        std::size_t getNumEquilRegions() const
         {
             return m_ntequl;
         }
 
-        size_t getNumDepthNodesP() const
+        std::size_t getNumDepthNodesP() const
         {
             return m_depth_nodes_p;
         }
 
 
-        size_t getNumDepthNodesTable() const
+        std::size_t getNumDepthNodesTable() const
         {
             return m_depth_nodes_tab;
         }
 
-        size_t getNumTracerTables() const
+        std::size_t getNumTracerTables() const
         {
             return m_nttrvd;
         }
 
-        size_t getNumDepthNodesTracer() const
+        std::size_t getNumDepthNodesTracer() const
         {
             return m_nstrvd;
         }
@@ -93,7 +93,7 @@ namespace Opm {
         }
 
     private:
-        size_t m_ntequl , m_depth_nodes_p , m_depth_nodes_tab , m_nttrvd , m_nstrvd;
+        std::size_t m_ntequl , m_depth_nodes_p , m_depth_nodes_tab , m_nttrvd , m_nstrvd;
 
     };
 }

--- a/opm/input/eclipse/EclipseState/Tables/PolyInjTables.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/PolyInjTables.cpp
@@ -17,22 +17,23 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 /* This is the implementation for the following three keywords related to
  * polymer injectivity study :
  * PLYMWINJ, SKPRWAT, SKPRPOLY
  */
+
+#include <opm/input/eclipse/EclipseState/Tables/PolyInjTable.hpp>
+
+#include <opm/input/eclipse/EclipseState/Tables/PlymwinjTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SkprpolyTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SkprwatTable.hpp>
 
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 
 #include <opm/input/eclipse/Parser/ParserKeywords/P.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>
 
-#include <opm/input/eclipse/EclipseState/Tables/PolyInjTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PlymwinjTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SkprwatTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SkprpolyTable.hpp>
-
+#include <cstddef>
 
 namespace Opm{
 
@@ -76,8 +77,6 @@ namespace Opm{
                this->getTableData() == data.getTableData();
     }
 
-
-
     // PlymwinjTable
     PlymwinjTable PlymwinjTable::serializationTestObject()
     {
@@ -100,7 +99,7 @@ namespace Opm{
         }
 
         m_throughputs = table.getRecord(1).getItem<PLYMWINJ::THROUGHPUT>().getSIDoubleData();
-        const size_t num_cols = m_throughputs.size();
+        const std::size_t num_cols = m_throughputs.size();
 
         if (table.size() != num_cols + 3) {
             const std::string msg = "PLYMWINJ table " + std::to_string(m_table_number)
@@ -109,9 +108,9 @@ namespace Opm{
         }
 
         m_velocities = table.getRecord(2).getItem<PLYMWINJ::VELOCITY>().getSIDoubleData();
-        const size_t num_rows = m_velocities.size();
+        const std::size_t num_rows = m_velocities.size();
 
-        for (size_t i = 3; i < table.size(); ++i) {
+        for (std::size_t i = 3; i < table.size(); ++i) {
             const DeckRecord& record_i = table.getRecord(i);
             const std::vector<double>& data_i = record_i.getItem<PLYMWINJ::MOLECULARWEIGHT>().getSIDoubleData();
             if (data_i.size() != num_rows) {
@@ -135,7 +134,6 @@ namespace Opm{
         return static_cast<const PolyInjTable&>(*this) == static_cast<const PolyInjTable&>(data);
     }
 
-
     // SkprwatTable
     SkprwatTable SkprwatTable::serializationTestObject()
     {
@@ -158,7 +156,7 @@ namespace Opm{
         }
 
         m_throughputs = table.getRecord(1).getItem<SKPRWAT::THROUGHPUT>().getSIDoubleData();
-        const size_t num_cols = m_throughputs.size();
+        const std::size_t num_cols = m_throughputs.size();
 
         if (table.size() != num_cols + 3) {
             const std::string msg = "SKPRWAT table " + std::to_string(m_table_number)
@@ -167,9 +165,9 @@ namespace Opm{
         }
 
         m_velocities = table.getRecord(2).getItem<SKPRWAT::VELOCITY>().getSIDoubleData();
-        const size_t num_rows = m_velocities.size();
+        const std::size_t num_rows = m_velocities.size();
 
-        for (size_t i = 3; i < table.size(); ++i) {
+        for (std::size_t i = 3; i < table.size(); ++i) {
             const DeckRecord& record_i = table.getRecord(i);
             const std::vector<double>& data_i = record_i.getItem<SKPRWAT::SKINPRESSURE>().getSIDoubleData();
             if (data_i.size() != num_rows) {
@@ -223,7 +221,7 @@ namespace Opm{
         }
 
         m_throughputs = table.getRecord(1).getItem<SKPRPOLY::THROUGHPUT>().getSIDoubleData();
-        const size_t num_cols = m_throughputs.size();
+        const std::size_t num_cols = m_throughputs.size();
 
         if (table.size() != num_cols + 3) {
             const std::string msg = "SKPRPOLY table " + std::to_string(m_table_number)
@@ -232,9 +230,9 @@ namespace Opm{
         }
 
         m_velocities = table.getRecord(2).getItem<SKPRPOLY::VELOCITY>().getSIDoubleData();
-        const size_t num_rows = m_velocities.size();
+        const std::size_t num_rows = m_velocities.size();
 
-        for (size_t i = 3; i < table.size(); ++i) {
+        for (std::size_t i = 3; i < table.size(); ++i) {
             const DeckRecord& record_i = table.getRecord(i);
             const std::vector<double>& data_i = record_i.getItem<SKPRPOLY::SKINPRESSURE>().getSIDoubleData();
             if (data_i.size() != num_rows) {

--- a/opm/input/eclipse/EclipseState/Tables/PvtgTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtgTable.hpp
@@ -21,6 +21,8 @@
 
 #include <opm/input/eclipse/EclipseState/Tables/PvtxTable.hpp>
 
+#include <cstddef>
+
 namespace Opm {
 
     class DeckKeyword;
@@ -28,7 +30,7 @@ namespace Opm {
     class PvtgTable : public PvtxTable {
     public:
         PvtgTable() = default;
-        PvtgTable( const DeckKeyword& keyword, size_t tableIdx);
+        PvtgTable( const DeckKeyword& keyword, std::size_t tableIdx);
 
         static PvtgTable serializationTestObject();
 

--- a/opm/input/eclipse/EclipseState/Tables/PvtgwTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtgwTable.hpp
@@ -22,6 +22,8 @@
 
 #include <opm/input/eclipse/EclipseState/Tables/PvtxTable.hpp>
 
+#include <cstddef>
+
 namespace Opm {
 
     class DeckKeyword;
@@ -29,7 +31,7 @@ namespace Opm {
     class PvtgwTable : public PvtxTable {
     public:
         PvtgwTable() = default;
-        PvtgwTable( const DeckKeyword& keyword, size_t tableIdx);
+        PvtgwTable( const DeckKeyword& keyword, std::size_t tableIdx);
 
         static PvtgwTable serializationTestObject();
 

--- a/opm/input/eclipse/EclipseState/Tables/PvtgwoTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtgwoTable.hpp
@@ -22,6 +22,8 @@
 
 #include <opm/input/eclipse/EclipseState/Tables/PvtxTable.hpp>
 
+#include <cstddef>
+
 namespace Opm {
 
     class DeckKeyword;
@@ -29,7 +31,7 @@ namespace Opm {
     class PvtgwoTable : public PvtxTable {
     public:
         PvtgwoTable() = default;
-        PvtgwoTable( const DeckKeyword& keyword, size_t tableIdx);
+        PvtgwoTable( const DeckKeyword& keyword, std::size_t tableIdx);
 
         static PvtgwoTable serializationTestObject();
 

--- a/opm/input/eclipse/EclipseState/Tables/PvtoTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtoTable.hpp
@@ -38,7 +38,7 @@ namespace Opm {
         };
 
         PvtoTable() = default;
-        PvtoTable(const DeckKeyword& keyword, size_t tableIdx);
+        PvtoTable(const DeckKeyword& keyword, std::size_t tableIdx);
 
         static PvtoTable serializationTestObject();
 

--- a/opm/input/eclipse/EclipseState/Tables/PvtsolTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtsolTable.hpp
@@ -21,6 +21,8 @@
 
 #include <opm/input/eclipse/EclipseState/Tables/PvtxTable.hpp>
 
+#include <cstddef>
+
 namespace Opm {
 
     class DeckKeyword;
@@ -28,7 +30,7 @@ namespace Opm {
     class PvtsolTable : public PvtxTable {
     public:
         PvtsolTable() = default;
-        PvtsolTable(const DeckKeyword& keyword, size_t tableIdx);
+        PvtsolTable(const DeckKeyword& keyword, std::size_t tableIdx);
         static PvtsolTable serializationTestObject();
         bool operator==(const PvtsolTable& data) const;
     };

--- a/opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.cpp
@@ -17,15 +17,18 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <vector>
+#include <opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.hpp>
+
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.hpp>
+
+#include <cstddef>
+#include <vector>
 
 namespace Opm {
 
-        static const size_t numEntries = 5;
+        static const std::size_t numEntries = 5;
         PvtwsaltTable::PvtwsaltTable()
         {
         }
@@ -48,7 +51,7 @@ namespace Opm {
             m_tableValues = record1.getItem("DATA").getSIDoubleData();
         }
 
-        size_t PvtwsaltTable::size() const
+        std::size_t PvtwsaltTable::size() const
         {
             return m_tableValues.size()/numEntries;
         }
@@ -70,9 +73,9 @@ namespace Opm {
 
         std::vector<double> PvtwsaltTable::getSaltConcentrationColumn() const
         {
-            size_t tableindex = 0;
+            std::size_t tableindex = 0;
             std::vector<double> saltCons(this->size());
-            for(size_t i=0; i<this->size(); ++i){
+            for(std::size_t i=0; i<this->size(); ++i){
                 saltCons[i] = m_tableValues[tableindex];
                 tableindex = tableindex+numEntries;
             }
@@ -82,9 +85,9 @@ namespace Opm {
 
         std::vector<double> PvtwsaltTable::getFormationVolumeFactorColumn() const
         {
-            size_t tableindex = 1;
+            std::size_t tableindex = 1;
             std::vector<double> formationvolumefactor(this->size());
-            for(size_t i=0; i<this->size(); ++i){
+            for(std::size_t i=0; i<this->size(); ++i){
                 formationvolumefactor[i] = m_tableValues[tableindex];
                 tableindex = tableindex+numEntries;
             }
@@ -94,9 +97,9 @@ namespace Opm {
 
         std::vector<double> PvtwsaltTable::getCompressibilityColumn() const
         {
-            size_t tableindex = 2;
+            std::size_t tableindex = 2;
             std::vector<double> compresibility(this->size());
-            for(size_t i=0; i<this->size(); ++i){
+            for(std::size_t i=0; i<this->size(); ++i){
                 compresibility[i] = m_tableValues[tableindex];
                 tableindex = tableindex+numEntries;
             }
@@ -106,9 +109,9 @@ namespace Opm {
 
         std::vector<double> PvtwsaltTable::getViscosityColumn() const
         {
-            size_t tableindex = 3;
+            std::size_t tableindex = 3;
             std::vector<double> viscosity(this->size());
-            for(size_t i=0; i<this->size(); ++i){
+            for(std::size_t i=0; i<this->size(); ++i){
                 viscosity[i] = m_tableValues[tableindex];
                 tableindex = tableindex+numEntries;
             }
@@ -118,9 +121,9 @@ namespace Opm {
 
         std::vector<double> PvtwsaltTable::getViscosibilityColumn() const
         {
-            size_t tableindex = 4;
+            std::size_t tableindex = 4;
             std::vector<double> viscosibility(this->size());
-            for(size_t i=0; i<this->size(); ++i){
+            for(std::size_t i=0; i<this->size(); ++i){
                 viscosibility[i] = m_tableValues[tableindex];
                 tableindex = tableindex+numEntries;
             }

--- a/opm/input/eclipse/EclipseState/Tables/Regdims.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/Regdims.hpp
@@ -40,7 +40,7 @@ namespace Opm {
 
         explicit Regdims(const Deck& deck);
 
-        Regdims(size_t ntfip , size_t nmfipr , size_t nrfregr , size_t ntfreg , size_t nplmix) :
+        Regdims(std::size_t ntfip , std::size_t nmfipr , std::size_t nrfregr , std::size_t ntfreg , std::size_t nplmix) :
             m_NTFIP( ntfip ),
             m_NMFIPR( nmfipr ),
             m_NRFREG( nrfregr ),
@@ -54,27 +54,27 @@ namespace Opm {
         }
 
 
-        size_t getNTFIP() const {
+        std::size_t getNTFIP() const {
             return m_NTFIP;
         }
 
 
-        size_t getNMFIPR() const {
+        std::size_t getNMFIPR() const {
             return m_NMFIPR;
         }
 
 
-        size_t getNRFREG() const {
+        std::size_t getNRFREG() const {
             return m_NRFREG;
         }
 
 
-        size_t getNTFREG() const {
+        std::size_t getNTFREG() const {
             return m_NTFREG;
         }
 
 
-        size_t getNPLMIX() const {
+        std::size_t getNPLMIX() const {
             return m_NPLMIX;
         }
 
@@ -98,11 +98,11 @@ namespace Opm {
         }
 
     private:
-        size_t m_NTFIP;
-        size_t m_NMFIPR;
-        size_t m_NRFREG;
-        size_t m_NTFREG;
-        size_t m_NPLMIX;
+        std::size_t m_NTFIP;
+        std::size_t m_NMFIPR;
+        std::size_t m_NRFREG;
+        std::size_t m_NTFREG;
+        std::size_t m_NPLMIX;
     };
 }
 

--- a/opm/input/eclipse/EclipseState/Tables/Rock2dTable.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Rock2dTable.cpp
@@ -17,11 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <vector>
+#include <opm/input/eclipse/EclipseState/Tables/Rock2dTable.hpp>
+
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Rock2dTable.hpp>
+
+#include <vector>
+#include <cstddef>
 
 namespace Opm {
 
@@ -38,28 +41,28 @@ namespace Opm {
             return result;
         }
 
-        void Rock2dTable::init(const DeckRecord& record, size_t /* tableIdx */)
+        void Rock2dTable::init(const DeckRecord& record, std::size_t /* tableIdx */)
         {
             m_pressureValues.push_back(record.getItem("PRESSURE").getSIDoubleData()[0]);
             m_pvmultValues.push_back(record.getItem("PVMULT").getSIDoubleData());
         }
 
-        size_t Rock2dTable::size() const
+        std::size_t Rock2dTable::size() const
         {
             return m_pressureValues.size();
         }
 
-        size_t Rock2dTable::sizeMultValues() const
+        std::size_t Rock2dTable::sizeMultValues() const
         {
             return m_pvmultValues[0].size();
         }
 
-        double Rock2dTable::getPressureValue(size_t index) const
+        double Rock2dTable::getPressureValue(std::size_t index) const
         {
             return m_pressureValues[index];
         }
 
-        double Rock2dTable::getPvmultValue(size_t pressureIndex, size_t saturationIndex) const
+        double Rock2dTable::getPvmultValue(std::size_t pressureIndex, std::size_t saturationIndex) const
         {
             return m_pvmultValues[pressureIndex][saturationIndex];
         }

--- a/opm/input/eclipse/EclipseState/Tables/Rock2dTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/Rock2dTable.hpp
@@ -19,6 +19,7 @@
 #ifndef OPM_PARSER_ROCK2D_TABLE_HPP
 #define	OPM_PARSER_ROCK2D_TABLE_HPP
 
+#include <cstddef>
 #include <vector>
 
 namespace Opm {
@@ -31,11 +32,11 @@ namespace Opm {
 
         static Rock2dTable serializationTestObject();
 
-        void init(const Opm::DeckRecord& record, size_t tableIdx);
-        size_t size() const;
-        size_t sizeMultValues() const;
-        double getPressureValue(size_t index) const;
-        double getPvmultValue(size_t pressureIndex, size_t saturationIndex ) const;
+        void init(const Opm::DeckRecord& record, std::size_t tableIdx);
+        std::size_t size() const;
+        std::size_t sizeMultValues() const;
+        double getPressureValue(std::size_t index) const;
+        double getPvmultValue(std::size_t pressureIndex, std::size_t saturationIndex ) const;
 
         bool operator==(const Rock2dTable& data) const;
 

--- a/opm/input/eclipse/EclipseState/Tables/Rock2dtrTable.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Rock2dtrTable.cpp
@@ -17,11 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <vector>
+#include <opm/input/eclipse/EclipseState/Tables/Rock2dtrTable.hpp>
+
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Rock2dtrTable.hpp>
+
+#include <vector>
+#include <cstddef>
 
 namespace Opm {
 
@@ -39,28 +42,28 @@ namespace Opm {
             return result;
         }
 
-        void Rock2dtrTable::init(const DeckRecord& record, size_t /* tableIdx */)
+        void Rock2dtrTable::init(const DeckRecord& record, std::size_t /* tableIdx */)
         {
             m_pressureValues.push_back(record.getItem("PRESSURE").getSIDoubleData()[0]);
             m_transMultValues.push_back(record.getItem("TRANSMULT").getSIDoubleData());
         }
 
-        size_t Rock2dtrTable::size() const
+        std::size_t Rock2dtrTable::size() const
         {
             return m_pressureValues.size();
         }
 
-        size_t Rock2dtrTable::sizeMultValues() const
+        std::size_t Rock2dtrTable::sizeMultValues() const
         {
             return m_transMultValues[0].size();
         }
 
-        double Rock2dtrTable::getPressureValue(size_t index) const
+        double Rock2dtrTable::getPressureValue(std::size_t index) const
         {
             return m_pressureValues[index];
         }
 
-        double Rock2dtrTable::getTransMultValue(size_t pressureIndex, size_t saturationIndex) const
+        double Rock2dtrTable::getTransMultValue(std::size_t pressureIndex, std::size_t saturationIndex) const
         {
             return m_transMultValues[pressureIndex][saturationIndex];
         }

--- a/opm/input/eclipse/EclipseState/Tables/Rock2dtrTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/Rock2dtrTable.hpp
@@ -19,6 +19,7 @@
 #ifndef OPM_PARSER_ROCK2DTR_TABLE_HPP
 #define	OPM_PARSER_ROCK2DTR_TABLE_HPP
 
+#include <cstddef>
 #include <vector>
 
 namespace Opm {
@@ -31,11 +32,11 @@ namespace Opm {
 
         static Rock2dtrTable serializationTestObject();
 
-        void init(const Opm::DeckRecord& record, size_t tableIdx);
-        size_t size() const;
-        size_t sizeMultValues() const;
-        double getPressureValue(size_t index) const;
-        double getTransMultValue(size_t pressureIndex, size_t saturationIndex ) const;
+        void init(const Opm::DeckRecord& record, std::size_t tableIdx);
+        std::size_t size() const;
+        std::size_t sizeMultValues() const;
+        double getPressureValue(std::size_t index) const;
+        double getTransMultValue(std::size_t pressureIndex, std::size_t saturationIndex ) const;
 
         bool operator==(const Rock2dtrTable& data) const;
 

--- a/opm/input/eclipse/EclipseState/Tables/RwgsaltTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/RwgsaltTable.hpp
@@ -22,6 +22,8 @@
 
 #include <opm/input/eclipse/EclipseState/Tables/PvtxTable.hpp>
 
+#include <cstddef>
+
 namespace Opm {
 
 class DeckKeyword;
@@ -29,7 +31,7 @@ class DeckKeyword;
 class RwgsaltTable : public PvtxTable {
 public:
     RwgsaltTable() = default;
-    RwgsaltTable( const DeckKeyword& keyword, size_t tableIdx);
+    RwgsaltTable( const DeckKeyword& keyword, std::size_t tableIdx);
 
     static RwgsaltTable serializationTestObject();
 

--- a/opm/input/eclipse/EclipseState/Tables/SimpleTable.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/SimpleTable.cpp
@@ -23,15 +23,17 @@
 
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 
-// <iostream> is for std::cerr in assertJFuncPressure().  This should really
-// go away or at least use the logging system instead.
-#include <iostream>
+#include <cstddef>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include <fmt/format.h>
+
+// <iostream> is for std::cerr in assertJFuncPressure().  This should really
+// go away or at least use the logging system instead.
+#include <iostream>
 
 namespace Opm {
 
@@ -90,12 +92,12 @@ namespace Opm {
         }
     }
 
-    double SimpleTable::get(const std::string& column, size_t row) const
+    double SimpleTable::get(const std::string& column, std::size_t row) const
     {
         return this->getColumn(column)[row];
     }
 
-    double SimpleTable::get(size_t column, size_t row) const
+    double SimpleTable::get(std::size_t column, std::size_t row) const
     {
         return this->getColumn(column)[row];
     }
@@ -119,13 +121,13 @@ namespace Opm {
             };
         }
 
-        const size_t rows = deckItem.data_size() / ncol;
+        const std::size_t rows = deckItem.data_size() / ncol;
 
-        for (size_t colIdx = 0; colIdx < ncol; ++colIdx) {
+        for (std::size_t colIdx = 0; colIdx < ncol; ++colIdx) {
             auto& column = this->getColumn(colIdx);
 
-            for (size_t rowIdx = 0; rowIdx < rows; ++rowIdx) {
-                const size_t deckItemIdx = rowIdx*ncol + colIdx;
+            for (std::size_t rowIdx = 0; rowIdx < rows; ++rowIdx) {
+                const std::size_t deckItemIdx = rowIdx*ncol + colIdx;
 
                 if (deckItem.defaultApplied(deckItemIdx)) {
                     column.addDefault(tableName);
@@ -147,12 +149,12 @@ namespace Opm {
         }
     }
 
-    size_t SimpleTable::numColumns() const
+    std::size_t SimpleTable::numColumns() const
     {
         return m_schema.size();
     }
 
-    size_t SimpleTable::numRows() const
+    std::size_t SimpleTable::numRows() const
     {
         return this->getColumn(0).size();
     }
@@ -170,7 +172,7 @@ namespace Opm {
         return this->m_columns.get(name);
     }
 
-    const TableColumn& SimpleTable::getColumn(size_t columnIndex) const
+    const TableColumn& SimpleTable::getColumn(std::size_t columnIndex) const
     {
         return this->m_columns.iget(columnIndex);
     }
@@ -188,7 +190,7 @@ namespace Opm {
         return this->m_columns.get(name);
     }
 
-    TableColumn& SimpleTable::getColumn(size_t columnIndex)
+    TableColumn& SimpleTable::getColumn(std::size_t columnIndex)
     {
         return this->m_columns.iget(columnIndex);
     }

--- a/opm/input/eclipse/EclipseState/Tables/SimpleTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/SimpleTable.hpp
@@ -23,6 +23,7 @@
 #include <opm/input/eclipse/EclipseState/Tables/TableSchema.hpp>
 #include <opm/input/eclipse/EclipseState/Util/OrderedMap.hpp>
 
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <string>
@@ -53,18 +54,18 @@ namespace Opm {
                    const DeckItem& deckItem,
                    const int tableID,
                    double scaling_factor = 0.0);
-        size_t numColumns() const;
-        size_t numRows() const;
+        std::size_t numColumns() const;
+        std::size_t numRows() const;
         void addRow( const std::vector<double>& row, const std::string& tableName);
         const TableColumn& getColumn(const std::string &name) const;
-        const TableColumn& getColumn(size_t colIdx) const;
+        const TableColumn& getColumn(std::size_t colIdx) const;
         bool hasColumn(const std::string& name) const;
 
         TableColumn& getColumn(const std::string &name);
-        TableColumn& getColumn(size_t colIdx);
+        TableColumn& getColumn(std::size_t colIdx);
 
-        double get(const std::string& column  , size_t row) const;
-        double get(size_t column  , size_t row) const;
+        double get(const std::string& column  , std::size_t row) const;
+        double get(std::size_t column  , std::size_t row) const;
         /*!
          * \brief Evaluate a column of the table at a given position.
          *

--- a/opm/input/eclipse/EclipseState/Tables/Tabdims.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/Tabdims.hpp
@@ -60,35 +60,35 @@ namespace Opm {
             return result;
         }
 
-        size_t getNumSatTables() const {
+        std::size_t getNumSatTables() const {
             return m_ntsfun;
         }
 
-        size_t getNumPVTTables() const {
+        std::size_t getNumPVTTables() const {
             return m_ntpvt;
         }
 
-        size_t getNumSatNodes() const {
+        std::size_t getNumSatNodes() const {
             return m_nssfun;
         }
 
-        size_t getNumPressureNodes() const {
+        std::size_t getNumPressureNodes() const {
             return m_nppvt;
         }
 
-        size_t getNumFIPRegions() const {
+        std::size_t getNumFIPRegions() const {
             return m_ntfip;
         }
 
-        size_t getNumRSNodes() const {
+        std::size_t getNumRSNodes() const {
             return m_nrpvt;
         }
 
-        size_t getNumEosRes() const {
+        std::size_t getNumEosRes() const {
             return m_neosres;
         }
 
-        size_t getNumEosSur() const {
+        std::size_t getNumEosSur() const {
             return m_neossur;
         }
 
@@ -117,7 +117,7 @@ namespace Opm {
         }
 
     private:
-        size_t m_ntsfun,m_ntpvt,m_nssfun,m_nppvt,m_ntfip,m_nrpvt, m_neosres, m_neossur;
+        std::size_t m_ntsfun,m_ntpvt,m_nssfun,m_nppvt,m_ntfip,m_nrpvt, m_neosres, m_neossur;
     };
 }
 

--- a/opm/input/eclipse/EclipseState/Tables/TableColumn.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableColumn.cpp
@@ -17,12 +17,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stddef.h>
-#include <stdexcept>
-#include <algorithm>
+#include <opm/input/eclipse/EclipseState/Tables/TableColumn.hpp>
 
 #include <opm/input/eclipse/EclipseState/Tables/ColumnSchema.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/TableColumn.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
 
 namespace Opm {
 
@@ -37,7 +38,6 @@ namespace Opm {
         m_defaultCount = 0;
     }
 
-
     TableColumn TableColumn::serializationTestObject()
     {
         TableColumn result;
@@ -50,13 +50,12 @@ namespace Opm {
         return result;
     }
 
-
-    size_t TableColumn::size() const {
+    std::size_t TableColumn::size() const {
         return m_values.size();
     }
 
 //TODO: Print schema
-    void TableColumn::assertOrder(double value1 , double value2, size_t index,
+    void TableColumn::assertOrder(double value1 , double value2, std::size_t index,
                                   const std::string& tableName) const
     {
         if (!m_schema.validOrder( value1 , value2) )
@@ -67,9 +66,9 @@ namespace Opm {
         return m_name;
     }
 
-    void TableColumn::assertNext(const std::string& tableName, size_t index , double value) const
+    void TableColumn::assertNext(const std::string& tableName, std::size_t index , double value) const
     {
-        size_t nextIndex = index + 1;
+        std::size_t nextIndex = index + 1;
         if (nextIndex < m_values.size()) {
             if (!m_default[nextIndex]) {
                 double nextValue = m_values[nextIndex];
@@ -78,11 +77,10 @@ namespace Opm {
         }
     }
 
-
-    void TableColumn::assertPrevious(const std::string& tableName, size_t index , double value) const
+    void TableColumn::assertPrevious(const std::string& tableName, std::size_t index , double value) const
     {
         if (index > 0) {
-            size_t prevIndex = index - 1;
+            std::size_t prevIndex = index - 1;
             if (!m_default[prevIndex]) {
                 double prevValue = m_values[prevIndex];
                 assertOrder( prevValue , value, index, tableName );
@@ -90,13 +88,11 @@ namespace Opm {
         }
     }
 
-
-    void TableColumn::assertUpdate(const std::string& tableName, size_t index, double value) const
+    void TableColumn::assertUpdate(const std::string& tableName, std::size_t index, double value) const
     {
         assertNext( tableName, index , value );
         assertPrevious( tableName, index, value );
     }
-
 
     void TableColumn::addValue(double value, const std::string& tableName)
     {
@@ -104,7 +100,6 @@ namespace Opm {
         m_values.push_back( value );
         m_default.push_back( false );
     }
-
 
     void TableColumn::addDefault(const std::string& tableName)
     {
@@ -121,8 +116,7 @@ namespace Opm {
 
     }
 
-
-    void TableColumn::updateValue(size_t index, double value, const std::string& tableName )
+    void TableColumn::updateValue(std::size_t index, double value, const std::string& tableName )
     {
         assertUpdate(  tableName,  index , value );
         m_values[index] = value;
@@ -132,14 +126,14 @@ namespace Opm {
         }
     }
 
-    bool TableColumn::defaultApplied(size_t index) const {
+    bool TableColumn::defaultApplied(std::size_t index) const {
         if (index >= m_values.size())
             throw std::invalid_argument("Value: " + std::to_string( index ) + " out of range: [0," + std::to_string( m_values.size()) + ")");
 
         return m_default[index];
     }
 
-    double TableColumn::operator[](size_t index) const {
+    double TableColumn::operator[](std::size_t index) const {
         if (index >= m_values.size())
             throw std::invalid_argument("Value: " + std::to_string( index ) + " out of range: [0," + std::to_string( m_values.size()) + ")");
 
@@ -152,7 +146,6 @@ namespace Opm {
     double TableColumn::back() const {
         return m_values.back( );
     }
-
 
     double TableColumn::front() const {
         return m_values.front( );
@@ -170,7 +163,6 @@ namespace Opm {
         }
     }
 
-
     double TableColumn::min( ) const {
         if (hasDefault()) {
             throw std::invalid_argument("Can not lookup elements in a column with defaulted values.");
@@ -182,7 +174,6 @@ namespace Opm {
             throw std::invalid_argument("Can not find max in empty column");
         }
     }
-
 
     bool TableColumn::inRange( double arg ) const {
         if (m_values.size( ) >= 2) {
@@ -198,7 +189,6 @@ namespace Opm {
             throw std::invalid_argument("Minimum size 2 ");
     }
 
-
     TableIndex TableColumn::lookup( double argValue ) const {
         if (!m_schema.lookupValid( ))
             throw std::invalid_argument("Must have an ordered column to perform table argument lookup.");
@@ -211,21 +201,21 @@ namespace Opm {
 
         if (argValue >= max()) {
             const auto max_iter = std::ranges::max_element(m_values);
-            const size_t max_index = max_iter - m_values.begin();
+            const std::size_t max_index = max_iter - m_values.begin();
             return TableIndex( max_index , 1.0 );
         }
 
         if (argValue <= min()) {
             const auto min_iter = std::ranges::min_element(m_values);
-            const size_t min_index = min_iter - m_values.begin();
+            const std::size_t min_index = min_iter - m_values.begin();
             return TableIndex( min_index , 1.0 );
         }
 
         {
             bool isDescending = m_schema.isDecreasing( );
-            size_t lowIntervalIdx = 0;
-            size_t intervalIdx = (size() - 1)/2;
-            size_t highIntervalIdx = size() - 1;
+            std::size_t lowIntervalIdx = 0;
+            std::size_t intervalIdx = (size() - 1)/2;
+            std::size_t highIntervalIdx = size() - 1;
             double weight1;
 
             while (lowIntervalIdx + 1 < highIntervalIdx) {
@@ -267,7 +257,6 @@ namespace Opm {
         return m_values.rend();
     }
 
-
     bool TableColumn::hasDefault( ) const {
         if (m_defaultCount > 0)
             return true;
@@ -275,9 +264,8 @@ namespace Opm {
             return false;
     }
 
-
     double TableColumn::eval( const TableIndex& index) const {
-        size_t index1 = index.getIndex1();
+        std::size_t index1 = index.getIndex1();
         double weight1 = index.getWeight1( );
         double value = m_values[index1] * weight1;
         if (weight1 < 1.0) {
@@ -286,7 +274,6 @@ namespace Opm {
         }
         return value;
     }
-
 
     TableColumn& TableColumn::operator= (const TableColumn& other) {
         if (this != &other) {
@@ -299,14 +286,13 @@ namespace Opm {
         return *this;
     }
 
-
     void TableColumn::applyDefaults(const TableColumn& argColumn, const std::string& tableName )
     {
         if (m_schema.getDefaultMode() == Table::DEFAULT_LINEAR) {
             if (size() != argColumn.size())
                 throw std::invalid_argument("Size mismatch with argument column");
 
-            for (size_t rowIdx = 0; rowIdx < size(); ++rowIdx) {
+            for (std::size_t rowIdx = 0; rowIdx < size(); ++rowIdx) {
                 if (defaultApplied( rowIdx )) {
                     // find first row which was not defaulted before the current one
                     int rowBeforeIdx = static_cast<int>(rowIdx);
@@ -320,7 +306,6 @@ namespace Opm {
                         if (!defaultApplied(rowAfterIdx))
                             break;
 
-
                     // switch to extrapolation by a constant at the fringes
                     if (rowBeforeIdx < 0 && rowAfterIdx >= static_cast<int>(size()))
                         throw std::invalid_argument("Column " + m_schema.name() + " can't be fully defaulted");
@@ -330,8 +315,8 @@ namespace Opm {
                         rowAfterIdx = rowBeforeIdx;
 
                     {
-                        const size_t before = static_cast<size_t>(rowBeforeIdx);
-                        const size_t after  = static_cast<size_t>(rowAfterIdx);
+                        const std::size_t before = static_cast<std::size_t>(rowBeforeIdx);
+                        const std::size_t after  = static_cast<std::size_t>(rowAfterIdx);
 
                         // linear interpolation
                         double alpha = 0.0;
@@ -348,7 +333,6 @@ namespace Opm {
         }
     }
 
-
     void TableColumn::assertUnitRange() const {
         if (front() != 0.0)
             throw std::invalid_argument("Column " + m_schema.name() + " must span range [0 1]");
@@ -356,7 +340,6 @@ namespace Opm {
         if (back() != 1.0)
             throw std::invalid_argument("Column " + m_schema.name() + " must span range [0 1]");
     }
-
 
     std::vector<double> TableColumn::vectorCopy() const {
         return std::vector<double>( begin() , end());

--- a/opm/input/eclipse/EclipseState/Tables/TableColumn.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableColumn.hpp
@@ -17,15 +17,15 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #ifndef OPM_TABLE_COLUMN_HPP
 #define OPM_TABLE_COLUMN_HPP
 
-#include <string>
-#include <vector>
-
 #include <opm/input/eclipse/EclipseState/Tables/ColumnSchema.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableIndex.hpp>
+
+#include <cstddef>
+#include <string>
+#include <vector>
 
 namespace Opm {
 
@@ -38,15 +38,15 @@ namespace Opm {
 
         static TableColumn serializationTestObject();
 
-        size_t size( ) const;
+        std::size_t size( ) const;
         const std::string& name() const;
-        void assertOrder(double value1 , double value2, size_t index,
+        void assertOrder(double value1 , double value2, std::size_t index,
                          const std::string& tableName) const;
         void addValue(double, const std::string& tableName);
         void addDefault(const std::string& tableName);
-        void updateValue(size_t index, double value, const std::string& tableName);
-        double operator[](size_t index) const;
-        bool defaultApplied(size_t index) const;
+        void updateValue(std::size_t index, double value, const std::string& tableName);
+        double operator[](std::size_t index) const;
+        bool defaultApplied(std::size_t index) const;
         bool hasDefault( ) const;
         double front() const;
         double back() const;
@@ -83,19 +83,17 @@ namespace Opm {
         }
 
     private:
-        void assertUpdate(const std::string& tableName, size_t index, double value) const;
-        void assertPrevious(const std::string& tableName, size_t index , double value) const;
-        void assertNext(const std::string& tableName, size_t index , double value) const;
+        void assertUpdate(const std::string& tableName, std::size_t index, double value) const;
+        void assertPrevious(const std::string& tableName, std::size_t index , double value) const;
+        void assertNext(const std::string& tableName, std::size_t index , double value) const;
 
         ColumnSchema m_schema;
         std::string m_name;
         std::vector<double> m_values;
         std::vector<bool> m_default;
-        size_t m_defaultCount;
+        std::size_t m_defaultCount;
     };
 
-
 }
-
 
 #endif

--- a/opm/input/eclipse/EclipseState/Tables/TableContainer.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableContainer.cpp
@@ -21,10 +21,9 @@
 
 #include <opm/input/eclipse/EclipseState/Tables/SimpleTable.hpp>
 
+#include <cstddef>
 #include <string>
 #include <utility>
-
-#include <stddef.h>
 
 #include <fmt/format.h>
 
@@ -34,7 +33,7 @@ namespace Opm {
         : m_maxTables(0)
     {}
 
-    TableContainer::TableContainer(size_t maxTables)
+    TableContainer::TableContainer(std::size_t maxTables)
         : m_maxTables(maxTables)
     {}
 
@@ -53,12 +52,12 @@ namespace Opm {
         return m_tables.empty();
     }
 
-    size_t TableContainer::size() const
+    std::size_t TableContainer::size() const
     {
         return m_tables.size();
     }
 
-    size_t TableContainer::max() const
+    std::size_t TableContainer::max() const
     {
         return m_maxTables;
     }
@@ -68,13 +67,13 @@ namespace Opm {
         return m_tables;
     }
 
-    bool TableContainer::hasTable(size_t tableNumber) const
+    bool TableContainer::hasTable(std::size_t tableNumber) const
     {
         return this->m_tables.find(tableNumber)
             != this->m_tables.end();
     }
 
-    const SimpleTable& TableContainer::getTable(size_t tableNumber) const
+    const SimpleTable& TableContainer::getTable(std::size_t tableNumber) const
     {
         if (tableNumber >= m_maxTables) {
             throw std::invalid_argument {
@@ -96,7 +95,7 @@ namespace Opm {
         }
     }
 
-    void TableContainer::addTable(size_t tableNumber, std::shared_ptr<SimpleTable> table)
+    void TableContainer::addTable(std::size_t tableNumber, std::shared_ptr<SimpleTable> table)
     {
         if (tableNumber >= m_maxTables) {
             throw std::invalid_argument {

--- a/opm/input/eclipse/EclipseState/Tables/TableContainer.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableContainer.hpp
@@ -60,35 +60,35 @@ namespace Opm {
     class TableContainer
     {
     public:
-        using TableMap = std::map<size_t, std::shared_ptr<SimpleTable>>;
+        using TableMap = std::map<std::size_t, std::shared_ptr<SimpleTable>>;
 
         TableContainer();
-        explicit TableContainer(size_t maxTables);
+        explicit TableContainer(std::size_t maxTables);
 
         static TableContainer serializationTestObject();
 
         bool empty() const;
 
         // This is the number of actual tables in the container.
-        size_t size() const;
-        size_t max() const;
+        std::size_t size() const;
+        std::size_t max() const;
 
         const TableMap& tables() const;
 
-        void addTable(size_t tableNumber, std::shared_ptr<SimpleTable> table);
+        void addTable(std::size_t tableNumber, std::shared_ptr<SimpleTable> table);
 
         // Observe that the hasTable() method does not invoke the "If table
         // N is not implemented use table N - 1 behavior.
-        bool hasTable(size_t tableNumber) const;
-        const SimpleTable& getTable(size_t tableNumber) const;
+        bool hasTable(std::size_t tableNumber) const;
+        const SimpleTable& getTable(std::size_t tableNumber) const;
 
-        const SimpleTable& operator[](size_t tableNumber) const
+        const SimpleTable& operator[](std::size_t tableNumber) const
         {
             return this->getTable(tableNumber);
         }
 
         template <class TableType>
-        const TableType& getTable(size_t tableNumber) const
+        const TableType& getTable(std::size_t tableNumber) const
         {
             // This is, strictly speaking, a downcast so we should prefer
             // dynamic_cast<>() instead.  However, serializeOp() by
@@ -111,7 +111,7 @@ namespace Opm {
         }
 
     private:
-        size_t m_maxTables;
+        std::size_t m_maxTables;
         TableMap m_tables;
     };
 

--- a/opm/input/eclipse/EclipseState/Tables/TableIndex.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableIndex.cpp
@@ -17,19 +17,18 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #include <opm/input/eclipse/EclipseState/Tables/TableIndex.hpp>
+
+#include <cstddef>
 
 namespace Opm {
 
-    TableIndex::TableIndex( size_t index1 , double weight1) :
+    TableIndex::TableIndex( std::size_t index1 , double weight1) :
         m_index1( index1 ),
         m_weight1( weight1 )
     {
 
     }
-
 
     TableIndex::TableIndex(const TableIndex& tableIndex)
         : m_index1( tableIndex.m_index1 ),
@@ -37,24 +36,20 @@ namespace Opm {
     {
     }
 
-
-    size_t TableIndex::getIndex1( ) const {
+    std::size_t TableIndex::getIndex1( ) const {
         return m_index1;
     }
 
-    size_t TableIndex::getIndex2( ) const {
+    std::size_t TableIndex::getIndex2( ) const {
         return m_index1 + 1;
     }
-
 
     double TableIndex::getWeight1( ) const {
         return m_weight1;
     }
 
-
     double TableIndex::getWeight2( ) const {
         return 1 - m_weight1;
     }
-
 
 }

--- a/opm/input/eclipse/EclipseState/Tables/TableIndex.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableIndex.hpp
@@ -35,14 +35,14 @@ namespace Opm {
 
     class TableIndex {
     public:
-        TableIndex( size_t index1 , double weight1);
+        TableIndex( std::size_t index1 , double weight1);
         TableIndex( const TableIndex& tableIndex);
-        size_t getIndex1( ) const;
-        size_t getIndex2( ) const;
+        std::size_t getIndex1( ) const;
+        std::size_t getIndex2( ) const;
         double getWeight1( ) const;
         double getWeight2( ) const;
     private:
-        size_t m_index1;
+        std::size_t m_index1;
         double m_weight1;
     };
 }

--- a/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -18,16 +18,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <algorithm>
-#include <cmath>
-#include <cstddef>
-#include <iomanip>
-#include <ios>
-#include <iterator>
-#include <memory>
-#include <sstream>
-
-#include <fmt/format.h>
+#include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 
 #include <opm/common/OpmLog/EclipsePRTLog.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
@@ -35,6 +26,76 @@
 #include <opm/common/OpmLog/StreamLog.hpp>
 
 #include <opm/common/utility/OpmInputError.hpp>
+
+#include <opm/input/eclipse/EclipseState/Tables/Aqudims.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/AqutabTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/BiofilmTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/BrineDensityTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/CompvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/DiffMICPTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/EnkrvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/EnptvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Eqldims.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/FoamadsTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/FoammobTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/GasvisctTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/GsfTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/ImkrvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/ImptvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/JFunc.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/MiscTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/MsfnTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/OilvisctTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/OverburdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PbvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PcfactTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PdvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PermfactTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PlyadsTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PlydhflfTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PlymaxTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PlyrockTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PlyviscTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PmiscTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PvdgTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PvdoTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PvdsTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Regdims.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/RocktabTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/RockwnodTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/RsconstTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/RsvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/RtempvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/RvvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/RvwvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SaltpvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SaltSolubilityTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SaltvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SgcwmisTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SgfnTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SgofTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SgwfnTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SlgofTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Sof2Table.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Sof3Table.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SolventDensityTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SorwmisTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SpecheatTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SpecrockTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SsfnTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SwfnTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SwofTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/TableContainer.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/TlpmixpaTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/WatvisctTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/WsfTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/ZmfvdTable.hpp>
+
+#include <opm/input/eclipse/Units/Units.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
 
 #include <opm/input/eclipse/Parser/ParserKeywords/A.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
@@ -52,77 +113,16 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/Z.hpp>
 
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <ios>
+#include <iterator>
+#include <memory>
+#include <sstream>
 
-#include <opm/input/eclipse/EclipseState/Tables/BrineDensityTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/EnkrvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/EnptvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/GasvisctTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/ImkrvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/ImptvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/MiscTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/MsfnTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/OilvisctTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PlyadsTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PlydhflfTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PlymaxTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PlyrockTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PlyviscTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/FoamadsTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/FoammobTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PmiscTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/TlpmixpaTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PvdgTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PvdoTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PvdsTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/RocktabTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/RockwnodTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/OverburdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/RsvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/RsconstTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PbvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PdvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/RtempvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/RvvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/RvwvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PcfactTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PermfactTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/BiofilmTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/DiffMICPTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SaltvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SaltpvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SaltSolubilityTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SgcwmisTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SgfnTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SgofTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SgwfnTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SlgofTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Sof2Table.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Sof3Table.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SolventDensityTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SorwmisTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SpecheatTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SpecrockTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SsfnTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SwfnTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SwofTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/GsfTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/WsfTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/TableContainer.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/WatvisctTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/AqutabTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/ZmfvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/CompvdTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/JFunc.hpp>
-
-#include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Eqldims.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Regdims.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Aqudims.hpp>
-
-#include <opm/input/eclipse/Units/Units.hpp>
+#include <fmt/format.h>
 
 namespace Opm {
 
@@ -136,8 +136,6 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 }
 
 }
-
-
 
     TableManager::TableManager( const Deck& deck )
         :
@@ -257,7 +255,6 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         if (deck.hasKeyword<ParserKeywords::WATJT>())
             this->watJT = JouleThomson( deck.get<ParserKeywords::WATJT>().back());
 
-
         if (deck.hasKeyword<ParserKeywords::STCOND>()) {
             auto stcondKeyword = deck["STCOND"].back();
             this->stcond.temperature = stcondKeyword.getRecord(0).getItem("TEMPERATURE").getSIDouble(0);
@@ -286,7 +283,6 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         if (deck.hasKeyword<GC>())
             this->m_gas_comp_index = deck.get<GC>().back().getRecord(0).getItem<GC::GAS_COMPONENT_INDEX>().get<int>(0);
     }
-
 
     TableManager TableManager::serializationTestObject()
     {
@@ -373,12 +369,10 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         }
     }
 
-
-    void TableManager::addTables(const std::string& tableName, size_t numTables)
+    void TableManager::addTables(const std::string& tableName, std::size_t numTables)
     {
         this->m_simpleTables.try_emplace(tableName, numTables);
     }
-
 
     bool TableManager::hasTables( const std::string& tableName ) const {
         auto pair = m_simpleTables.find( tableName );
@@ -390,7 +384,6 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         }
     }
 
-
     const TableContainer& TableManager::getTables( const std::string& tableName ) const {
         auto pair = m_simpleTables.find( tableName );
         if (pair == m_simpleTables.end())
@@ -399,7 +392,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             return pair->second;
     }
 
-    TableContainer& TableManager::forceGetTables( const std::string& tableName , size_t numTables )  {
+    TableContainer& TableManager::forceGetTables( const std::string& tableName , std::size_t numTables )  {
         auto pair = m_simpleTables.find( tableName );
         if (pair == m_simpleTables.end()) {
             addTables( tableName , numTables );
@@ -492,11 +485,11 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         addTables( "AQUTAB", m_aqudims.getNumInfluenceTablesCT());
         {
-            size_t numMiscibleTables = ParserKeywords::MISCIBLE::NTMISC::defaultValue;
+            std::size_t numMiscibleTables = ParserKeywords::MISCIBLE::NTMISC::defaultValue;
             if (deck.hasKeyword<ParserKeywords::MISCIBLE>()) {
                 const auto& keyword = deck.get<ParserKeywords::MISCIBLE>().back();
                 const auto& record = keyword.getRecord(0);
-                numMiscibleTables =  static_cast<size_t>(record.getItem<ParserKeywords::MISCIBLE::NTMISC>().get< int >(0));
+                numMiscibleTables =  static_cast<std::size_t>(record.getItem<ParserKeywords::MISCIBLE::NTMISC>().get< int >(0));
             }
             addTables( "SORWMIS", numMiscibleTables);
             addTables( "SGCWMIS", numMiscibleTables);
@@ -505,12 +498,12 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             addTables( "TLPMIXPA",numMiscibleTables);
         }
         {
-            size_t numEndScaleTables = ParserKeywords::ENDSCALE::NTENDP::defaultValue;
+            std::size_t numEndScaleTables = ParserKeywords::ENDSCALE::NTENDP::defaultValue;
 
             if (deck.hasKeyword<ParserKeywords::ENDSCALE>()) {
                 const auto& keyword = deck.get<ParserKeywords::ENDSCALE>().back();
                 const auto& record = keyword.getRecord(0);
-                numEndScaleTables = static_cast<size_t>(record.getItem<ParserKeywords::ENDSCALE::NTENDP>().get< int >(0));
+                numEndScaleTables = static_cast<std::size_t>(record.getItem<ParserKeywords::ENDSCALE::NTENDP>().get< int >(0));
             }
 
             addTables( "ENKRVD", numEndScaleTables);
@@ -519,18 +512,17 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             addTables( "IMPTVD", numEndScaleTables);
         }
         {
-            size_t numRocktabTables = ParserKeywords::ROCKCOMP::NTROCC::defaultValue;
+            std::size_t numRocktabTables = ParserKeywords::ROCKCOMP::NTROCC::defaultValue;
 
             if (deck.hasKeyword<ParserKeywords::ROCKCOMP>()) {
                 const auto& keyword = deck.get<ParserKeywords::ROCKCOMP>().back();
                 const auto& record = keyword.getRecord(0);
-                numRocktabTables = static_cast<size_t>(record.getItem<ParserKeywords::ROCKCOMP::NTROCC>().get< int >(0));
+                numRocktabTables = static_cast<std::size_t>(record.getItem<ParserKeywords::ROCKCOMP::NTROCC>().get< int >(0));
             }
             addTables( "ROCKTAB", numRocktabTables);
             addTables( "ROCKWNOD", numRocktabTables);
             addTables( "OVERBURD", numRocktabTables);
         }
-
 
         initSimpleTableContainer<SgwfnTable>(deck, "SGWFN", m_tabdims.getNumSatTables());
         initSimpleTableContainer<Sof2Table>(deck, "SOF2" , m_tabdims.getNumSatTables());
@@ -563,12 +555,12 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         initSimpleTableContainer<DiffMICPTable>(deck, "DIFFMICP" , m_tabdims.getNumPVTTables());
         initSimpleTableContainer<AqutabTable>(deck, "AQUTAB" , m_aqudims.getNumInfluenceTablesCT());
         {
-            size_t numEndScaleTables = ParserKeywords::ENDSCALE::NTENDP::defaultValue;
+            std::size_t numEndScaleTables = ParserKeywords::ENDSCALE::NTENDP::defaultValue;
 
             if (deck.hasKeyword<ParserKeywords::ENDSCALE>()) {
                 const auto& keyword = deck.get<ParserKeywords::ENDSCALE>().back();
                 const auto& record = keyword.getRecord(0);
-                numEndScaleTables = static_cast<size_t>(record.getItem<ParserKeywords::ENDSCALE::NTENDP>().get< int >(0));
+                numEndScaleTables = static_cast<std::size_t>(record.getItem<ParserKeywords::ENDSCALE::NTENDP>().get< int >(0));
             }
 
             initSimpleTableContainer<EnkrvdTable>( deck , "ENKRVD", numEndScaleTables);
@@ -577,11 +569,11 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             initSimpleTableContainer<ImptvdTable>( deck , "IMPTVD", numEndScaleTables);
         }
         {
-            size_t numMiscibleTables = ParserKeywords::MISCIBLE::NTMISC::defaultValue;
+            std::size_t numMiscibleTables = ParserKeywords::MISCIBLE::NTMISC::defaultValue;
             if (deck.hasKeyword<ParserKeywords::MISCIBLE>()) {
                 const auto& keyword = deck.get<ParserKeywords::MISCIBLE>().back();
                 const auto& record = keyword.getRecord(0);
-                numMiscibleTables =  static_cast<size_t>(record.getItem<ParserKeywords::MISCIBLE::NTMISC>().get< int >(0));
+                numMiscibleTables =  static_cast<std::size_t>(record.getItem<ParserKeywords::MISCIBLE::NTMISC>().get< int >(0));
             }
             initSimpleTableContainer<SorwmisTable>(deck, "SORWMIS", numMiscibleTables);
             initSimpleTableContainer<SgcwmisTable>(deck, "SGCWMIS", numMiscibleTables);
@@ -591,12 +583,12 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         }
         {
-            size_t numRocktabTables = ParserKeywords::ROCKCOMP::NTROCC::defaultValue;
+            std::size_t numRocktabTables = ParserKeywords::ROCKCOMP::NTROCC::defaultValue;
 
             if (deck.hasKeyword<ParserKeywords::ROCKCOMP>()) {
                 const auto& keyword = deck.get<ParserKeywords::ROCKCOMP>().back();
                 const auto& record = keyword.getRecord(0);
-                numRocktabTables = static_cast<size_t>(record.getItem<ParserKeywords::ROCKCOMP::NTROCC>().get< int >(0));
+                numRocktabTables = static_cast<std::size_t>(record.getItem<ParserKeywords::ROCKCOMP::NTROCC>().get< int >(0));
             }
             initSimpleTableContainer<RockwnodTable>(deck, "ROCKWNOD", numRocktabTables);
             initSimpleTableContainer<OverburdTable>(deck, "OVERBURD", numRocktabTables);
@@ -631,7 +623,6 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         initSkprwatTables(deck);
     }
 
-
     void TableManager::initRTempTables(const Deck& deck) {
         // the temperature vs depth table. the problem here is that
         // the TEMPVD (E300) and RTEMPVD (E300 + E100) keywords are
@@ -649,7 +640,6 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             initSimpleTableContainer<RtempvdTable>(deck, "RTEMPVD", "RTEMPVD", m_eqldims.getNumEquilRegions());
         }
     }
-
 
     void TableManager::initZmfvdTables(const Deck& deck) {
         if (!deck.hasKeyword<ParserKeywords::ZMFVD>())
@@ -694,7 +684,6 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         }
     }
 
-
     void TableManager::initCompvdTables(const Deck& deck) {
         if (!deck.hasKeyword<ParserKeywords::COMPVD>())
             return;
@@ -738,7 +727,6 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             }
         }
     }
-
 
     void TableManager::initPlyshlogTables(const Deck& deck) {
         const std::string keywordName = "PLYSHLOG";
@@ -815,9 +803,9 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             return;
         }
 
-        const size_t num_tables = deck.count("PLYMWINJ");
+        const std::size_t num_tables = deck.count("PLYMWINJ");
         const auto& keywords = deck.getKeywordList<ParserKeywords::PLYMWINJ>();
-        for (size_t i = 0; i < num_tables; ++i) {
+        for (std::size_t i = 0; i < num_tables; ++i) {
             const DeckKeyword &keyword = *keywords[i];
 
             // not const for std::move
@@ -845,9 +833,9 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             return;
         }
 
-        const size_t num_tables = deck.count("SKPRWAT");
+        const std::size_t num_tables = deck.count("SKPRWAT");
         const auto& keywords = deck.getKeywordList<ParserKeywords::SKPRWAT>();
-        for (size_t i = 0; i < num_tables; ++i) {
+        for (std::size_t i = 0; i < num_tables; ++i) {
             const DeckKeyword &keyword = *keywords[i];
 
             // not const for std::move
@@ -875,9 +863,9 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             return;
         }
 
-        const size_t num_tables = deck.count("SKPRPOLY");
+        const std::size_t num_tables = deck.count("SKPRPOLY");
         const auto& keywords = deck.getKeywordList<ParserKeywords::SKPRPOLY>();
-        for (size_t i = 0; i < num_tables; ++i) {
+        for (std::size_t i = 0; i < num_tables; ++i) {
             const DeckKeyword &keyword = *keywords[i];
 
             // not const for std::move
@@ -901,7 +889,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
     }
 
     void TableManager::initPlyrockTables(const Deck& deck) {
-        size_t numTables = m_tabdims.getNumSatTables();
+        std::size_t numTables = m_tabdims.getNumSatTables();
         const std::string keywordName = "PLYROCK";
         if (!deck.hasKeyword(keywordName)) {
             return;
@@ -914,16 +902,15 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         const auto& keyword = deck.get<ParserKeywords::PLYROCK>().back();
         auto& container = forceGetTables(keywordName , numTables);
-        for (size_t tableIdx = 0; tableIdx < keyword.size(); ++tableIdx) {
+        for (std::size_t tableIdx = 0; tableIdx < keyword.size(); ++tableIdx) {
             const auto& tableRecord = keyword.getRecord( tableIdx );
             std::shared_ptr<PlyrockTable> table = std::make_shared<PlyrockTable>(tableRecord);
             container.addTable( tableIdx , table );
         }
     }
 
-
     void TableManager::initPlymaxTables(const Deck& deck) {
-        size_t numTables = m_regdims.getNPLMIX();
+        std::size_t numTables = m_regdims.getNPLMIX();
         const std::string keywordName = "PLYMAX";
         if (!deck.hasKeyword(keywordName)) {
             return;
@@ -936,7 +923,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         const auto& keyword = deck.get<ParserKeywords::PLYMAX>().back();
         auto& container = forceGetTables(keywordName , numTables);
-        for (size_t tableIdx = 0; tableIdx < keyword.size(); ++tableIdx) {
+        for (std::size_t tableIdx = 0; tableIdx < keyword.size(); ++tableIdx) {
             const auto& tableRecord = keyword.getRecord( tableIdx );
             std::shared_ptr<PlymaxTable> table = std::make_shared<PlymaxTable>( tableRecord );
             container.addTable( tableIdx , table );
@@ -967,7 +954,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         }
         const auto& rockcompKeyword = deck.get<ParserKeywords::ROCKCOMP>().back();
         const auto& record = rockcompKeyword.getRecord( 0 );
-        size_t numTables = record.getItem<ParserKeywords::ROCKCOMP::NTROCC>().get< int >(0);
+        std::size_t numTables = record.getItem<ParserKeywords::ROCKCOMP::NTROCC>().get< int >(0);
         auto& container = forceGetTables("ROCKTAB" , numTables);
         const auto rocktabKeyword = deck["ROCKTAB"].back();
 
@@ -996,7 +983,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             }
         }
 
-        for (size_t tableIdx = 0; tableIdx < rocktabKeyword.size(); ++tableIdx) {
+        for (std::size_t tableIdx = 0; tableIdx < rocktabKeyword.size(); ++tableIdx) {
             const auto& tableRecord = rocktabKeyword.getRecord( tableIdx );
             const auto& dataItem = tableRecord.getItem( 0 );
             if (dataItem.data_size() > 0) {
@@ -1006,8 +993,8 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         }
     }
 
-        size_t TableManager::numFIPRegions() const {
-        size_t ntfip = m_tabdims.getNumFIPRegions();
+        std::size_t TableManager::numFIPRegions() const {
+        std::size_t ntfip = m_tabdims.getNumFIPRegions();
         if (m_regdims.getNTFIP( ) > ntfip)
             return m_regdims.getNTFIP( );
         else
@@ -1047,7 +1034,6 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
     const TableContainer& TableManager::getSlgofTables() const {
         return getTables("SLGOF");
     }
-
 
     const TableContainer& TableManager::getSgofTables() const {
         return getTables("SGOF");
@@ -1136,7 +1122,6 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         return getTables("ENPTVD");
     }
 
-
     const TableContainer& TableManager::getImkrvdTables() const {
         return getTables("IMKRVD");
     }
@@ -1192,7 +1177,6 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
     const TableContainer& TableManager::getRocktabTables() const {
         return getTables("ROCKTAB");
     }
-
 
     const TableContainer& TableManager::getPlyadsTables() const {
         return getTables("PLYADS");
@@ -1418,11 +1402,10 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             return false;
     }
 
-
     void TableManager::complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) {
         OpmLog::error("The " + keywordName + " keyword must be unique in the deck. Ignoring all!");
         const auto& keywords = deck.getKeywordList(keywordName);
-        for (size_t i = 0; i < keywords.size(); ++i) {
+        for (std::size_t i = 0; i < keywords.size(); ++i) {
             std::string msg = "Ambiguous keyword "+keywordName+" defined here";
             OpmLog::error(Log::fileMessage(keywords[i]->location(), msg));
         }
@@ -1498,11 +1481,11 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
     }
 
     void TableManager::initSolventTables(const Deck& deck,  std::vector<SolventDensityTable>& solventtables) {
-        size_t numTables = m_tabdims.getNumPVTTables();
+        std::size_t numTables = m_tabdims.getNumPVTTables();
         solventtables.resize(numTables);
 
         const auto& keyword = deck["SDENSITY"].back();
-        size_t numEntries = keyword.size();
+        std::size_t numEntries = keyword.size();
         assert(numEntries == numTables);
         for (unsigned lineIdx = 0; lineIdx < numEntries; ++lineIdx) {
             solventtables[lineIdx].init(keyword.getRecord(lineIdx));
@@ -1665,13 +1648,13 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         const auto& rockcompKeyword = deck["ROCKCOMP"].back();
         const auto& record = rockcompKeyword.getRecord( 0 );
-        size_t numTables = record.getItem("NTROCC").get< int >(0);
+        std::size_t numTables = record.getItem("NTROCC").get< int >(0);
         rocktable.resize(numTables);
 
         const auto& keyword = deck[keywordName].back();
-        size_t numEntries = keyword.size();
-        size_t regionIdx = 0;
-        size_t tableIdx = 0;
+        std::size_t numEntries = keyword.size();
+        std::size_t regionIdx = 0;
+        std::size_t tableIdx = 0;
         for (unsigned lineIdx = 0; lineIdx < numEntries; ++lineIdx) {
             if (keyword.getRecord(lineIdx).getItem("PRESSURE").hasValue(0)) {
                 rocktable[regionIdx].init(keyword.getRecord(lineIdx), tableIdx);
@@ -1687,12 +1670,12 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
     template <class TableType>
     void TableManager::initPvtwsaltTables(const Deck& deck,  std::vector<TableType>& pvtwtables ) {
 
-        size_t numTables = m_tabdims.getNumPVTTables();
+        std::size_t numTables = m_tabdims.getNumPVTTables();
         pvtwtables.resize(numTables);
 
         const auto& keyword = deck["PVTWSALT"].back();
-        size_t numEntries = keyword.size();
-        size_t regionIdx = 0;
+        std::size_t numEntries = keyword.size();
+        std::size_t regionIdx = 0;
         for (unsigned lineIdx = 0; lineIdx < numEntries; lineIdx += 2) {
             pvtwtables[regionIdx].init(keyword.getRecord(lineIdx), keyword.getRecord(lineIdx+1));
             ++regionIdx;
@@ -1703,11 +1686,11 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
     template <class TableType>
     void TableManager::initBrineTables(const Deck& deck,  std::vector<TableType>& brinetables ) {
 
-        size_t numTables = m_tabdims.getNumPVTTables();
+        std::size_t numTables = m_tabdims.getNumPVTTables();
         brinetables.resize(numTables);
 
         const auto& keyword = deck["BDENSITY"].back();
-        size_t numEntries = keyword.size();
+        std::size_t numEntries = keyword.size();
         assert(numEntries == numTables);
         for (unsigned lineIdx = 0; lineIdx < numEntries; ++lineIdx) {
             brinetables[lineIdx].init(keyword.getRecord(lineIdx));
@@ -1718,7 +1701,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
     void TableManager::initSimpleTableContainerWithJFunc(const Deck& deck,
                                                          const std::string& keywordName,
                                                          const std::string& tableName,
-                                                         size_t numTables) {
+                                                         std::size_t numTables) {
         if (!deck.hasKeyword(keywordName))
             return; // the table is not featured by the deck...
 
@@ -1731,7 +1714,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         auto lastComplete = 0 * numTables;
         const auto& tableKeyword = deck[keywordName].back();
-        for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
+        for (std::size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
             const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem("DATA");
             if (dataItem.data_size() > 0) {
                 try {
@@ -1744,7 +1727,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
                     throw OpmInputError(err, tableKeyword.location());
                 }
             }
-            else if (tableIdx > static_cast<size_t>(0)) {
+            else if (tableIdx > static_cast<std::size_t>(0)) {
                 const auto& item = tableKeyword.getRecord(lastComplete).getItem("DATA");
                 container.addTable(tableIdx, std::make_shared<TableType>(item, useJFunc(), tableIdx));
             }
@@ -1761,7 +1744,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
     void TableManager::initSimpleTableContainer(const Deck& deck,
                                                 const std::string& keywordName,
                                                 const std::string& tableName,
-                                                size_t numTables) {
+                                                std::size_t numTables) {
         if (!deck.hasKeyword(keywordName)) {
             return; // the table is not featured by the deck...
         }
@@ -1775,7 +1758,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         auto lastComplete = 0 * numTables;
         const auto& tableKeyword = deck[keywordName].back();
-        for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
+        for (std::size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
             const auto& dataItem = tableKeyword.getRecord(tableIdx).getItem("DATA");
 
             if (dataItem.data_size() > 0) {
@@ -1790,7 +1773,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
                     throw OpmInputError(err, tableKeyword.location());
                 }
             }
-            else if (tableIdx > static_cast<size_t>(0)) {
+            else if (tableIdx > static_cast<std::size_t>(0)) {
                 const auto& item = tableKeyword.getRecord(lastComplete).getItem("DATA");
                 container.addTable(tableIdx, std::make_shared<TableType>(item, tableIdx));
             }
@@ -1806,15 +1789,14 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
     template <class TableType>
     void TableManager::initSimpleTableContainer(const Deck& deck,
                                                 const std::string& keywordName,
-                                                size_t numTables) {
+                                                std::size_t numTables) {
         initSimpleTableContainer<TableType>(deck , keywordName , keywordName , numTables);
     }
-
 
     template <class TableType>
     void TableManager::initSimpleTableContainerWithJFunc(const Deck& deck,
                                                          const std::string& keywordName,
-                                                         size_t numTables) {
+                                                         std::size_t numTables) {
         initSimpleTableContainerWithJFunc<TableType>(deck , keywordName , keywordName , numTables);
     }
 
@@ -1831,7 +1813,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         }
 
         const auto& tableKeyword = deck[keywordName].back();
-        for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
+        for (std::size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
             const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem("DATA");
             if (dataItem.data_size() == 0) {
                 // for simple tables, an empty record indicates that the previous table

--- a/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
@@ -21,43 +21,48 @@
 #ifndef OPM_TABLE_MANAGER_HPP
 #define OPM_TABLE_MANAGER_HPP
 
-#include <cassert>
-#include <optional>
-#include <set>
-
+#include <opm/input/eclipse/EclipseState/Tables/Aqudims.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/BrineDensityTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/DenT.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Eqldims.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/FlatTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/JFunc.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/JouleThomson.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/MiscTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/MsfnTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PlymwinjTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PmiscTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Ppcwmax.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PvtgTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PvtgwTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PvtgwoTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PvtgwTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PvtoTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PvtsolTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/RocktabTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Regdims.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/Rock2dTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/Rock2dtrTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/RocktabTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/RwgsaltTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/BrineDensityTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SolventDensityTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/StandardCond.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/FlatTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SorwmisTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/SgcwmisTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/MiscTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PmiscTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/MsfnTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/JFunc.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SkprpolyTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SkprwatTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SolventDensityTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SorwmisTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/StandardCond.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableContainer.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Aqudims.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/PlymwinjTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SkprwatTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/SkprpolyTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Eqldims.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Regdims.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TLMixpar.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Ppcwmax.hpp>
+
+#include <cassert>
+#include <cstddef>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace Opm {
 
@@ -83,7 +88,7 @@ namespace Opm {
         /*
           WIll return max{ Tabdims::NTFIP , Regdims::NTFIP }.
         */
-        size_t numFIPRegions() const;
+        std::size_t numFIPRegions() const;
 
         const TableContainer& getSwofTables() const;
         const TableContainer& getSgwfnTables() const;
@@ -292,11 +297,11 @@ namespace Opm {
         }
 
     private:
-        TableContainer& forceGetTables( const std::string& tableName , size_t numTables);
+        TableContainer& forceGetTables( const std::string& tableName , std::size_t numTables);
 
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName);
 
-        void addTables( const std::string& tableName , size_t numTables);
+        void addTables( const std::string& tableName , std::size_t numTables);
         void initSimpleTables(const Deck& deck);
         void initRTempTables(const Deck& deck);
         void initZmfvdTables(const Deck& deck);
@@ -336,23 +341,23 @@ namespace Opm {
         void initSimpleTableContainerWithJFunc(const Deck& deck,
                                       const std::string& keywordName,
                                       const std::string& tableName,
-                                      size_t numTables);
+                                      std::size_t numTables);
 
         template <class TableType>
         void initSimpleTableContainer(const Deck& deck,
                                       const std::string& keywordName,
                                       const std::string& tableName,
-                                      size_t numTables);
+                                      std::size_t numTables);
 
         template <class TableType>
         void initSimpleTableContainer(const Deck& deck,
                                       const std::string& keywordName,
-                                      size_t numTables);
+                                      std::size_t numTables);
 
         template <class TableType>
         void initSimpleTableContainerWithJFunc(const Deck& deck,
                                                const std::string& keywordName,
-                                               size_t numTables);
+                                               std::size_t numTables);
 
         template <class TableType>
         void initSimpleTable(const Deck& deck,
@@ -427,15 +432,14 @@ namespace Opm {
         bool m_diff_mole_fraction {true};
 
         struct SplitSimpleTables {
-          size_t plyshMax = 0;
-          size_t rockMax = 0;
-          std::map<size_t, std::shared_ptr<PlyshlogTable>> plyshMap;
-          std::map<size_t, std::shared_ptr<RocktabTable>> rockMap;
+          std::size_t plyshMax = 0;
+          std::size_t rockMax = 0;
+          std::map<std::size_t, std::shared_ptr<PlyshlogTable>> plyshMap;
+          std::map<std::size_t, std::shared_ptr<RocktabTable>> rockMap;
         };
 
         SplitSimpleTables splitSimpleTable(std::map<std::string,TableContainer>& simpleTables);
     };
 }
-
 
 #endif

--- a/opm/input/eclipse/EclipseState/Tables/Tables.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Tables.cpp
@@ -121,8 +121,6 @@
 #include <utility>
 #include <vector>
 
-#include <stddef.h>
-
 #include <fmt/format.h>
 
 namespace {
@@ -498,7 +496,7 @@ namespace {
     }
 } // Anonymous namespace
 
-PvtgTable::PvtgTable(const DeckKeyword& keyword, size_t tableIdx)
+PvtgTable::PvtgTable(const DeckKeyword& keyword, std::size_t tableIdx)
     : PvtxTable("P")
 {
     m_underSaturatedSchema.addColumn(ColumnSchema("RV", Table::STRICTLY_DECREASING, Table::DEFAULT_NONE));
@@ -565,7 +563,7 @@ PvtgTable::operator==(const PvtgTable& data) const
     return static_cast<const PvtxTable&>(*this) == static_cast<const PvtxTable&>(data);
 }
 
-PvtgwTable::PvtgwTable(const DeckKeyword& keyword, size_t tableIdx)
+PvtgwTable::PvtgwTable(const DeckKeyword& keyword, std::size_t tableIdx)
     : PvtxTable("P")
 {
     m_underSaturatedSchema.addColumn(ColumnSchema("RW", Table::STRICTLY_DECREASING, Table::DEFAULT_NONE));
@@ -595,7 +593,7 @@ PvtgwTable::operator==(const PvtgwTable& data) const
     return static_cast<const PvtxTable&>(*this) == static_cast<const PvtxTable&>(data);
 }
 
-PvtgwoTable::PvtgwoTable(const DeckKeyword& keyword, size_t tableIdx)
+PvtgwoTable::PvtgwoTable(const DeckKeyword& keyword, std::size_t tableIdx)
     : PvtxTable("P")
 {
 
@@ -628,7 +626,7 @@ PvtgwoTable::operator==(const PvtgwoTable& data) const
     return static_cast<const PvtxTable&>(*this) == static_cast<const PvtxTable&>(data);
 }
 
-PvtoTable::PvtoTable(const DeckKeyword& keyword, size_t tableIdx)
+PvtoTable::PvtoTable(const DeckKeyword& keyword, std::size_t tableIdx)
     : PvtxTable("RS")
 {
     m_underSaturatedSchema.addColumn(ColumnSchema("P", Table::STRICTLY_INCREASING, Table::DEFAULT_NONE));
@@ -685,7 +683,7 @@ PvtoTable::nonMonotonicSaturatedFVF() const
     return nonmonoFVF;
 }
 
-PvtsolTable::PvtsolTable(const DeckKeyword& keyword, size_t tableIdx)
+PvtsolTable::PvtsolTable(const DeckKeyword& keyword, std::size_t tableIdx)
     : PvtxTable("ZCO2")
 {
     m_underSaturatedSchema.addColumn(ColumnSchema("P", Table::STRICTLY_INCREASING, Table::DEFAULT_NONE));
@@ -727,7 +725,7 @@ PvtsolTable::operator==(const PvtsolTable& data) const
     return static_cast<const PvtxTable&>(*this) == static_cast<const PvtxTable&>(data);
 }
 
-RwgsaltTable::RwgsaltTable(const DeckKeyword& keyword, size_t tableIdx)
+RwgsaltTable::RwgsaltTable(const DeckKeyword& keyword, std::size_t tableIdx)
     : PvtxTable("P")
 {
 
@@ -1413,7 +1411,7 @@ PlymaxTable::PlymaxTable(const DeckRecord& record)
     m_schema.addColumn(ColumnSchema("C_POLYMER_MAX", Table::RANDOM, Table::DEFAULT_NONE));
 
     addColumns();
-    for (size_t colIdx = 0; colIdx < record.size(); colIdx++) {
+    for (std::size_t colIdx = 0; colIdx < record.size(); colIdx++) {
         auto& column = getColumn(colIdx);
 
         column.addValue(record.getItem(colIdx).getSIDouble(0), "PLYMAX");
@@ -1459,7 +1457,7 @@ PlyrockTable::PlyrockTable(const DeckRecord& record)
     m_schema.addColumn(ColumnSchema("MaxAdsorbtion", Table::RANDOM, Table::DEFAULT_NONE));
 
     addColumns();
-    for (size_t colIdx = 0; colIdx < record.size(); colIdx++) {
+    for (std::size_t colIdx = 0; colIdx < record.size(); colIdx++) {
         auto& column = getColumn(colIdx);
 
         column.addValue(record.getItem(colIdx).getSIDouble(0), "PLYROCK");

--- a/opm/input/eclipse/EclipseState/TracerConfig.cpp
+++ b/opm/input/eclipse/EclipseState/TracerConfig.cpp
@@ -18,21 +18,27 @@
 */
 
 #include <config.h>
+
 #include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
 
 #include <opm/common/utility/OpmInputError.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/InfoLogger.hpp>
-#include <opm/input/eclipse/Deck/Deck.hpp>
+
 #include <opm/input/eclipse/EclipseState/Tables/TracerVdTable.hpp>
-#include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
+
 #include <opm/input/eclipse/Units/Dimension.hpp>
 #include <opm/input/eclipse/Units/Units.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
+#include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
+
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cstddef>
 
 namespace Opm {
 
@@ -168,7 +174,7 @@ TracerConfig TracerConfig::serializationTestObject()
     return result;
 }
 
-size_t TracerConfig::size() const {
+std::size_t TracerConfig::size() const {
     return this->tracers.size();
 }
 

--- a/opm/input/eclipse/EclipseState/TracerConfig.hpp
+++ b/opm/input/eclipse/EclipseState/TracerConfig.hpp
@@ -23,6 +23,7 @@
 #include <opm/input/eclipse/EclipseState/Phase.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TracerVdTable.hpp>
 
+#include <cstddef>
 #include <optional>
 
 namespace Opm {
@@ -52,7 +53,6 @@ public:
         std::string wellsname() const {
             return "S" + this->name;
         }
-
 
         TracerEntry() = default;
         TracerEntry(const std::string& name_, const std::string& unit_string_,
@@ -123,7 +123,7 @@ public:
 
     static TracerConfig serializationTestObject();
 
-    size_t size() const;
+    std::size_t size() const;
     bool empty() const;
 
     const std::vector<TracerEntry>::const_iterator begin() const;

--- a/opm/input/eclipse/EclipseState/checkDeck.cpp
+++ b/opm/input/eclipse/EclipseState/checkDeck.cpp
@@ -16,26 +16,31 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include <opm/input/eclipse/EclipseState/checkDeck.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
 
+#include <opm/common/utility/String.hpp>
+
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckSection.hpp>
+
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
-#include <opm/common/utility/String.hpp>
+
+#include <cstddef>
 
 namespace Opm {
-bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& parseContext, ErrorGuard& errorGuard, size_t enabledChecks) {
+bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& parseContext, ErrorGuard& errorGuard, std::size_t enabledChecks) {
     bool deckValid = true;
 
     // make sure that the deck does not contain unknown keywords
     if (enabledChecks & UnknownKeywords) {
-        size_t keywordIdx = 0;
+        std::size_t keywordIdx = 0;
         for (; keywordIdx < deck.size(); keywordIdx++) {
             const auto& keyword = deck[keywordIdx];
             if (!parser.isRecognizedKeyword( keyword.name() ) ) {

--- a/opm/input/eclipse/EclipseState/checkDeck.hpp
+++ b/opm/input/eclipse/EclipseState/checkDeck.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_CHECK_DECK_HPP
 #define OPM_CHECK_DECK_HPP
 
+#include <cstddef>
 #include <memory>
 
 namespace Opm {
@@ -42,7 +43,7 @@ enum DeckChecks {
 
 // some semantical correctness checks of the deck. this method adds a warning to
 // the deck object if any issue is found ...
-bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& parseContext, ErrorGuard& errorGuard, size_t enabledChecks  = AllChecks);
+bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& parseContext, ErrorGuard& errorGuard, std::size_t enabledChecks  = AllChecks);
 
 }
 

--- a/opm/input/eclipse/Parser/Parser.cpp
+++ b/opm/input/eclipse/Parser/Parser.cpp
@@ -59,16 +59,17 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
 #include <cstdio>
 #include <filesystem>
 #include <iostream>
 #include <iterator>
 #include <optional>
+#include <regex>
 #include <stack>
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <regex>
 #include <utility>
 #include <vector>
 
@@ -463,7 +464,7 @@ struct file {
     {}
 
     std::string_view input;
-    size_t lineNR = 0;
+    std::size_t lineNR = 0;
     std::filesystem::path path;
 };
 
@@ -512,7 +513,7 @@ class ParserState {
         void addPathAlias( const std::string& alias, const std::string& path );
 
         const std::filesystem::path& current_path() const;
-        size_t line() const;
+        std::size_t line() const;
 
         bool done() const;
         std::string_view getline();
@@ -548,7 +549,7 @@ const std::filesystem::path& ParserState::current_path() const {
     return this->input_stack.top().path;
 }
 
-size_t ParserState::line() const {
+std::size_t ParserState::line() const {
     return this->input_stack.top().lineNR;
 }
 
@@ -745,11 +746,11 @@ std::optional<std::filesystem::path> ParserState::getIncludeFilePath( std::strin
     static const std::string pathKeywordPrefix("$");
     static const std::string validPathNameCharacters("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_");
 
-    size_t positionOfPathName = path.find(pathKeywordPrefix);
+    std::size_t positionOfPathName = path.find(pathKeywordPrefix);
 
     if ( positionOfPathName != std::string::npos) {
         std::string stringStartingAtPathName = path.substr(positionOfPathName+1);
-        size_t cutOffPosition = stringStartingAtPathName.find_first_not_of(validPathNameCharacters);
+        std::size_t cutOffPosition = stringStartingAtPathName.find_first_not_of(validPathNameCharacters);
         std::string stringToFind = stringStartingAtPathName.substr(0, cutOffPosition);
         std::string stringToReplace = this->pathMap.at( stringToFind );
         replaceAll(path, pathKeywordPrefix + stringToFind, stringToReplace);
@@ -1762,7 +1763,7 @@ bool parseState( ParserState& parserState, const Parser& parser, ErrorGuard& err
         return this->parseString(data, ParseContext(), errors);
     }
 
-    size_t Parser::size() const {
+    std::size_t Parser::size() const {
         return m_deckParserKeywords.size();
     }
 
@@ -1869,7 +1870,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
 
     void Parser::loadKeywords(const Json::JsonObject& jsonKeywords) {
         if (jsonKeywords.is_array()) {
-            for (size_t index = 0; index < jsonKeywords.size(); index++) {
+            for (std::size_t index = 0; index < jsonKeywords.size(); index++) {
                 Json::JsonObject jsonKeyword = jsonKeywords.get_array_item(index);
                 addParserKeyword( ParserKeyword( jsonKeyword ) );
             }
@@ -1964,7 +1965,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
         // We put errors on the top level to the end of the list to make them
         // more prominent
         std::vector<std::string> topLevelErrors;
-        size_t curKwIdx = 0;
+        std::size_t curKwIdx = 0;
 
         while(curKwIdx < deck.size() && isGlobalKeyword(deck[curKwIdx])) {
             ++curKwIdx;

--- a/opm/input/eclipse/Parser/Parser.hpp
+++ b/opm/input/eclipse/Parser/Parser.hpp
@@ -20,6 +20,9 @@
 #ifndef OPM_PARSER_HPP
 #define OPM_PARSER_HPP
 
+#include <opm/input/eclipse/Parser/ParserKeyword.hpp>
+
+#include <cstddef>
 #include <filesystem>
 #include <iosfwd>
 #include <list>
@@ -28,10 +31,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <stddef.h>
-
-#include <opm/input/eclipse/Parser/ParserKeyword.hpp>
 
 namespace Json {
     class JsonObject;
@@ -137,7 +136,7 @@ namespace Opm {
          *
          * This is an approximate number because regular expresions are disconsidered.
          */
-        size_t size() const;
+        std::size_t size() const;
 
         template <class T>
         void addKeyword() {

--- a/opm/input/eclipse/Parser/ParserItem.cpp
+++ b/opm/input/eclipse/Parser/ParserItem.cpp
@@ -17,17 +17,21 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <ostream>
-#include <sstream>
-#include <iomanip>
-#include <cmath>
+#include <opm/input/eclipse/Parser/ParserItem.hpp>
 
 #include <opm/json/JsonObject.hpp>
 
-#include <opm/input/eclipse/Parser/ParserItem.hpp>
 #include <opm/input/eclipse/Parser/ParserEnums.hpp>
+
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
+
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <ostream>
+#include <sstream>
 
 #include "raw/RawRecord.hpp"
 #include "raw/StarToken.hpp"
@@ -115,7 +119,6 @@ T& ParserItem::value_ref() {
             );
 }
 
-
 ParserItem::ParserItem( const std::string& itemName, ParserItem::itype input_type_arg) :
     m_name(itemName),
     m_defaultSet(false)
@@ -142,7 +145,7 @@ ParserItem::ParserItem( const Json::JsonObject& json ) :
             this->push_backDimension( dim.as_string() );
         }
         else if( dim.is_array() ) {
-            for( size_t i = 0; i < dim.size(); ++i )
+            for( std::size_t i = 0; i < dim.size(); ++i )
                 this->push_backDimension( dim.get_array_item( i ).as_string() );
         }
         else {
@@ -186,7 +189,6 @@ void ParserItem::setDefault( T val ) {
     this->m_defaultSet = true;
 }
 
-
 void ParserItem::setInputType(ParserItem::itype input_type_arg) {
     this->input_type = input_type_arg;
 
@@ -211,7 +213,6 @@ void ParserItem::setInputType(ParserItem::itype input_type_arg) {
         throw std::invalid_argument("BUG: input type not recognized in setInputType()");
 }
 
-
 template< typename T >
 void ParserItem::setDataType( T) {
     this->data_type = get_type< T >();
@@ -220,7 +221,6 @@ void ParserItem::setDataType( T) {
 bool ParserItem::hasDefault() const {
     return this->m_defaultSet;
 }
-
 
 template< typename T>
 const T& ParserItem::getDefault() const {
@@ -233,7 +233,6 @@ const T& ParserItem::getDefault() const {
 
     return this->value_ref< T >();
 }
-
 
 const std::vector<std::string>& ParserItem::dimensions() const {
     return this->m_dimensions;
@@ -261,11 +260,9 @@ void ParserItem::push_backDimension( const std::string& dim ) {
         return m_name;
     }
 
-
     type_tag ParserItem::dataType() const {
         return this->data_type;
     }
-
 
     ParserItem::item_size ParserItem::sizeType() const {
         return m_sizeType;
@@ -279,7 +276,6 @@ void ParserItem::push_backDimension( const std::string& dim ) {
     {
         return m_description;
     }
-
 
     void ParserItem::setSizeType(item_size size_type) {
         /*
@@ -297,11 +293,9 @@ void ParserItem::push_backDimension( const std::string& dim ) {
         this->m_sizeType = size_type;
     }
 
-
     void ParserItem::setDescription(const std::string& description) {
         m_description = description;
     }
-
 
     bool ParserItem::operator==( const ParserItem& rhs ) const {
     if( !( this->data_type      == rhs.data_type
@@ -352,7 +346,6 @@ bool ParserItem::operator!=( const ParserItem& rhs ) const {
     return !( *this == rhs );
 }
 
-
 std::string ParserItem::size_literal() const {
     if (this->m_sizeType == item_size::ALL)
         return "ParserItem::item_size::ALL";
@@ -395,7 +388,6 @@ std::string ParserItem::to_string(itype input_type) {
     throw std::invalid_argument("Can not convert to string");
 }
 
-
 ParserItem::itype ParserItem::from_string(const std::string& string_value) {
     if( string_value == "INT" )       return itype::INT;
     if( string_value == "DOUBLE" )    return itype::DOUBLE;
@@ -404,7 +396,6 @@ ParserItem::itype ParserItem::from_string(const std::string& string_value) {
     if( string_value == "UDA")        return itype::UDA;
     throw std::invalid_argument( string_value + " cannot be converted to ParserInputType" );
 }
-
 
 std::string ParserItem::createCode(const std::string& indent) const {
     std::stringstream stream;
@@ -557,7 +548,6 @@ void scan_item( DeckItem& deck_item, const ParserItem& parser_item, RawRecord& r
 
 }
 
-
 /// Scans the records data according to the ParserItems definition.
 /// returns a DeckItem object.
 /// NOTE: data are popped from the records deque!
@@ -691,7 +681,6 @@ std::string ParserItem::inlineClassInit(const std::string& parentClass,
 
     return ss.str();
 }
-
 
 std::ostream& operator<<( std::ostream& stream, const ParserItem::item_size& sz ) {
     return stream << ParserItem::string_from_size( sz );

--- a/opm/input/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/input/eclipse/Parser/ParserKeyword.cpp
@@ -16,21 +16,25 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <algorithm>
-#include <cctype>
-#include <fmt/format.h>
-#include <iostream>
-#include <sstream>
-#include <stdexcept>
-#include <string>
+#include <opm/input/eclipse/Parser/ParserKeyword.hpp>
 
 #include <opm/json/JsonObject.hpp>
 
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
+
 #include <opm/input/eclipse/Parser/ParserConst.hpp>
-#include <opm/input/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/input/eclipse/Parser/ParserRecord.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include <fmt/format.h>
 
 #include "raw/RawConsts.hpp"
 #include "raw/RawKeyword.hpp"
@@ -201,7 +205,6 @@ std::string KeywordSize::construct() const
     throw std::logic_error("No string serialization known?");
 }
 
-
     ParserKeyword::ParserKeyword(const std::string& name)
         : ParserKeyword(name, KeywordSize{})
     {
@@ -230,7 +233,6 @@ std::string KeywordSize::construct() const
         return std::ranges::any_of(*this, have_dim);
     }
 
-
     bool ParserKeyword::isTableCollection() const {
         return this->keyword_size.table_collection();
     }
@@ -243,7 +245,6 @@ std::string KeywordSize::construct() const
     void ParserKeyword::setDescription(const std::string& description) {
         m_Description = description;
     }
-
 
     void ParserKeyword::setCodeEnd(const std::string& end) {
         this->code_end = end;
@@ -302,18 +303,16 @@ std::string KeywordSize::construct() const
         this->keyword_size = KeywordSize(0);
     }
 
-
     void ParserKeyword::parseRecords( const Json::JsonObject& recordsConfig) {
          if (recordsConfig.is_array()) {
-             size_t num_records = recordsConfig.size();
-             for (size_t i = 0; i < num_records; i++) {
+             std::size_t num_records = recordsConfig.size();
+             for (std::size_t i = 0; i < num_records; i++) {
                   const Json::JsonObject itemsConfig = recordsConfig.get_array_item(i);
                   addItems(itemsConfig);
              }
          } else
              throw std::invalid_argument("The records item must point to an array item");
     }
-
 
     ParserKeyword::ParserKeyword(const Json::JsonObject& jsonConfig) :
         ParserKeyword(jsonConfig.get_string("name"))
@@ -432,7 +431,6 @@ std::string KeywordSize::construct() const
         }
     }
 
-
     bool ParserKeyword::validNameStart( const std::string_view& name) {
         if (!isalpha(name[0]))
             return false;
@@ -448,7 +446,6 @@ std::string KeywordSize::construct() const
 
         return std::all_of(name.begin() + 1, name.end(), ok);
     }
-
 
     bool ParserKeyword::validDeckName( const std::string_view& name) {
 
@@ -478,7 +475,7 @@ std::string KeywordSize::construct() const
         if (namesObject.size() > 0)
             m_deckNames.clear();
 
-        for (size_t nameIdx = 0; nameIdx < namesObject.size(); ++ nameIdx) {
+        for (std::size_t nameIdx = 0; nameIdx < namesObject.size(); ++ nameIdx) {
             const Json::JsonObject nameObject = namesObject.get_array_item(nameIdx);
 
             if (!nameObject.is_string())
@@ -498,7 +495,7 @@ std::string KeywordSize::construct() const
             throw std::invalid_argument("The 'sections' JSON item of keyword "+m_name+" needs to be a list");
 
         m_validSectionNames.clear();
-        for (size_t nameIdx = 0; nameIdx < namesObject.size(); ++ nameIdx) {
+        for (std::size_t nameIdx = 0; nameIdx < namesObject.size(); ++ nameIdx) {
             const Json::JsonObject nameObject = namesObject.get_array_item(nameIdx);
 
             if (!nameObject.is_string())
@@ -541,10 +538,10 @@ std::string KeywordSize::construct() const
         if( !itemsConfig.is_array() )
             throw std::invalid_argument("The 'items' JSON item missing must be an array in keyword "+getName()+".");
 
-        size_t num_items = itemsConfig.size();
+        std::size_t num_items = itemsConfig.size();
         ParserRecord record;
 
-        for (size_t i = 0; i < num_items; i++) {
+        for (std::size_t i = 0; i < num_items; i++) {
             const Json::JsonObject& itemConfig = itemsConfig.get_array_item(i);
             record.addItem( ParserItem( itemConfig ) );
         }
@@ -564,7 +561,7 @@ void set_dimensions( ParserItem& item,
         item.push_backDimension( dim.as_string() );
     }
     else if( dim.is_array() ) {
-        for (size_t idim = 0; idim < dim.size(); idim++)
+        for (std::size_t idim = 0; idim < dim.size(); idim++)
             item.push_backDimension( dim.get_array_item( idim ).as_string() );
     }
     else {
@@ -591,7 +588,6 @@ void set_dimensions( ParserItem& item,
         record.addItem(item);
         this->addRecord(record);
     }
-
 
     void ParserKeyword::initData(const Json::JsonObject& jsonConfig) {
         const Json::JsonObject dataConfig = jsonConfig.get_item("data");
@@ -640,8 +636,7 @@ void set_dimensions( ParserItem& item,
         throw std::invalid_argument("While initializing keyword "+getName()+": Values of type "+dataConfig.get_string("value_type")+" are not implemented.");
     }
 
-
-    const ParserRecord& ParserKeyword::getRecord(size_t recordIndex) const {
+    const ParserRecord& ParserKeyword::getRecord(std::size_t recordIndex) const {
         if( this->m_records.empty() )
             throw std::invalid_argument( "Trying to get record from empty keyword" );
 
@@ -656,12 +651,11 @@ void set_dimensions( ParserItem& item,
         return this->m_records[ recordIndex ];
     }
 
-    ParserRecord& ParserKeyword::getRecord( size_t index ) {
+    ParserRecord& ParserKeyword::getRecord( std::size_t index ) {
         return const_cast< ParserRecord& >(
                  const_cast< const ParserKeyword& >( *this ).getRecord( index )
                 );
     }
-
 
     std::vector< ParserRecord >::const_iterator ParserKeyword::begin() const {
         return m_records.begin();
@@ -700,7 +694,6 @@ void set_dimensions( ParserItem& item,
 
         this->addRecord(std::move(record));
     }
-
 
     const std::string ParserKeyword::className() const {
         return getName();
@@ -755,7 +748,7 @@ void set_dimensions( ParserItem& item,
             /* Note: this merely dumps all records sequentially into m_recordList.
                Each block of records is separated by an empty DeckRecord.
             */
-            size_t record_nr = 0;
+            std::size_t record_nr = 0;
             try {
                 for (auto& rawRecord : rawKeyword) {
                     if (rawRecord.size() == 0) {
@@ -775,7 +768,7 @@ void set_dimensions( ParserItem& item,
             }
         }
         else {
-            size_t record_nr = 0;
+            std::size_t record_nr = 0;
             try {
                 for( auto& rawRecord : rawKeyword ) {
                     if( m_records.size() == 0 && rawRecord.size() > 0 )
@@ -811,7 +804,7 @@ void set_dimensions( ParserItem& item,
         return this->keyword_size.min_size();
     }
 
-    size_t ParserKeyword::getFixedSize() const {
+    std::size_t ParserKeyword::getFixedSize() const {
         if (!hasFixedSize())
             throw std::logic_error("The parser keyword "+getName()+" does not have a fixed size!");
         const auto& max_size = this->keyword_size.max_size();
@@ -978,11 +971,9 @@ void set_dimensions( ParserItem& item,
         return ss.str();
     }
 
-
     std::string ParserKeyword::createDecl() const {
         return className() + "::" + className() + "()";
     }
-
 
     std::string ParserKeyword::createCode() const {
         std::stringstream ss;
@@ -1109,8 +1100,6 @@ void set_dimensions( ParserItem& item,
 
         return ss.str();
     }
-
-
 
     bool ParserKeyword::operator==( const ParserKeyword& rhs ) const {
         // compare the deck names. we don't care about the ordering of the strings.

--- a/opm/input/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/input/eclipse/Parser/ParserKeyword.hpp
@@ -19,6 +19,10 @@
 #ifndef PARSER_KEYWORD_H
 #define PARSER_KEYWORD_H
 
+#include <opm/input/eclipse/Parser/ParserEnums.hpp>
+#include <opm/input/eclipse/Parser/ParserRecord.hpp>
+
+#include <cstddef>
 #include <iosfwd>
 #include <optional>
 #include <regex>
@@ -26,9 +30,6 @@
 #include <unordered_set>
 #include <utility>
 #include <variant>
-
-#include <opm/input/eclipse/Parser/ParserEnums.hpp>
-#include <opm/input/eclipse/Parser/ParserRecord.hpp>
 
 namespace Json {
     class JsonObject;
@@ -90,7 +91,6 @@ namespace Opm {
 
         void initSizeKeyword( const std::string& sizeKeyword, const std::string& sizeItem, bool table_collection, int size_shift);
 
-
         static bool validInternalName(const std::string& name);
         static bool validDeckName(const std::string_view& name);
         bool hasMatchRegex() const;
@@ -101,14 +101,14 @@ namespace Opm {
         bool hasDimension() const;
         void addRecord( ParserRecord );
         void addDataRecord( ParserRecord );
-        const ParserRecord& getRecord(size_t recordIndex) const;
-        ParserRecord& getRecord(size_t recordIndex);
+        const ParserRecord& getRecord(std::size_t recordIndex) const;
+        ParserRecord& getRecord(std::size_t recordIndex);
         std::vector< ParserRecord >::const_iterator begin() const;
         std::vector< ParserRecord >::const_iterator end() const;
         const std::string className() const;
         const std::string& getName() const;
         std::optional<std::size_t> min_size() const;
-        size_t getFixedSize() const;
+        std::size_t getFixedSize() const;
         bool hasFixedSize() const;
         bool isTableCollection() const;
         const std::string& getDescription() const;

--- a/opm/input/eclipse/Parser/ParserRecord.cpp
+++ b/opm/input/eclipse/Parser/ParserRecord.cpp
@@ -19,18 +19,21 @@
 
 #include <opm/input/eclipse/Parser/ParserRecord.hpp>
 
-#include <fmt/format.h>
-
-#include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/Parser/ParseContext.hpp>
-#include <opm/input/eclipse/Parser/ParserItem.hpp>
-#include <opm/input/eclipse/Units/UnitSystem.hpp>
-
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 
-#include "raw/RawRecord.hpp"
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <opm/input/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+#include <opm/input/eclipse/Parser/ParserItem.hpp>
+
+#include <cstddef>
 #include <ostream>
+
+#include <fmt/format.h>
+
+#include "raw/RawRecord.hpp"
 
 namespace Opm {
 
@@ -49,7 +52,7 @@ namespace {
     {
     }
 
-    size_t ParserRecord::size() const {
+    std::size_t ParserRecord::size() const {
         return m_items.size();
     }
 
@@ -80,17 +83,13 @@ namespace {
         m_dataRecord = true;
     }
 
-
-
     std::vector< ParserItem >::const_iterator ParserRecord::begin() const {
         return m_items.begin();
     }
 
-
     std::vector< ParserItem >::const_iterator ParserRecord::end() const {
         return m_items.end();
     }
-
 
     bool ParserRecord::hasDimension() const
     {
@@ -99,10 +98,7 @@ namespace {
                                    { return x.dimensions().size() > 0; } );
     }
 
-
-
-
-    const ParserItem& ParserRecord::get(size_t index) const {
+    const ParserItem& ParserRecord::get(std::size_t index) const {
         return this->m_items.at( index );
     }
 
@@ -146,7 +142,7 @@ namespace {
     bool ParserRecord::equal(const ParserRecord& other) const {
         bool equal_ = true;
         if (size() == other.size()) {
-           size_t itemIndex = 0;
+           std::size_t itemIndex = 0;
            while (true) {
                if (itemIndex == size())
                    break;
@@ -186,7 +182,6 @@ namespace {
 
         return stream << "    }";
     }
-
 
     const std::string& ParserRecord::end_string() const {
         return this->record_end;

--- a/opm/input/eclipse/Parser/ParserRecord.hpp
+++ b/opm/input/eclipse/Parser/ParserRecord.hpp
@@ -20,11 +20,12 @@
 #ifndef PARSERRECORD_HPP
 #define PARSERRECORD_HPP
 
-#include <iosfwd>
-#include <vector>
-#include <memory>
-
 #include <opm/input/eclipse/Parser/ParserItem.hpp>
+
+#include <cstddef>
+#include <iosfwd>
+#include <memory>
+#include <vector>
 
 namespace Opm {
 
@@ -39,10 +40,10 @@ namespace Opm {
     class ParserRecord {
     public:
         ParserRecord();
-        size_t size() const;
+        std::size_t size() const;
         void addItem( ParserItem );
         void addDataItem( ParserItem item );
-        const ParserItem& get(size_t index) const;
+        const ParserItem& get(std::size_t index) const;
         const ParserItem& get(const std::string& itemName) const;
         DeckRecord parse( const ParseContext&, ErrorGuard&, RawRecord&, UnitSystem& active_unitsystem, UnitSystem& default_unitsystem, const KeywordLocation& location) const;
         bool isDataRecord() const;
@@ -66,6 +67,5 @@ namespace Opm {
 
 std::ostream& operator<<( std::ostream&, const ParserRecord& );
 }
-
 
 #endif  /* PARSERRECORD_HPP */

--- a/opm/input/eclipse/Parser/createDefaultKeywordList.cpp
+++ b/opm/input/eclipse/Parser/createDefaultKeywordList.cpp
@@ -17,14 +17,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <cstdlib>
-
-#include <fstream>
-#include <locale>
-
 #include <opm/input/eclipse/Generator/KeywordGenerator.hpp>
 #include <opm/input/eclipse/Generator/KeywordLoader.hpp>
 
+#include <cstddef>
+#include <cstdlib>
+#include <fstream>
+#include <locale>
 
 int main(int argc, char ** argv) {
     const char * source_file_path = argv[2];
@@ -41,9 +40,9 @@ int main(int argc, char ** argv) {
         std::getline( is , buffer );
         is.close();
 
-        size_t start = 0;
+        std::size_t start = 0;
         while (true) {
-            size_t end = buffer.find( ";" , start);
+            std::size_t end = buffer.find( ";" , start);
             if (end == std::string::npos) {
                 keyword_list.push_back( buffer.substr(start) );
                 break;

--- a/opm/input/eclipse/Parser/raw/RawRecord.hpp
+++ b/opm/input/eclipse/Parser/raw/RawRecord.hpp
@@ -20,11 +20,12 @@
 #ifndef RECORD_HPP
 #define RECORD_HPP
 
+#include <cstddef>
 #include <deque>
+#include <list>
 #include <memory>
 #include <string>
 #include <string_view>
-#include <list>
 
 namespace Opm {
 class KeywordLocation;
@@ -41,11 +42,11 @@ class KeywordLocation;
         inline std::string_view pop_front();
         inline std::string_view front() const;
         void push_front( std::string_view token, std::size_t count );
-        inline size_t size() const;
+        inline std::size_t size() const;
         std::size_t max_size() const;
 
         std::string getRecordString() const;
-        inline std::string_view getItem(size_t index) const;
+        inline std::string_view getItem(std::size_t index) const;
 
     private:
         std::string_view m_sanitizedRecordString;
@@ -67,11 +68,11 @@ class KeywordLocation;
         return this->m_recordItems.front();
     }
 
-    size_t RawRecord::size() const {
+    std::size_t RawRecord::size() const {
         return m_recordItems.size();
     }
 
-    std::string_view RawRecord::getItem(size_t index) const {
+    std::string_view RawRecord::getItem(std::size_t index) const {
         return this->m_recordItems.at( index );
     }
 }

--- a/opm/input/eclipse/Parser/raw/StarToken.cpp
+++ b/opm/input/eclipse/Parser/raw/StarToken.cpp
@@ -25,6 +25,7 @@
 #include <boost/spirit/include/qi.hpp>
 
 #include <cctype>
+#include <cstddef>
 #include <cstdlib>
 #include <stdexcept>
 #include <string>
@@ -44,7 +45,7 @@ namespace Opm {
                            std::string& countString,
                            std::string& valueString) {
         // find first character which is not a digit
-        size_t pos = 0;
+        std::size_t pos = 0;
         for (; pos < token.length(); ++pos)
             if (!std::isdigit(token[pos]))
                 break;

--- a/opm/input/eclipse/Schedule/Group/GConSale.cpp
+++ b/opm/input/eclipse/Schedule/Group/GConSale.cpp
@@ -17,12 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
+
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 
-#include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
-#include "../eval_uda.hpp"
-
+#include <cstddef>
 #include <stdexcept>
+
+#include "../eval_uda.hpp"
 
 namespace Opm {
 
@@ -85,7 +87,7 @@ void GConSale::add(const std::string& name, const UDAValue& sales_target, const 
     group.unit_system = unit_system;
 }
 
-size_t GConSale::size() const {
+std::size_t GConSale::size() const {
     return groups.size();
 }
 

--- a/opm/input/eclipse/Schedule/Group/GConSale.hpp
+++ b/opm/input/eclipse/Schedule/Group/GConSale.hpp
@@ -21,8 +21,10 @@
 #define GCONSALE_H
 
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
+
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <cstddef>
 #include <map>
 #include <string>
 
@@ -80,7 +82,7 @@ namespace Opm {
         const GCONSALEGroupProp get(const std::string& name, const SummaryState& st) const;
         static MaxProcedure stringToProcedure(const std::string& procedure);
         void add(const std::string& name, const UDAValue& sales_target, const UDAValue& max_rate, const UDAValue& min_rate, const std::string& procedure, double udq_undefined_arg, const UnitSystem& unit_system);
-        size_t size() const;
+        std::size_t size() const;
 
         bool operator==(const GConSale& data) const;
 
@@ -95,6 +97,5 @@ namespace Opm {
     };
 
 }
-
 
 #endif

--- a/opm/input/eclipse/Schedule/Group/GConSump.cpp
+++ b/opm/input/eclipse/Schedule/Group/GConSump.cpp
@@ -19,9 +19,10 @@
 
 #include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
 
-#include "../eval_uda.hpp"
-
+#include <cstddef>
 #include <stdexcept>
+
+#include "../eval_uda.hpp"
 
 namespace Opm {
 
@@ -38,7 +39,6 @@ bool GConSump::has(const std::string& name) const {
     return (groups.find(name) != groups.end());
 }
 
-
 const GConSump::GCONSUMPGroup& GConSump::get(const std::string& name) const {
 
     auto it = groups.find(name);
@@ -47,7 +47,6 @@ const GConSump::GCONSUMPGroup& GConSump::get(const std::string& name) const {
     else
         return it->second;
 }
-
 
 const GConSump::GCONSUMPGroupProp GConSump::get(const std::string& name, const SummaryState& st) const {
 
@@ -72,8 +71,7 @@ void GConSump::add(const std::string& name, const UDAValue& consumption_rate,
     group.unit_system = unit_system;
 }
 
-
-size_t GConSump::size() const {
+std::size_t GConSump::size() const {
     return groups.size();
 }
 

--- a/opm/input/eclipse/Schedule/Group/GConSump.hpp
+++ b/opm/input/eclipse/Schedule/Group/GConSump.hpp
@@ -23,6 +23,7 @@
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <cstddef>
 #include <map>
 #include <string>
 
@@ -72,7 +73,7 @@ namespace Opm {
         void add(const std::string& name, const UDAValue& consumption_rate,
                  const UDAValue& import_rate, const std::string& network_node,
                  double udq_undefined_arg, const UnitSystem& unit_system);
-        size_t size() const;
+        std::size_t size() const;
 
         bool operator==(const GConSump& data) const;
 

--- a/opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.cpp
+++ b/opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.cpp
@@ -19,12 +19,15 @@
 
 #include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
 
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
+
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
+#include <cstddef>
+
 #include "../eval_uda.hpp"
 
 namespace {
@@ -98,8 +101,6 @@ bool GroupEconProductionLimits::operator!=(const GroupEconProductionLimits& othe
     return !(*this == other);
 }
 
-
-
 GroupEconProductionLimits GroupEconProductionLimits::serializationTestObject()
 {
     GroupEconProductionLimits gecon;
@@ -107,7 +108,7 @@ GroupEconProductionLimits GroupEconProductionLimits::serializationTestObject()
     return gecon;
 }
 
-size_t GroupEconProductionLimits::size() const {
+std::size_t GroupEconProductionLimits::size() const {
     return this->m_groups.size();
 }
 
@@ -223,7 +224,6 @@ GroupEconProductionLimits::EconWorkover GroupEconProductionLimits::GEconGroup::w
     return m_workover;
 }
 
-
 /* Methods for inner class GEconGroupProp */
 
 GroupEconProductionLimits::GEconGroupProp::GEconGroupProp(
@@ -284,6 +284,5 @@ std::optional<double> GroupEconProductionLimits::GEconGroupProp::maxWaterGasRati
 GroupEconProductionLimits::EconWorkover GroupEconProductionLimits::GEconGroupProp::workover() const {
     return m_workover;
 }
-
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp
+++ b/opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp
@@ -22,6 +22,7 @@
 
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 
+#include <cstddef>
 #include <map>
 #include <optional>
 #include <string>
@@ -134,7 +135,7 @@ public:
         serializer(m_groups);
     }
     static GroupEconProductionLimits serializationTestObject();
-    size_t size() const;
+    std::size_t size() const;
 
 private:
     std::map<std::string, GEconGroup> m_groups;

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -158,7 +158,7 @@ namespace Opm {
         return m_comp_pressure_drop;
     }
 
-    const Segment& WellSegments::operator[](size_t idx) const {
+    const Segment& WellSegments::operator[](std::size_t idx) const {
         return m_segments[idx];
     }
 
@@ -300,7 +300,7 @@ namespace Opm {
 
         // Read all the information out from the DECK first then process to
         // get all the requisite information.
-        for (size_t recordIndex = 1; recordIndex < welsegsKeyword.size(); ++recordIndex) {
+        for (std::size_t recordIndex = 1; recordIndex < welsegsKeyword.size(); ++recordIndex) {
             const auto& record = welsegsKeyword.getRecord(recordIndex);
             const int segment1 = record.getItem("SEGMENT1").get<int>(0);
             const int segment2 = record.getItem("SEGMENT2").get<int>(0);

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -99,7 +99,7 @@ namespace Opm {
 
         const Segment& getFromSegmentNumber(const int segment_number) const;
 
-        const Segment& operator[](size_t idx) const;
+        const Segment& operator[](std::size_t idx) const;
         void orderSegments();
 
         bool operator==( const WellSegments& ) const;

--- a/opm/input/eclipse/Schedule/OilVaporizationProperties.cpp
+++ b/opm/input/eclipse/Schedule/OilVaporizationProperties.cpp
@@ -16,8 +16,10 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
 
+#include <cstddef>
 #include <stdexcept>
 
 namespace Opm {
@@ -28,7 +30,7 @@ namespace Opm {
         m_vap1 = m_vap2 = -1.0;
     }
 
-    OilVaporizationProperties::OilVaporizationProperties(const size_t numPvtRegionIdx):
+    OilVaporizationProperties::OilVaporizationProperties(const std::size_t numPvtRegionIdx):
          m_vap1(-1.0),
          m_vap2(-1.0),
          m_maxDRSDT(numPvtRegionIdx, -1.0),
@@ -53,7 +55,7 @@ namespace Opm {
         return result;
     }
 
-    double OilVaporizationProperties::getMaxDRVDT(const size_t pvtRegionIdx) const{
+    double OilVaporizationProperties::getMaxDRVDT(const std::size_t pvtRegionIdx) const{
         if (drvdtActive(pvtRegionIdx)){
             return m_maxDRVDT[pvtRegionIdx];
         }else{
@@ -61,7 +63,7 @@ namespace Opm {
         }
     }
 
-    double OilVaporizationProperties::getMaxDRSDT(const size_t pvtRegionIdx) const{
+    double OilVaporizationProperties::getMaxDRSDT(const std::size_t pvtRegionIdx) const{
         if (drsdtActive(pvtRegionIdx)){
             return m_maxDRSDT[pvtRegionIdx];
         }else{
@@ -69,7 +71,7 @@ namespace Opm {
         }
     }
 
-    bool OilVaporizationProperties::getOption(const size_t pvtRegionIdx) const{
+    bool OilVaporizationProperties::getOption(const std::size_t pvtRegionIdx) const{
         if (drsdtActive(pvtRegionIdx)){
             return m_maxDRSDT_allCells[pvtRegionIdx];
         }else{
@@ -77,7 +79,7 @@ namespace Opm {
         }
     }
 
-    double OilVaporizationProperties::getOmega(const size_t pvtRegionIdx) const{
+    double OilVaporizationProperties::getOmega(const std::size_t pvtRegionIdx) const{
         if (drsdtConvective(pvtRegionIdx)){
             return m_omega[pvtRegionIdx];
         }else{
@@ -85,7 +87,7 @@ namespace Opm {
         }
     }
 
-    double OilVaporizationProperties::getPsi(const size_t pvtRegionIdx) const{
+    double OilVaporizationProperties::getPsi(const std::size_t pvtRegionIdx) const{
         if (drsdtConvective(pvtRegionIdx)){
             return m_psi[pvtRegionIdx];
         }else{
@@ -100,7 +102,7 @@ namespace Opm {
     void OilVaporizationProperties::updateDRSDT(OilVaporizationProperties& ovp, const std::vector<double>& maximums, const std::vector<std::string>& options){
         ovp.m_type = OilVaporization::DRDT;
         ovp.m_maxDRSDT = maximums;
-        for (size_t pvtRegionIdx = 0; pvtRegionIdx < options.size(); ++pvtRegionIdx) {
+        for (std::size_t pvtRegionIdx = 0; pvtRegionIdx < options.size(); ++pvtRegionIdx) {
             if (options[pvtRegionIdx] == "ALL"){
                 ovp.m_maxDRSDT_allCells[pvtRegionIdx] = true;
             } else if (options[pvtRegionIdx] == "FREE") {
@@ -117,7 +119,7 @@ namespace Opm {
         ovp.m_maxDRSDT = maximums;
         ovp.m_omega = omega;
         ovp.m_psi = psi;
-        for (size_t pvtRegionIdx = 0; pvtRegionIdx < options.size(); ++pvtRegionIdx) {
+        for (std::size_t pvtRegionIdx = 0; pvtRegionIdx < options.size(); ++pvtRegionIdx) {
             if (options[pvtRegionIdx] == "ALL"){
                 ovp.m_maxDRSDT_allCells[pvtRegionIdx] = true;
             } else if (options[pvtRegionIdx] == "FREE") {
@@ -145,7 +147,7 @@ namespace Opm {
 
     bool OilVaporizationProperties::drsdtActive() const {
         // return true if one region is active
-         for (size_t pvtRegionIdx = 0; pvtRegionIdx < m_maxDRSDT.size(); ++pvtRegionIdx) {
+         for (std::size_t pvtRegionIdx = 0; pvtRegionIdx < m_maxDRSDT.size(); ++pvtRegionIdx) {
             if (drsdtActive(pvtRegionIdx))
                 return true;
          }
@@ -154,7 +156,7 @@ namespace Opm {
 
     bool OilVaporizationProperties::drsdtConvective() const {
         // return true if one region is active
-         for (size_t pvtRegionIdx = 0; pvtRegionIdx < m_maxDRSDT.size(); ++pvtRegionIdx) {
+         for (std::size_t pvtRegionIdx = 0; pvtRegionIdx < m_maxDRSDT.size(); ++pvtRegionIdx) {
             if (drsdtConvective(pvtRegionIdx))
                 return true;
          }
@@ -163,22 +165,22 @@ namespace Opm {
 
     bool OilVaporizationProperties::drvdtActive() const {
         // return true if one region is active
-         for (size_t pvtRegionIdx = 0; pvtRegionIdx < m_maxDRSDT.size(); ++pvtRegionIdx) {
+         for (std::size_t pvtRegionIdx = 0; pvtRegionIdx < m_maxDRSDT.size(); ++pvtRegionIdx) {
             if (drvdtActive(pvtRegionIdx))
                 return true;
          }
          return false;
     }
 
-    bool OilVaporizationProperties::drsdtActive(const size_t pvtRegionIdx) const {
+    bool OilVaporizationProperties::drsdtActive(const std::size_t pvtRegionIdx) const {
         return (m_maxDRSDT[pvtRegionIdx] >= 0 && (m_type == OilVaporization::DRDT || m_type == OilVaporization::DRSDTCON));
     }
 
-    bool OilVaporizationProperties::drsdtConvective(const size_t pvtRegionIdx) const {
+    bool OilVaporizationProperties::drsdtConvective(const std::size_t pvtRegionIdx) const {
         return (m_maxDRSDT[pvtRegionIdx] >= 0 && this->m_type == OilVaporization::DRSDTCON);
     }
 
-    bool OilVaporizationProperties::drvdtActive(const size_t pvtRegionIdx) const {
+    bool OilVaporizationProperties::drvdtActive(const std::size_t pvtRegionIdx) const {
         return (m_maxDRVDT[pvtRegionIdx] >= 0 && m_type == OilVaporization::DRDT);
     }
 

--- a/opm/input/eclipse/Schedule/OilVaporizationProperties.hpp
+++ b/opm/input/eclipse/Schedule/OilVaporizationProperties.hpp
@@ -19,6 +19,7 @@
 #ifndef DRSDT_HPP
 #define DRSDT_HPP
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -42,7 +43,7 @@ namespace Opm
 
 
         OilVaporizationProperties();
-        explicit OilVaporizationProperties(const size_t numPvtReginIdx);
+        explicit OilVaporizationProperties(const std::size_t numPvtReginIdx);
 
         static OilVaporizationProperties serializationTestObject();
 
@@ -53,25 +54,25 @@ namespace Opm
         static void updateVAPPARS(Opm::OilVaporizationProperties& ovp, double vap1, double vap2);
 
         OilVaporization getType() const;
-        double getMaxDRSDT(const size_t pvtRegionIdx) const;
-        double getMaxDRVDT(const size_t pvtRegionIdx) const;
-        bool getOption(const size_t pvtRegionIdx) const;
-        bool drsdtActive(const size_t pvtRegionIdx) const;
-        bool drvdtActive(const size_t pvtRegionIdx) const;
-        bool drsdtConvective(const size_t pvtRegionIdx) const;
+        double getMaxDRSDT(const std::size_t pvtRegionIdx) const;
+        double getMaxDRVDT(const std::size_t pvtRegionIdx) const;
+        bool getOption(const std::size_t pvtRegionIdx) const;
+        bool drsdtActive(const std::size_t pvtRegionIdx) const;
+        bool drvdtActive(const std::size_t pvtRegionIdx) const;
+        bool drsdtConvective(const std::size_t pvtRegionIdx) const;
 
         bool drsdtActive() const;
         bool drvdtActive() const;
         bool drsdtConvective() const;
 
         bool defined() const;
-        size_t numPvtRegions() const {return m_maxDRSDT.size();}
+        std::size_t numPvtRegions() const {return m_maxDRSDT.size();}
 
         double vap1() const;
         double vap2() const;
 
-        double getPsi(const size_t pvtRegionIdx) const;
-        double getOmega(const size_t pvtRegionIdx) const;
+        double getPsi(const std::size_t pvtRegionIdx) const;
+        double getOmega(const std::size_t pvtRegionIdx) const;
         /*
          * if either argument was default constructed == will always be false
          * and != will always be true

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -107,6 +107,7 @@
 #include "Well/injection.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <ctime>
 #include <functional>
 #include <initializer_list>
@@ -2231,7 +2232,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         return sched_state->wlist_manager.get().hasList(pattern);
     }
 
-    const std::map< std::string, int >& Schedule::rst_keywords( size_t report_step ) const {
+    const std::map< std::string, int >& Schedule::rst_keywords( std::size_t report_step ) const {
         if (report_step == 0)
             return this->m_static.rst_config.keywords;
 

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -19,19 +19,6 @@
 #ifndef SCHEDULE_HPP
 #define SCHEDULE_HPP
 
-#include <cstddef>
-#include <ctime>
-#include <functional>
-#include <iosfwd>
-#include <map>
-#include <memory>
-#include <optional>
-#include <set>
-#include <string>
-#include <unordered_map>
-#include <utility>
-#include <vector>
-
 #include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
 #include <opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp>
 #include <opm/input/eclipse/Schedule/Action/WGNames.hpp>
@@ -44,7 +31,22 @@
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
 #include <opm/input/eclipse/Schedule/WriteRestartFileEvents.hpp>
+
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <ctime>
+#include <functional>
+#include <iosfwd>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace Opm {
     class ActiveGridCells;
@@ -372,7 +374,7 @@ namespace Opm {
         std::size_t size() const;
 
         bool write_rst_file(std::size_t report_step) const;
-        const std::map< std::string, int >& rst_keywords( size_t timestep ) const;
+        const std::map< std::string, int >& rst_keywords( std::size_t timestep ) const;
 
         // The applyAction() member function is invoked from the simulator
         // *after* an ACTIONX has triggered.  Its return value is a small

--- a/opm/input/eclipse/Schedule/VFPInjTable.cpp
+++ b/opm/input/eclipse/Schedule/VFPInjTable.cpp
@@ -17,19 +17,23 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <cassert>
-#include <cmath>
-#include <iostream>
-#include <fmt/format.h>
+#include <opm/input/eclipse/Schedule/VFPInjTable.hpp>
+
+#include <opm/input/eclipse/Units/Dimension.hpp>
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/Parser/ParserKeywords/V.hpp>
-#include <opm/input/eclipse/Units/Dimension.hpp>
-#include <opm/input/eclipse/Units/UnitSystem.hpp>
 
-#include <opm/input/eclipse/Schedule/VFPInjTable.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/V.hpp>
+
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+
+#include <fmt/format.h>
 
 //Anonymous namespace
 namespace {
@@ -48,9 +52,6 @@ inline const Opm::DeckItem& getNonEmptyItem( const Opm::DeckRecord& record) {
 
 } //Namespace
 
-
-
-
 namespace Opm {
 
 VFPInjTable::VFPInjTable()
@@ -59,7 +60,6 @@ VFPInjTable::VFPInjTable()
     m_datum_depth = 0.0;
     m_flo_type = FLO_TYPE::FLO_OIL;
 }
-
 
 VFPInjTable::VFPInjTable( const DeckKeyword& table, const UnitSystem& deck_unit_system) :
     m_location(table.location())
@@ -130,7 +130,6 @@ VFPInjTable::VFPInjTable( const DeckKeyword& table, const UnitSystem& deck_unit_
         throw std::invalid_argument("Invalid BODY_DEF string");
     }
 
-
     //Get actual rate / flow values
     m_flo_data = getNonEmptyItem<VFPINJ::FLOW_VALUES>(table.getRecord(1)).getData< double >();
     convertFloToSI(m_flo_type, m_flo_data, deck_unit_system);
@@ -140,8 +139,8 @@ VFPInjTable::VFPInjTable( const DeckKeyword& table, const UnitSystem& deck_unit_
     convertTHPToSI(m_thp_data, deck_unit_system);
 
     //Finally, read the actual table itself.
-    size_t nt = m_thp_data.size();
-    size_t nf = m_flo_data.size();
+    std::size_t nt = m_thp_data.size();
+    std::size_t nf = m_flo_data.size();
     m_data.resize(nt*nf);
     std::fill_n(m_data.data(), m_data.size(), std::nan("0"));
 
@@ -151,7 +150,7 @@ VFPInjTable::VFPInjTable( const DeckKeyword& table, const UnitSystem& deck_unit_
     }
 
     const double table_scaling_factor = deck_unit_system.parse("Pressure").getSIScaling();
-    for (size_t i=3; i<table.size(); ++i) {
+    for (std::size_t i=3; i<table.size(); ++i) {
         const auto& record = table.getRecord(i);
         //Get indices (subtract 1 to get 0-based index)
         int t = getNonEmptyItem<VFPINJ::THP_INDEX>(record).get< int >(0) - 1;
@@ -177,7 +176,6 @@ VFPInjTable::VFPInjTable( const DeckKeyword& table, const UnitSystem& deck_unit_
     check();
 }
 
-
 VFPInjTable VFPInjTable::serializationTestObject()
 {
     VFPInjTable result;
@@ -192,9 +190,6 @@ VFPInjTable VFPInjTable::serializationTestObject()
     return result;
 }
 
-
-
-
 namespace {
 
 void check_axis(const std::vector<double>& axis) {
@@ -206,9 +201,6 @@ void check_axis(const std::vector<double>& axis) {
 }
 
 }
-
-
-
 
 void VFPInjTable::check() {
     if (this->m_table_num <= 0)
@@ -240,14 +232,6 @@ void VFPInjTable::check() {
     }
 }
 
-
-
-
-
-
-
-
-
 VFPInjTable::FLO_TYPE VFPInjTable::getFloType(const std::string& flo_string)
 {
     if (flo_string == "OIL")
@@ -262,13 +246,6 @@ VFPInjTable::FLO_TYPE VFPInjTable::getFloType(const std::string& flo_string)
     throw std::invalid_argument("Invalid RATE_TYPE string");
 }
 
-
-
-
-
-
-
-
 void VFPInjTable::scaleValues(std::vector<double>& values,
                                const double& scaling_factor) {
     if (scaling_factor == 1.0) {
@@ -280,12 +257,6 @@ void VFPInjTable::scaleValues(std::vector<double>& values,
         }
     }
 }
-
-
-
-
-
-
 
 void VFPInjTable::convertFloToSI(const FLO_TYPE& type,
                                   std::vector<double>& values,
@@ -305,18 +276,11 @@ void VFPInjTable::convertFloToSI(const FLO_TYPE& type,
     scaleValues(values, scaling_factor);
 }
 
-
-
-
-
-
-
 void VFPInjTable::convertTHPToSI(std::vector<double>& values,
                                  const UnitSystem& unit_system) {
     double scaling_factor = unit_system.parse("Pressure").getSIScaling();
     scaleValues(values, scaling_factor);
 }
-
 
 bool VFPInjTable::operator==(const VFPInjTable& data) const {
     return this->getTableNum() == data.getTableNum() &&
@@ -328,20 +292,16 @@ bool VFPInjTable::operator==(const VFPInjTable& data) const {
            this->location() == data.location();
 }
 
-
-double VFPInjTable::operator()(size_t thp_idx, size_t flo_idx) const {
+double VFPInjTable::operator()(std::size_t thp_idx, std::size_t flo_idx) const {
     return m_data[thp_idx*m_flo_data.size() + flo_idx];
 }
 
-
-double& VFPInjTable::operator()(size_t thp_idx, size_t flo_idx) {
+double& VFPInjTable::operator()(std::size_t thp_idx, std::size_t flo_idx) {
     return m_data[thp_idx*m_flo_data.size() + flo_idx];
 }
 
-
-std::array<size_t,2> VFPInjTable::shape() const {
+std::array<std::size_t,2> VFPInjTable::shape() const {
     return {m_thp_data.size(), m_flo_data.size()};
 }
-
 
 } //Namespace

--- a/opm/input/eclipse/Schedule/VFPInjTable.hpp
+++ b/opm/input/eclipse/Schedule/VFPInjTable.hpp
@@ -17,16 +17,15 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef OPM_PARSER_ECLIPSE_ECLIPSESTATE_TABLES_VFPINJTABLE_HPP_
 #define OPM_PARSER_ECLIPSE_ECLIPSESTATE_TABLES_VFPINJTABLE_HPP_
 
+#include <opm/common/OpmLog/KeywordLocation.hpp>
 
 #include <array>
-#include <vector>
+#include <cstddef>
 #include <string>
-
-#include <opm/common/OpmLog/KeywordLocation.hpp>
+#include <vector>
 
 namespace Opm {
 
@@ -41,7 +40,6 @@ public:
         FLO_WAT,
         FLO_GAS,
     };
-
 
     VFPInjTable();
     VFPInjTable(const DeckKeyword& table, const UnitSystem& deck_unit_system);
@@ -95,9 +93,9 @@ public:
 
     bool operator==(const VFPInjTable& data) const;
 
-    std::array<size_t,2> shape() const;
+    std::array<std::size_t,2> shape() const;
 
-    double operator()(size_t thp_idx, size_t flo_idx) const;
+    double operator()(std::size_t thp_idx, std::size_t flo_idx) const;
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)
@@ -119,13 +117,12 @@ private:
     std::vector<double> m_flo_data;
     std::vector<double> m_thp_data;
 
-
     std::vector<double> m_data;
     KeywordLocation m_location;
 
     void check();
 
-    double& operator()(size_t thp_idx, size_t flo_idx);
+    double& operator()(std::size_t thp_idx, std::size_t flo_idx);
 
     static FLO_TYPE getFloType(const std::string& flo_string);
 
@@ -139,8 +136,6 @@ private:
                             const UnitSystem& unit_system);
 };
 
-
 }
-
 
 #endif

--- a/opm/input/eclipse/Schedule/VFPProdTable.cpp
+++ b/opm/input/eclipse/Schedule/VFPProdTable.cpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstddef>
 
 #include <fmt/format.h>
 
@@ -420,11 +421,11 @@ void VFPProdTable::check() {
     check_axis(this->m_gfr_data);
     check_axis(this->m_alq_data);
 
-    size_t nt = this->m_thp_data.size();
-    size_t nw = this->m_wfr_data.size();
-    size_t ng = this->m_gfr_data.size();
-    size_t na = this->m_alq_data.size();
-    size_t nf = this->m_flo_data.size();
+    std::size_t nt = this->m_thp_data.size();
+    std::size_t nw = this->m_wfr_data.size();
+    std::size_t ng = this->m_gfr_data.size();
+    std::size_t na = this->m_alq_data.size();
+    std::size_t nf = this->m_flo_data.size();
 
     //Check that bhp(thp) is a monotonic increasing function.
     //If this is not the case, we might not be able to determine
@@ -482,7 +483,7 @@ void VFPProdTable::scaleValues(std::vector<double>& values,
         return;
     }
     else {
-        for (size_t i=0; i < values.size(); ++i) {
+        for (std::size_t i=0; i < values.size(); ++i) {
             values[i] *= scaling_factor;
         }
     }
@@ -637,32 +638,32 @@ bool VFPProdTable::operator==(const VFPProdTable& data) const {
 }
 
 
-double VFPProdTable::operator()(size_t thp_idx, size_t wfr_idx, size_t gfr_idx, size_t alq_idx, size_t flo_idx) const {
-    size_t nw = m_wfr_data.size();
-    size_t ng = m_gfr_data.size();
-    size_t na = m_alq_data.size();
-    size_t nf = m_flo_data.size();
+double VFPProdTable::operator()(std::size_t thp_idx, std::size_t wfr_idx, std::size_t gfr_idx, std::size_t alq_idx, std::size_t flo_idx) const {
+    std::size_t nw = m_wfr_data.size();
+    std::size_t ng = m_gfr_data.size();
+    std::size_t na = m_alq_data.size();
+    std::size_t nf = m_flo_data.size();
 
     return m_data[thp_idx*nw*ng*na*nf + wfr_idx*ng*na*nf + gfr_idx*na*nf + alq_idx*nf + flo_idx];
 }
 
 
-double& VFPProdTable::mutableData(size_t thp_idx, size_t wfr_idx, size_t gfr_idx, size_t alq_idx, size_t flo_idx) {
-    size_t nw = m_wfr_data.size();
-    size_t ng = m_gfr_data.size();
-    size_t na = m_alq_data.size();
-    size_t nf = m_flo_data.size();
+double& VFPProdTable::mutableData(std::size_t thp_idx, std::size_t wfr_idx, std::size_t gfr_idx, std::size_t alq_idx, std::size_t flo_idx) {
+    std::size_t nw = m_wfr_data.size();
+    std::size_t ng = m_gfr_data.size();
+    std::size_t na = m_alq_data.size();
+    std::size_t nf = m_flo_data.size();
 
     return m_data[thp_idx*nw*ng*na*nf + wfr_idx*ng*na*nf + gfr_idx*na*nf + alq_idx*nf + flo_idx];
 }
 
 
-std::array<size_t,5> VFPProdTable::shape() const {
-    size_t nt = m_thp_data.size();
-    size_t nw = m_wfr_data.size();
-    size_t ng = m_gfr_data.size();
-    size_t na = m_alq_data.size();
-    size_t nf = m_flo_data.size();
+std::array<std::size_t,5> VFPProdTable::shape() const {
+    std::size_t nt = m_thp_data.size();
+    std::size_t nw = m_wfr_data.size();
+    std::size_t ng = m_gfr_data.size();
+    std::size_t na = m_alq_data.size();
+    std::size_t nf = m_flo_data.size();
 
     return {nt, nw, ng, na, nf};
 }

--- a/opm/input/eclipse/Schedule/VFPProdTable.hpp
+++ b/opm/input/eclipse/Schedule/VFPProdTable.hpp
@@ -25,6 +25,7 @@
 #include <opm/input/eclipse/Units/Dimension.hpp>
 
 #include <array>
+#include <cstddef>
 #include <utility>
 #include <vector>
 
@@ -167,9 +168,9 @@ public:
 
     bool operator==(const VFPProdTable& data) const;
 
-    std::array<size_t,5> shape() const;
+    std::array<std::size_t,5> shape() const;
 
-    double operator()(size_t thp_idx, size_t wfr_idx, size_t gfr_idx, size_t alq_idx, size_t flo_idx) const;
+    double operator()(std::size_t thp_idx, std::size_t wfr_idx, std::size_t gfr_idx, std::size_t alq_idx, std::size_t flo_idx) const;
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)
@@ -208,7 +209,7 @@ private:
 
     void check();
 
-    double& mutableData(size_t thp_idx, size_t wfr_idx, size_t gfr_idx, size_t alq_idx, size_t flo_idx);
+    double& mutableData(std::size_t thp_idx, std::size_t wfr_idx, std::size_t gfr_idx, std::size_t alq_idx, std::size_t flo_idx);
 
     static void scaleValues(std::vector<double>& values,
                             const double& scaling_factor);

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -71,8 +71,6 @@
 
 #include <fmt/format.h>
 
-#include <stddef.h>
-
 namespace {
 
     // Compute direction permutation corresponding to completion's
@@ -727,7 +725,7 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
         const auto m_top = perf_top.getSIDouble(0);
         const auto m_bot = perf_bot.getSIDouble(0);
         external::cvf::Vec3d p_top, p_bot;
-        for (size_t i = 0; i < 3 ; ++i) {
+        for (std::size_t i = 0; i < 3 ; ++i) {
             p_top[i] = linearInterpolation(this->md, this->coord[i], m_top);
             p_bot[i] = linearInterpolation(this->md, this->coord[i], m_bot);
         }
@@ -736,7 +734,7 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
 
         points.reserve(this->coord[0].size());
         measured_depths.reserve(this->coord[0].size());
-        for (size_t i = 0; i < coord[0].size(); ++i) {
+        for (std::size_t i = 0; i < coord[0].size(); ++i) {
             if (this->md[i] > m_top and this->md[i] < m_bot) {
                 points.push_back(external::cvf::Vec3d(coord[0][i], coord[1][i], coord[2][i]));
                 measured_depths.push_back(this->md[i]);
@@ -763,7 +761,7 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
         // exit cell face point and connection length.
         wellTraj.intersections = e->cellIntersectionInfosAlongWellPath();
 
-        for (size_t is = 0; is < wellTraj.intersections.size(); ++is) {
+        for (std::size_t is = 0; is < wellTraj.intersections.size(); ++is) {
             const auto ijk = ecl_grid->getIJK(wellTraj.intersections[is].globCellIndex);
 
             // When using WELTRAJ & COMPTRAJ one may use default settings in
@@ -949,15 +947,15 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
 
     bool WellConnections::empty() const
     {
-        return this->size() == size_t{0};
+        return this->size() == std::size_t{0};
     }
 
-    const Connection& WellConnections::get(size_t index) const
+    const Connection& WellConnections::get(std::size_t index) const
     {
         return (*this)[index];
     }
 
-    const Connection& WellConnections::operator[](size_t index) const
+    const Connection& WellConnections::operator[](std::size_t index) const
     {
         return this->m_connections.at(index);
     }
@@ -986,7 +984,7 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
     const Connection&
     WellConnections::getFromIJK(const int i, const int j, const int k) const
     {
-        for (size_t ic = 0; ic < size(); ++ic) {
+        for (std::size_t ic = 0; ic < size(); ++ic) {
             if (get(ic).sameCoordinate(i, j, k)) {
                 return get(ic);
             }
@@ -1011,7 +1009,7 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
 
     Connection& WellConnections::getFromIJK(const int i, const int j, const int k)
     {
-        for (size_t ic = 0; ic < size(); ++ic) {
+        for (std::size_t ic = 0; ic < size(); ++ic) {
             if (get(ic).sameCoordinate(i, j, k)) {
                 return this->m_connections[ic];
             }
@@ -1073,7 +1071,7 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
     {
         // Find the first connection and swap it into the 0-position.
         const double surface_z = 0.0;
-        size_t first_index = findClosestConnection(this->headI, this->headJ, surface_z, 0);
+        std::size_t first_index = findClosestConnection(this->headI, this->headJ, surface_z, 0);
         std::swap(m_connections[first_index], m_connections[0]);
 
         // Repeat for remaining connections.
@@ -1086,20 +1084,20 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
             return;
         }
 
-        for (size_t pos = 1; pos < m_connections.size() - 1; ++pos) {
+        for (std::size_t pos = 1; pos < m_connections.size() - 1; ++pos) {
             const auto& prev = m_connections[pos - 1];
             const double prevz = prev.depth();
-            size_t next_index = findClosestConnection(prev.getI(), prev.getJ(), prevz, pos);
+            std::size_t next_index = findClosestConnection(prev.getI(), prev.getJ(), prevz, pos);
             std::swap(m_connections[next_index], m_connections[pos]);
         }
     }
 
-    size_t WellConnections::findClosestConnection(int oi, int oj, double oz, size_t start_pos)
+    std::size_t WellConnections::findClosestConnection(int oi, int oj, double oz, std::size_t start_pos)
     {
-        size_t closest = std::numeric_limits<size_t>::max();
+        std::size_t closest = std::numeric_limits<std::size_t>::max();
         int min_ijdist2 = std::numeric_limits<int>::max();
         double min_zdiff = std::numeric_limits<double>::max();
-        for (size_t pos = start_pos; pos < m_connections.size(); ++pos) {
+        for (std::size_t pos = start_pos; pos < m_connections.size(); ++pos) {
             const auto& connection = m_connections[ pos ];
 
             const double depth = connection.depth();
@@ -1119,7 +1117,7 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                 }
             }
         }
-        assert(closest != std::numeric_limits<size_t>::max());
+        assert(closest != std::numeric_limits<std::size_t>::max());
         return closest;
     }
 

--- a/opm/input/eclipse/Schedule/Well/WellConnections.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.hpp
@@ -28,8 +28,6 @@
 #include <string>
 #include <vector>
 
-#include <stddef.h>
-
 namespace Opm {
     class ActiveGridCells;
     class DeckRecord;
@@ -124,8 +122,8 @@ namespace Opm {
         std::size_t size() const;
         bool empty() const;
         std::size_t num_open() const;
-        const Connection& operator[](size_t index) const;
-        const Connection& get(size_t index) const;
+        const Connection& operator[](std::size_t index) const;
+        const Connection& get(std::size_t index) const;
         const Connection& getFromIJK(const int i, const int j, const int k) const;
         const Connection& getFromGlobalIndex(std::size_t global_index) const;
         const Connection& lowest() const;
@@ -212,7 +210,7 @@ namespace Opm {
                            int lgr_grid_number,
                            const bool defaultSatTabId);
 
-        size_t findClosestConnection(int oi, int oj, double oz, size_t start_pos);
+        std::size_t findClosestConnection(int oi, int oj, double oz, std::size_t start_pos);
         void orderTRACK();
         void orderMSW();
         void orderDEPTH();

--- a/opm/input/eclipse/Schedule/Well/WellTestState.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestState.cpp
@@ -129,7 +129,7 @@ namespace Opm {
     }
 
 
-    size_t WellTestState::num_closed_wells() const
+    std::size_t WellTestState::num_closed_wells() const
     {
         return std::ranges::count_if(this->wells,
                                      [](const auto& well_pair)
@@ -210,7 +210,7 @@ namespace Opm {
         return true;
     }
 
-    size_t WellTestState::num_closed_completions() const {
+    std::size_t WellTestState::num_closed_completions() const {
         std::size_t count = 0;
         for (const auto& [_, comp_map] : this->completions) {
             (void)_;

--- a/opm/input/eclipse/Schedule/WellTraj/RigEclipseWellLogExtractor.cpp
+++ b/opm/input/eclipse/Schedule/WellTraj/RigEclipseWellLogExtractor.cpp
@@ -23,9 +23,10 @@
 //     ApplicationLibCode\ReservoirDataModel\RigMainGrid.cpp
 //     ApplicationLibCode\ReservoirDataModel\RigWellPathIntersectionTools.cpp
 
-
 #include "RigEclipseWellLogExtractor.hpp"
+
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+
 #include <opm/input/eclipse/Schedule/ScheduleGrid.hpp>
 
 #include <external/resinsight/ReservoirDataModel/RigWellLogExtractionTools.h>
@@ -33,11 +34,13 @@
 #include <external/resinsight/ReservoirDataModel/cvfGeometryTools.h>
 #include <external/resinsight/ReservoirDataModel/RigWellLogExtractor.h>
 #include <external/resinsight/ReservoirDataModel/RigCellGeometryTools.h>
+
 #include <external/resinsight/CommonCode/cvfStructGrid.h>
+
 #include <external/resinsight/LibGeometry/cvfBoundingBox.h>
 
+#include <cstddef>
 #include <map>
-
 
 namespace external {
 
@@ -51,7 +54,6 @@ namespace external {
     calculateIntersection();
 }
 
-
 // Modified version of ApplicationLibCode\ReservoirDataModel\RigEclipseWellLogExtractor.cpp
 void RigEclipseWellLogExtractor::calculateIntersection()
 {
@@ -61,7 +63,7 @@ void RigEclipseWellLogExtractor::calculateIntersection()
 
     buildCellSearchTree();
 
-    for ( size_t wpp = 0; wpp < m_wellPathGeometry->wellPathPoints().size() - 1; ++wpp )
+    for ( std::size_t wpp = 0; wpp < m_wellPathGeometry->wellPathPoints().size() - 1; ++wpp )
     {
         std::vector<HexIntersectionInfo> intersections;
         cvf::Vec3d                       p1 = m_wellPathGeometry->wellPathPoints()[wpp];
@@ -72,7 +74,7 @@ void RigEclipseWellLogExtractor::calculateIntersection()
         bb.add( p1 );
         bb.add( p2 );
 
-        std::vector<size_t> closeCellIndices = findCloseCellIndices( bb );
+        std::vector<std::size_t> closeCellIndices = findCloseCellIndices( bb );
 
         for ( const auto& globalCellIndex : closeCellIndices )
         {
@@ -97,7 +99,7 @@ void RigEclipseWellLogExtractor::calculateIntersection()
 }
 
 // Modified version of ApplicationLibCode\ReservoirDataModel\RigEclipseWellLogExtractor.cpp
-cvf::Vec3d RigEclipseWellLogExtractor::calculateLengthInCell( size_t            cellIndex,
+cvf::Vec3d RigEclipseWellLogExtractor::calculateLengthInCell( std::size_t            cellIndex,
                                                               const cvf::Vec3d& startPoint,
                                                               const cvf::Vec3d& endPoint ) const
 {
@@ -105,7 +107,7 @@ cvf::Vec3d RigEclipseWellLogExtractor::calculateLengthInCell( size_t            
     RigEclipseWellLogExtractor::hexCornersOpmToResinsight( hexCorners, cellIndex );
 
     std::array<cvf::Vec3d, 8> hexCorners2;
-    for (size_t i = 0; i < 8; i++)
+    for (std::size_t i = 0; i < 8; i++)
            hexCorners2[i] =  hexCorners[i];
 
     return RigEclipseWellLogExtractor::calculateLengthInCell( hexCorners2, startPoint, endPoint );
@@ -184,7 +186,7 @@ void RigEclipseWellLogExtractor::findCellLocalXYZ( const std::array<cvf::Vec3d, 
 }
 
 // Convert opm to resinsight numbering of cornerpoints, see RigCellGeometryTools.cpp
-void RigEclipseWellLogExtractor::hexCornersOpmToResinsight( cvf::Vec3d hexCorners[8], size_t cellIndex ) const
+void RigEclipseWellLogExtractor::hexCornersOpmToResinsight( cvf::Vec3d hexCorners[8], std::size_t cellIndex ) const
 {
     const auto[i,j,k] = m_grid.getIJK(cellIndex);
     std::array<std::size_t, 8> opm2resinsight = {0, 1, 3, 2, 4, 5, 7, 6};
@@ -205,15 +207,15 @@ void RigEclipseWellLogExtractor::buildCellSearchTree()
         auto ny = m_grid.getNY();
         auto nz = m_grid.getNZ();
 
-        size_t cellCount = nx * ny * nz;
-        std::vector<size_t>           cellIndicesForBoundingBoxes;
+        std::size_t cellCount = nx * ny * nz;
+        std::vector<std::size_t>           cellIndicesForBoundingBoxes;
         std::vector<cvf::BoundingBox> cellBoundingBoxes;
 
 // #pragma omp parallel
 //         {
-            size_t threadCellCount = cellCount;
+            std::size_t threadCellCount = cellCount;
 
-            std::vector<size_t>           threadIndicesForBoundingBoxes;
+            std::vector<std::size_t>           threadIndicesForBoundingBoxes;
             std::vector<cvf::BoundingBox> threadBoundingBoxes;
 
             threadIndicesForBoundingBoxes.reserve( threadCellCount );
@@ -255,7 +257,7 @@ void RigEclipseWellLogExtractor::buildCellSearchTree()
 }
 
 // From ApplicationLibCode\ReservoirDataModel\RigMainGrid.cpp
-void RigEclipseWellLogExtractor::findIntersectingCells( const cvf::BoundingBox& inputBB, std::vector<size_t>* cellIndices ) const
+void RigEclipseWellLogExtractor::findIntersectingCells( const cvf::BoundingBox& inputBB, std::vector<std::size_t>* cellIndices ) const
 {
     CVF_ASSERT( m_cellSearchTree.notNull() );
 
@@ -263,9 +265,9 @@ void RigEclipseWellLogExtractor::findIntersectingCells( const cvf::BoundingBox& 
 }
 
 // Modified version of ApplicationLibCode\ReservoirDataModel\RigEclipseWellLogExtractor.cpp
-std::vector<size_t> RigEclipseWellLogExtractor::findCloseCellIndices( const cvf::BoundingBox& bb )
+std::vector<std::size_t> RigEclipseWellLogExtractor::findCloseCellIndices( const cvf::BoundingBox& bb )
 {
-    std::vector<size_t> closeCells;
+    std::vector<std::size_t> closeCells;
     this->findIntersectingCells( bb, &closeCells );
     return closeCells;
 }

--- a/opm/input/eclipse/Schedule/WellTraj/RigEclipseWellLogExtractor.hpp
+++ b/opm/input/eclipse/Schedule/WellTraj/RigEclipseWellLogExtractor.hpp
@@ -21,8 +21,11 @@
 
 #include <external/resinsight/ReservoirDataModel/RigWellLogExtractor.h>
 #include <external/resinsight/LibGeometry/cvfBoundingBoxTree.h>
+
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleGrid.hpp>
+
+#include <cstddef>
 
 namespace Opm {
 class EclipseGrid;
@@ -40,7 +43,6 @@ namespace cvf
 class BoundingBox;
 }
 
-
 //==================================================================================================
 ///
 //==================================================================================================
@@ -52,23 +54,23 @@ public:
     cvf::ref<cvf::BoundingBoxTree> getCellSearchTree();
 private:
     void                calculateIntersection();
-    std::vector<size_t> findCloseCellIndices( const cvf::BoundingBox& bb );
+    std::vector<std::size_t> findCloseCellIndices( const cvf::BoundingBox& bb );
     cvf::Vec3d
-        calculateLengthInCell( size_t cellIndex, const cvf::Vec3d& startPoint, const cvf::Vec3d& endPoint ) const override;
+        calculateLengthInCell( std::size_t cellIndex, const cvf::Vec3d& startPoint, const cvf::Vec3d& endPoint ) const override;
 
     cvf::Vec3d calculateLengthInCell( const std::array<cvf::Vec3d, 8>& hexCorners,
                                       const cvf::Vec3d&                startPoint,
                                       const cvf::Vec3d&                endPoint ) const;
 
     void hexCornersOpmToResinsight( cvf::Vec3d    hexCorners[8],
-                                    size_t        cellIndex ) const;
+                                    std::size_t        cellIndex ) const;
 
     void findCellLocalXYZ( const std::array<cvf::Vec3d, 8>& hexCorners,
                            cvf::Vec3d&                      localXdirection,
                            cvf::Vec3d&                      localYdirection,
                            cvf::Vec3d&                      localZdirection ) const;
     void buildCellSearchTree();
-    void findIntersectingCells( const cvf::BoundingBox& inputBB, std::vector<size_t>* cellIndices ) const;
+    void findIntersectingCells( const cvf::BoundingBox& inputBB, std::vector<std::size_t>* cellIndices ) const;
     void computeCachedData();
 
     const Opm::EclipseGrid& m_grid;

--- a/opm/input/eclipse/Utility/Functional.cpp
+++ b/opm/input/eclipse/Utility/Functional.cpp
@@ -16,7 +16,10 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <opm/input/eclipse/Utility/Functional.hpp>
+
+#include <cstddef>
 
 namespace Opm {
 namespace fun {
@@ -25,7 +28,7 @@ namespace fun {
 
     iota::iota( int lst ) : iota( 0, lst ) {}
 
-    size_t iota::size() const {
+    std::size_t iota::size() const {
         return this->last - this->first;
     }
 
@@ -61,7 +64,6 @@ namespace fun {
     }
 
     iota::const_iterator::const_iterator( int x ) : value( x ) {}
-
 
 }
 }

--- a/opm/input/eclipse/Utility/Functional.hpp
+++ b/opm/input/eclipse/Utility/Functional.hpp
@@ -21,10 +21,11 @@
 #define OPM_FUNCTIONAL_HPP
 
 #include <algorithm>
-#include <iterator>
-#include <vector>
-#include <numeric>
+#include <cstddef>
 #include <functional>
+#include <iterator>
+#include <numeric>
+#include <vector>
 
 namespace Opm {
 
@@ -224,7 +225,7 @@ namespace fun {
                     friend class iota;
             };
 
-            size_t size() const;
+            std::size_t size() const;
 
             const_iterator begin() const;
             const_iterator end() const;

--- a/opm/io/eclipse/EGrid.cpp
+++ b/opm/io/eclipse/EGrid.cpp
@@ -24,6 +24,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -174,7 +176,7 @@ EGrid::EGrid(const std::string& filename, const std::string& grid_name)
     if (actnum_array_index != -1) {
         auto actnum = this->get<int>(actnum_array_index);
         nactive = 0;
-        for (size_t i = 0; i < actnum.size(); ++i) {
+        for (std::size_t i = 0; i < actnum.size(); ++i) {
             if (actnum[i] > 0) {
                 act_index.push_back(nactive);
                 glob_index.push_back(i);
@@ -229,7 +231,7 @@ std::vector<NNCentry> EGrid::get_nnc_ijk()
     std::vector<NNCentry> res_vect;
     res_vect.reserve(nnc1_array.size());
 
-    for (size_t n=0; n< nnc1_array.size(); n++){
+    for (std::size_t n=0; n< nnc1_array.size(); n++){
         auto ijk1 = ijk_from_global_index(nnc1_array[n] - 1);
         auto ijk2 = ijk_from_global_index(nnc2_array[n] - 1);
 
@@ -477,7 +479,7 @@ std::vector<std::array<float, 3>> EGrid::getXYZ_layer(int layer, const std::arra
         coord_array = getImpl(coord_array_index, REAL, real_array, "float");
 
     if (zcorn_array.size() > 0){
-        for (size_t n = 0; n < static_cast<size_t>(nodes_pr_surf); n++)
+        for (std::size_t n = 0; n < static_cast<std::size_t>(nodes_pr_surf); n++)
             layer_zcorn.push_back(zcorn_array[zcorn_offset + n]);
 
     } else {
@@ -499,7 +501,7 @@ std::vector<std::array<float, 3>> EGrid::getXYZ_layer(int layer, const std::arra
 
             this->getCellCorners(ijk, layer_zcorn, X, Y, Z );
 
-            for (size_t n = 0; n < 4; n++){
+            for (std::size_t n = 0; n < 4; n++){
                 std::array<float, 3> xyz;
                 xyz[0] = X[n];
                 xyz[1] = Y[n];
@@ -542,10 +544,10 @@ std::vector<float> EGrid::  get_zcorn_from_disk(int layer, bool bottom)
 
     std::string arrName(8,' ');
     eclArrType arrType;
-    int64_t num;
+    std::int64_t num;
     int sizeOfElement;
 
-    uint64_t zcorn_pos = 0;
+    std::uint64_t zcorn_pos = 0;
 
     while (!isEOF(&fileH)) {
 
@@ -556,7 +558,7 @@ std::vector<float> EGrid::  get_zcorn_from_disk(int layer, bool bottom)
             break;
         }
 
-        uint64_t sizeOfNextArray = sizeOnDiskBinary(num, arrType, sizeOfElement);
+        std::uint64_t sizeOfNextArray = sizeOnDiskBinary(num, arrType, sizeOfElement);
         fileH.seekg(static_cast<std::streamoff>(sizeOfNextArray), std::ios_base::cur);
     }
 
@@ -564,28 +566,28 @@ std::vector<float> EGrid::  get_zcorn_from_disk(int layer, bool bottom)
     int num_blocks_start = zcorn_offset / elements_pr_block;
 
     // adding size of zcorn real data before to ignored
-    uint64_t start_pos = zcorn_pos + Opm::EclIO::sizeOfReal * zcorn_offset;
+    std::uint64_t start_pos = zcorn_pos + Opm::EclIO::sizeOfReal * zcorn_offset;
 
     // adding size of blocks (head and tail flags)
     start_pos = start_pos + (1 + num_blocks_start * 2) * Opm::EclIO::sizeOfInte;
 
     fileH.seekg(start_pos, std::ios_base::beg);
 
-    uint64_t zcorn_to = zcorn_offset + nodes_pr_surf;
+    std::uint64_t zcorn_to = zcorn_offset + nodes_pr_surf;
 
     int i1 = zcorn_offset / 1000 + 1;
-    uint64_t elemets = static_cast<uint64_t>(i1 * elements_pr_block - zcorn_offset);
+    std::uint64_t elemets = static_cast<std::uint64_t>(i1 * elements_pr_block - zcorn_offset);
 
-    uint64_t next_block = elemets < zcorn_to ? elemets : zcorn_to - zcorn_offset + 1 ;
+    std::uint64_t next_block = elemets < zcorn_to ? elemets : zcorn_to - zcorn_offset + 1 ;
 
-    uint64_t p1 = zcorn_offset;
+    std::uint64_t p1 = zcorn_offset;
 
     while (p1 < zcorn_to){
 
         std::vector<float> buf(next_block);
         fileH.read(reinterpret_cast<char*>(buf.data()), buf.size()*sizeof(float));
 
-        for (size_t n = 0; n < next_block; n++)
+        for (std::size_t n = 0; n < next_block; n++)
             zcorn_layer.push_back(Opm::EclIO::flipEndianFloat(buf[n]));
 
         p1 = p1 + next_block;
@@ -596,7 +598,7 @@ std::vector<float> EGrid::  get_zcorn_from_disk(int layer, bool bottom)
             fileH.read(reinterpret_cast<char*>(&dtail), sizeof(dtail));
             dtail = Opm::EclIO::flipEndianInt(dtail);
 
-            next_block = static_cast<uint64_t>(dtail) / static_cast<uint64_t>(Opm::EclIO::sizeOfReal);
+            next_block = static_cast<std::uint64_t>(dtail) / static_cast<std::uint64_t>(Opm::EclIO::sizeOfReal);
 
             if ((p1 + next_block) > zcorn_to)
                 next_block = zcorn_to - p1;

--- a/opm/io/eclipse/EInit.cpp
+++ b/opm/io/eclipse/EInit.cpp
@@ -30,7 +30,7 @@ EInit::EInit(const std::string &filename) : EclFile(filename)
 
     lgrname = "global";
 
-    for (size_t n = 0; n < array_name.size(); n++) {
+    for (std::size_t n = 0; n < array_name.size(); n++) {
         if (array_name[n] == "LGR"){
             auto lgr = this->get<std::string>(n);
             lgrname = lgr[0];

--- a/opm/io/eclipse/ERft.cpp
+++ b/opm/io/eclipse/ERft.cpp
@@ -21,6 +21,7 @@
 #include <opm/common/ErrorMacros.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstring>
 #include <iterator>
 #include <string>
@@ -39,7 +40,7 @@ ERft::ERft(const std::string &filename) : EclFile(filename)
 
     auto listOfArrays = getList();
 
-    for (size_t i = 0; i < listOfArrays.size(); i++) {
+    for (std::size_t i = 0; i < listOfArrays.size(); i++) {
         std::string name = std::get<0>(listOfArrays[i]);
 
         if (name == "TIME") {
@@ -62,7 +63,7 @@ ERft::ERft(const std::string &filename) : EclFile(filename)
         }
     }
 
-    for (size_t i = 0; i < first.size(); i++) {
+    for (std::size_t i = 0; i < first.size(); i++) {
         std::tuple<int,int> range;
         if (i == first.size() - 1) {
             range = std::make_tuple(first[i], listOfArrays.size());
@@ -75,7 +76,7 @@ ERft::ERft(const std::string &filename) : EclFile(filename)
 
     numReports = first.size();
 
-    for (size_t i = 0; i < wellName.size(); i++) {
+    for (std::size_t i = 0; i < wellName.size(); i++) {
         std::tuple<std::string, RftDate> wellDateTuple = std::make_tuple(wellName[i], dates[i]);
         std::tuple<std::string, RftDate, float> wellDateTimeTuple = std::make_tuple(wellName[i], dates[i], timeList[i]);
         reportIndices[wellDateTuple] = i;

--- a/opm/io/eclipse/ERst.cpp
+++ b/opm/io/eclipse/ERst.cpp
@@ -21,6 +21,7 @@
 #include <opm/common/ErrorMacros.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstring>
 #include <exception>
 #include <iterator>
@@ -177,7 +178,7 @@ void ERst::initUnified()
 
     std::vector<int> firstIndex;
 
-    for (size_t i = 0;  i < array_name.size(); i++) {
+    for (std::size_t i = 0;  i < array_name.size(); i++) {
         if (array_name[i] == "SEQNUM") {
             auto seqn = get<int>(i);
             seqnum.push_back(seqn[0]);
@@ -191,7 +192,7 @@ void ERst::initUnified()
         }
     }
 
-    for (size_t i = 0; i < seqnum.size(); i++) {
+    for (std::size_t i = 0; i < seqnum.size(); i++) {
         std::pair<int,int> range;
         range.first = firstIndex[i];
 

--- a/opm/io/eclipse/ERst.hpp
+++ b/opm/io/eclipse/ERst.hpp
@@ -21,12 +21,12 @@
 
 #include <opm/io/eclipse/EclFile.hpp>
 
+#include <cstddef>
 #include <ios>
 #include <map>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
 
 namespace Opm { namespace EclIO { namespace OutputStream {
     class Restart;
@@ -71,7 +71,7 @@ public:
     const std::vector<T>& getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
 
     int occurrence_count(const std::string& name, int reportStepNumber) const;
-    size_t numberOfReportSteps() const { return seqnum.size(); };
+    std::size_t numberOfReportSteps() const { return seqnum.size(); };
 
     const std::vector<int>& listOfReportStepNumbers() const { return seqnum; }
 

--- a/opm/io/eclipse/ESmry.cpp
+++ b/opm/io/eclipse/ESmry.cpp
@@ -31,6 +31,8 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <exception>
@@ -166,7 +168,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
         auto arrays = smspecList.back().getList();
         std::vector<int> vectIndices;
 
-        for (size_t n = 0; n < arrays.size(); n++) {
+        for (std::size_t n = 0; n < arrays.size(); n++) {
             if (std::ranges::find(vectList, std::get<0>(arrays[n])) != vectList.end()) {
                vectIndices.push_back(static_cast<int>(n));
             }
@@ -313,7 +315,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
         auto arrays = smspecList.back().getList();
         std::vector<int> vectIndices;
 
-        for (size_t n = 0; n < arrays.size(); n++) {
+        for (std::size_t n = 0; n < arrays.size(); n++) {
             if (std::ranges::find(vectList, std::get<0>(arrays[n])) != vectList.end()) {
                vectIndices.push_back(static_cast<int>(n));
             }
@@ -352,7 +354,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
         combindKeyList.reserve(dimens[0]);
 
         if (have_lgr) {
-            for (size_t i = 0; i < keywords.size(); i++) {
+            for (std::size_t i = 0; i < keywords.size(); i++) {
                 Opm::EclIO::lgr_info lgr { lgrs[i], {numlx[i], numly[i], numlz[i]}};
 
                 const auto category = SummaryNode::category_from_keyword(keywords[i]);
@@ -379,7 +381,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
 
         } else {
 
-            for (size_t i = 0; i < keywords.size(); i++) {
+            for (std::size_t i = 0; i < keywords.size(); i++) {
 
                 const auto category = SummaryNode::category_from_keyword(keywords[i]);
                 const auto normKw = SummaryNode::normalise_keyword(category, keywords[i]);
@@ -420,7 +422,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
 
     std::map<std::string, int> keyIndex;
     {
-        size_t m = 0;
+        std::size_t m = 0;
         for (const auto& key : keywList)
             if (!key.empty())
                 keyIndex[key] = m++;
@@ -465,7 +467,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
         const bool have_lgr = !lgrs.empty();
 
         if (have_lgr) {
-            for (size_t i=0; i < keywords.size(); i++) {
+            for (std::size_t i=0; i < keywords.size(); i++) {
                 Opm::EclIO::lgr_info lgr { lgrs[i], {numlx[i], numly[i], numlz[i]}};
 
                 const auto normKw = SummaryNode::normalise_keyword(keywords[i]);
@@ -474,7 +476,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
                     arrayPos[specInd][keyIndex[keyw]]=i;
             }
         } else {
-            for (size_t i=0; i < keywords.size(); i++) {
+            for (std::size_t i=0; i < keywords.size(); i++) {
                 const auto normKw = SummaryNode::normalise_keyword(keywords[i]);
                 const std::string keyw = makeKeyString(normKw, wgnames[i], nums[i], {});
                 if ((!keyw.empty()) && (keywList.find(keyw) != keywList.end()))
@@ -503,7 +505,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
     vectorData.reserve(nVect);
     vectorLoaded.reserve(nVect);
 
-    for (size_t n = 0; n < nVect; n ++){
+    for (std::size_t n = 0; n < nVect; n ++){
         vectorData.push_back({});
         vectorLoaded.push_back(false);
     }
@@ -564,7 +566,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
             std::vector<std::tuple <std::string, std::uint64_t>> arrayList;
             arrayList = this->getListOfArrays(fileName, formattedFiles[specInd]);
 
-            for (size_t n = 0; n < arrayList.size(); n++) {
+            for (std::size_t n = 0; n < arrayList.size(); n++) {
                 ArrSourceEntry  t1 = std::make_tuple(std::get<0>(arrayList[n]), fileName, n, std::get<1>(arrayList[n]));
                 arraySourceList.push_back(t1);
             }
@@ -577,7 +579,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
         //       else : MINISTEP and PARAMS
 
 
-        size_t i = std::get<0>(arraySourceList[0]) == "SEQHDR" ? 1 : 0 ;
+        std::size_t i = std::get<0>(arraySourceList[0]) == "SEQHDR" ? 1 : 0 ;
 
         while  (i < arraySourceList.size()) {
 
@@ -653,7 +655,7 @@ void ESmry::read_ministeps_from_disk()
 
     int ministep_value;
 
-    for (size_t n = 0; n < miniStepList.size(); n++) {
+    for (std::size_t n = 0; n < miniStepList.size(); n++) {
 
         if (dataFileIndex != std::get<1>(miniStepList[n])) {
             fileH.close();
@@ -666,7 +668,7 @@ void ESmry::read_ministeps_from_disk()
                 fileH.open(dataFileList[dataFileIndex], std::ios::in |  std::ios::binary);
         }
 
-        uint64_t stepFilePos = std::get<2>(miniStepList[n]);
+        std::uint64_t stepFilePos = std::get<2>(miniStepList[n]);
 
         fileH.seekg (stepFilePos , fileH.beg);
 
@@ -689,7 +691,7 @@ bool ESmry::all_steps_available()
     if (mini_steps.size() == 0)
         this->read_ministeps_from_disk();
 
-    for (size_t n = 1; n < mini_steps.size(); n++)
+    for (std::size_t n = 1; n < mini_steps.size(); n++)
         if ((mini_steps[n] - mini_steps[n-1]) > 1)
             return false;
 
@@ -710,7 +712,7 @@ int ESmry::read_ministep_formatted(std::fstream& fileH)
 }
 
 
-std::string ESmry::read_string_from_disk(std::fstream& fileH, uint64_t size) const
+std::string ESmry::read_string_from_disk(std::fstream& fileH, std::uint64_t size) const
 {
     std::vector<char> buffer(size);
     fileH.read (buffer.data(), size);
@@ -722,7 +724,7 @@ std::string ESmry::read_string_from_disk(std::fstream& fileH, uint64_t size) con
 void ESmry::loadData(const std::vector<std::string>& vectList) const
 {
     auto start = std::chrono::system_clock::now();
-    size_t nvect = vectList.size();
+    std::size_t nvect = vectList.size();
 
     std::vector<int> keywIndVect;
     keywIndVect.reserve(nvect);
@@ -787,7 +789,7 @@ void ESmry::loadData(const std::vector<std::string>& vectList) const
                     int sizeOfLastBlock = paramPos %  MaxBlockSizeReal;
 
                     if (nBlocks > 0)
-                        elementPos = static_cast<uint64_t>(nBlocks * blockSize_f);
+                        elementPos = static_cast<std::uint64_t>(nBlocks * blockSize_f);
 
                     int nLines = sizeOfLastBlock / numColumnsReal;
                     elementPos = stepFilePos + elementPos + static_cast<std::uint64_t>(sizeOfLastBlock*columnWidthReal + nLines);
@@ -916,7 +918,7 @@ void ESmry::loadData() const
             }
         }
         else {
-            std::int64_t rest = static_cast<int64_t>(nParamsSpecFile[specInd]);
+            std::int64_t rest = static_cast<std::int64_t>(nParamsSpecFile[specInd]);
             std::size_t p = 0;
 
             while (rest > 0) {
@@ -959,16 +961,16 @@ void ESmry::loadData() const
 }
 
 
-std::vector<std::tuple <std::string, uint64_t>>
+std::vector<std::tuple <std::string, std::uint64_t>>
 ESmry::getListOfArrays(const std::string& filename, bool formatted)
 {
-    std::vector<std::tuple <std::string, uint64_t>> resultVect;
+    std::vector<std::tuple <std::string, std::uint64_t>> resultVect;
 
     FILE *ptr;
     char arrName[9];
     char numstr[13];
 
-    int64_t num;
+    std::int64_t num;
 
     if (formatted) {
         ptr = fopen(filename.c_str(),"r");  // r for read, files opened as text files
@@ -1004,7 +1006,7 @@ ESmry::getListOfArrays(const std::string& filename, bool formatted)
             numstr[12]='\0';
 
             int num_int = std::stoi(numstr);
-            num = static_cast<int64_t>(num_int);
+            num = static_cast<std::int64_t>(num_int);
 
             fseek(ptr, 8, SEEK_CUR);
 
@@ -1029,7 +1031,7 @@ ESmry::getListOfArrays(const std::string& filename, bool formatted)
             if (fread(&num_int, 4, 1, ptr) != 1)
                 throw std::runtime_error("fread error when loading summary data");
 
-            num = static_cast<int64_t>(Opm::EclIO::flipEndianInt(num_int));
+            num = static_cast<std::int64_t>(Opm::EclIO::flipEndianInt(num_int));
 
             fseek(ptr, 8, SEEK_CUR);
 
@@ -1045,18 +1047,18 @@ ESmry::getListOfArrays(const std::string& filename, bool formatted)
 
 
         if (std::ranges::find(ignore_keyword_list, std::string(arrName)) == ignore_keyword_list.end()) {
-            uint64_t filePos = static_cast<uint64_t>(ftell(ptr));
-            std::tuple <std::string, uint64_t> t1;
+            std::uint64_t filePos = static_cast<std::uint64_t>(ftell(ptr));
+            std::tuple <std::string, std::uint64_t> t1;
             t1 = std::make_tuple(Opm::EclIO::trimr(arrName), filePos);
             resultVect.push_back(t1);
         }
 
         if (num > 0) {
             if (formatted) {
-                uint64_t sizeOfNextArray = sizeOnDiskFormatted(num, arrType, 4);
+                std::uint64_t sizeOfNextArray = sizeOnDiskFormatted(num, arrType, 4);
                 fseek(ptr, static_cast<long int>(sizeOfNextArray), SEEK_CUR);
             } else {
-                uint64_t sizeOfNextArray = sizeOnDiskBinary(num, arrType, 4);
+                std::uint64_t sizeOfNextArray = sizeOnDiskBinary(num, arrType, 4);
                 fseek(ptr, static_cast<long int>(sizeOfNextArray), SEEK_CUR);
             }
         }
@@ -1100,7 +1102,7 @@ bool ESmry::make_esmry_file()
 
         int rstep_num = 0;
 
-        for (size_t i = 0; i < timeStepList.size(); ++i) {
+        for (std::size_t i = 0; i < timeStepList.size(); ++i) {
             if (std::ranges::find(seqIndex, i) != seqIndex.end()) {
                 is_rstep.push_back(++rstep_num);
             }
@@ -1144,7 +1146,7 @@ bool ESmry::make_esmry_file()
             outFile.write<int>("RSTEP", is_rstep);
             outFile.write<int>("TSTEP", mini_steps);
 
-            for (size_t n = 0; n < vectorData.size(); n++ ) {
+            for (std::size_t n = 0; n < vectorData.size(); n++ ) {
                 const std::string vect_name = fmt::format("V{}", n);
                 outFile.write<float>(vect_name, vectorData[n]);
             }

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -19,23 +19,24 @@
 #ifndef OPM_IO_ESMRY_HPP
 #define OPM_IO_ESMRY_HPP
 
-#include <algorithm>
-#include <chrono>
-#include <filesystem>
-#include <iosfwd>
-#include <string>
-#include <unordered_map>
-#include <vector>
-#include <map>
-#include <stdint.h>
-
 #include <opm/common/utility/TimeService.hpp>
 #include <opm/io/eclipse/SummaryNode.hpp>
 
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <iosfwd>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 namespace Opm { namespace EclIO {
 
-using ArrSourceEntry = std::tuple<std::string, std::string, int, uint64_t>;
-using TimeStepEntry = std::tuple<int, int, uint64_t>;
+using ArrSourceEntry = std::tuple<std::string, std::string, int, std::uint64_t>;
+using TimeStepEntry = std::tuple<int, int, std::uint64_t>;
 using RstEntry = std::tuple<std::string, int>;
 
 class ESmry
@@ -71,7 +72,7 @@ public:
 
     int timestepIdxAtReportstepStart(const int reportStep) const;
 
-    size_t numberOfTimeSteps() const { return nTstep; }
+    std::size_t numberOfTimeSteps() const { return nTstep; }
 
     const std::string& get_unit(const std::string& name) const;
     const std::string& get_unit(const SummaryNode& node) const;
@@ -89,7 +90,7 @@ private:
 
     int nI, nJ, nK, nSpecFiles;
     bool fromSingleRun;
-    size_t nVect, nTstep;
+    std::size_t nVect, nTstep;
 
     std::vector<bool> formattedFiles;
     std::vector<std::string> dataFileList;
@@ -128,13 +129,11 @@ private:
 
     void updatePathAndRootName(std::filesystem::path& dir, std::filesystem::path& rootN) const;
 
-
     std::string makeKeyString(const std::string& keyword, const std::string& wgname, int num,
                               const std::optional<Opm::EclIO::lgr_info> lgr_info) const;
 
     std::string unpackNumber(const SummaryNode&) const;
     std::string lookupKey(const SummaryNode&) const;
-
 
     void write_block(std::ostream &, bool write_dates, const std::vector<std::string>& time_column, const std::vector<SummaryNode>&) const;
 
@@ -150,11 +149,11 @@ private:
         return result;
     }
 
-    std::vector<std::tuple <std::string, uint64_t>>
+    std::vector<std::tuple <std::string, std::uint64_t>>
     getListOfArrays(const std::string& filename, bool formatted);
 
     std::vector<int> makeKeywPosVector(int speInd) const;
-    std::string read_string_from_disk(std::fstream& fileH, uint64_t size) const;
+    std::string read_string_from_disk(std::fstream& fileH, std::uint64_t size) const;
 
     void read_ministeps_from_disk();
     int read_ministep_formatted(std::fstream& fileH);

--- a/opm/io/eclipse/EclFile.cpp
+++ b/opm/io/eclipse/EclFile.cpp
@@ -17,6 +17,7 @@
    */
 
 #include <opm/io/eclipse/EclFile.hpp>
+
 #include <opm/io/eclipse/EclUtil.hpp>
 #include <opm/common/ErrorMacros.hpp>
 
@@ -243,7 +244,7 @@ void EclFile::loadData(const std::string& name)
             OPM_THROW(std::runtime_error, "Could not open file: '" + inputFilename +"'");
         }
 
-        for (size_t i = 0; i < array_name.size(); i++) {
+        for (std::size_t i = 0; i < array_name.size(); i++) {
             if (array_name[i] == name) {
                 loadBinaryArray(fileH, i);
             }
@@ -336,7 +337,7 @@ bool EclFile::is_ix() const
     //   >> if logi array exists in file, look for IX spes binary representation of true value
 
     if (formatted) {
-        for (size_t n=0; n < array_type.size(); n++) {
+        for (std::size_t n=0; n < array_type.size(); n++) {
             if (array_type[n] == Opm::EclIO::C0NN) {
                 return true;
             } else if (array_type[n] == Opm::EclIO::REAL) {
@@ -359,7 +360,7 @@ bool EclFile::is_ix() const
             }
         }
     } else {
-        for (size_t n=0; n < array_type.size(); n++) {
+        for (std::size_t n=0; n < array_type.size(); n++) {
             if (array_type[n] == Opm::EclIO::C0NN) {
                 return true;
             } else if (array_type[n] == Opm::EclIO::LOGI) {
@@ -430,7 +431,7 @@ std::vector<EclFile::EclEntry> EclFile::getList() const
     std::vector<EclEntry> list;
     list.reserve(this->array_name.size());
 
-    for (size_t i = 0; i < array_name.size(); i++) {
+    for (std::size_t i = 0; i < array_name.size(); i++) {
         list.emplace_back(array_name[i], array_type[i], array_size[i]);
     }
 
@@ -484,7 +485,7 @@ bool EclFile::hasKey(const std::string &name) const
     return search != array_index.end();
 }
 
-size_t EclFile::count(const std::string &name) const
+std::size_t EclFile::count(const std::string &name) const
 {
     return std::count (array_name.begin(), array_name.end(), name);
 }

--- a/opm/io/eclipse/EclOutput.cpp
+++ b/opm/io/eclipse/EclOutput.cpp
@@ -23,6 +23,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <iterator>
@@ -99,7 +101,7 @@ void EclOutput::write(const std::string& name, const std::vector<std::string>& d
                                      [](const std::string& str1, const std::string& str2)
                                      { return str2.size() > str1.size(); });
 
-        if (it->size() > static_cast<size_t>(element_size)) {
+        if (it->size() > static_cast<std::size_t>(element_size)) {
             OPM_THROW(std::runtime_error, "specified element size for type C0NN less than maximum string length in output data");
         }
     }
@@ -155,15 +157,15 @@ void EclOutput::flushStream()
     this->ofileH.flush();
 }
 
-void EclOutput::writeBinaryHeader(const std::string&arrName, int64_t size, eclArrType arrType, int element_size)
+void EclOutput::writeBinaryHeader(const std::string&arrName, std::int64_t size, eclArrType arrType, int element_size)
 {
     int bhead = flipEndianInt(16);
     std::string name = arrName + std::string(8 - arrName.size(),' ');
 
     // write X231 header if size larger that limits for 4 byte integers
     if (size > std::numeric_limits<int>::max()) {
-        int64_t val231 = std::pow(2,31);
-        int64_t x231 = size / val231;
+        std::int64_t val231 = std::pow(2,31);
+        std::int64_t x231 = size / val231;
 
         int flippedx231 = flipEndianInt(static_cast<int>( (-1)*x231 ));
 
@@ -222,9 +224,9 @@ template <typename T>
 void EclOutput::writeBinaryArray(const std::vector<T>& data)
 {
     int num;
-    int64_t rest, offset;
+    std::int64_t rest, offset;
     int dhead;
-    int64_t size = data.size();
+    std::int64_t size = data.size();
 
     eclArrType arrType = MESS;
 
@@ -253,7 +255,7 @@ void EclOutput::writeBinaryArray(const std::vector<T>& data)
 
     int logi_true_val = ix_standard ? true_value_ix : true_value_ecl;
 
-    rest = size * static_cast<int64_t>(sizeOfElement);
+    rest = size * static_cast<std::int64_t>(sizeOfElement);
 
     offset = 0;
 

--- a/opm/io/eclipse/EclOutput.hpp
+++ b/opm/io/eclipse/EclOutput.hpp
@@ -21,6 +21,7 @@
 #include <opm/io/eclipse/EclIOdata.hpp>
 #include <opm/io/eclipse/PaddedOutputString.hpp>
 
+#include <cstdint>
 #include <fstream>
 #include <ios>
 #include <stdexcept>
@@ -106,7 +107,7 @@ public:
     friend class OutputStream::SummarySpecification;
 
 private:
-    void writeBinaryHeader(const std::string& arrName, int64_t size, eclArrType arrType, int element_size);
+    void writeBinaryHeader(const std::string& arrName, std::int64_t size, eclArrType arrType, int element_size);
 
     template <typename T>
     void writeBinaryArray(const std::vector<T>& data);
@@ -131,7 +132,6 @@ private:
     bool isFormatted, ix_standard;
     std::ofstream ofileH;
 };
-
 
 template<>
 void EclOutput::write<std::string>(const std::string& name,

--- a/opm/io/eclipse/EclUtil.cpp
+++ b/opm/io/eclipse/EclUtil.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -48,14 +49,14 @@ int Opm::EclIO::flipEndianInt(int num)
 #endif
 }
 
-std::int64_t Opm::EclIO::flipEndianLongInt(int64_t num)
+std::int64_t Opm::EclIO::flipEndianLongInt(std::int64_t num)
 {
 #ifdef _MSC_VER
     std::uint64_t tmp = _byteswap_uint64(num);
-    return static_cast<int64_t>(tmp);
+    return static_cast<std::int64_t>(tmp);
 #else
     std::uint64_t tmp = __builtin_bswap64(num);
-    return static_cast<int64_t>(tmp);
+    return static_cast<std::int64_t>(tmp);
 #endif
 }
 

--- a/opm/io/eclipse/ExtESmry.cpp
+++ b/opm/io/eclipse/ExtESmry.cpp
@@ -27,9 +27,11 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
-#include <fstream>
 #include <filesystem>
+#include <fstream>
 #include <iterator>
 #include <stdexcept>
 #include <string>
@@ -108,7 +110,7 @@ ExtESmry::ExtESmry(const std::string &filename, bool loadBaseRunData) :
 
     ExtSmryHeadType ext_esmry_head;
 
-    uint64_t rstep_offset;
+    std::uint64_t rstep_offset;
 
     bool res = open_esmry(m_inputFileName, ext_esmry_head, rstep_offset);
     int n_attempts = 1;
@@ -130,14 +132,14 @@ ExtESmry::ExtESmry(const std::string &filename, bool loadBaseRunData) :
     auto keyword = std::get<2>(ext_esmry_head);
     auto units = std::get<3>(ext_esmry_head);
 
-    for (size_t n = 0; n < keyword.size(); n++){
+    for (std::size_t n = 0; n < keyword.size(); n++){
         key_index[keyword[n]] = n;
         m_keyword.push_back(keyword[n]);
     }
 
     m_keyword_index.push_back(key_index);
 
-    for (size_t n = 0; n < m_keyword.size(); n++)
+    for (std::size_t n = 0; n < m_keyword.size(); n++)
         kwunits[m_keyword[n]] = units[n];
 
     RstEntry rst_entry = std::get<1>(ext_esmry_head);
@@ -178,14 +180,14 @@ ExtESmry::ExtESmry(const std::string &filename, bool loadBaseRunData) :
             m_nTstep_v.push_back(m_tstep_v.back().size());
             const auto it = std::ranges::find(m_rstep_v[sim_ind], rstNum);
 
-            size_t ind =  std::distance(m_rstep_v[sim_ind].begin(), it);
+            std::size_t ind =  std::distance(m_rstep_v[sim_ind].begin(), it);
 
             m_tstep_range.push_back(std::make_tuple(0, ind));
 
             key_index.clear();
             keyword = std::get<2>(ext_esmry_head);
 
-            for (size_t n = 0; n < keyword.size(); n++)
+            for (std::size_t n = 0; n < keyword.size(); n++)
                 key_index[keyword[n]] = n;
 
             m_keyword_index.push_back(key_index);
@@ -212,7 +214,7 @@ ExtESmry::ExtESmry(const std::string &filename, bool loadBaseRunData) :
 
     m_nTstep = m_rstep.size();
 
-    for (size_t m = 0; m < m_rstep.size(); m++)
+    for (std::size_t m = 0; m < m_rstep.size(); m++)
         if (m_rstep[m] > 0)
             m_seqIndex.push_back(m);
 
@@ -247,14 +249,14 @@ std::string& ExtESmry::get_unit(const std::string& name)
 
 bool ExtESmry::all_steps_available()
 {
-    for (size_t n = 1; n < m_tstep.size(); n++)
+    for (std::size_t n = 1; n < m_tstep.size(); n++)
         if ((m_tstep[n] - m_tstep[n-1]) > 1)
             return false;
 
     return true;
 }
 
-bool ExtESmry::open_esmry(const std::filesystem::path& inputFileName, ExtSmryHeadType& ext_smry_head, uint64_t& rstep_offset)
+bool ExtESmry::open_esmry(const std::filesystem::path& inputFileName, ExtSmryHeadType& ext_smry_head, std::uint64_t& rstep_offset)
 {
     std::fstream fileH;
 
@@ -264,7 +266,7 @@ bool ExtESmry::open_esmry(const std::filesystem::path& inputFileName, ExtSmryHea
         return false;
 
     std::string arrName;
-    int64_t arr_size;
+    std::int64_t arr_size;
     Opm::EclIO::eclArrType arrType;
     int sizeOfElement;
 
@@ -308,7 +310,7 @@ bool ExtESmry::open_esmry(const std::filesystem::path& inputFileName, ExtSmryHea
             rst_entry = std::make_tuple(rstfile[0], rst_num[0]);
 
         } else {
-            uint64_t numIgnore = sizeOnDiskBinary(arr_size, arrType, sizeOfElement);
+            std::uint64_t numIgnore = sizeOnDiskBinary(arr_size, arrType, sizeOfElement);
             numIgnore = numIgnore + 24 + sizeOnDiskBinary(1, Opm::EclIO::INTE, Opm::EclIO::sizeOfInte);
             fileH.seekg(static_cast<std::streamoff>(numIgnore), std::ios_base::cur);
         }
@@ -351,7 +353,7 @@ bool ExtESmry::open_esmry(const std::filesystem::path& inputFileName, ExtSmryHea
     if (keywords.size() != units.size())
         OPM_THROW( std::runtime_error, "invalid ESMRY file " + inputFileName.string() + ". Size of UNITS not equal size of KEYCHECK");
 
-    rstep_offset = static_cast<uint64_t>(fileH.tellg());
+    rstep_offset = static_cast<std::uint64_t>(fileH.tellg());
 
     try {
         Opm::EclIO::readBinaryHeader(fileH, arrName, arr_size, arrType, sizeOfElement);
@@ -423,7 +425,7 @@ bool ExtESmry::load_esmry(const std::vector<std::string>& stringVect, const std:
 
     std::string arrName;
     Opm::EclIO::eclArrType arrType;
-    int64_t num_tstep;
+    std::int64_t num_tstep;
     int sizeOfElement;
 
     // Read actual number of time steps on disk from RSTEP array before loading
@@ -445,7 +447,7 @@ bool ExtESmry::load_esmry(const std::vector<std::string>& stringVect, const std:
     std::vector<std::vector<float>> smry_data;
     smry_data.resize(loadKeyIndex.size(), {});
 
-    for (size_t n = 0 ; n < loadKeyIndex.size(); n++) {
+    for (std::size_t n = 0 ; n < loadKeyIndex.size(); n++) {
 
         const auto& key = stringVect[loadKeyIndex[n]];
 
@@ -457,17 +459,17 @@ bool ExtESmry::load_esmry(const std::vector<std::string>& stringVect, const std:
 
             int key_ind = m_keyword_index[ind].at(key);
 
-            uint64_t pos = m_rstep_offset[ind] + smry_arr_size*static_cast<uint64_t>(key_ind);
+            std::uint64_t pos = m_rstep_offset[ind] + smry_arr_size*static_cast<std::uint64_t>(key_ind);
 
             // adding size of TSTEP and RSTEP INTE data
             pos = pos + 2 * sizeOnDiskBinary(num_tstep, Opm::EclIO::INTE, sizeOfInte);
 
-            pos = pos + static_cast<uint64_t>(2 * 24);  // adding size of binary headers (TSTEP and RSTEP)
-            pos = pos + static_cast<uint64_t>(key_ind * 24);  // adding size of binary headers
+            pos = pos + static_cast<std::uint64_t>(2 * 24);  // adding size of binary headers (TSTEP and RSTEP)
+            pos = pos + static_cast<std::uint64_t>(key_ind * 24);  // adding size of binary headers
 
             fileH.seekg (pos, fileH.beg);
 
-            int64_t size;
+            std::int64_t size;
 
             try {
                 readBinaryHeader(fileH, arrName, size, arrType, sizeOfElement);
@@ -494,7 +496,7 @@ bool ExtESmry::load_esmry(const std::vector<std::string>& stringVect, const std:
 
     fileH.close();
 
-    for (size_t n = 0 ; n < loadKeyIndex.size(); n++)
+    for (std::size_t n = 0 ; n < loadKeyIndex.size(); n++)
         m_vectorData[keyIndexVect[n]].insert(m_vectorData[keyIndexVect[n]].end(), smry_data[n].begin(), smry_data[n].begin() + to_ind + 1);
 
     return true;

--- a/opm/io/eclipse/ExtESmry.hpp
+++ b/opm/io/eclipse/ExtESmry.hpp
@@ -19,21 +19,22 @@
 #ifndef OPM_IO_ExtESmry_HPP
 #define OPM_IO_ExtESmry_HPP
 
+#include <opm/common/utility/TimeService.hpp>
+
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <filesystem>
+#include <map>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <map>
-#include <stdint.h>
-
-#include <opm/common/utility/TimeService.hpp>
 
 namespace Opm { namespace EclIO {
 
-using ArrSourceEntry = std::tuple<std::string, std::string, int, uint64_t>;
-using TimeStepEntry = std::tuple<int, int, uint64_t>;
+using ArrSourceEntry = std::tuple<std::string, std::string, int, std::uint64_t>;
+using TimeStepEntry = std::tuple<int, int, std::uint64_t>;
 using RstEntry = std::tuple<std::string, int>;
 
 // start, rstart + rstnum, keycheck, units, rstep, tstep
@@ -59,8 +60,8 @@ public:
 
     bool hasKey(const std::string& key) const;
 
-    size_t numberOfTimeSteps() const { return m_nTstep; }
-    size_t numberOfVectors() const { return m_nVect; }
+    std::size_t numberOfTimeSteps() const { return m_nTstep; }
+    std::size_t numberOfVectors() const { return m_nVect; }
 
     const std::vector<std::string>& keywordList() const { return m_keyword;}
     std::vector<std::string> keywordList(const std::string& pattern) const;
@@ -88,12 +89,12 @@ private:
     std::vector<bool> m_vectorLoaded;
     std::unordered_map<std::string, std::string> kwunits;
 
-    size_t m_nVect;
-    std::vector<size_t> m_nTstep_v;
-    size_t m_nTstep;
+    std::size_t m_nVect;
+    std::vector<std::size_t> m_nTstep_v;
+    std::size_t m_nTstep;
     std::vector<int> m_seqIndex;
 
-    std::vector<uint64_t> m_rstep_offset;
+    std::vector<std::uint64_t> m_rstep_offset;
 
     time_point m_startdat;
     std::vector<int> m_start_vect;
@@ -101,7 +102,7 @@ private:
     double m_io_opening;
     double m_io_loading;
 
-    bool open_esmry(const std::filesystem::path& inputFileName, ExtSmryHeadType& ext_smry_head, uint64_t& rstep_offset);
+    bool open_esmry(const std::filesystem::path& inputFileName, ExtSmryHeadType& ext_smry_head, std::uint64_t& rstep_offset);
 
     bool load_esmry(const std::vector<std::string>& stringVect, const std::vector<int>& keyIndexVect,
                                const std::vector<int>& loadKeyIndex, int ind, int to_ind );
@@ -110,6 +111,5 @@ private:
 };
 
 }} // namespace Opm::EclIO
-
 
 #endif // OPM_IO_ExtESmry_HPP

--- a/opm/io/eclipse/ExtSmryOutput.cpp
+++ b/opm/io/eclipse/ExtSmryOutput.cpp
@@ -26,12 +26,12 @@
 
 #include <opm/common/utility/TimeService.hpp>
 
+#include <cstddef>
+#include <filesystem>
 #include <stdexcept>
 #include <string>
-#include <filesystem>
 
 namespace Opm { namespace EclIO {
-
 
 ExtSmryOutput::ExtSmryOutput(const std::vector<std::string>& valueKeys, const std::vector<std::string>& valueUnits,
                  const EclipseState& es, const time_t start_time)
@@ -68,15 +68,14 @@ ExtSmryOutput::ExtSmryOutput(const std::vector<std::string>& valueKeys, const st
     m_start_date_vect = {ts.day(), ts.month(), ts.year(),
         ts.hour(), ts.minutes(), ts.seconds(), 0 };
 
-    for (size_t n = 0; n < static_cast<size_t>(m_nVect); n++)
+    for (std::size_t n = 0; n < static_cast<std::size_t>(m_nVect); n++)
         m_smrydata.push_back({});
 }
-
 
 void ExtSmryOutput::write(const std::vector<float>& ts_data, int report_step, bool is_final_summary)
 {
 
-    if (ts_data.size() != static_cast<size_t>(m_nVect))
+    if (ts_data.size() != static_cast<std::size_t>(m_nVect))
         throw std::invalid_argument("size of ts_data vector not same as number of smry vectors");
 
     auto current = std::chrono::system_clock::now();
@@ -95,7 +94,7 @@ void ExtSmryOutput::write(const std::vector<float>& ts_data, int report_step, bo
     else
         m_tstep.push_back(m_tstep.back()+1);
 
-    for (size_t n = 0; n < static_cast<size_t>(m_nVect); n++)
+    for (std::size_t n = 0; n < static_cast<std::size_t>(m_nVect); n++)
         m_smrydata[n].push_back(ts_data[n]);
 
     if ((is_final_summary) || (elapsed_seconds.count() > m_min_write_interval))
@@ -124,7 +123,7 @@ void ExtSmryOutput::write(const std::vector<float>& ts_data, int report_step, bo
             outFile.write<int>("RSTEP", m_rstep);
             outFile.write<int>("TSTEP", m_tstep);
 
-            for (size_t n = 0; n < static_cast<size_t>(m_nVect); n++ ) {
+            for (std::size_t n = 0; n < static_cast<std::size_t>(m_nVect); n++ ) {
                 std::string vect_name="V" + std::to_string(n);
                 outFile.write<float>(vect_name, m_smrydata[n]);
             }
@@ -155,15 +154,14 @@ bool ExtSmryOutput::rename_tmpfile(const std::string& tmp_fname)
     return true;
 }
 
-
 std::vector<std::string> ExtSmryOutput::make_modified_keys(const std::vector<std::string>& valueKeys, const GridDims& dims)
 {
     std::vector<std::string> mod_keys;
     mod_keys.reserve(valueKeys.size());
 
-    for (size_t n=0; n < valueKeys.size(); n++){
+    for (std::size_t n=0; n < valueKeys.size(); n++){
         if (valueKeys[n].substr(0,1) == "C"){
-            size_t p = valueKeys[n].find_first_of(":");
+            std::size_t p = valueKeys[n].find_first_of(":");
             p = valueKeys[n].find_first_of(":", p + 1);
 
             int num = std::stod(valueKeys[n].substr(p + 1)) - 1;
@@ -177,7 +175,7 @@ std::vector<std::string> ExtSmryOutput::make_modified_keys(const std::vector<std
 
         } else if (valueKeys[n].substr(0,1) == "B"){
 
-            size_t p = valueKeys[n].find_first_of(":");
+            std::size_t p = valueKeys[n].find_first_of(":");
 
             int num = std::stod(valueKeys[n].substr(p + 1)) - 1;
 
@@ -222,7 +220,7 @@ std::vector<std::string> ExtSmryOutput::make_modified_keys(const std::vector<std
 std::array<int, 3> ExtSmryOutput::ijk_from_global_index(const GridDims& dims, int globInd) const
 {
 
-    if (globInd < 0 || static_cast<size_t>(globInd) >= dims[0] * dims[1] * dims[2])
+    if (globInd < 0 || static_cast<std::size_t>(globInd) >= dims[0] * dims[1] * dims[2])
         throw std::invalid_argument("global index out of range");
 
     std::array<int, 3> result;
@@ -234,6 +232,5 @@ std::array<int, 3> ExtSmryOutput::ijk_from_global_index(const GridDims& dims, in
 
     return result;
 }
-
 
 }} // namespace Opm::EclIO

--- a/opm/material/common/FastSmallVector.hpp
+++ b/opm/material/common/FastSmallVector.hpp
@@ -35,6 +35,7 @@
 
 #include <array>
 #include <algorithm>
+#include <cstddef>
 #include <vector>
 
 namespace Opm {
@@ -57,14 +58,14 @@ public:
     }
 
     //! constructor based on the number of the element
-    explicit FastSmallVector(const size_t numElem)
+    explicit FastSmallVector(const std::size_t numElem)
     {
         init_(numElem);
     }
 
     //! constructor based on the number of the element, and all the elements
     //! will have the same value
-    FastSmallVector(const size_t numElem, const ValueType value)
+    FastSmallVector(const std::size_t numElem, const ValueType value)
     {
         init_(numElem);
 
@@ -132,11 +133,11 @@ public:
     }
 
     //! access the idx th element
-    ValueType& operator[](size_t idx)
+    ValueType& operator[](std::size_t idx)
     { return dataPtr_[idx]; }
 
     //! const access the idx th element
-    const ValueType& operator[](size_t idx) const
+    const ValueType& operator[](std::size_t idx) const
     { return dataPtr_[idx]; }
 
     using size_type = typename std::vector<ValueType>::size_type;
@@ -201,7 +202,7 @@ public:
         }
     }
 
-    void resize(size_t numElem)
+    void resize(std::size_t numElem)
     {
         if (numElem == size_) return; // nothing to do
 
@@ -227,7 +228,7 @@ public:
     }
 
 private:
-    void init_(size_t numElem)
+    void init_(std::size_t numElem)
     {
         size_ = numElem;
 

--- a/opm/material/common/IntervalTabulated2DFunction.hpp
+++ b/opm/material/common/IntervalTabulated2DFunction.hpp
@@ -35,6 +35,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <limits>
 #include <string>
 #include <type_traits>
@@ -97,13 +98,13 @@ public:
     /*!
      * \brief Returns the number of sampling points in X direction.
      */
-    size_t numX() const
+    std::size_t numX() const
     { return xPos_.size(); }
 
     /*!
      * \brief Returns the number of sampling points in Y direction.
      */
-    size_t numY() const
+    std::size_t numY() const
     { return yPos_.size(); }
 
     /*!
@@ -156,7 +157,7 @@ public:
     /*!
      * \brief Returns the value of a sampling point.
      */
-    Scalar valueAt(size_t i, size_t j) const
+    Scalar valueAt(std::size_t i, std::size_t j) const
     { return samples_[i][j]; }
 
     /*!
@@ -271,10 +272,10 @@ private:
 
         // bisection. this assumes that the vPos array is strictly mononically
         // increasing.
-        size_t lowerIdx = 0;
-        size_t upperIdx = vPos.size() - 1;
+        std::size_t lowerIdx = 0;
+        std::size_t upperIdx = vPos.size() - 1;
         while (lowerIdx + 1 < upperIdx) {
-            size_t pivotIdx = (lowerIdx + upperIdx) / 2;
+            std::size_t pivotIdx = (lowerIdx + upperIdx) / 2;
             if (v < vPos[pivotIdx])
                 upperIdx = pivotIdx;
             else

--- a/opm/material/common/Spline.cpp
+++ b/opm/material/common/Spline.cpp
@@ -22,8 +22,10 @@
 */
 
 #include <config.h>
+
 #include <opm/material/common/Spline.hpp>
 
+#include <cstddef>
 #include <ostream>
 
 namespace Opm
@@ -31,13 +33,13 @@ namespace Opm
 
 template<class Scalar>
 void Spline<Scalar>::printCSV(Scalar xi0, Scalar xi1,
-                              size_t k, std::ostream& os) const
+                              std::size_t k, std::ostream& os) const
 {
     Scalar x0 = std::min(xi0, xi1);
     Scalar x1 = std::max(xi0, xi1);
-    const size_t n = numSamples() - 1;
+    const std::size_t n = numSamples() - 1;
 
-    for (size_t i = 0; i <= k; ++i) {
+    for (std::size_t i = 0; i <= k; ++i) {
         const double x = i * (x1 - x0) / k + x0;
         double y;
         double dy_dx;
@@ -68,7 +70,7 @@ void Spline<Scalar>::printCSV(Scalar xi0, Scalar xi1,
     }
 }
 
-template void Spline<double>::printCSV(double,double,size_t,std::ostream&) const;
-template void Spline<float>::printCSV(float,float,size_t,std::ostream&) const;
+template void Spline<double>::printCSV(double,double,std::size_t,std::ostream&) const;
+template void Spline<float>::printCSV(float,float,std::size_t,std::ostream&) const;
 
 }

--- a/opm/material/common/Spline.hpp
+++ b/opm/material/common/Spline.hpp
@@ -32,6 +32,7 @@
 #include <opm/material/common/TridiagonalMatrix.hpp>
 #include <opm/material/common/PolynomialUtils.hpp>
 
+#include <cstddef>
 #include <iosfwd>
 #include <vector>
 
@@ -138,7 +139,7 @@ public:
      * \param sortInputs True to sort inputs
      */
     template <class ScalarArrayX, class ScalarArrayY>
-    Spline(size_t nSamples,
+    Spline(std::size_t nSamples,
            const ScalarArrayX& x,
            const ScalarArrayY& y,
            SplineType splineType = Natural,
@@ -154,7 +155,7 @@ public:
      * \param sortInputs True to sort inputs
      */
     template <class PointArray>
-    Spline(size_t nSamples,
+    Spline(std::size_t nSamples,
            const PointArray& points,
            SplineType splineType = Natural,
            bool sortInputs = true)
@@ -199,7 +200,7 @@ public:
      * \param sortInputs Indicates whether the sample points should be sorted (this is not necessary if they are already sorted in ascending or descending order)
      */
     template <class ScalarArray>
-    Spline(size_t nSamples,
+    Spline(std::size_t nSamples,
            const ScalarArray& x,
            const ScalarArray& y,
            Scalar m0,
@@ -217,7 +218,7 @@ public:
      * \param sortInputs Indicates whether the sample points should be sorted (this is not necessary if they are already sorted in ascending or descending order)
      */
     template <class PointArray>
-    Spline(size_t nSamples,
+    Spline(std::size_t nSamples,
            const PointArray& points,
            Scalar m0,
            Scalar m1,
@@ -302,7 +303,6 @@ public:
         this->setSlopesFromMoments_(slopeVec_, moments);
     }
 
-
     ///////////////////////////////////////
     ///////////////////////////////////////
     ///////////////////////////////////////
@@ -323,7 +323,7 @@ public:
      * sampling points must be larger than 1.
      */
     template <class ScalarArrayX, class ScalarArrayY>
-    void setXYArrays(size_t nSamples,
+    void setXYArrays(std::size_t nSamples,
                      const ScalarArrayX& x,
                      const ScalarArrayY& y,
                      Scalar m0, Scalar m1,
@@ -332,7 +332,7 @@ public:
         assert(nSamples > 1);
 
         setNumSamples_(nSamples);
-        for (size_t i = 0; i < nSamples; ++i) {
+        for (std::size_t i = 0; i < nSamples; ++i) {
             xPos_[i] = x[i];
             yPos_[i] = y[i];
         }
@@ -391,7 +391,7 @@ public:
      * the number of sampling points must be larger than 1.
      */
     template <class PointArray>
-    void setArrayOfPoints(size_t nSamples,
+    void setArrayOfPoints(std::size_t nSamples,
                           const PointArray& points,
                           Scalar m0,
                           Scalar m1,
@@ -402,7 +402,7 @@ public:
         assert(nSamples > 1);
 
         setNumSamples_(nSamples);
-        for (size_t i = 0; i < nSamples; ++i) {
+        for (std::size_t i = 0; i < nSamples; ++i) {
             xPos_[i] = points[i][0];
             yPos_[i] = points[i][1];
         }
@@ -440,7 +440,7 @@ public:
         setNumSamples_(points.size());
         typename XYContainer::const_iterator it = points.begin();
         typename XYContainer::const_iterator endIt = points.end();
-        for (size_t i = 0; it != endIt; ++i, ++it) {
+        for (std::size_t i = 0; it != endIt; ++i, ++it) {
             xPos_[i] = (*it)[0];
             yPos_[i] = (*it)[1];
         }
@@ -511,7 +511,7 @@ public:
      * sampling points must be larger than 1.
      */
     template <class ScalarArrayX, class ScalarArrayY>
-    void setXYArrays(size_t nSamples,
+    void setXYArrays(std::size_t nSamples,
                      const ScalarArrayX& x,
                      const ScalarArrayY& y,
                      SplineType splineType = Natural,
@@ -520,7 +520,7 @@ public:
         assert(nSamples > 1);
 
         setNumSamples_(nSamples);
-        for (size_t i = 0; i < nSamples; ++i) {
+        for (std::size_t i = 0; i < nSamples; ++i) {
             xPos_[i] = x[i];
             yPos_[i] = y[i];
         }
@@ -592,7 +592,7 @@ public:
      * the number of sampling points must be larger than 1.
      */
     template <class PointArray>
-    void setArrayOfPoints(size_t nSamples,
+    void setArrayOfPoints(std::size_t nSamples,
                           const PointArray& points,
                           SplineType splineType = Natural,
                           bool sortInputs = true)
@@ -602,7 +602,7 @@ public:
         assert(nSamples > 1);
 
         setNumSamples_(nSamples);
-        for (size_t i = 0; i < nSamples; ++i) {
+        for (std::size_t i = 0; i < nSamples; ++i) {
             xPos_[i] = points[i][0];
             yPos_[i] = points[i][1];
         }
@@ -645,7 +645,7 @@ public:
         setNumSamples_(points.size());
         typename XYContainer::const_iterator it = points.begin();
         typename XYContainer::const_iterator endIt = points.end();
-        for (size_t i = 0; it != endIt; ++ i, ++it) {
+        for (std::size_t i = 0; it != endIt; ++ i, ++it) {
             xPos_[i] = (*it)[0];
             yPos_[i] = (*it)[1];
         }
@@ -718,19 +718,19 @@ public:
     /*!
      * \brief Return the number of (x, y) values.
      */
-    size_t numSamples() const
+    std::size_t numSamples() const
     { return xPos_.size(); }
 
     /*!
      * \brief Return the x value of a given sampling point.
      */
-    Scalar xAt(size_t sampleIdx) const
+    Scalar xAt(std::size_t sampleIdx) const
     { return x_(sampleIdx); }
 
     /*!
      * \brief Return the x value of a given sampling point.
      */
-    Scalar valueAt(size_t sampleIdx) const
+    Scalar valueAt(std::size_t sampleIdx) const
     { return y_(sampleIdx); }
 
     /*!
@@ -750,7 +750,7 @@ public:
      "spline.csv" using 1:4 w p ti "Monotonic"
      ----------- snap -----------
     */
-    void printCSV(Scalar xi0, Scalar xi1, size_t k, std::ostream& os) const;
+    void printCSV(Scalar xi0, Scalar xi1, std::size_t k, std::ostream& os) const;
 
     /*!
      * \brief Evaluate the spline at a given position.
@@ -776,11 +776,11 @@ public:
                 Scalar y0 = y_(0);
                 return y0 + m*(x - xAt(0));
             }
-            else if (x > xAt(static_cast<size_t>(static_cast<long int>(numSamples()) - 1))) {
-                Scalar m = evalDerivative_(xAt(static_cast<size_t>(numSamples() - 1)),
-                                           /*segmentIdx=*/static_cast<size_t>(numSamples()-2));
-                Scalar y0 = y_(static_cast<size_t>(numSamples() - 1));
-                return y0 + m*(x - xAt(static_cast<size_t>(numSamples() - 1)));
+            else if (x > xAt(static_cast<std::size_t>(static_cast<long int>(numSamples()) - 1))) {
+                Scalar m = evalDerivative_(xAt(static_cast<std::size_t>(numSamples() - 1)),
+                                           /*segmentIdx=*/static_cast<std::size_t>(numSamples()-2));
+                Scalar y0 = y_(static_cast<std::size_t>(numSamples() - 1));
+                return y0 + m*(x - xAt(static_cast<std::size_t>(numSamples() - 1)));
             }
         }
 
@@ -893,12 +893,12 @@ public:
         assert(applies(x0) && applies(x1));
 
         Evaluation tmpSol[3], sol = 0;
-        size_t nSol = 0;
-        size_t iFirst = segmentIdx_(x0);
-        size_t iLast = segmentIdx_(x1);
-        for (size_t i = iFirst; i <= iLast; ++i)
+        std::size_t nSol = 0;
+        std::size_t iFirst = segmentIdx_(x0);
+        std::size_t iLast = segmentIdx_(x1);
+        for (std::size_t i = iFirst; i <= iLast; ++i)
         {
-            size_t nCur = intersectSegment_(tmpSol, i, a, b, c, d, x0, x1);
+            std::size_t nCur = intersectSegment_(tmpSol, i, a, b, c, d, x0, x1);
             if (nCur == 1)
                 sol = tmpSol[0];
 
@@ -942,7 +942,7 @@ public:
             x0 = xAt(0);
         };
 
-        size_t i = segmentIdx_(x0);
+        std::size_t i = segmentIdx_(x0);
         if (x_(i + 1) >= x1) {
             // interval is fully contained within a single spline
             // segment
@@ -957,7 +957,7 @@ public:
 
         // make sure that the segments which are completly in the
         // interval [x0, x1] all exhibit the same monotonicity.
-        size_t iEnd = segmentIdx_(x1);
+        std::size_t iEnd = segmentIdx_(x1);
         for (; i < iEnd - 1; ++i) {
             monotonic_(i, x_(i), x_(i + 1), r);
             if (!r)
@@ -1013,7 +1013,7 @@ protected:
      */
     void sortInput_()
     {
-        size_t n = numSamples();
+        std::size_t n = numSamples();
 
         // create a vector containing 0...n-1
         std::vector<unsigned> idxVector(n);
@@ -1027,7 +1027,7 @@ protected:
 
         // reorder the sample points
         std::vector<Scalar> tmpX(n), tmpY(n);
-        for (size_t i = 0; i < idxVector.size(); ++ i) {
+        for (std::size_t i = 0; i < idxVector.size(); ++ i) {
             tmpX[i] = xPos_[idxVector[i]];
             tmpY[i] = yPos_[idxVector[i]];
         }
@@ -1042,7 +1042,7 @@ protected:
     void reverseSamplingPoints_()
     {
         // reverse the arrays
-        size_t n = numSamples();
+        std::size_t n = numSamples();
         for (unsigned i = 0; i <= (n - 1)/2; ++i) {
             std::swap(xPos_[i], xPos_[n - i - 1]);
             std::swap(yPos_[i], yPos_[n - i - 1]);
@@ -1052,7 +1052,7 @@ protected:
     /*!
      * \brief Resizes the internal vectors to store the sample points.
      */
-    void setNumSamples_(size_t nSamples)
+    void setNumSamples_(std::size_t nSamples)
     {
         xPos_.resize(nSamples);
         yPos_.resize(nSamples);
@@ -1231,7 +1231,7 @@ protected:
     {
         makeNaturalSystem_(M, d);
 
-        size_t n = numSamples() - 1;
+        std::size_t n = numSamples() - 1;
         // first row
         M[0][1] = 1;
         d[0] = 6/h_(1) * ( (y_(1) - y_(0))/h_(1) - m0);
@@ -1257,10 +1257,10 @@ protected:
 
         // See: J. Stoer: "Numerische Mathematik 1", 9th edition,
         // Springer, 2005, p. 111
-        size_t n = numSamples() - 1;
+        std::size_t n = numSamples() - 1;
 
         // second to next to last rows
-        for (size_t i = 1; i < n; ++i) {
+        for (std::size_t i = 1; i < n; ++i) {
             Scalar lambda_i = h_(i + 1) / (h_(i) + h_(i + 1));
             Scalar mu_i = 1 - lambda_i;
             Scalar d_i =
@@ -1303,12 +1303,12 @@ protected:
 
         // See: J. Stoer: "Numerische Mathematik 1", 9th edition,
         // Springer, 2005, p. 111
-        size_t n = numSamples() - 1;
+        std::size_t n = numSamples() - 1;
 
         assert(M.rows() == n);
 
         // second to next to last rows
-        for (size_t i = 2; i < n; ++i) {
+        for (std::size_t i = 2; i < n; ++i) {
             Scalar lambda_i = h_(i + 1) / (h_(i) + h_(i + 1));
             Scalar mu_i = 1 - lambda_i;
             Scalar d_i =
@@ -1335,7 +1335,6 @@ protected:
             6 / (h_(n) + h_(1))
             *
             ( (y_(1) - y_(n))/h_(1) - (y_(n) - y_(n-1))/h_(n));
-
 
         // first row
         M[0][0] = 2;
@@ -1365,17 +1364,17 @@ protected:
 
         // calculate the slopes of the secant lines
         std::vector<Scalar> delta(n);
-        for (size_t k = 0; k < n - 1; ++k)
+        for (std::size_t k = 0; k < n - 1; ++k)
             delta[k] = (y_(k + 1) - y_(k))/(x_(k + 1) - x_(k));
 
         // calculate the "raw" slopes at the sample points
-        for (size_t k = 1; k < n - 1; ++k)
+        for (std::size_t k = 1; k < n - 1; ++k)
             slopes[k] = (delta[k - 1] + delta[k])/2;
         slopes[0] = delta[0];
         slopes[n - 1] = delta[n - 2];
 
         // post-process the "raw" slopes at the sample points
-        for (size_t k = 0; k < n - 1; ++k) {
+        for (std::size_t k = 0; k < n - 1; ++k) {
             if (std::abs(delta[k]) < 1e-50) {
                 // make the spline flat if the inputs are equal
                 slopes[k] = 0;
@@ -1410,7 +1409,7 @@ protected:
     template <class MomentsVector, class SlopeVector>
     void setSlopesFromMoments_(SlopeVector& slopes, const MomentsVector& moments)
     {
-        size_t n = numSamples();
+        std::size_t n = numSamples();
 
         // evaluate slope at the rightmost point.
         // See: J. Stoer: "Numerische Mathematik 1", 9th edition,
@@ -1436,7 +1435,7 @@ protected:
         }
 
         // evaluate the slope for the first n-1 sample points
-        for (size_t i = 0; i < n - 1; ++ i) {
+        for (std::size_t i = 0; i < n - 1; ++ i) {
             // See: J. Stoer: "Numerische Mathematik 1", 9th edition,
             // Springer, 2005, p. 109
             Scalar h_i = this->h_(i + 1);
@@ -1459,11 +1458,10 @@ protected:
         slopes[n - 1] = mRight;
     }
 
-
     // evaluate the spline at a given the position and given the
     // segment index
     template <class Evaluation>
-    Evaluation eval_(const Evaluation& x, size_t i) const
+    Evaluation eval_(const Evaluation& x, std::size_t i) const
     {
         // See http://en.wikipedia.org/wiki/Cubic_Hermite_spline
         Scalar delta = h_(i + 1);
@@ -1479,7 +1477,7 @@ protected:
     // evaluate the derivative of a spline given the actual position
     // and the segment index
     template <class Evaluation>
-    Evaluation evalDerivative_(const Evaluation& x, size_t i) const
+    Evaluation evalDerivative_(const Evaluation& x, std::size_t i) const
     {
         // See http://en.wikipedia.org/wiki/Cubic_Hermite_spline
         Scalar delta = h_(i + 1);
@@ -1497,7 +1495,7 @@ protected:
     // evaluate the second derivative of a spline given the actual
     // position and the segment index
     template <class Evaluation>
-    Evaluation evalDerivative2_(const Evaluation& x, size_t i) const
+    Evaluation evalDerivative2_(const Evaluation& x, std::size_t i) const
     {
         // See http://en.wikipedia.org/wiki/Cubic_Hermite_spline
         Scalar delta = h_(i + 1);
@@ -1515,7 +1513,7 @@ protected:
     // evaluate the third derivative of a spline given the actual
     // position and the segment index
     template <class Evaluation>
-    Evaluation evalDerivative3_(const Evaluation& x, size_t i) const
+    Evaluation evalDerivative3_(const Evaluation& x, std::size_t i) const
     {
         // See http://en.wikipedia.org/wiki/Cubic_Hermite_spline
         Scalar delta = h_(i + 1);
@@ -1606,7 +1604,7 @@ protected:
     // 1: spline is monotonously increasing in the specified interval
     // 0: spline is not monotonic (or constant) in the specified interval
     // -1: spline is monotonously decreasing in the specified interval
-    int monotonic_(size_t i, Scalar x0, Scalar x1, int& r) const
+    int monotonic_(std::size_t i, Scalar x0, Scalar x1, int& r) const
     {
         // coefficients of derivative in monomial basis
         Scalar a = 3*a_(i);
@@ -1674,8 +1672,8 @@ protected:
      *        with a cubic polynomial within a specified interval.
      */
     template <class Evaluation>
-    size_t intersectSegment_(Evaluation* sol,
-                             size_t segIdx,
+    std::size_t intersectSegment_(Evaluation* sol,
+                             std::size_t segIdx,
                              const Evaluation& a,
                              const Evaluation& b,
                              const Evaluation& c,
@@ -1692,7 +1690,7 @@ protected:
         x1 = std::min(x_(segIdx+1), x1);
 
         // filter the intersections outside of the specified interval
-        size_t k = 0;
+        std::size_t k = 0;
         for (unsigned j = 0; j < n; ++j) {
             if (x0 <= sol[j] && sol[j] <= x1) {
                 sol[k] = sol[j];
@@ -1703,14 +1701,14 @@ protected:
     }
 
     // find the segment index for a given x coordinate
-    size_t segmentIdx_(Scalar x) const
+    std::size_t segmentIdx_(Scalar x) const
     {
         // bisection
-        size_t iLow = 0;
-        size_t iHigh = numSamples() - 1;
+        std::size_t iLow = 0;
+        std::size_t iHigh = numSamples() - 1;
 
         while (iLow + 1 < iHigh) {
-            size_t i = (iLow + iHigh) / 2;
+            std::size_t i = (iLow + iHigh) / 2;
             if (x_(i) > x)
                 iHigh = i;
             else
@@ -1722,7 +1720,7 @@ protected:
     /*!
      * \brief Returns x[i] - x[i - 1]
      */
-    Scalar h_(size_t i) const
+    Scalar h_(std::size_t i) const
     {
         assert(x_(i) > x_(i-1)); // the sampling points must be given
                                  // in ascending order
@@ -1732,40 +1730,40 @@ protected:
     /*!
      * \brief Returns the y coordinate of the i-th sampling point.
      */
-    Scalar x_(size_t i) const
+    Scalar x_(std::size_t i) const
     { return xPos_[i]; }
 
     /*!
      * \brief Returns the y coordinate of the i-th sampling point.
      */
-    Scalar y_(size_t i) const
+    Scalar y_(std::size_t i) const
     { return yPos_[i]; }
 
     /*!
      * \brief Returns the slope (i.e. first derivative) of the spline at
      *        the i-th sampling point.
      */
-    Scalar slope_(size_t i) const
+    Scalar slope_(std::size_t i) const
     { return slopeVec_[i]; }
 
     // returns the coefficient in front of the x^3 term. In Stoer this
     // is delta.
-    Scalar a_(size_t i) const
+    Scalar a_(std::size_t i) const
     { return evalDerivative3_(/*x=*/Scalar(0.0), i)/6.0; }
 
     // returns the coefficient in front of the x^2 term In Stoer this
     // is gamma.
-    Scalar b_(size_t i) const
+    Scalar b_(std::size_t i) const
     { return evalDerivative2_(/*x=*/Scalar(0.0), i)/2.0; }
 
     // returns the coefficient in front of the x^1 term. In Stoer this
     // is beta.
-    Scalar c_(size_t i) const
+    Scalar c_(std::size_t i) const
     { return evalDerivative_(/*x=*/Scalar(0.0), i); }
 
     // returns the coefficient in front of the x^0 term. In Stoer this
     // is alpha.
-    Scalar d_(size_t i) const
+    Scalar d_(std::size_t i) const
     { return eval_(/*x=*/Scalar(0.0), i); }
 
     Vector xPos_;

--- a/opm/material/common/Tabulated1DFunction.hpp
+++ b/opm/material/common/Tabulated1DFunction.hpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <iosfwd>
 #include <stdexcept>
 #include <vector>
@@ -39,7 +40,7 @@
 namespace Opm {
 
 struct SegmentIndex {
-    size_t value;
+    std::size_t value;
 };
 
 /*!
@@ -67,7 +68,7 @@ public:
      * \param sortInputs True to sort inputs
      */
     template <class ScalarArrayX, class ScalarArrayY>
-    Tabulated1DFunction(size_t nSamples,
+    Tabulated1DFunction(std::size_t nSamples,
                         const ScalarArrayX& x,
                         const ScalarArrayY& y,
                         bool sortInputs = true)
@@ -106,7 +107,7 @@ public:
      * This method takes C-style arrays (pointers) as arguments.
      */
     template <class ScalarArrayX, class ScalarArrayY>
-    void setXYArrays(size_t nSamples,
+    void setXYArrays(std::size_t nSamples,
                      const ScalarArrayX& x,
                      const ScalarArrayY& y,
                      bool sortInputs = true)
@@ -114,7 +115,7 @@ public:
         assert(nSamples > 1);
 
         resizeArrays_(nSamples);
-        for (size_t i = 0; i < nSamples; ++i) {
+        for (std::size_t i = 0; i < nSamples; ++i) {
             xValues_[i] = x[i];
             yValues_[i] = y[i];
         }
@@ -153,7 +154,7 @@ public:
      * \brief Set the sampling points for the piecewise linear function
      */
     template <class PointArray>
-    void setArrayOfPoints(size_t nSamples,
+    void setArrayOfPoints(std::size_t nSamples,
                           const PointArray& points,
                           bool sortInputs = true)
     {
@@ -162,7 +163,7 @@ public:
         assert(nSamples > 1);
 
         resizeArrays_(nSamples);
-        for (size_t i = 0; i < nSamples; ++i) {
+        for (std::size_t i = 0; i < nSamples; ++i) {
             xValues_[i] = points[i][0];
             yValues_[i] = points[i][1];
         }
@@ -212,7 +213,7 @@ public:
     /*!
      * \brief Returns the number of sampling points.
      */
-    size_t numSamples() const
+    std::size_t numSamples() const
     { return xValues_.size(); }
 
     /*!
@@ -230,7 +231,7 @@ public:
     /*!
      * \brief Return the x value of the a sample point with a given index.
      */
-    Scalar xAt(size_t i) const
+    Scalar xAt(std::size_t i) const
     { return xValues_[i]; }
 
     const std::vector<Scalar>& xValues() const
@@ -242,7 +243,7 @@ public:
     /*!
      * \brief Return the value of the a sample point with a given index.
      */
-    Scalar valueAt(size_t i) const
+    Scalar valueAt(std::size_t i) const
     { return yValues_[i]; }
 
     /*!
@@ -271,7 +272,7 @@ public:
     template <class Evaluation>
     Evaluation eval(const Evaluation& x, SegmentIndex segIdxIn) const
     {
-        size_t segIdx = segIdxIn.value;
+        std::size_t segIdx = segIdxIn.value;
         Scalar x0 = xValues_[segIdx];
         Scalar x1 = xValues_[segIdx + 1];
 
@@ -295,7 +296,7 @@ public:
     template <class Evaluation>
     Evaluation evalDerivative(const Evaluation& x, bool extrapolate = false) const
     {
-        size_t segIdx = findSegmentIndex(x, extrapolate).value;
+        std::size_t segIdx = findSegmentIndex(x, extrapolate).value;
         return evalDerivative_(x, segIdx);
     }
 
@@ -361,7 +362,7 @@ public:
             x0 = xMin();
         };
 
-        size_t i = findSegmentIndex(x0, extrapolate).value;
+        std::size_t i = findSegmentIndex(x0, extrapolate).value;
         if (xValues_[i + 1] >= x1) {
             // interval is fully contained within a single function
             // segment
@@ -376,7 +377,7 @@ public:
 
         // make sure that the segments which are completly in the
         // interval [x0, x1] all exhibit the same monotonicity.
-        size_t iEnd = findSegmentIndex(x1, extrapolate).value;
+        std::size_t iEnd = findSegmentIndex(x1, extrapolate).value;
         for (; i < iEnd - 1; ++i) {
             updateMonotonicity_(i, r);
             if (!r)
@@ -461,10 +462,10 @@ public:
             return SegmentIndex{xValues_.size() - 2};
         else {
             // bisection
-            size_t lowerIdx = 1;
-            size_t upperIdx = xValues_.size() - 2;
+            std::size_t lowerIdx = 1;
+            std::size_t upperIdx = xValues_.size() - 2;
             while (lowerIdx + 1 < upperIdx) {
-                size_t pivotIdx = (lowerIdx + upperIdx) / 2;
+                std::size_t pivotIdx = (lowerIdx + upperIdx) / 2;
                 if (x < xValues_[pivotIdx])
                     upperIdx = pivotIdx;
                 else
@@ -486,7 +487,7 @@ public:
                                   ", respectively.\n";
                 msg += "Outputting the problematic table for more information "
                        "(with *** marking the found segment):";
-                for (size_t i = 0; i < numSamples(); ++i) {
+                for (std::size_t i = 0; i < numSamples(); ++i) {
                     if (i % 10 == 0)
                         msg += "\n";
                     if (i == lowerIdx)
@@ -505,7 +506,7 @@ public:
 
 private:
     template <class Evaluation>
-    Evaluation evalDerivative_(const Evaluation& x, size_t segIdx) const
+    Evaluation evalDerivative_(const Evaluation& x, std::size_t segIdx) const
     {
 
         Scalar x0 = xValues_[segIdx];
@@ -527,7 +528,7 @@ private:
     // 1: function is monotonously increasing in the specified interval
     // 0: function is not monotonic in the specified interval
     // -1: function is monotonously decreasing in the specified interval
-    int updateMonotonicity_(size_t i, int& r) const
+    int updateMonotonicity_(std::size_t i, int& r) const
     {
         if (yValues_[i] < yValues_[i + 1]) {
             // monotonically increasing?
@@ -558,7 +559,7 @@ private:
             : x_(x)
         {}
 
-        bool operator ()(size_t idxA, size_t idxB) const
+        bool operator ()(std::size_t idxA, std::size_t idxB) const
         { return x_.at(idxA) < x_.at(idxB); }
 
         const std::vector<Scalar>& x_;
@@ -569,7 +570,7 @@ private:
      */
     void sortInput_()
     {
-        size_t n = numSamples();
+        std::size_t n = numSamples();
 
         // create a vector containing 0...n-1
         std::vector<unsigned> idxVector(n);
@@ -583,7 +584,7 @@ private:
 
         // reorder the sample points
         std::vector<Scalar> tmpX(n), tmpY(n);
-        for (size_t i = 0; i < idxVector.size(); ++ i) {
+        for (std::size_t i = 0; i < idxVector.size(); ++ i) {
             tmpX[i] = xValues_[idxVector[i]];
             tmpY[i] = yValues_[idxVector[i]];
         }
@@ -598,8 +599,8 @@ private:
     void reverseSamplingPoints_()
     {
         // reverse the arrays
-        size_t n = numSamples();
-        for (size_t i = 0; i <= (n - 1)/2; ++i) {
+        std::size_t n = numSamples();
+        for (std::size_t i = 0; i <= (n - 1)/2; ++i) {
             std::swap(xValues_[i], xValues_[n - i - 1]);
             std::swap(yValues_[i], yValues_[n - i - 1]);
         }
@@ -608,7 +609,7 @@ private:
     /*!
      * \brief Resizes the internal vectors to store the sample points.
      */
-    void resizeArrays_(size_t nSamples)
+    void resizeArrays_(std::size_t nSamples)
     {
         xValues_.resize(nSamples);
         yValues_.resize(nSamples);

--- a/opm/material/common/TridiagonalMatrix.cpp
+++ b/opm/material/common/TridiagonalMatrix.cpp
@@ -22,8 +22,10 @@
 */
 
 #include <config.h>
+
 #include <opm/material/common/TridiagonalMatrix.hpp>
 
+#include <cstddef>
 #include <ostream>
 
 namespace Opm {
@@ -31,7 +33,7 @@ namespace Opm {
 template<class Scalar>
 void TridiagonalMatrix<Scalar>::print(std::ostream& os) const
 {
-    size_t n = size();
+    std::size_t n = size();
 
     // row 0
     os << at(0, 0) << "\t"

--- a/opm/material/common/TridiagonalMatrix.hpp
+++ b/opm/material/common/TridiagonalMatrix.hpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstddef>
 #include <iosfwd>
 #include <vector>
 
@@ -49,15 +50,15 @@ template <class Scalar>
 class TridiagonalMatrix
 {
     struct TridiagRow_ {
-        TridiagRow_(TridiagonalMatrix& m, size_t rowIdx)
+        TridiagRow_(TridiagonalMatrix& m, std::size_t rowIdx)
             : matrix_(m)
             , rowIdx_(rowIdx)
         {}
 
-        Scalar& operator[](size_t colIdx)
+        Scalar& operator[](std::size_t colIdx)
         { return matrix_.at(rowIdx_, colIdx); }
 
-        Scalar operator[](size_t colIdx) const
+        Scalar operator[](std::size_t colIdx) const
         { return matrix_.at(rowIdx_, colIdx); }
 
         /*!
@@ -95,27 +96,27 @@ class TridiagonalMatrix
          *
          * 0 is the first row.
          */
-        size_t index() const
+        std::size_t index() const
         { return rowIdx_; }
 
     private:
         TridiagonalMatrix& matrix_;
-        mutable size_t rowIdx_;
+        mutable std::size_t rowIdx_;
     };
 
 public:
     typedef Scalar FieldType;
     typedef TridiagRow_ RowType;
-    typedef size_t SizeType;
+    typedef std::size_t SizeType;
     typedef TridiagRow_ iterator;
     typedef TridiagRow_ const_iterator;
 
-    explicit TridiagonalMatrix(size_t numRows = 0)
+    explicit TridiagonalMatrix(std::size_t numRows = 0)
     {
         resize(numRows);
     }
 
-    TridiagonalMatrix(size_t numRows, Scalar value)
+    TridiagonalMatrix(std::size_t numRows, Scalar value)
     {
         resize(numRows);
         this->operator=(value);
@@ -130,25 +131,25 @@ public:
     /*!
      * \brief Return the number of rows/columns of the matrix.
      */
-    size_t size() const
+    std::size_t size() const
     { return diag_[0].size(); }
 
     /*!
      * \brief Return the number of rows of the matrix.
      */
-    size_t rows() const
+    std::size_t rows() const
     { return size(); }
 
     /*!
      * \brief Return the number of columns of the matrix.
      */
-    size_t cols() const
+    std::size_t cols() const
     { return size(); }
 
     /*!
      * \brief Change the number of rows of the matrix.
      */
-    void resize(size_t n)
+    void resize(std::size_t n)
     {
         if (n == size())
             return;
@@ -160,9 +161,9 @@ public:
     /*!
      * \brief Access an entry.
      */
-    Scalar& at(size_t rowIdx, size_t colIdx)
+    Scalar& at(std::size_t rowIdx, std::size_t colIdx)
     {
-        size_t n = size();
+        std::size_t n = size();
 
         // special cases
         if (n > 2) {
@@ -172,7 +173,7 @@ public:
                 return diag_[0][n - 1];
         }
 
-        size_t diagIdx = 1 + colIdx - rowIdx;
+        std::size_t diagIdx = 1 + colIdx - rowIdx;
         // make sure that the requested column is in range
         assert(diagIdx < 3);
         return diag_[diagIdx][colIdx];
@@ -181,9 +182,9 @@ public:
     /*!
      * \brief Access an entry.
      */
-    Scalar at(size_t rowIdx, size_t colIdx) const
+    Scalar at(std::size_t rowIdx, std::size_t colIdx) const
     {
-        size_t n = size();
+        std::size_t n = size();
 
         // special cases
         if (rowIdx == 0 && colIdx == n - 1)
@@ -191,7 +192,7 @@ public:
         if (rowIdx == n - 1 && colIdx == 0)
             return diag_[0][n - 1];
 
-        size_t diagIdx = 1 + colIdx - rowIdx;
+        std::size_t diagIdx = 1 + colIdx - rowIdx;
         // make sure that the requested column is in range
         assert(diagIdx < 3);
         return diag_[diagIdx][colIdx];
@@ -240,13 +241,13 @@ public:
     /*!
      * \brief Row access operator.
      */
-    TridiagRow_ operator[](size_t rowIdx)
+    TridiagRow_ operator[](std::size_t rowIdx)
     { return TridiagRow_(*this, rowIdx); }
 
     /*!
      * \brief Row access operator.
      */
-    const TridiagRow_ operator[](size_t rowIdx) const
+    const TridiagRow_ operator[](std::size_t rowIdx) const
     { return TridiagRow_(*this, rowIdx); }
 
     /*!
@@ -727,7 +728,7 @@ private:
     template <class XVector, class BVector>
     void solveWithUpperRight_(XVector& x, const BVector& b) const
     {
-        size_t n = size();
+        std::size_t n = size();
 
         std::vector<Scalar> lowerDiag(diag_[0]), mainDiag(diag_[1]), upperDiag(diag_[2]), lastColumn(n);
         std::vector<Scalar> bStar(n);
@@ -736,7 +737,7 @@ private:
         lastColumn[0] = upperDiag[0];
 
         // forward elimination
-        for (size_t i = 1; i < n; ++i) {
+        for (std::size_t i = 1; i < n; ++i) {
             Scalar alpha = lowerDiag[i - 1]/mainDiag[i - 1];
 
             lowerDiag[i - 1] -= alpha * mainDiag[i - 1];
@@ -748,7 +749,7 @@ private:
         // deal with the last row if the entry on the lower left is not zero
         if (lowerDiag[n - 1] != 0.0 && size() > 2) {
             Scalar lastRow = lowerDiag[n - 1];
-            for (size_t i = 0; i < n - 1; ++i) {
+            for (std::size_t i = 0; i < n - 1; ++i) {
                 Scalar alpha = lastRow/mainDiag[i];
                 lastRow = - alpha*upperDiag[i + 1];
                 bStar[n - 1] -= alpha * bStar[i];
@@ -768,14 +769,14 @@ private:
     template <class XVector, class BVector>
     void solveWithoutUpperRight_(XVector& x, const BVector& b) const
     {
-        size_t n = size();
+        std::size_t n = size();
 
         std::vector<Scalar> lowerDiag(diag_[0]), mainDiag(diag_[1]), upperDiag(diag_[2]);
         std::vector<Scalar> bStar(n);
         std::ranges::copy(b, bStar.begin());
 
         // forward elimination
-        for (size_t i = 1; i < n; ++i) {
+        for (std::size_t i = 1; i < n; ++i) {
             Scalar alpha = lowerDiag[i - 1]/mainDiag[i - 1];
 
             lowerDiag[i - 1] -= alpha * mainDiag[i - 1];
@@ -787,7 +788,7 @@ private:
         // deal with the last row if the entry on the lower left is not zero
         if (lowerDiag[n - 1] != 0.0 && size() > 2) {
             Scalar lastRow = lowerDiag[n - 1];
-            for (size_t i = 0; i < n - 1; ++i) {
+            for (std::size_t i = 0; i < n - 1; ++i) {
                 Scalar alpha = lastRow/mainDiag[i];
                 lastRow = - alpha*upperDiag[i + 1];
                 bStar[n - 1] -= alpha * bStar[i];

--- a/opm/material/common/UniformXTabulated2DFunction.cpp
+++ b/opm/material/common/UniformXTabulated2DFunction.cpp
@@ -22,8 +22,10 @@
 */
 
 #include <config.h>
+
 #include <opm/material/common/UniformXTabulated2DFunction.hpp>
 
+#include <cstddef>
 #include <ostream>
 
 namespace Opm {
@@ -37,7 +39,7 @@ void UniformXTabulated2DFunction<Scalar>::print(std::ostream& os) const
 
     Scalar y0 = 1e30;
     Scalar y1 = -1e30;
-    size_t n = 0;
+    std::size_t n = 0;
     for (int i = 0; i < m; ++ i) {
         y0 = std::min(y0, yMin(i));
         y1 = std::max(y1, yMax(i));
@@ -48,7 +50,7 @@ void UniformXTabulated2DFunction<Scalar>::print(std::ostream& os) const
     n *= 3;
     for (int i = 0; i <= m; ++i) {
         Scalar x = x0 + (x1 - x0)*i/m;
-        for (size_t j = 0; j <= n; ++j) {
+        for (std::size_t j = 0; j <= n; ++j) {
             Scalar y = y0 + (y1 - y0)*j/n;
             os << x << " " << y << " " << eval(x, y) << "\n";
         }

--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -35,6 +35,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <cstddef>
 #include <iosfwd>
 #include <limits>
 #include <tuple>
@@ -101,25 +102,25 @@ public:
     /*!
      * \brief Returns the value of the X coordinate of the sampling points.
      */
-    Scalar xAt(size_t i) const
+    Scalar xAt(std::size_t i) const
     { return xPos_[i]; }
 
     /*!
      * \brief Returns the value of the Y coordinate of a sampling point.
      */
-    Scalar yAt(size_t i, size_t j) const
+    Scalar yAt(std::size_t i, std::size_t j) const
     { return std::get<1>(samples_[i][j]); }
 
     /*!
      * \brief Returns the value of a sampling point.
      */
-    Scalar valueAt(size_t i, size_t j) const
+    Scalar valueAt(std::size_t i, std::size_t j) const
     { return std::get<2>(samples_[i][j]); }
 
     /*!
      * \brief Returns the number of sampling points in X direction.
      */
-    size_t numX() const
+    std::size_t numX() const
     { return xPos_.size(); }
 
     /*!
@@ -137,7 +138,7 @@ public:
     /*!
      * \brief Returns the number of sampling points in Y direction a given column.
      */
-    size_t numY(unsigned i) const
+    std::size_t numY(unsigned i) const
     { return samples_.at(i).size(); }
 
     /*!
@@ -176,7 +177,7 @@ public:
     Scalar jToY(unsigned i, unsigned j) const
     {
         assert(i < numX());
-        assert(size_t(j) < samples_[i].size());
+        assert(std::size_t(j) < samples_[i].size());
 
         return std::get<1>(samples_.at(i).at(j));
     }
@@ -414,7 +415,7 @@ public:
      *
      * Returns the i index of that line.
      */
-    size_t appendXPos(Scalar nextX)
+    std::size_t appendXPos(Scalar nextX)
     {
         if (xPos_.empty() || xPos_.back() < nextX) {
             xPos_.push_back(nextX);
@@ -438,7 +439,7 @@ public:
      *
      * Returns the i index of the new point within its line.
      */
-    size_t appendSamplePoint(size_t i, Scalar y, Scalar value)
+    std::size_t appendSamplePoint(std::size_t i, Scalar y, Scalar value)
     {
         assert(i < numX());
         Scalar x = iToX(i);

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -48,6 +48,7 @@
 #include <dune/common/fmatrix.hh>
 #include <dune/common/classname.hh>
 
+#include <cstddef>
 #include <limits>
 #include <stdexcept>
 #include <type_traits>
@@ -375,7 +376,6 @@ public:
             }
         }
 
-
         return L;
     }
 
@@ -520,7 +520,6 @@ protected:
                 fluid_state_global.setFugacityCoefficient(phaseIdx2, compIdx, phiGlobal);
             }
 
-
             ComponentVector R;
             for (int compIdx=0; compIdx<numComponents; ++compIdx){
                 if (isGas){
@@ -643,8 +642,8 @@ protected:
     {
         // Note: due to the need for inverse flash update for derivatives, the following two can be different
         // Looking for a good way to organize them
-        constexpr size_t num_equations = numMisciblePhases * numMiscibleComponents + 1;
-        constexpr size_t num_primary_variables = numMisciblePhases * numMiscibleComponents + 1;
+        constexpr std::size_t num_equations = numMisciblePhases * numMiscibleComponents + 1;
+        constexpr std::size_t num_primary_variables = numMisciblePhases * numMiscibleComponents + 1;
         using NewtonVector = Dune::FieldVector<Scalar, num_equations>;
         using NewtonMatrix = Dune::FieldMatrix<Scalar, num_equations, num_primary_variables>;
 
@@ -791,7 +790,7 @@ protected:
     }
 
     // TODO: the interface will need to refactor for later usage
-    template<typename FlashFluidState, typename ComponentVector, size_t num_primary, size_t num_equation >
+    template<typename FlashFluidState, typename ComponentVector, std::size_t num_primary, std::size_t num_equation >
     static void assembleNewton_(const FlashFluidState& fluid_state,
                                 const ComponentVector& global_composition,
                                 Dune::FieldMatrix<double, num_equation, num_primary>& jac,
@@ -867,8 +866,8 @@ protected:
         }
 
         // getting the secondary Jocobian matrix
-        constexpr size_t num_equations = numMisciblePhases * numMiscibleComponents + 1;
-        constexpr size_t secondary_num_pv = isThermal ? numComponents + 2 : numComponents + 1;
+        constexpr std::size_t num_equations = numMisciblePhases * numMiscibleComponents + 1;
+        constexpr std::size_t secondary_num_pv = isThermal ? numComponents + 2 : numComponents + 1;
         // secondary variables: pressure, [temperature if thermal], z for all the components
         using SecondaryEval = Opm::DenseAd::Evaluation<double, secondary_num_pv>;
         using SecondaryComponentVector = Dune::FieldVector<SecondaryEval, numComponents>;
@@ -928,15 +927,13 @@ protected:
         SecondaryNewtonMatrix sec_jac;
         SecondaryNewtonVector sec_res;
 
-
         //use the regular equations
         assembleNewton_<SecondaryFlashFluidState, SecondaryComponentVector, secondary_num_pv, num_equations>
             (secondary_fluid_state, secondary_z, sec_jac, sec_res);
 
-
         // assembly the major matrix here
         // primary variables are x, y and L
-        constexpr size_t primary_num_pv = numMisciblePhases * numMiscibleComponents + 1;
+        constexpr std::size_t primary_num_pv = numMisciblePhases * numMiscibleComponents + 1;
         using PrimaryEval = Opm::DenseAd::Evaluation<double, primary_num_pv>;
         using PrimaryComponentVector = Dune::FieldVector<double, numComponents>;
         using PrimaryFlashFluidState = Opm::CompositionalFluidState<PrimaryEval, FluidSystem>;
@@ -1011,7 +1008,7 @@ protected:
         // p_l and p_v are the same here, in the future, there might be slightly more complicated scenarios when capillary
         // pressure joins
 
-        constexpr size_t num_deri = InputEval::numVars;
+        constexpr std::size_t num_deri = InputEval::numVars;
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             std::vector<double> deri(num_deri, 0.);
             // derivatives from P
@@ -1104,7 +1101,6 @@ protected:
         }
         fluid_state.setLvalue(L_eval);
     } //end updateDerivativesSinglePhase
-
 
     // TODO: or use typename FlashFluidState::ValueType
     template <class FlashFluidState, class ComponentVector>

--- a/opm/material/densead/DynamicEvaluation.hpp
+++ b/opm/material/densead/DynamicEvaluation.hpp
@@ -36,6 +36,7 @@
 #include <opm/material/common/Valgrind.hpp>
 #endif
 #include <opm/material/common/FastSmallVector.hpp>
+#include <cstddef>
 
 #include <cassert>
 #include <iosfwd>
@@ -712,7 +713,7 @@ public:
 private:
     FastSmallVector<ValueT, staticSize> data_;
 
-    void appendDerivativesToConstant(size_t numDer) {
+    void appendDerivativesToConstant(std::size_t numDer) {
         assert(size() == 0); // we only append derivatives to a constant
         if (numDer > 0) {
             data_.resize(1 + numDer);

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -22,6 +22,7 @@
 */
 
 #include <config.h>
+
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
 
 #include <opm/common/TimingMacros.hpp>
@@ -35,6 +36,7 @@
 #include <opm/material/fluidstates/SimpleModularFluidState.hpp>
 
 #include <algorithm>
+#include <cstddef>
 
 namespace Opm::EclMaterialLaw {
 
@@ -44,7 +46,7 @@ initFromState(const EclipseState& eclState)
 {
     // get the number of saturation regions and the number of cells in the deck
     const auto&  runspec       = eclState.runspec();
-    const size_t numSatRegions = runspec.tabdims().getNumSatTables();
+    const std::size_t numSatRegions = runspec.tabdims().getNumSatTables();
 
     const auto& ph = runspec.phases();
     this->hasGas_ = ph.active(Phase::GAS);
@@ -119,7 +121,7 @@ initFromState(const EclipseState& eclState)
 
 template<class TraitsT>
 void Manager<TraitsT>::
-initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
+initParamsForElements(const EclipseState& eclState, std::size_t numCompressedElems,
                       const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner,
                       const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -41,6 +41,7 @@
 #include <opm/material/fluidmatrixinteractions/DirectionalMaterialLawParams.hpp>
 
 #include <cassert>
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -144,7 +145,7 @@ public:
     //        field properties of cells on the leaf grid view for CpGrid with local grid refinement.
     //        Function argument 'lookupIdxOnLevelZeroAssigner' is added to lookup, for each
     //        leaf gridview cell with index 'elemIdx', its 'lookupIdx' (index of the parent/equivalent cell on level zero).
-    void initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
+    void initParamsForElements(const EclipseState& eclState, std::size_t numCompressedElems,
                                const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>&
                                fieldPropIntOnLeafAssigner,
                                const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
@@ -311,7 +312,7 @@ public:
 
     EclEpsScalingPoints<Scalar>& oilWaterScaledEpsPointsDrainage(unsigned elemIdx);
 
-    const EclEpsScalingPointsInfo<Scalar>& oilWaterScaledEpsInfoDrainage(size_t elemIdx) const
+    const EclEpsScalingPointsInfo<Scalar>& oilWaterScaledEpsInfoDrainage(std::size_t elemIdx) const
     { return params_.oilWaterScaledEpsInfoDrainage[elemIdx]; }
 
     template<class Serializer>

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -28,14 +28,15 @@
 #define OPM_PIECEWISE_LINEAR_TWO_PHASE_MATERIAL_HPP
 
 #include "PiecewiseLinearTwoPhaseMaterialParams.hpp"
+
 #include <opm/common/TimingMacros.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
+#include <cstddef>
 #include <stdexcept>
 #include <type_traits>
-
-
-#include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {
 /*!
@@ -231,12 +232,12 @@ public:
     { return eval_(params.krnSamples(), params.SwKrnSamples(), krn); }
 
     template <class Evaluation>
-    OPM_HOST_DEVICE static size_t findSegmentIndex(const ValueVector& xValues, const Evaluation& x){
+    OPM_HOST_DEVICE static std::size_t findSegmentIndex(const ValueVector& xValues, const Evaluation& x){
         return findSegmentIndex_(xValues, scalarValue(x));
     }
 
     template <class Evaluation>
-    OPM_HOST_DEVICE static size_t findSegmentIndexDescending(const ValueVector& xValues, const Evaluation& x){
+    OPM_HOST_DEVICE static std::size_t findSegmentIndexDescending(const ValueVector& xValues, const Evaluation& x){
         return findSegmentIndexDescending_(xValues, scalarValue(x));
     }
 
@@ -276,7 +277,7 @@ private:
         if (x >= xValues.back())
             return yValues.back();
 
-        size_t segIdx = findSegmentIndex_(xValues, scalarValue(x));
+        std::size_t segIdx = findSegmentIndex_(xValues, scalarValue(x));
 
         return eval(xValues, yValues, x, segIdx);
     }
@@ -292,7 +293,7 @@ private:
         if (x <= xValues.back())
             return yValues.back();
 
-        size_t segIdx = findSegmentIndexDescending_(xValues, scalarValue(x));
+        std::size_t segIdx = findSegmentIndexDescending_(xValues, scalarValue(x));
 
         return eval(xValues, yValues, x, segIdx);
     }
@@ -308,7 +309,7 @@ private:
         if (x >= xValues.back())
             return 0.0;
 
-        size_t segIdx = findSegmentIndex_(xValues, scalarValue(x));
+        std::size_t segIdx = findSegmentIndex_(xValues, scalarValue(x));
 
         Scalar x0 = xValues[segIdx];
         Scalar x1 = xValues[segIdx + 1];
@@ -319,20 +320,20 @@ private:
         return (y1 - y0)/(x1 - x0);
     }
     template<class ScalarT>
-    OPM_HOST_DEVICE static size_t findSegmentIndex_(const ValueVector& xValues, const ScalarT& x)
+    OPM_HOST_DEVICE static std::size_t findSegmentIndex_(const ValueVector& xValues, const ScalarT& x)
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         assert(xValues.size() > 1); // we need at least two sampling points!
-        size_t n = xValues.size() - 1;
+        std::size_t n = xValues.size() - 1;
         if (xValues.back() <= x)
             return n - 1;
         else if (x <= xValues.front())
             return 0;
 
         // bisection
-        size_t lowIdx = 0, highIdx = n;
+        std::size_t lowIdx = 0, highIdx = n;
         while (lowIdx + 1 < highIdx) {
-            size_t curIdx = (lowIdx + highIdx)/2;
+            std::size_t curIdx = (lowIdx + highIdx)/2;
             if (xValues[curIdx] < x)
                 lowIdx = curIdx;
             else
@@ -342,20 +343,20 @@ private:
         return lowIdx;
     }
 
-    OPM_HOST_DEVICE static size_t findSegmentIndexDescending_(const ValueVector& xValues, Scalar x)
+    OPM_HOST_DEVICE static std::size_t findSegmentIndexDescending_(const ValueVector& xValues, Scalar x)
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         assert(xValues.size() > 1); // we need at least two sampling points!
-        size_t n = xValues.size() - 1;
+        std::size_t n = xValues.size() - 1;
         if (x <= xValues.back())
             return n;
         else if (xValues.front() <= x)
             return 0;
 
         // bisection
-        size_t lowIdx = 0, highIdx = n;
+        std::size_t lowIdx = 0, highIdx = n;
         while (lowIdx + 1 < highIdx) {
-            size_t curIdx = (lowIdx + highIdx)/2;
+            std::size_t curIdx = (lowIdx + highIdx)/2;
             if (xValues[curIdx] >= x)
                 lowIdx = curIdx;
             else

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -27,17 +27,17 @@
 #ifndef OPM_PIECEWISE_LINEAR_TWO_PHASE_MATERIAL_PARAMS_HPP
 #define OPM_PIECEWISE_LINEAR_TWO_PHASE_MATERIAL_PARAMS_HPP
 
-#include <algorithm>
-#include <cassert>
-#include <vector>
-#include <stdexcept>
-#include <type_traits>
-
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/material/common/EnsureFinalized.hpp>
-#include <vector>
 
 #include <opm/common/utility/gpuDecorators.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
 
 // forward declaration of the class so the function in the next namespace can be declared
 template <class TraitsT, class VectorT = std::vector<typename TraitsT::Scalar>>
@@ -169,7 +169,7 @@ public:
     {
         assert(SwValues.size() == values.size());
 
-        size_t n = SwValues.size();
+        std::size_t n = SwValues.size();
         SwPcwnSamples_.resize(n);
         pcwnSamples_.resize(n);
 
@@ -200,7 +200,7 @@ public:
     {
         assert(SwValues.size() == values.size());
 
-        size_t n = SwValues.size();
+        std::size_t n = SwValues.size();
         SwKrwSamples_.resize(n);
         krwSamples_.resize(n);
 
@@ -231,7 +231,7 @@ public:
     {
         assert(SwValues.size() == values.size());
 
-        size_t n = SwValues.size();
+        std::size_t n = SwValues.size();
         SwKrnSamples_.resize(n);
         krnSamples_.resize(n);
 
@@ -249,7 +249,7 @@ private:
             // The const expr ensures we can create constant parameter views.
             if constexpr (!std::is_const_v<typename ValueVector::value_type> && !std::is_const_v<ValueVector>) {
                 for (unsigned origSampleIdx = 0; origSampleIdx < swValues.size() / 2; ++origSampleIdx) {
-                    size_t newSampleIdx = swValues.size() - origSampleIdx - 1;
+                    std::size_t newSampleIdx = swValues.size() - origSampleIdx - 1;
 
                     std::swap(swValues[origSampleIdx], swValues[newSampleIdx]);
                     std::swap(values[origSampleIdx], values[newSampleIdx]);

--- a/opm/material/fluidsystems/blackoilpvt/H2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/H2GasPvt.hpp
@@ -33,6 +33,7 @@
 #include <opm/material/binarycoefficients/Brine_H2.hpp>
 #include <opm/material/common/UniformTabulated2DFunction.hpp>
 
+#include <cstddef>
 #include <vector>
 
 namespace Opm {
@@ -66,7 +67,7 @@ public:
     */
     void initFromState(const EclipseState& eclState, const Schedule&);
 
-    void setNumRegions(size_t numRegions);
+    void setNumRegions(std::size_t numRegions);
 
     void setVapPars(const Scalar, const Scalar)
     {

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -34,6 +34,8 @@
 #include <opm/material/common/UniformXTabulated2DFunction.hpp>
 #include <opm/material/common/Tabulated1DFunction.hpp>
 
+#include <cstddef>
+
 namespace Opm {
 
 class EclipseState;
@@ -65,7 +67,7 @@ private:
                           const SimpleTable& masterTable);
 
 public:
-    void setNumRegions(size_t numRegions);
+    void setNumRegions(std::size_t numRegions);
 
     void setVapPars(const Scalar, const Scalar par2)
     {

--- a/opm/material/thermal/EclThermalLawManager.cpp
+++ b/opm/material/thermal/EclThermalLawManager.cpp
@@ -22,6 +22,7 @@
 */
 
 #include <config.h>
+
 #include <opm/material/thermal/EclThermalLawManager.hpp>
 
 #include <opm/common/ErrorMacros.hpp>
@@ -33,13 +34,14 @@
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 
 #include <cassert>
+#include <cstddef>
 #include <stdexcept>
 
 namespace Opm {
 
 template<class Scalar, class FluidSystem>
 void EclThermalLawManager<Scalar,FluidSystem>::
-initParamsForElements(const EclipseState& eclState, size_t numElems,
+initParamsForElements(const EclipseState& eclState, std::size_t numElems,
                       const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>& fieldPropsDoubleOnLeafAssigner,
                       const std::function<std::vector<unsigned int>(const FieldPropsManager&, const std::string&, bool)>&
                       fieldPropsIntOnLeafAssigner)
@@ -119,7 +121,7 @@ thermalConductionLawParams(unsigned elemIdx) const
 
 template<class Scalar, class FluidSystem>
 void EclThermalLawManager<Scalar,FluidSystem>::
-initHeatcr_(const EclipseState& eclState, size_t numElems,
+initHeatcr_(const EclipseState& eclState, std::size_t numElems,
             const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>& fieldPropsDoubleOnLeafAssigner)
 {
     solidEnergyApproach_ = EclSolidEnergyApproach::Heatcr;
@@ -186,7 +188,7 @@ initNullRockEnergy_()
 
 template<class Scalar, class FluidSystem>
 void EclThermalLawManager<Scalar,FluidSystem>::
-initThconr_(const EclipseState& eclState, size_t numElems,
+initThconr_(const EclipseState& eclState, std::size_t numElems,
             const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>& fieldPropsDoubleOnLeafAssigner)
 {
     thermalConductivityApproach_ = EclThermalConductionApproach::Thconr;
@@ -218,7 +220,7 @@ initThconr_(const EclipseState& eclState, size_t numElems,
 
 template<class Scalar, class FluidSystem>
 void EclThermalLawManager<Scalar,FluidSystem>::
-initThc_(const EclipseState& eclState, size_t numElems,
+initThc_(const EclipseState& eclState, std::size_t numElems,
          const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>& fieldPropsDoubleOnLeafAssigner)
 {
     thermalConductivityApproach_ = EclThermalConductionApproach::Thc;

--- a/opm/material/thermal/EclThermalLawManager.hpp
+++ b/opm/material/thermal/EclThermalLawManager.hpp
@@ -33,6 +33,7 @@
 #include "EclThermalConductionLawMultiplexer.hpp"
 #include "EclThermalConductionLawMultiplexerParams.hpp"
 
+#include <cstddef>
 #include <functional>
 #include <vector>
 
@@ -59,7 +60,7 @@ public:
     using ThermalConductionLaw = EclThermalConductionLawMultiplexer<Scalar, FluidSystem>;
     using ThermalConductionLawParams = typename ThermalConductionLaw::Params;
 
-    void initParamsForElements(const EclipseState& eclState, size_t numElems,
+    void initParamsForElements(const EclipseState& eclState, std::size_t numElems,
                                const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>&
                                fieldPropDoubleOnLeafAssigner,
                                const std::function<std::vector<unsigned int>(const FieldPropsManager&, const std::string&,
@@ -73,7 +74,7 @@ private:
     /*!
      * \brief Initialize the parameters for the solid energy law using using HEATCR and friends.
      */
-    void initHeatcr_(const EclipseState& eclState, size_t numElems,
+    void initHeatcr_(const EclipseState& eclState, std::size_t numElems,
                      const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>&
                      fieldPropDoubleOnLeafAssigner);
 
@@ -92,14 +93,14 @@ private:
     /*!
      * \brief Initialize the parameters for the thermal conduction law using THCONR and friends.
      */
-    void initThconr_(const EclipseState& eclState, size_t numElems,
+    void initThconr_(const EclipseState& eclState, std::size_t numElems,
                      const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>&
                      fieldPropsDoubleOnLeafAssigner);
 
     /*!
      * \brief Initialize the parameters for the thermal conduction law using THCROCK and friends.
      */
-    void initThc_(const EclipseState& eclState, size_t numElems,
+    void initThc_(const EclipseState& eclState, std::size_t numElems,
                   const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>&
                   fieldPropsDoubleOnLeafAssigner);
 

--- a/opm/ml/ml_model.hpp
+++ b/opm/ml/ml_model.hpp
@@ -27,19 +27,20 @@
 #ifndef ML_MODEL_H_
 #define ML_MODEL_H_
 
-#include <fmt/format.h>
-
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/material/densead/Math.hpp>
 
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstddef>
 #include <cstdio>
+#include <fstream>
 #include <numeric>
 #include <string>
 #include <vector>
-#include <fstream>
+
+#include <fmt/format.h>
 
 namespace Opm
 {
@@ -537,7 +538,7 @@ namespace ML
     }
 
     template <typename T>
-    bool readFile(std::ifstream& file, T* data, size_t n)
+    bool readFile(std::ifstream& file, T* data, std::size_t n)
     {
         file.read(reinterpret_cast<char*>(data), sizeof(T) * n);
         return !file.fail();
@@ -587,19 +588,19 @@ namespace ML
         case ActivationType::kLinear:
             break;
         case ActivationType::kRelu:
-            for (size_t i = 0; i < out.data_.size(); i++) {
+            for (std::size_t i = 0; i < out.data_.size(); i++) {
                 if (out.data_[i] < 0.0) {
                     out.data_[i] = 0.0;
                 }
             }
             break;
         case ActivationType::kSoftPlus:
-            for (size_t i = 0; i < out.data_.size(); i++) {
+            for (std::size_t i = 0; i < out.data_.size(); i++) {
                 out.data_[i] = log(1.0 + exp(out.data_[i]));
             }
             break;
         case ActivationType::kHardSigmoid:
-            for (size_t i = 0; i < out.data_.size(); i++) {
+            for (std::size_t i = 0; i < out.data_.size(); i++) {
                 constexpr double sigmoid_scale = 0.2;
                 const Evaluation& x = (out.data_[i] * sigmoid_scale) + 0.5;
 
@@ -613,7 +614,7 @@ namespace ML
             }
             break;
         case ActivationType::kSigmoid:
-            for (size_t i = 0; i < out.data_.size(); i++) {
+            for (std::size_t i = 0; i < out.data_.size(); i++) {
                 const Evaluation& x = out.data_[i];
 
                 if (x >= 0) {
@@ -625,7 +626,7 @@ namespace ML
             }
             break;
         case ActivationType::kTanh:
-            for (size_t i = 0; i < out.data_.size(); i++) {
+            for (std::size_t i = 0; i < out.data_.size(); i++) {
                 out.data_[i] = sinh(out.data_[i]) / cosh(out.data_[i]);
             }
             break;
@@ -660,7 +661,7 @@ namespace ML
     {
         out.data_.resize(in.data_.size());
         out.dims_ = in.dims_;
-        for (size_t i = 0; i < out.data_.size(); i++) {
+        for (std::size_t i = 0; i < out.data_.size(); i++) {
             auto tempscale = (in.data_[i] - data_min_) / (data_max_ - data_min_);
             out.data_[i] = tempscale * (feat_sup_ - feat_inf_) + feat_inf_;
         }
@@ -694,7 +695,7 @@ namespace ML
     {
         out.data_.resize(in.data_.size());
         out.dims_ = in.dims_;
-        for (size_t i = 0; i < out.data_.size(); i++) {
+        for (std::size_t i = 0; i < out.data_.size(); i++) {
             auto tempscale = (in.data_[i] - feat_inf_) / (feat_sup_ - feat_inf_);
 
             out.data_[i] = tempscale * (data_max_ - data_min_) + data_min_;

--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -29,6 +29,7 @@
 #include <array>
 #include <climits>
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <stdexcept>
 #include <string>
@@ -50,7 +51,7 @@ namespace Opm { namespace data {
 
         public:
             Rates() = default;
-            enum class opt : uint32_t {
+            enum class opt : std::uint32_t {
                 wat               = (1 << 0),
                 oil               = (1 << 1),
                 gas               = (1 << 2),
@@ -1244,7 +1245,7 @@ namespace Opm { namespace data {
         void read(MessageBufferType& buffer) {
             unsigned int size;
             buffer.read(size);
-            for (size_t i = 0; i < size; ++i) {
+            for (std::size_t i = 0; i < size; ++i) {
                 std::string name;
                 buffer.read(name);
                 Well well;
@@ -1659,7 +1660,7 @@ namespace Opm { namespace data {
             //tracer:
             unsigned int size;
             buffer.read(size);
-            for (size_t i = 0; i < size; ++i) {
+            for (std::size_t i = 0; i < size; ++i) {
                 std::string tracer_name;
                 buffer.read(tracer_name);
                 double tracer_rate;

--- a/opm/output/eclipse/AggregateGroupData.cpp
+++ b/opm/output/eclipse/AggregateGroupData.cpp
@@ -1484,8 +1484,8 @@ allocate(const std::vector<int>& inteHead)
 template <class XGrpArray>
 void dynamicContrib(const std::vector<std::string>&      restart_group_keys,
                     const std::vector<std::string>&      restart_field_keys,
-                    const std::map<std::string, size_t>& groupKeyToIndex,
-                    const std::map<std::string, size_t>& fieldKeyToIndex,
+                    const std::map<std::string, std::size_t>& groupKeyToIndex,
+                    const std::map<std::string, std::size_t>& fieldKeyToIndex,
                     const Opm::Group&                    group,
                     const Opm::SummaryState&             sumState,
                     XGrpArray&                           xGrp)
@@ -1495,7 +1495,7 @@ void dynamicContrib(const std::vector<std::string>&      restart_group_keys,
     std::string groupName = group.name();
     const std::vector<std::string>& keys = (groupName == "FIELD")
                                            ? restart_field_keys : restart_group_keys;
-    const std::map<std::string, size_t>& keyToIndex = (groupName == "FIELD")
+    const std::map<std::string, std::size_t>& keyToIndex = (groupName == "FIELD")
             ? fieldKeyToIndex : groupKeyToIndex;
 
     for (const auto& key : keys) {
@@ -1523,7 +1523,7 @@ void dynamicContrib(const std::vector<std::string>&      restart_group_keys,
 template <class XGrpArray>
 void dynamicContribLGR(const std::vector<std::reference_wrapper<const Opm::Well>>& filtered_wells,
                        const std::vector<std::string>&                      restart_well_keys,
-                       const std::map<std::string, size_t>&                 wellKeyToIndex,
+                       const std::map<std::string, std::size_t>&                 wellKeyToIndex,
                        const Opm::SummaryState&                             sumState,
                        XGrpArray&                                           xGrp)
 {

--- a/opm/output/eclipse/AggregateGroupData.hpp
+++ b/opm/output/eclipse/AggregateGroupData.hpp
@@ -107,7 +107,7 @@ public:
                                                         /*"WGCR",*/  /*"WGCT",*/ /*"WGIMR",*/ /*"WGIMT",*/
                                                         "WWITH", "WGITH"};
 
-    const std::map<std::string, size_t> groupKeyToIndex = {
+    const std::map<std::string, std::size_t> groupKeyToIndex = {
                                                            {"GOPR",  0},
                                                            {"GWPR",  1},
                                                            {"GGPR",  2},
@@ -145,7 +145,7 @@ public:
                                                            {"GGITH", 144},
     };
 
-    const std::map<std::string, size_t> fieldKeyToIndex = {
+    const std::map<std::string, std::size_t> fieldKeyToIndex = {
                                                            {"FOPR",  0},
                                                            {"FWPR",  1},
                                                            {"FGPR",  2},
@@ -176,7 +176,7 @@ public:
                                                            {"FGITH", 144},
     };
 
-        const std::map<std::string, size_t> wellKeyToIndex = {
+        const std::map<std::string, std::size_t> wellKeyToIndex = {
                                                            {"WOPR",  0},
                                                            {"WWPR",  1},
                                                            {"WGPR",  2},

--- a/opm/output/eclipse/AggregateMSWData.cpp
+++ b/opm/output/eclipse/AggregateMSWData.cpp
@@ -305,8 +305,8 @@ namespace {
         int sumConn = 0;
         if (noConnectionsSegment(compSet, segSet, segIndex) > 0) {
             // add up the number of connections for å segments with lower segment index than current segment
-            for (size_t ind = 0; ind <= segIndex; ind++) {
-                size_t addCon = (ind == segIndex) ? 1 : noConnectionsSegment(compSet, segSet, ind);
+            for (std::size_t ind = 0; ind <= segIndex; ind++) {
+                std::size_t addCon = (ind == segIndex) ? 1 : noConnectionsSegment(compSet, segSet, ind);
                 sumConn += addCon;
             }
         }

--- a/opm/output/eclipse/AggregateNetworkData.cpp
+++ b/opm/output/eclipse/AggregateNetworkData.cpp
@@ -43,9 +43,10 @@
 #include <cstddef>
 #include <cstring>
 #include <exception>
-#include <string>
-#include <stdexcept>
 #include <optional>
+#include <stdexcept>
+#include <string>
+
 #include <fmt/format.h>
 
 #define ENABLE_GCNTL_DEBUG_OUTPUT 0
@@ -186,7 +187,7 @@ std::vector<int> inobrFunc( const Opm::Schedule&    sched,
 
 bool fixedPressureNode(const Opm::Schedule&         sched,
                        const std::string&           nodeName,
-                       const size_t                 lookup_step
+                       const std::size_t                 lookup_step
                       )
 {
     auto& network = sched[lookup_step].network();
@@ -198,7 +199,7 @@ double nodePressure(const Opm::Schedule&               sched,
                     const ::Opm::SummaryState&         smry,
                     const std::string&                 nodeName,
                     const Opm::UnitSystem&             units,
-                    const size_t                       lookup_step
+                    const std::size_t                       lookup_step
                    )
 {
     using M = ::Opm::UnitSystem::measure;
@@ -271,7 +272,7 @@ nodeProps wellGroupRateDensity(const Opm::EclipseState&                  es,
                                const Opm::Schedule&                      sched,
                                const ::Opm::SummaryState&                smry,
                                const std::string&                        groupName,
-                               const size_t                              lookup_step
+                               const std::size_t                              lookup_step
                               )
 {
     const auto& stdDensityTable = es.getTableManager().getDensityTable();
@@ -314,7 +315,7 @@ nodeProps nodeRateDensity(const Opm::EclipseState&                  es,
                           const ::Opm::SummaryState&                smry,
                           const std::string&                        nodeName,
                           const Opm::UnitSystem&                    units,
-                          const size_t                              lookup_step
+                          const std::size_t                              lookup_step
                          )
 {
     const auto& network = sched[lookup_step].network();
@@ -400,7 +401,7 @@ allocate(const std::vector<int>& inteHead)
     };
 }
 
-int numberOfBranchesConnToNode(const Opm::Schedule& sched, const std::string& nodeName, const size_t lookup_step)
+int numberOfBranchesConnToNode(const Opm::Schedule& sched, const std::string& nodeName, const std::size_t lookup_step)
 {
     auto& network = sched[lookup_step].network();
     if (network.has_node(nodeName)) {
@@ -413,7 +414,7 @@ int numberOfBranchesConnToNode(const Opm::Schedule& sched, const std::string& no
     }
 }
 
-int cumNumberOfBranchesConnToNode(const Opm::Schedule& sched, const std::string& nodeName, const size_t lookup_step)
+int cumNumberOfBranchesConnToNode(const Opm::Schedule& sched, const std::string& nodeName, const std::size_t lookup_step)
 {
     auto& network = sched[lookup_step].network();
     auto result = findInVector<std::string>(network.node_names(), nodeName);

--- a/opm/output/eclipse/AggregateWellData.cpp
+++ b/opm/output/eclipse/AggregateWellData.cpp
@@ -150,22 +150,22 @@ namespace {
             };
         }
 
-        std::map <const std::string, size_t>  currentGroupMapNameIndex(const Opm::Schedule& sched, const size_t simStep, const std::vector<int>& inteHead)
+        std::map <const std::string, std::size_t>  currentGroupMapNameIndex(const Opm::Schedule& sched, const std::size_t simStep, const std::vector<int>& inteHead)
         {
             // make group name to index map for the current time step
-            std::map <const std::string, size_t> groupIndexMap;
+            std::map <const std::string, std::size_t> groupIndexMap;
             for (const auto& group_name : sched.groupNames(simStep)) {
                 const auto& group = sched.getGroup(group_name, simStep);
                 int ind = (group.name() == "FIELD")
                     ? inteHead[VI::intehead::NGMAXZ]-1 : group.insert_index()-1;
-                std::pair<const std::string, size_t> groupPair = std::make_pair(group.name(), ind);
+                std::pair<const std::string, std::size_t> groupPair = std::make_pair(group.name(), ind);
                 groupIndexMap.insert(groupPair);
             }
             return groupIndexMap;
         }
 
         int groupIndex(const std::string&              grpName,
-                       const std::map <const std::string, size_t>&  currentGroupMapNameIndex)
+                       const std::map <const std::string, std::size_t>&  currentGroupMapNameIndex)
         {
             int ind = 0;
             auto searchGTName = currentGroupMapNameIndex.find(grpName);
@@ -581,7 +581,7 @@ namespace {
                            const Opm::WellTestState&       wtest_state,
                            const Opm::SummaryState&        st,
                            const std::size_t               msWellID,
-                           const std::map<const std::string, size_t>& GroupMapNameInd,
+                           const std::map<const std::string, std::size_t>& GroupMapNameInd,
                            IWellArray&                     iWell,
                            const std::optional<std::reference_wrapper<const Opm::EclipseGrid>>&
                                                            grid = std::nullopt,

--- a/opm/output/eclipse/EclipseIOUtil.hpp
+++ b/opm/output/eclipse/EclipseIOUtil.hpp
@@ -1,8 +1,8 @@
 #ifndef ECLIPSE_IO_UTIL_HPP
 #define ECLIPSE_IO_UTIL_HPP
 
+#include <cstddef>
 #include <vector>
-
 
 namespace Opm
 {
@@ -10,9 +10,9 @@ namespace EclipseIOUtil
 {
 
     template <typename T>
-    void addToStripedData(const std::vector<T>& data, std::vector<T>& result, size_t offset, size_t stride) {
+    void addToStripedData(const std::vector<T>& data, std::vector<T>& result, std::size_t offset, std::size_t stride) {
         int dataindex = 0;
-        for (size_t index = offset; index < result.size(); index += stride) {
+        for (std::size_t index = offset; index < result.size(); index += stride) {
             result[index] = data[dataindex];
             ++dataindex;
         }
@@ -20,8 +20,8 @@ namespace EclipseIOUtil
 
 
     template <typename T>
-    void extractFromStripedData(const std::vector<T>& data, std::vector<T>& result, size_t offset, size_t stride) {
-        for (size_t index = offset; index < data.size(); index += stride) {
+    void extractFromStripedData(const std::vector<T>& data, std::vector<T>& result, std::size_t offset, std::size_t stride) {
+        for (std::size_t index = offset; index < data.size(); index += stride) {
             result.push_back(data[index]);
         }
     }

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -1303,7 +1303,7 @@ inline quantity ratel( const fn_args& args ) {
     double sum = 0;
     const auto& connections = well->getConnections( args.num );
     for (const auto* conn_ptr : connections) {
-        const size_t global_index = conn_ptr->global_index();
+        const std::size_t global_index = conn_ptr->global_index();
         const auto& conn_data =
             std::ranges::find_if(well_data.connections,
                                  [global_index](const Opm::data::Connection& cdata)
@@ -1327,7 +1327,7 @@ inline quantity cpr( const fn_args& args ) {
     // NUMS array in the eclipse SMSPEC file; the values in this array
     // are offset 1 - whereas we need to use this index here to look
     // up a connection with offset 0.
-    const size_t global_index = args.num - 1;
+    const std::size_t global_index = args.num - 1;
     if (args.schedule_wells.empty())
         return zero;
 
@@ -1381,7 +1381,7 @@ inline quantity cratel( const fn_args& args ) {
     double lsum = 0.0;
     const auto& connections = well->getConnections(*complnum);
     for (const auto& conn_ptr : connections) {
-        const size_t global_index = conn_ptr->global_index();
+        const std::size_t global_index = conn_ptr->global_index();
         const auto& conn_data =
             std::ranges::find_if(well_data.connections,
                                  [global_index] (const Opm::data::Connection& cdata)
@@ -1466,7 +1466,7 @@ inline quantity crate( const fn_args& args ) {
     // carried on data::Connection (lgr_grid / index) instead of on
     // args.num.  For plain C* keywords both filters are empty and
     // behaviour is unchanged.
-    const size_t global_index = args.num - 1;
+    const std::size_t global_index = args.num - 1;
     if (args.schedule_wells.empty())
         return zero;
 
@@ -1677,7 +1677,7 @@ inline quantity trans_factors ( const fn_args& args ) {
         return zero;
 
     // Like connection rate we need to look up a connection with offset 0.
-    const size_t global_index = args.num - 1;
+    const std::size_t global_index = args.num - 1;
     const auto& connections = xwPos->second.connections;
     const auto connPos =
             std::ranges::find_if(connections,
@@ -1705,7 +1705,7 @@ inline quantity d_factors ( const fn_args& args ) {
         return zero;
 
     // Like connection rate we need to look up a connection with offset 0.
-    const size_t global_index = args.num - 1;
+    const std::size_t global_index = args.num - 1;
     const auto& connections = xwPos->second.connections;
     auto connPos = std::find_if(connections.begin(), connections.end(),
         [global_index](const Opm::data::Connection& c)

--- a/opm/output/eclipse/WriteInit.cpp
+++ b/opm/output/eclipse/WriteInit.cpp
@@ -825,7 +825,7 @@ namespace {
         // aquifer cells
         const auto& aquifer_cells = num_aquifers.allAquiferCells();
         for ([[maybe_unused]] const auto& [cell_idx, cell] : aquifer_cells) {
-            const size_t active_index = grid.activeIndex(cell->global_index);
+            const std::size_t active_index = grid.activeIndex(cell->global_index);
             aquifern[active_index] = -(1 << (cell->aquifer_id - 1));
         }
 
@@ -834,7 +834,7 @@ namespace {
             const auto& connections = aqu.connections();
             const int exp2_id_1 = 1 << (id - 1);
             for (const auto& con : connections) {
-                const size_t active_index = grid.activeIndex(con.global_index);
+                const std::size_t active_index = grid.activeIndex(con.global_index);
                 aquifern[active_index] += exp2_id_1;
             }
         }
@@ -852,7 +852,7 @@ namespace {
         for (const auto& [id, cons] : cons_data) {
             const int exp2_id_1 = 1 << (id - 1);
             for (const auto& con : cons) {
-                const size_t active_index = grid.activeIndex(con.global_index);
+                const std::size_t active_index = grid.activeIndex(con.global_index);
                 aquifera[active_index] += exp2_id_1;
             }
         }

--- a/opm/utility/EModel.cpp
+++ b/opm/utility/EModel.cpp
@@ -22,6 +22,7 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstring>
 #include <filesystem>
 #include <iterator>
@@ -105,12 +106,12 @@ EModel::EModel(const std::string& filename) :
 
     auto initArrList = initfile.getList();
 
-    for (size_t m = 0; m < initArrList.size(); m++) {
+    for (std::size_t m = 0; m < initArrList.size(); m++) {
         std::string name = std::get<0>(initArrList[m]);
         auto arrType = std::get<1>(initArrList[m]);
         auto sizeArray=std::get<2>(initArrList[m]);
 
-        if (static_cast<size_t>(sizeArray) == nActive) {
+        if (static_cast<std::size_t>(sizeArray) == nActive) {
             initParam[name] = index;
             initParamName.push_back(name);
             initParamType.push_back(arrType);
@@ -164,7 +165,7 @@ void EModel::initSolutionData(int rstep){
 
     int index = -1;
 
-    for (size_t n = 0; n < rstArrList.size(); n++) {
+    for (std::size_t n = 0; n < rstArrList.size(); n++) {
         std::string name = std::get<0>(rstArrList[n]);
         auto arrType = std::get<1>(rstArrList[n]);
         auto sizeArray=std::get<2>(rstArrList[n]);
@@ -172,7 +173,7 @@ void EModel::initSolutionData(int rstep){
         if (name == "ENDSOL")
             solparam=false;
 
-        if ((solparam == true) && (static_cast<size_t>(sizeArray) == nActive)) {
+        if ((solparam == true) && (static_cast<std::size_t>(sizeArray) == nActive)) {
             index++;
             solutionParam[name] = index;
             solutionParamName.push_back(name);
@@ -197,7 +198,7 @@ void EModel::get_cell_volumes_from_grid()
 
     CELLVOL.clear();
 
-    for (size_t n = 0;n < nActive; n++)
+    for (std::size_t n = 0;n < nActive; n++)
         CELLVOL.push_back(grid->getCellVolume(I[n]-1, J[n]-1, K[n]-1));
 
     celVolCalculated = true;
@@ -207,12 +208,12 @@ std::vector<ParamEntry> EModel::getListOfParameters() const
 {
     std::vector<ParamEntry> res;
 
-    for (size_t i = 0; i < initParamName.size(); i++) {
+    for (std::size_t i = 0; i < initParamName.size(); i++) {
 	    ParamEntry entry = std::make_tuple(initParamName[i],initParamType[i]);
         res.push_back(entry);
     }
 
-    for (size_t i = 0; i<solutionParamName.size(); i++) {
+    for (std::size_t i = 0; i<solutionParamName.size(); i++) {
         ParamEntry entry = std::make_tuple(solutionParamName[i],solutionParamType[i]);
         res.push_back(entry);
     }
@@ -263,17 +264,17 @@ template <typename T>
 void EModel::updateActiveFilter(const std::vector<T>& paramVect, const std::string& opperator, T value)
 {
     if ((opperator == "eq") || (opperator == "==")){
-       for (size_t i = 0; i < paramVect.size(); i++)
+       for (std::size_t i = 0; i < paramVect.size(); i++)
             if ((ActFilter[i]) && (paramVect[i] != value))
                 ActFilter[i] = false;
 
     } else if ((opperator=="lt") || (opperator=="<")) {
-        for (size_t i = 0; i < paramVect.size(); i++)
+        for (std::size_t i = 0; i < paramVect.size(); i++)
             if ((ActFilter[i]) && (paramVect[i] >= value))
                 ActFilter[i] = false;
 
     } else if ((opperator == "gt") || (opperator == ">")){
-        for (size_t i = 0; i < paramVect.size(); i++)
+        for (std::size_t i = 0; i < paramVect.size(); i++)
             if ((ActFilter[i]) && (paramVect[i] <= value))
                 ActFilter[i] = false;
 
@@ -290,7 +291,7 @@ template <typename T>
 void EModel::updateActiveFilter(const std::vector<T>& paramVect, const std::string& opperator, T value1, T value2)
 {
     if ((opperator == "in") || (opperator == "between")) {
-        for (size_t i = 0; i < paramVect.size(); i++)
+        for (std::size_t i = 0; i < paramVect.size(); i++)
             if ((ActFilter[i]) && ((paramVect[i] <= value1) || (paramVect[i] >= value2)))
                 ActFilter[i] = false;
 
@@ -385,7 +386,7 @@ void EModel::addHCvolFilter()
     auto depth = initfile.get<float>("DEPTH");
     activeFilter = true;
 
-    for (size_t n = 0; n < eqlnum.size();n++){
+    for (std::size_t n = 0; n < eqlnum.size();n++){
         int eql = eqlnum[n];
         float fwl = FreeWaterlevel[eql-1];
 
@@ -402,7 +403,7 @@ const std::vector<float>& EModel::getParam<float>(const std::string& name)
         std::vector<float> param = get_filter_param<float>(name);
         filteredFloatVect.clear();
 
-        for (size_t i = 0; i < param.size(); i++)
+        for (std::size_t i = 0; i < param.size(); i++)
             if (ActFilter[i])
                 filteredFloatVect.push_back(param[i]);
 
@@ -422,7 +423,7 @@ const std::vector<int>& EModel::getParam<int>(const std::string& name)
         std::vector<int> param = get_filter_param<int>(name);
         filteredIntVect.clear();
 
-        for (size_t i = 0; i < param.size(); i++)
+        for (std::size_t i = 0; i < param.size(); i++)
             if (ActFilter[i])
                 filteredIntVect.push_back(param[i]);
 

--- a/opm/utility/EModel.hpp
+++ b/opm/utility/EModel.hpp
@@ -19,17 +19,16 @@
 #ifndef EMODEL_HPP
 #define EMODEL_HPP
 
-
 #include <opm/io/eclipse/EclFile.hpp>
 #include <opm/io/eclipse/ERst.hpp>
 
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
-#include <string>
-#include <vector>
+#include <cstddef>
 #include <ctime>
 #include <map>
-
+#include <string>
+#include <vector>
 
 class EModel
 {
@@ -64,16 +63,14 @@ public:
 
     int getNumberOfActiveCells();
 
-
     std::tuple<int, int, int> gridDims(){ return std::make_tuple(nI, nJ, nK); };
-
 
 private:
 
     int nI, nJ, nK;
     int activeReportStep;
 
-    size_t nActive;
+    std::size_t nActive;
 
     bool activeFilter, celVolCalculated;
 
@@ -88,7 +85,6 @@ private:
     Opm::EclIO::EclFile initfile;
     std::optional<Opm::EclipseGrid> grid;
     std::optional<Opm::EclIO::ERst> rstfile;
-
 
     std::map<std::string, int> initParam;
     std::vector<std::string> initParamName;

--- a/tests/material/test_eclblackoilfluidsystemnonstatic.cpp
+++ b/tests/material/test_eclblackoilfluidsystemnonstatic.cpp
@@ -27,7 +27,9 @@
  *
  * This test requires the presence of opm-parser.
  */
+
 #include "config.h"
+
 #include <boost/test/tools/old/interface.hpp>
 
 #include <boost/mpl/list.hpp>
@@ -49,6 +51,7 @@
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 
 #include <cmath>
+#include <cstddef>
 #include <type_traits>
 
 // values of strings based on the SPE1 and NORNE cases of opm-data.
@@ -642,8 +645,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(BlackOil, Evaluation, Types)
     // with the nonstatic version as well.
     using ParamCache = typename FluidSystem::template ParameterCache<Scalar>;
 
-    const size_t numberOfRegions = FluidSystem::numRegions();
-    for (size_t regionIndexToUse = 0; regionIndexToUse < numberOfRegions; ++regionIndexToUse) {
+    const std::size_t numberOfRegions = FluidSystem::numRegions();
+    for (std::size_t regionIndexToUse = 0; regionIndexToUse < numberOfRegions; ++regionIndexToUse) {
         ParamCache paramCache(regionIndexToUse);
 
         // create a parameter cache

--- a/tests/material/test_eclmateriallawmanager.cpp
+++ b/tests/material/test_eclmateriallawmanager.cpp
@@ -44,6 +44,8 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
+#include <cstddef>
+
 // values of strings taken from the SPE1 test case1 of opm-data
 static constexpr const char* fam1DeckString =
     "RUNSPEC\n"
@@ -411,7 +413,6 @@ static constexpr const char* fam2DeckStringGasOil =
     "0.999  1       \n"
     "1.0    1       \n /\n";
 
-
 static constexpr const char* letDeckString =
     "RUNSPEC\n"
     "\n"
@@ -649,7 +650,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Fam1Fam2Hysteresis, Scalar, Types)
     const Opm::EclipseState eclState(deck);
 
     const auto& eclGrid = eclState.getInputGrid();
-    size_t n = eclGrid.getCartesianSize();
+    std::size_t n = eclGrid.getCartesianSize();
 
     MaterialLawManager fam1materialLawManager;
     fam1materialLawManager.initFromState(eclState);
@@ -760,7 +761,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(GasOil, Scalar, Types)
     const Opm::EclipseState fam1EclState(fam1Deck);
 
     const auto& eclGrid = fam1EclState.getInputGrid();
-    const size_t n = eclGrid.getCartesianSize();
+    const std::size_t n = eclGrid.getCartesianSize();
 
     MaterialLawManager fam1materialLawManager;
     fam1materialLawManager.initFromState(fam1EclState);
@@ -822,7 +823,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(GasWater, Scalar, Types)
     const Opm::EclipseState fam2EclState(fam2Deck);
 
     const auto& eclGrid = fam2EclState.getInputGrid();
-    const size_t n = eclGrid.getCartesianSize();
+    const std::size_t n = eclGrid.getCartesianSize();
 
     MaterialLawManager fam2materialLawManager;
     fam2materialLawManager.initFromState(fam2EclState);
@@ -887,7 +888,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Let, Scalar, Types)
     const Opm::EclipseState letEclState(letDeck);
 
     const auto& eclGrid = letEclState.getInputGrid();
-    const size_t n = eclGrid.getCartesianSize();
+    const std::size_t n = eclGrid.getCartesianSize();
 
     MaterialLawManager letmaterialLawManager;
     letmaterialLawManager.initFromState(letEclState);

--- a/tests/material/test_hysteresis.cpp
+++ b/tests/material/test_hysteresis.cpp
@@ -44,10 +44,11 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
+#include <array>
+#include <cstddef>
 #include <functional>
 #include <string>
 #include <vector>
-#include <array>
 
 //Test Killogh hysteresis Gas Oil System
 static const char* hysterDeckStringKilloughGasOil = R"(
@@ -1874,7 +1875,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKilloughOilWater, Scalar, Types)
     const Opm::EclipseState eclState(deck);
 
     const auto& eclGrid = eclState.getInputGrid();
-    size_t n = eclGrid.getCartesianSize();
+    std::size_t n = eclGrid.getCartesianSize();
 
     MaterialLawManager hysteresis;
     hysteresis.initFromState(eclState);

--- a/tests/material/test_pengrobinson.cpp
+++ b/tests/material/test_pengrobinson.cpp
@@ -36,6 +36,8 @@
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
 
+#include <cstddef>
+
 template <class FluidSystem, class FluidState>
 void createSurfaceGasFluidSystem(FluidState& gasFluidState)
 {
@@ -254,20 +256,20 @@ Scalar bringOilToSurface(FluidState& surfaceFluidState, Scalar alpha, const Flui
 template <class RawTable>
 void printResult(const RawTable& rawTable,
                  const std::string& fieldName,
-                 size_t firstIdx,
-                 size_t secondIdx,
+                 std::size_t firstIdx,
+                 std::size_t secondIdx,
                  double hiresThres)
 {
     std::cout << "std::vector<std::pair<Scalar, Scalar> > "<<fieldName<<" = {\n";
 
-    size_t sampleIdx = 0;
-    size_t numSamples = 20;
-    size_t numRawHires = 0;
+    std::size_t sampleIdx = 0;
+    std::size_t numSamples = 20;
+    std::size_t numRawHires = 0;
     for (; rawTable[numRawHires][firstIdx] > hiresThres; ++numRawHires)
     {}
 
     for (; sampleIdx < numSamples; ++sampleIdx) {
-        size_t rawIdx = sampleIdx*numRawHires/numSamples;
+        std::size_t rawIdx = sampleIdx*numRawHires/numSamples;
         std::cout << "{ " << rawTable[rawIdx][firstIdx] << ", "
                   << rawTable[rawIdx][secondIdx] << " }"
                   << ",\n";
@@ -275,7 +277,7 @@ void printResult(const RawTable& rawTable,
 
     numSamples = 15;
     for (sampleIdx = 0; sampleIdx < numSamples; ++sampleIdx) {
-        size_t rawIdx = sampleIdx*(rawTable.size() - numRawHires)/numSamples + numRawHires;
+        std::size_t rawIdx = sampleIdx*(rawTable.size() - numRawHires)/numSamples + numRawHires;
         std::cout << "{ " << rawTable[rawIdx][firstIdx] << ", "
                   << rawTable[rawIdx][secondIdx] << " }";
         if (sampleIdx < numSamples - 1)

--- a/tests/material/test_spline.cpp
+++ b/tests/material/test_spline.cpp
@@ -44,6 +44,7 @@ gnuplot> plot "spline.csv" using 1:2 w l ti "Curve", \
 #include <opm/material/common/Spline.hpp>
 
 #include <array>
+#include <cstddef>
 #include <iostream>
 
 template <class Spline, class Array>
@@ -53,8 +54,8 @@ void testCommon(const Spline& sp,
 {
     static double eps = 1e-10;
     static double epsFD = 1e-7;
-    size_t n = sp.numSamples();
-    for (size_t i = 0; i < n; ++i) {
+    std::size_t n = sp.numSamples();
+    for (std::size_t i = 0; i < n; ++i) {
         // sure that we hit all sampling points
         double y0 = (i>0)?sp.eval(x[i]-eps):y[0];
         double y1 = sp.eval(x[i]);
@@ -72,8 +73,8 @@ void testCommon(const Spline& sp,
                             "Spline seems to exhibit a discontinuous derivative at sampling point " << i);
     }
     // make sure the derivatives are consistent with the curve
-    size_t np = 3*n;
-    for (size_t i = 0; i < np; ++i) {
+    std::size_t np = 3*n;
+    for (std::size_t i = 0; i < np; ++i) {
         double xMin = sp.xAt(0);
         double xMax = sp.xAt(sp.numSamples() - 1);
         double xval = xMin + (xMax - xMin)*i/np;
@@ -114,7 +115,7 @@ void testFull(const Spline& sp,
     // test the common properties of splines
     testCommon(sp, x, y);
     static double eps = 1e-5;
-    size_t n = sp.numSamples();
+    std::size_t n = sp.numSamples();
     // make sure the derivative at both end points is correct
     double d0 = sp.evalDerivative(x[0]);
     double d1 = sp.evalDerivative(x[n-1]);
@@ -134,7 +135,7 @@ void testNatural(const Spline& sp,
     // test the common properties of splines
     testCommon(sp, x, y);
     static double eps = 1e-5;
-    size_t n = sp.numSamples();
+    std::size_t n = sp.numSamples();
     // make sure the second derivatives at both end points are 0
     double d0 = sp.evalDerivative(x[0]);
     double d1 = sp.evalDerivative(x[0] + eps);
@@ -155,8 +156,8 @@ void testMonotonic(const Spline& sp,
 {
     // test the common properties of splines
     testCommon(sp, x, y);
-    size_t n = sp.numSamples();
-    for (size_t i = 0; i < n - 1; ++ i) {
+    std::size_t n = sp.numSamples();
+    for (std::size_t i = 0; i < n - 1; ++ i) {
         // make sure that the spline is monotonic for each interval
         // between sampling points
         BOOST_CHECK_MESSAGE(sp.monotonic(x[i], x[i + 1]),
@@ -177,7 +178,7 @@ void testMonotonic(const Spline& sp,
                        "Spline says it is not monotonic on left side where it should be");
     BOOST_CHECK_MESSAGE(sp.monotonic((x[n - 2]+ x[n - 1])/2, x[n-1] + 1.0, /*extrapolate=*/true),
                        "Spline says it is not monotonic on right side where it should be");
-    for (size_t i = 0; i < n - 2; ++ i) {
+    for (std::size_t i = 0; i < n - 2; ++ i) {
         // make sure that the spline says that it is non-monotonic for
         // if extrema are within the queried interval
         BOOST_CHECK_MESSAGE(!sp.monotonic((x[i] + x[i + 1])/2, (x[i + 1] + x[i + 2])/2),
@@ -232,7 +233,7 @@ BOOST_AUTO_TEST_CASE(TwoPointArray)
 
 BOOST_AUTO_TEST_CASE(TwoPoint2DArray)
 {
-    Opm::Spline<double> sp(static_cast<size_t>(2), points, m0, m1);
+    Opm::Spline<double> sp(static_cast<std::size_t>(2), points, m0, m1);
     sp.setArrayOfPoints(2, points, m0, m1);
     testFull(sp, x, y, m0, m1);
 }

--- a/tests/ml/test_ml_layer.cpp
+++ b/tests/ml/test_ml_layer.cpp
@@ -25,6 +25,8 @@
 
 #include <opm/ml/ml_model.hpp>
 
+#include <cstddef>
+
 using namespace Opm::ML;
 
 template <typename T>
@@ -32,7 +34,7 @@ static void check_vector_close(const Tensor<T>& t, const std::vector<double>& ex
 {
     BOOST_REQUIRE_EQUAL((int)t.dims_.size(), 1);
     BOOST_REQUIRE_EQUAL(t.dims_[0], (int)expected.size());
-    for (size_t i = 0; i < expected.size(); ++i) {
+    for (std::size_t i = 0; i < expected.size(); ++i) {
         double g = t(i);
         double e = expected[i];
         BOOST_REQUIRE_CLOSE(g, e, rel_tol);

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -22,14 +22,6 @@
 
 #include <opm/msim/msim.hpp>
 
-#include <algorithm>
-#include <filesystem>
-#include <memory>
-#include <iostream>
-#include <stdexcept>
-#include <utility>
-
-#include <opm/input/eclipse/Python/Python.hpp>
 #include <opm/io/eclipse/ERst.hpp>
 #include <opm/io/eclipse/ESmry.hpp>
 #include <opm/io/eclipse/ERsm.hpp>
@@ -38,13 +30,28 @@
 
 #include <opm/output/data/Wells.hpp>
 #include <opm/output/eclipse/EclipseIO.hpp>
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Units/Units.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
+
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+#include <opm/input/eclipse/Python/Python.hpp>
+
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
-#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+#include <opm/input/eclipse/Units/Units.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <utility>
 
 #include <tests/WorkArea.hpp>
 
@@ -52,27 +59,27 @@ using namespace Opm;
 
 namespace {
 
-double prod_opr(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, size_t /* report_step */, double seconds_elapsed) {
+double prod_opr(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, std::size_t /* report_step */, double seconds_elapsed) {
     const auto& units = es.getUnits();
     return -units.to_si(UnitSystem::measure::rate, seconds_elapsed);
 }
 
-double prod_rft(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
+double prod_rft(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, std::size_t /* report_step */, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     return -units.to_si(UnitSystem::measure::rate, 0.0);
 }
 
-double inj_rfti(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
+double inj_rfti(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, std::size_t /* report_step */, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     return units.to_si(UnitSystem::measure::rate, 0.0);
 }
 
-double inj_inj(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
+double inj_inj(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, std::size_t /* report_step */, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     return units.to_si(UnitSystem::measure::rate, 100);
 }
 
-void pressure(const EclipseState& es, const Schedule& /* sched */, data::Solution& sol, size_t /* report_step */, double seconds_elapsed) {
+void pressure(const EclipseState& es, const Schedule& /* sched */, data::Solution& sol, std::size_t /* report_step */, double seconds_elapsed) {
     const auto& units = es.getUnits();
     if (!sol.has("PRESSURE")) {
         const auto& grid = es.getInputGrid();

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -72,6 +72,7 @@
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -361,7 +362,7 @@ BOOST_AUTO_TEST_CASE(TestActions)
 
     {
         constexpr double min_wait = 86400;
-        constexpr size_t max_eval = 3;
+        constexpr std::size_t max_eval = 3;
         Opm::Action::ActionX action("NAME", max_eval, min_wait, asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 7, 1 })) );
         config.add(action);
         BOOST_CHECK_EQUAL(config.ecl_size(), 1U);

--- a/tests/parser/BoxTests.cpp
+++ b/tests/parser/BoxTests.cpp
@@ -147,9 +147,9 @@ BOOST_AUTO_TEST_CASE(TestKeywordBox) {
 
 
 BOOST_AUTO_TEST_CASE(BoxNineArg) {
-    const size_t nx = 10;
-    const size_t ny = 7;
-    const size_t nz = 6;
+    const std::size_t nx = 10;
+    const std::size_t ny = 7;
+    const std::size_t nz = 6;
     Opm::GridDims gridDims(nx,ny,nz);
     BOOST_CHECK_NO_THROW( Opm::Box(gridDims, allActive(), identityMapping(), 0,7,0,5,1,2) );
 

--- a/tests/parser/CompositionalTests.cpp
+++ b/tests/parser/CompositionalTests.cpp
@@ -270,7 +270,7 @@ END
 
 void check_vectors_close(const std::vector<double>& v1, const std::vector<double>& v2, double tolerance) {
     BOOST_CHECK_EQUAL(v1.size(), v2.size());
-    for(size_t i = 0; i < v1.size(); ++i) {
+    for(std::size_t i = 0; i < v1.size(); ++i) {
         BOOST_CHECK_CLOSE(v1[i], v2[i], tolerance);
     }
 }

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -732,7 +732,7 @@ BOOST_AUTO_TEST_CASE(loadCOMPTRAJTESTSPE1) {
     const std::array<double, 4> connection_factor{311.783, 7.79428, 38.9674, 62.3465};
     const std::array<int, 4> global_index{0, 100, 111, 211};
     BOOST_CHECK_EQUAL(connections.size(), 4);
-    for (size_t i = 0 ; i < connections.size();  ++i ) {
+    for (std::size_t i = 0 ; i < connections.size();  ++i ) {
          BOOST_CHECK_CLOSE(connections[i].CF(), units.to_si(Opm::UnitSystem::measure::transmissibility, connection_factor[i]), 2e-2);
          BOOST_CHECK_EQUAL(connections[i].global_index(), global_index[i]);
     }
@@ -764,7 +764,7 @@ BOOST_AUTO_TEST_CASE(loadCOMPTRAJTESTSPE1_2) {
     const std::array<double, 5> connection_factor{78.5921, 11.7884, 77.9007, 311.585, 155.784};
     const std::array<int, 5> global_index{0, 100, 200, 211, 222};
     BOOST_CHECK_EQUAL(connections.size(), 5);
-    for (size_t i = 0 ; i < connections.size();  ++i ) {
+    for (std::size_t i = 0 ; i < connections.size();  ++i ) {
          BOOST_CHECK_CLOSE(connections[i].CF(), units.to_si(Opm::UnitSystem::measure::transmissibility, connection_factor[i]), 2e-2);
          BOOST_CHECK_EQUAL(connections[i].global_index(), global_index[i]);
     }

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(PushBackMultipleString) {
     DeckItem stringItem( "TEST", std::string() );
     stringItem.push_back("Heisann ", 100U );
     BOOST_CHECK_EQUAL( 100U , stringItem.data_size() );
-    for (size_t i=0; i < 100; i++)
+    for (std::size_t i=0; i < 100; i++)
         BOOST_CHECK_EQUAL("Heisann " , stringItem.get< std::string >(i));
 }
 
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(PushBackMultipleDouble) {
     DeckItem item( "HEI", double() , dims.first, dims.second);
     item.push_back(10.22 , 100 );
     BOOST_CHECK_EQUAL( 100U , item.data_size() );
-    for (size_t i=0; i < 100; i++)
+    for (std::size_t i=0; i < 100; i++)
         BOOST_CHECK_EQUAL(10.22 , item.get< double >(i));
 }
 
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(GetSIMultipleDim) {
 
     item.push_back( 1.0, 16 );
 
-    for (size_t i=0; i < 16; i+= 4) {
+    for (std::size_t i=0; i < 16; i+= 4) {
         BOOST_CHECK_EQUAL( 2   , item.getSIDouble(i) );
         BOOST_CHECK_EQUAL( 4   , item.getSIDouble(i+ 1) );
         BOOST_CHECK_EQUAL( 8   , item.getSIDouble(i+2) );
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(PushBackMultipleInt) {
     DeckItem item( "HEI", int() );
     item.push_back(10 , 100U );
     BOOST_CHECK_EQUAL( 100U , item.data_size() );
-    for (size_t i=0; i < 100; i++)
+    for (std::size_t i=0; i < 100; i++)
         BOOST_CHECK_EQUAL(10 , item.get< int >(i));
 }
 

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -399,13 +399,13 @@ BOOST_AUTO_TEST_CASE(DEPTHZ_EQUAL_TOPS) {
         BOOST_CHECK_THROW( grid1.getCellVolume(0,10,0) , std::invalid_argument);
         BOOST_CHECK_THROW( grid1.getCellVolume(0,0,10) , std::invalid_argument);
 
-        for (size_t g=0; g < 1000; g++)
+        for (std::size_t g=0; g < 1000; g++)
             BOOST_CHECK_CLOSE( grid1.getCellVolume(g) , 0.25*0.25*0.25 , 0.001);
 
 
-        for (size_t k= 0; k < 10; k++)
-            for (size_t j= 0; j < 10; j++)
-                for (size_t i= 0; i < 10; i++)
+        for (std::size_t k= 0; k < 10; k++)
+            for (std::size_t j= 0; j < 10; j++)
+                for (std::size_t i= 0; i < 10; i++)
                     BOOST_CHECK_CLOSE( grid1.getCellVolume(i, j, k) , 0.25*0.25*0.25 , 0.001 );
 
     }
@@ -416,9 +416,9 @@ BOOST_AUTO_TEST_CASE(DEPTHZ_EQUAL_TOPS) {
         BOOST_CHECK_THROW( grid1.getCellCenter(0,10,0) , std::invalid_argument);
         BOOST_CHECK_THROW( grid1.getCellCenter(0,0,10) , std::invalid_argument);
 
-        for (size_t k= 0; k < 10; k++) {
-            for (size_t j= 0; j < 10; j++) {
-                for (size_t i= 0; i < 10; i++) {
+        for (std::size_t k= 0; k < 10; k++) {
+            for (std::size_t j= 0; j < 10; j++) {
+                for (std::size_t i= 0; i < 10; i++) {
                     auto pos = grid1.getCellCenter(i, j, k);
 
                     BOOST_CHECK_CLOSE( std::get<0>(pos) , i*0.25 + 0.125, 0.001);
@@ -1149,7 +1149,7 @@ BOOST_AUTO_TEST_CASE(GridBoxActnum) {
 
     BOOST_CHECK_NO_THROW(fp.get_int("ACTNUM"));
 
-    size_t active = 10 * 10 * 10     // 1000
+    std::size_t active = 10 * 10 * 10     // 1000
                     - (10 * 10 * 1)  // - top layer
                     - ( 3 *  3 * 3)  // - [5,7]^3 box
                     - ( 3 *  3 * 3)  // - [6,8]^3 box
@@ -1161,13 +1161,13 @@ BOOST_AUTO_TEST_CASE(GridBoxActnum) {
     BOOST_CHECK_EQUAL(es.getInputGrid().getNumActive(), active);
 
     {
-        size_t active_index = 0;
+        std::size_t active_index = 0;
         // NB: The implementation of this test actually assumes that
         //     the loops are running with z as the outer and x as the
         //     inner direction.
-        for (size_t z = 0; z < grid.getNZ(); z++) {
-            for (size_t y = 0; y < grid.getNY(); y++) {
-                for (size_t x = 0; x < grid.getNX(); x++) {
+        for (std::size_t z = 0; z < grid.getNZ(); z++) {
+            for (std::size_t y = 0; y < grid.getNY(); y++) {
+                for (std::size_t x = 0; x < grid.getNX(); x++) {
                     if (z == 0)
                         BOOST_CHECK(!grid.cellActive(x, y, z));
                     else if (x >= 4 && x <= 6 && y >= 4 && y <= 6 && z >= 4 && z <= 6)
@@ -1175,7 +1175,7 @@ BOOST_AUTO_TEST_CASE(GridBoxActnum) {
                     else if (x >= 5 && x <= 7 && y >= 5 && y <= 7 && z >= 5 && z <= 7)
                         BOOST_CHECK(!grid.cellActive(x, y, z));
                     else {
-                        size_t g = grid.getGlobalIndex( x,y,z );
+                        std::size_t g = grid.getGlobalIndex( x,y,z );
 
                         BOOST_CHECK(grid.cellActive(x, y, z));
                         BOOST_CHECK_EQUAL( grid.activeIndex(x,y,z) , active_index );
@@ -1250,7 +1250,7 @@ BOOST_AUTO_TEST_CASE(GridBoxActnum2) {
 
     BOOST_CHECK_NO_THROW(fp.get_int("ACTNUM"));
 
-    size_t active = 10 * 10 * 10     // 1000
+    std::size_t active = 10 * 10 * 10     // 1000
                     - (10 * 10 * 1)  // - top layer
                     - ( 3 *  3 * 3)  // - [5,7]^3 box
                     - ( 3 *  3 * 3)  // - [6,8]^3 box
@@ -1262,19 +1262,19 @@ BOOST_AUTO_TEST_CASE(GridBoxActnum2) {
     BOOST_CHECK_EQUAL(es.getInputGrid().getNumActive(), active);
 
     {
-        size_t active_index = 0;
+        std::size_t active_index = 0;
         // NB: The implementation of this test actually assumes that
         //     the loops are running with z as the outer and x as the
         //     inner direction.
-        for (size_t z = 0; z < grid.getNZ(); z++) {
-            for (size_t y = 0; y < grid.getNY(); y++) {
-                for (size_t x = 0; x < grid.getNX(); x++) {
+        for (std::size_t z = 0; z < grid.getNZ(); z++) {
+            for (std::size_t y = 0; y < grid.getNY(); y++) {
+                for (std::size_t x = 0; x < grid.getNX(); x++) {
                     if (z == 0)
                         BOOST_CHECK(!grid.cellActive(x, y, z));
                     else if (x == 6 && y == 6 && z == 6) {
                         BOOST_CHECK(grid.cellActive(x, y, z));
                         BOOST_CHECK_EQUAL( grid.activeIndex(x,y,z) , active_index );
-                        size_t g = grid.getGlobalIndex( x,y,z );
+                        std::size_t g = grid.getGlobalIndex( x,y,z );
                         BOOST_CHECK_EQUAL( grid.activeIndex(g) , active_index );
                         ++active_index;
                     } else if (x >= 4 && x <= 6 && y >= 4 && y <= 6 && z >= 4 && z <= 6)
@@ -1282,7 +1282,7 @@ BOOST_AUTO_TEST_CASE(GridBoxActnum2) {
                     else if (x >= 5 && x <= 7 && y >= 5 && y <= 7 && z >= 5 && z <= 7)
                         BOOST_CHECK(!grid.cellActive(x, y, z));
                     else {
-                        size_t g = grid.getGlobalIndex( x,y,z );
+                        std::size_t g = grid.getGlobalIndex( x,y,z );
 
                         BOOST_CHECK(grid.cellActive(x, y, z));
                         BOOST_CHECK_EQUAL( grid.activeIndex(x,y,z) , active_index );
@@ -2155,8 +2155,8 @@ BOOST_AUTO_TEST_CASE(RadialDetailsDZ) {
 }
 
 BOOST_AUTO_TEST_CASE(CoordMapper) {
-    size_t nx = 10;
-    size_t ny = 7;
+    std::size_t nx = 10;
+    std::size_t ny = 7;
     Opm::CoordMapper cmp = Opm::CoordMapper( nx , ny );
     BOOST_CHECK_THROW( cmp.index(12,6,0,0), std::invalid_argument );
     BOOST_CHECK_THROW( cmp.index(10,8,0,0), std::invalid_argument );
@@ -2225,13 +2225,13 @@ BOOST_AUTO_TEST_CASE(CART_Deck_3x4x2) {
 
     BOOST_CHECK_EQUAL( t_coord.size() , ref_coord.size());
 
-    for (size_t i=0; i< t_coord.size(); i++) {
+    for (std::size_t i=0; i< t_coord.size(); i++) {
         BOOST_CHECK_CLOSE( t_coord[i] , ref_coord[i], 1.0e-5);
     }
 
     BOOST_CHECK_EQUAL( t_zcorn.size() , ref_zcorn.size());
 
-    for (size_t i=0; i< t_zcorn.size(); i++) {
+    for (std::size_t i=0; i< t_zcorn.size(); i++) {
         BOOST_CHECK_CLOSE( t_zcorn[i] , ref_zcorn[i], 1.0e-5);
     }
 }
@@ -2284,13 +2284,13 @@ BOOST_AUTO_TEST_CASE(CART_Deck_DEPTHZ_2x3x2) {
 
     BOOST_CHECK_EQUAL( t_coord.size() , ref_coord.size());
 
-    for (size_t i=0; i< t_coord.size(); i++) {
+    for (std::size_t i=0; i< t_coord.size(); i++) {
         BOOST_CHECK_CLOSE( t_coord[i] , ref_coord[i], 1.0e-5);
     }
 
     BOOST_CHECK_EQUAL( t_zcorn.size() , ref_zcorn.size());
 
-    for (size_t i=0; i< t_zcorn.size(); i++) {
+    for (std::size_t i=0; i< t_zcorn.size(); i++) {
         BOOST_CHECK_CLOSE( t_zcorn[i] , ref_zcorn[i], 1.0e-5);
     }
 }
@@ -2400,7 +2400,7 @@ BOOST_AUTO_TEST_CASE(SAVE_FIELD_UNITS) {
         std::vector<float> coord_input_f;
         coord_input_f.reserve(coord_input_si.size());
 
-        for (size_t n = 0; n < coord_egrid.size(); n++) {
+        for (std::size_t n = 0; n < coord_egrid.size(); n++) {
             coord_input_f.push_back(static_cast<float>(units.from_si(length, coord_input_si[n])));
             BOOST_CHECK_CLOSE(coord_input_f[n], coord_egrid[n], 1e-6);
         }
@@ -2414,7 +2414,7 @@ BOOST_AUTO_TEST_CASE(SAVE_FIELD_UNITS) {
         std::vector<float> zcorn_input_f;
         zcorn_input_f.reserve(zcorn_input_si.size());
 
-        for (size_t n = 0; n < zcorn_egrid.size(); n++) {
+        for (std::size_t n = 0; n < zcorn_egrid.size(); n++) {
             zcorn_input_f.push_back(static_cast<float>(units.from_si(length, zcorn_input_si[n])));
             BOOST_CHECK_CLOSE(zcorn_input_f[n], zcorn_egrid[n], 1e-6);
         }
@@ -2478,7 +2478,7 @@ BOOST_AUTO_TEST_CASE(SAVE_FIELD_UNITS) {
 
         BOOST_CHECK(test_mapaxes2.size() == ref2_mapaxes.size());
 
-        for (size_t n = 0; n < ref2_mapaxes.size(); n++) {
+        for (std::size_t n = 0; n < ref2_mapaxes.size(); n++) {
             BOOST_CHECK_EQUAL(ref2_mapaxes[n], test_mapaxes2[n]);
         }
 
@@ -2528,7 +2528,7 @@ BOOST_AUTO_TEST_CASE(SAVE_FIELD_UNITS) {
 
         BOOST_CHECK(test_mapaxes3.size() == ref3_mapaxes.size());
 
-        for (size_t n = 0; n < ref3_mapaxes.size(); n++) {
+        for (std::size_t n = 0; n < ref3_mapaxes.size(); n++) {
             BOOST_CHECK(ref3_mapaxes[n] == test_mapaxes3[n]);
         }
     }
@@ -2601,7 +2601,7 @@ BOOST_AUTO_TEST_CASE(SAVE_METRIC_UNITS) {
         std::vector<float> coord_input_f;
         coord_input_f.reserve(coord_input_si.size());
 
-        for (size_t n = 0; n < coord_egrid.size(); n++) {
+        for (std::size_t n = 0; n < coord_egrid.size(); n++) {
             coord_input_f.push_back(static_cast<float>(units1.from_si(length, coord_input_si[n])));
             BOOST_CHECK_CLOSE(coord_input_f[n], coord_egrid[n], 1e-6);
         }
@@ -2615,7 +2615,7 @@ BOOST_AUTO_TEST_CASE(SAVE_METRIC_UNITS) {
         std::vector<float> zcorn_input_f;
         zcorn_input_f.reserve(zcorn_input_si.size());
 
-        for (size_t n = 0; n < zcorn_egrid.size(); n++) {
+        for (std::size_t n = 0; n < zcorn_egrid.size(); n++) {
             zcorn_input_f.push_back(static_cast<float>(units1.from_si(length, zcorn_input_si[n])));
             BOOST_CHECK_CLOSE(zcorn_input_f[n], zcorn_egrid[n], 1e-6);
         }
@@ -2628,7 +2628,7 @@ BOOST_AUTO_TEST_CASE(SAVE_METRIC_UNITS) {
         BOOST_CHECK(file1.hasKey("MAPAXES"));
         std::vector<float> mapaxes = file1.get<float>("MAPAXES");
 
-        for (size_t n = 0; n < 6; n++) {
+        for (std::size_t n = 0; n < 6; n++) {
             BOOST_CHECK_CLOSE(mapaxes[n], ref_mapaxes1[n], 1e-6);
         }
 
@@ -2651,11 +2651,11 @@ BOOST_AUTO_TEST_CASE(SAVE_METRIC_UNITS) {
 
         BOOST_CHECK(nnc1.size() == nnc2.size());
 
-        for (size_t n = 0; n < nnc1.size(); n++) {
+        for (std::size_t n = 0; n < nnc1.size(); n++) {
             BOOST_CHECK(nnc1[n] == ref_nnc1[n]);
         }
 
-        for (size_t n = 0; n < nnc2.size(); n++) {
+        for (std::size_t n = 0; n < nnc2.size(); n++) {
             BOOST_CHECK(nnc2[n] == ref_nnc2[n]);
         }
 
@@ -2709,7 +2709,7 @@ BOOST_AUTO_TEST_CASE(SAVE_METRIC_UNITS) {
 
         BOOST_CHECK(test_mapaxes2.size() == ref_mapaxes2.size());
 
-        for (size_t n = 0; n < ref_mapaxes2.size(); n++) {
+        for (std::size_t n = 0; n < ref_mapaxes2.size(); n++) {
             BOOST_CHECK(ref_mapaxes2[n] == test_mapaxes2[n]);
         }
     }
@@ -2722,7 +2722,7 @@ BOOST_AUTO_TEST_CASE(CalcCellDims) {
 
     std::array<int, 3> dims = grid.getNXYZ();
 
-    size_t nCells = dims[0]*dims[1]*dims[2];
+    std::size_t nCells = dims[0]*dims[1]*dims[2];
 
     std::vector<double> dz_ref = { 0.33223500E+01, 0.40973248E+01, 0.32474000E+01, 0.28723750E+01, 0.49961748E+01, 0.49961748E+01,
                                    0.49961748E+01, 0.49961748E+01
@@ -2740,7 +2740,7 @@ BOOST_AUTO_TEST_CASE(CalcCellDims) {
                                       0.10660616E+03, 0.10643174E+03, 0.10678072E+03
                                     };
 
-    for (size_t n=0; n<nCells; n++) {
+    for (std::size_t n=0; n<nCells; n++) {
 
         BOOST_CHECK_CLOSE( grid.getCellThickness(n) , dz_ref[n], 1e-5 );
 
@@ -2756,7 +2756,7 @@ BOOST_AUTO_TEST_CASE(CalcCellDims) {
     for (int k = 0; k < dims[2]; k++) {
         for (int j = 0; j < dims[1]; j++) {
             for (int i = 0; i < dims[0]; i++) {
-                size_t globInd = i + j*dims[0] + k*dims[0]*dims[1];
+                std::size_t globInd = i + j*dims[0] + k*dims[0]*dims[1];
                 BOOST_CHECK_CLOSE( grid.getCellThickness(i, j, k) , dz_ref[globInd], 1e-5 );
 
                 std::array<double, 3> cellDims = grid.getCellDims(i, j, k);
@@ -2822,7 +2822,7 @@ BOOST_AUTO_TEST_CASE(TESTCP_ACTNUM_UPDATE) {
 
     BOOST_CHECK( actGrid1.size() == actGrid2.size());
 
-    for (size_t n=0; n< actGrid1.size(); n++) {
+    for (std::size_t n=0; n< actGrid1.size(); n++) {
         BOOST_CHECK_EQUAL( actGrid1[n], actInDeck[n]);
         BOOST_CHECK_EQUAL( actGrid2[n], newAct[n]);
     }
@@ -2884,7 +2884,7 @@ BOOST_AUTO_TEST_CASE(TESTCP_ACTNUM_AQUNUM) {
 
     BOOST_CHECK( grid_actnum.size() == desired_actnum.size() );
 
-    for (size_t n=0; n< grid_actnum.size(); n++) {
+    for (std::size_t n=0; n< grid_actnum.size(); n++) {
         BOOST_CHECK_EQUAL( grid_actnum[n], desired_actnum[n] );
     }
 
@@ -2892,7 +2892,7 @@ BOOST_AUTO_TEST_CASE(TESTCP_ACTNUM_AQUNUM) {
     const auto& grid_actnum2 = es.getInputGrid().getACTNUM();
 
     BOOST_CHECK( desired_actnum.size() == grid_actnum2.size());
-    for (size_t n=0; n< grid_actnum.size(); n++) {
+    for (std::size_t n=0; n< grid_actnum.size(); n++) {
         BOOST_CHECK_EQUAL( grid_actnum2[n], desired_actnum[n] );
     }
 }
@@ -3040,7 +3040,7 @@ BOOST_AUTO_TEST_CASE(TEST_getCellCenters) {
         std::array<double, 3> cellC = grid1.getCellCenter(ind);
         std::array<double, 3> cellD = grid1.getCellDims(ind);
 
-        for (size_t i = 0; i < 3; i++) {
+        for (std::size_t i = 0; i < 3; i++) {
             BOOST_CHECK_CLOSE( ref_centers_prev[n][i], cellC[i], 1e-10);
             BOOST_CHECK_CLOSE( ref_dims_prev[n][i], cellD[i], 1e-10);
         }
@@ -3090,7 +3090,7 @@ BOOST_AUTO_TEST_CASE(TEST_constructFromEgrid) {
 
     BOOST_CHECK( actGrid1.size() == actGrid2.size() );
 
-    for (size_t n= 0; n< actGrid1.size(); n++) {
+    for (std::size_t n= 0; n< actGrid1.size(); n++) {
         BOOST_CHECK( actGrid1[n] == actGrid2[n] );
     }
 
@@ -3105,13 +3105,13 @@ BOOST_AUTO_TEST_CASE(TEST_constructFromEgrid) {
 
     BOOST_CHECK( zcornGrid1.size() == zcornGrid2.size() );
 
-    for (size_t n = 0; n < zcornGrid1.size(); n++){
+    for (std::size_t n = 0; n < zcornGrid1.size(); n++){
         BOOST_CHECK_CLOSE( zcornGrid1[n], zcornGrid2[n], 1.0e-6 );
     }
 
     BOOST_CHECK( grid1.getCartesianSize() == grid2.getCartesianSize() );
 
-    for (size_t n=0; n < grid1.getCartesianSize(); n++){
+    for (std::size_t n=0; n < grid1.getCartesianSize(); n++){
         BOOST_CHECK_CLOSE( grid1.getCellVolume(n), grid2.getCellVolume(n), 1e-6);
 
     }
@@ -3304,17 +3304,17 @@ BOOST_AUTO_TEST_CASE(TEST_GDFILE_2) {
         BOOST_CHECK(coordGrid1.size() == coord_egrid_f.size());
         BOOST_CHECK(zcornGrid1.size() == zcorn_egrid_f.size());
 
-        for (size_t n = 0; n < coordGrid1.size(); n++) {
+        for (std::size_t n = 0; n < coordGrid1.size(); n++) {
             BOOST_CHECK(coordGrid1_f[n] == coord_egrid_f[n]);
         }
 
-        for (size_t n = 0; n < zcornGrid1.size(); n++) {
+        for (std::size_t n = 0; n < zcornGrid1.size(); n++) {
             BOOST_CHECK(zcornGrid1_f[n] == zcorn_egrid_f[n]);
         }
 
         // all cells are active, since ACTNUM not present
         std::vector<int> actGrid1 = grid1.getACTNUM();
-        for (size_t n = 0; n < actGrid1.size(); n++) {
+        for (std::size_t n = 0; n < actGrid1.size(); n++) {
             BOOST_CHECK(actGrid1[n] == 1);
         }
 
@@ -3335,7 +3335,7 @@ BOOST_AUTO_TEST_CASE(TEST_GDFILE_2) {
 
         // check that actnum is reset from gdfile
 
-        for (size_t n = 0; n < actGrid2.size(); n++) {
+        for (std::size_t n = 0; n < actGrid2.size(); n++) {
             BOOST_CHECK(actGrid2[n] == ref_act_egrid[n]);
         }
 
@@ -3365,12 +3365,12 @@ BOOST_AUTO_TEST_CASE(TEST_GDFILE_2) {
         // check that actnum is reset from gdfile, ACTNUM input in deck
         // but before keyword GDFILE
 
-        for (size_t n = 0; n < actGrid3.size(); n++) {
+        for (std::size_t n = 0; n < actGrid3.size(); n++) {
             BOOST_CHECK(actGrid3[n] == ref_act_egrid[n]);
         }
 
         // check that depth values are in SI units
-        for (size_t n = 0; n < refDepthGrid3a.size(); n++) {
+        for (std::size_t n = 0; n < refDepthGrid3a.size(); n++) {
             BOOST_CHECK_CLOSE(grid3a.getCellDepth(n), refDepthGrid3a[n], 1e-3);
         }
 
@@ -3399,12 +3399,12 @@ BOOST_AUTO_TEST_CASE(TEST_GDFILE_2) {
         actGrid3 = grid3b.getACTNUM();
 
         // check that actnum is reset from deck since input after keyword GDFILE
-        for (size_t n = 0; n < actGrid3.size(); n++) {
+        for (std::size_t n = 0; n < actGrid3.size(); n++) {
             BOOST_CHECK(actGrid3[n] == ref_act_deck3[n]);
         }
 
         // check that depth values are converted from Field to SI units
-        for (size_t n = 0; n < refDepthGrid3b.size(); n++) {
+        for (std::size_t n = 0; n < refDepthGrid3b.size(); n++) {
             BOOST_CHECK_CLOSE(grid3b.getCellDepth(n), refDepthGrid3b[n], 1e-3);
         }
 

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -25,22 +25,28 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <boost/version.hpp>
 
-#include <opm/input/eclipse/Python/Python.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
-#include <opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/Box.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/Fault.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/Fault.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/TransMult.hpp>
 #include <opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp>
+#include <opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
+#include <opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+
+#include <opm/input/eclipse/Python/Python.hpp>
+
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+
 #include <opm/input/eclipse/Units/Units.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
+
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
 
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <cstddef>
 #include <filesystem>
 
 using namespace Opm;
@@ -111,7 +117,7 @@ BOOST_AUTO_TEST_CASE(GetPOROTOPBased) {
     const auto& poro  = fp.get_double( "PORO" );
     const auto& permx = fp.get_double( "PERMX" );
 
-    for (size_t i=0; i < poro.size(); i++) {
+    for (std::size_t i=0; i < poro.size(); i++) {
         BOOST_CHECK_EQUAL( 0.10 , poro[i]);
         BOOST_CHECK_EQUAL( 0.25 * Metric::Permeability , permx[i]);
     }
@@ -168,7 +174,6 @@ const char *deckData =
     return parser.parseString( deckData );
 }
 
-
 static Deck createDeckNoFaults() {
 const char *deckData =
 "RUNSPEC\n"
@@ -214,8 +219,6 @@ BOOST_AUTO_TEST_CASE(CreateSchedule) {
     BOOST_CHECK_EQUAL(schedule.getStartTime(), asTimeT(TimeStampUTC( 1998 , 3 , 8)));
 }
 
-
-
 static Deck createDeckSimConfig() {
 const std::string& inputStr = "RUNSPEC\n"
                 "EQLOPTS\n"
@@ -245,7 +248,6 @@ const std::string& inputStr = "RUNSPEC\n"
                 "2 3 7.0/\n"
                 "/\n"
                 "\n";
-
 
     Parser parser;
     return parser.parseString( inputStr );
@@ -286,14 +288,13 @@ BOOST_AUTO_TEST_CASE(IntProperties) {
     BOOST_CHECK_EQUAL( true,  state.fieldProps().has_int( "SATNUM" ) );
 }
 
-
 BOOST_AUTO_TEST_CASE(GetProperty) {
     auto deck = createDeck();
     EclipseState state(deck);
 
     const auto& satnum = state.fieldProps().get_global_int("SATNUM");
     BOOST_CHECK_EQUAL(1000U , satnum.size() );
-    for (size_t i=0; i < satnum.size(); i++)
+    for (std::size_t i=0; i < satnum.size(); i++)
         BOOST_CHECK_EQUAL( 2 , satnum[i]);
 }
 
@@ -325,7 +326,6 @@ BOOST_AUTO_TEST_CASE(GetFaults) {
     BOOST_CHECK_EQUAL( transMult.getMultiplier( 4, 3, 0, FaceDir::XMinus ), 0.25 );
     BOOST_CHECK_EQUAL( transMult.getMultiplier( 4, 3, 0, FaceDir::ZPlus ), 1.00 );
 }
-
 
 BOOST_AUTO_TEST_CASE(FaceTransMults) {
     auto deck = createDeckNoFaults();
@@ -369,7 +369,6 @@ BOOST_AUTO_TEST_CASE(FaceTransMults) {
     }
 }
 
-
 static Deck createDeckNoGridOpts() {
     const char *deckData =
         "RUNSPEC\n"
@@ -395,7 +394,6 @@ static Deck createDeckNoGridOpts() {
     Parser parser;
     return parser.parseString(deckData) ;
 }
-
 
 static Deck createDeckWithGridOpts() {
     const char *deckData =
@@ -425,7 +423,6 @@ static Deck createDeckWithGridOpts() {
     return parser.parseString( deckData );
 }
 
-
 BOOST_AUTO_TEST_CASE(NoGridOptsDefaultRegion) {
     auto deck = createDeckNoGridOpts();
     EclipseState state(deck);
@@ -438,7 +435,6 @@ BOOST_AUTO_TEST_CASE(NoGridOptsDefaultRegion) {
     BOOST_CHECK_EQUAL( &fluxnum  , &def_pro );
     BOOST_CHECK_NE( &fluxnum  , &multnum );
 }
-
 
 BOOST_AUTO_TEST_CASE(WithGridOptsDefaultRegion) {
     auto deck = createDeckWithGridOpts();
@@ -468,7 +464,6 @@ BOOST_AUTO_TEST_CASE(TestIOConfigBaseName) {
     BOOST_CHECK_EQUAL(io2.getBaseName(), "");
     BOOST_CHECK_EQUAL(io2.getOutputDir(), ".");
 }
-
 
 BOOST_AUTO_TEST_CASE(TestBox) {
     const char * regionData =

--- a/tests/parser/FaultTests.cpp
+++ b/tests/parser/FaultTests.cpp
@@ -17,22 +17,23 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "opm/input/eclipse/Deck/Deck.hpp"
-#include "opm/input/eclipse/EclipseState/EclipseState.hpp"
-#include "opm/input/eclipse/Parser/Parser.hpp"
-#include <stdexcept>
-#include <ostream>
-
 #define BOOST_TEST_MODULE FaultTests
 
 #include <boost/test/unit_test.hpp>
 
-#include <opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/Fault.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/FaultFace.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FaultFace.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/Fault.hpp>
 
+#include <opm/input/eclipse/Deck/Deck.hpp>
 
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <cstddef>
+#include <ostream>
+#include <stdexcept>
 
 BOOST_AUTO_TEST_CASE(CreateInvalidFace) {
     // I out of range
@@ -46,23 +47,22 @@ BOOST_AUTO_TEST_CASE(CreateInvalidFace) {
 
 }
 
-
 BOOST_AUTO_TEST_CASE(CreateFace) {
     Opm::FaultFace face1(10,10,10,0, 2  , 0 , 0 , 0 , 0 , Opm::FaceDir::YPlus);
     Opm::FaultFace face2(10,10,10,0, 2  , 1 , 1 , 0 , 0 , Opm::FaceDir::YPlus);
     Opm::FaultFace face3(10,10,10,0, 2  , 0 , 0 , 1 , 1 , Opm::FaceDir::YPlus);
 
     {
-        const std::vector<size_t> trueValues1{0,1,2};
-        const std::vector<size_t> trueValues2{10,11,12};
-        const std::vector<size_t> trueValues3{100,101,102};
+        const std::vector<std::size_t> trueValues1{0,1,2};
+        const std::vector<std::size_t> trueValues2{10,11,12};
+        const std::vector<std::size_t> trueValues3{100,101,102};
         auto iter3 = face3.begin();
         auto iter2 = face2.begin();
-        size_t i = 0;
+        std::size_t i = 0;
         for (auto iter1 = face1.begin(); iter1 != face1.end(); ++iter1) {
-            size_t index1 = *iter1;
-            size_t index2 = *iter2;
-            size_t index3 = *iter3;
+            std::size_t index1 = *iter1;
+            std::size_t index2 = *iter2;
+            std::size_t index3 = *iter3;
 
             BOOST_CHECK_EQUAL( index1 , trueValues1[i] );
             BOOST_CHECK_EQUAL( index2 , trueValues2[i] );
@@ -75,7 +75,6 @@ BOOST_AUTO_TEST_CASE(CreateFace) {
     }
     BOOST_CHECK_EQUAL( face1.getDir() , Opm::FaceDir::YPlus);
 }
-
 
 BOOST_AUTO_TEST_CASE(CreateFault) {
     Opm::Fault fault("FAULT1");
@@ -111,15 +110,12 @@ BOOST_AUTO_TEST_CASE(AddFaceToFaults) {
 
 }
 
-
-
 BOOST_AUTO_TEST_CASE(CreateFaultCollection) {
     Opm::FaultCollection faults;
     BOOST_CHECK_EQUAL( faults.size() , 0U );
     BOOST_CHECK(! faults.hasFault("NO-NotThisOne"));
     BOOST_CHECK_THROW( faults.getFault("NO") , std::invalid_argument );
 }
-
 
 BOOST_AUTO_TEST_CASE(AddFaultsToCollection) {
     Opm::FaultCollection faults;

--- a/tests/parser/LgrOutputTests.cpp
+++ b/tests/parser/LgrOutputTests.cpp
@@ -31,6 +31,7 @@
 
 #include <opm/input/eclipse/Deck/DeckSection.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
+
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
 #include <array>
@@ -147,8 +148,8 @@ std::vector<double> gnfloat = {
 int sum_gnint = std::accumulate(gnint.begin(), gnint.end(), 0);
 std::vector<double> zcorn;
 zcorn.reserve(sum_gnint);
-for (size_t i = 0; i < gnint.size(); ++i) {
-    for (size_t j = 0; j < static_cast<size_t>(gnint[i]); ++j) {
+for (std::size_t i = 0; i < gnint.size(); ++i) {
+    for (std::size_t j = 0; j < static_cast<std::size_t>(gnint[i]); ++j) {
         zcorn.push_back(gnfloat[i]);
     }
 }
@@ -1408,7 +1409,7 @@ END
 
     lgr_depth.reserve(27);
     lgr_porv.reserve(27);
-    for (size_t i = 0; i < 27; i++) {
+    for (std::size_t i = 0; i < 27; i++) {
         lgr_depth.push_back(lgr1.getCellDepth(i));
         lgr_porv.push_back(0.3*lgr1.getCellVolume(i));
     }

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -52,6 +52,7 @@
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 
+#include <cstddef>
 #include <memory>
 #include <set>
 #include <stdexcept>
@@ -680,7 +681,6 @@ COMPSEGS
      4    16    15    14  3607.9574 3687.96236    1*    1*       2643    1*    28 /
 /
 
-
 -- modified some connection lengths to test the scaling factor
 COMPSEGS
  'OP1' /
@@ -746,7 +746,6 @@ DATES             -- 3
             BOOST_CHECK(!segment.isAICD());
         }
     }
-
 
     {
         // check well OP2 at the second report step
@@ -1168,7 +1167,6 @@ namespace {
     }
 } // Anonymous namespace
 
-
 BOOST_AUTO_TEST_CASE(MSW_SEGMENT_LENGTH) {
     const auto& sched = make_schedule("MSW.DATA");
     const auto& well = sched.getWell("PROD01", 0);
@@ -1214,7 +1212,6 @@ BOOST_AUTO_TEST_CASE(MSW_BRANCH_SEGMENTS) {
             BOOST_CHECK_EQUAL( expected[index], seg5[index].segmentNumber());
     }
 }
-
 
 BOOST_AUTO_TEST_CASE(Branches) {
     const auto& sched = make_schedule("MSW.DATA");
@@ -1591,7 +1588,6 @@ WELSEGS
     BOOST_CHECK_THROW(::Opm::Schedule(deck, es, std::make_shared<const ::Opm::Python>()), ::Opm::OpmInputError);
 }
 
-
 BOOST_AUTO_TEST_CASE(loadCOMPTRAJTESTSPE1_MSW) {
   Opm::Parser parser;
 
@@ -1620,7 +1616,7 @@ BOOST_AUTO_TEST_CASE(loadCOMPTRAJTESTSPE1_MSW) {
   };
   const std::array<int, 9> global_index{11, 111, 211, 212, 222, 223, 233, 234, 244};
   BOOST_CHECK_EQUAL(connections.size(), 9);
-  for (size_t i = 0 ; i < connections.size();  ++i ) {
+  for (std::size_t i = 0 ; i < connections.size();  ++i ) {
        BOOST_CHECK_CLOSE(connections[i].CF(), units.to_si(Opm::UnitSystem::measure::transmissibility, connection_factor[i]), 2e-2);
        BOOST_CHECK_EQUAL(connections[i].global_index(), global_index[i]);
   }
@@ -1629,7 +1625,7 @@ BOOST_AUTO_TEST_CASE(loadCOMPTRAJTESTSPE1_MSW) {
     8325.0, 8425.8, 8689.4, 8935.1, 9157.9, 9838.8, 10597.0, 11321.0, 11997.0, 12369.0
   };
   BOOST_CHECK_EQUAL(segments.size(), 10);
-  for (size_t i = 0; i < segments.size(); ++i) {
+  for (std::size_t i = 0; i < segments.size(); ++i) {
     BOOST_CHECK_EQUAL(segments[i].segmentNumber(), i + 1);
     BOOST_CHECK_EQUAL(segments[i].outletSegment(), i);
     BOOST_CHECK_CLOSE(segments[i].totalLength(), units.to_si(Opm::UnitSystem::measure::length, lengths[i]), 2e-2);

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -82,7 +82,7 @@ ParserKeyword createDynamicSized(const std::string& kw) {
     return pkw;
 }
 
-ParserKeyword createFixedSized(const std::string& kw , size_t size) {
+ParserKeyword createFixedSized(const std::string& kw , std::size_t size) {
     ParserKeyword pkw(kw, KeywordSize(size));
     return pkw;
 }
@@ -1330,7 +1330,7 @@ BOOST_AUTO_TEST_CASE(construct_withname_nameSet) {
 
 BOOST_AUTO_TEST_CASE(NamedInit) {
     std::string keyword("KEYWORD");
-    const auto& parserKeyword = createFixedSized(keyword, (size_t) 100);
+    const auto& parserKeyword = createFixedSized(keyword, (std::size_t) 100);
     BOOST_CHECK_EQUAL(parserKeyword.getName(), keyword);
 }
 
@@ -1343,7 +1343,7 @@ BOOST_AUTO_TEST_CASE(ParserKeyword_default_SizeTypedefault) {
 
 BOOST_AUTO_TEST_CASE(ParserKeyword_withSize_SizeTypeFIXED) {
     std::string keyword("KEYWORD");
-    const auto& parserKeyword = createFixedSized(keyword, (size_t) 100);
+    const auto& parserKeyword = createFixedSized(keyword, (std::size_t) 100);
     BOOST_CHECK_EQUAL(parserKeyword.getSizeType() , FIXED);
 }
 
@@ -1392,7 +1392,7 @@ BOOST_AUTO_TEST_CASE(ParserKeyword_validInternalName) {
 }
 
 BOOST_AUTO_TEST_CASE(ParserKeywordMatches) {
-    auto parserKeyword = createFixedSized("HELLO", (size_t) 1);
+    auto parserKeyword = createFixedSized("HELLO", (std::size_t) 1);
     parserKeyword.clearDeckNames();
     parserKeyword.setMatchRegex("WORLD.+");
     BOOST_CHECK_EQUAL( false , parserKeyword.matches("HELLO"));
@@ -1402,7 +1402,7 @@ BOOST_AUTO_TEST_CASE(ParserKeywordMatches) {
 }
 
 BOOST_AUTO_TEST_CASE(AddDataKeyword_correctlyConfigured) {
-    auto parserKeyword = createFixedSized("PORO", (size_t) 1);
+    auto parserKeyword = createFixedSized("PORO", (std::size_t) 1);
     ParserItem item( "ACTNUM", INT);
     ParserRecord record;
 
@@ -1607,14 +1607,14 @@ BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_WithoutDescription_DescriptionPrope
 /* </Json> */
 /*****************************************************************/
 BOOST_AUTO_TEST_CASE(getFixedSize_sizeObjectHasFixedSize_sizeReturned) {
-    const auto& parserKeyword = createFixedSized("JA", (size_t) 3);
+    const auto& parserKeyword = createFixedSized("JA", (std::size_t) 3);
     BOOST_CHECK_EQUAL(3U, parserKeyword.getFixedSize());
 
 }
 
 
 BOOST_AUTO_TEST_CASE(hasFixedSize_hasFixedSizeObject_returnstrue) {
-    const auto& parserKeyword = createFixedSized("JA", (size_t) 2);
+    const auto& parserKeyword = createFixedSized("JA", (std::size_t) 2);
     BOOST_CHECK(parserKeyword.hasFixedSize());
 }
 

--- a/tests/parser/RestartConfigTests.cpp
+++ b/tests/parser/RestartConfigTests.cpp
@@ -1039,7 +1039,7 @@ RPTSCHED
 
     auto sched = make_schedule(data);
     BOOST_CHECK(sched.write_rst_file(0));
-    for( size_t ts = 1; ts < 4; ++ts )
+    for( std::size_t ts = 1; ts < 4; ++ts )
         BOOST_CHECK( !sched.write_rst_file( ts ) );
 }
 
@@ -1065,7 +1065,7 @@ BASIC=1
 
     auto sched = make_schedule(data);
     BOOST_CHECK(sched.write_rst_file(0));
-    for( size_t ts = 1; ts < 3; ++ts )
+    for( std::size_t ts = 1; ts < 3; ++ts )
         BOOST_CHECK( !sched.write_rst_file( ts ) );
 
     BOOST_CHECK( sched.write_rst_file( 3 ) );

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -587,7 +587,7 @@ BOOST_AUTO_TEST_CASE(WellsIterator_Empty_EmptyVectorReturned) {
 
 BOOST_AUTO_TEST_CASE(WellsIterator_HasWells_WellsReturned) {
     const auto& schedule = make_schedule( createDeckWithWells() );
-    size_t timeStep = 0;
+    std::size_t timeStep = 0;
 
     const auto wells_alltimesteps = schedule.getWellsatEnd();
     BOOST_CHECK_EQUAL(3U, wells_alltimesteps.size());
@@ -722,7 +722,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndSkinFactorChanges)
     {
         const auto& well = schedule.getWell("OP_2", 2);
         const auto& cs = well.getConnections();
-        for (size_t i = 0; i < cs.size(); i++) {
+        for (std::size_t i = 0; i < cs.size(); i++) {
             BOOST_CHECK_CLOSE(cs.get(i).skinFactor(), -1.0, 1e-10);
         }
 
@@ -1639,13 +1639,13 @@ COMPDAT
     const auto& cs2 = schedule.getWell("OP_1", 2).getConnections();
     const auto& cs3 = schedule.getWell("OP_1", 3).getConnections();
     const auto& cs4 = schedule.getWell("OP_1", 4).getConnections();
-    for(size_t i = 0; i < cs2.size(); i++)
+    for(std::size_t i = 0; i < cs2.size(); i++)
         BOOST_CHECK_CLOSE(cs2.get( i ).CF() / cs1.get(i).CF(), 1.3, 1e-13);
 
-    for(size_t i = 0; i < cs3.size(); i++ )
+    for(std::size_t i = 0; i < cs3.size(); i++ )
         BOOST_CHECK_CLOSE(cs3.get( i ).CF() / cs1.get(i).CF(), (1.3*1.3), 1e-13);
 
-    for(size_t i = 0; i < cs4.size(); i++ )
+    for(std::size_t i = 0; i < cs4.size(); i++ )
         BOOST_CHECK_CLOSE(cs4.get( i ).CF(), cs1.get(i).CF(), 1e-13);
 
     auto sim_time1 = TimeStampUTC{ schedule.simTime(1) };
@@ -1822,12 +1822,12 @@ END
     const auto& cs2_2 = schedule.getWell("OP_2", 2).getConnections();
     const auto& cs7_2 = schedule.getWell("OP_2", 7).getConnections();
 
-    for (size_t i = 0; i < cs1_2.size(); ++i ) {
+    for (std::size_t i = 0; i < cs1_2.size(); ++i ) {
         BOOST_CHECK_CLOSE(cs1_2.get(i).CF() / cs0_2.get(i).CF(), 7.0, 1.e-13);
         BOOST_CHECK_CLOSE(cs2_2.get(i).CF() / cs1_2.get(i).CF(), 1.0, 1.e-13);
         BOOST_CHECK_CLOSE(cs7_2.get(i).CF() / cs0_2.get(i).CF(), 7.0, 1.e-13);
     }
-    for (size_t i = 0; i < cs1.size(); ++i ) {
+    for (std::size_t i = 0; i < cs1.size(); ++i ) {
         BOOST_CHECK_CLOSE(cs1.get(i).CF() / cs0.get(i).CF(), 0.8, 1.e-13);
         BOOST_CHECK_CLOSE(cs2.get(i).CF() / cs1.get(i).CF(), 0.5, 1.e-13);
         BOOST_CHECK_CLOSE(cs3.get(i).CF() / cs0.get(i).CF(), 1.6, 1.e-13);
@@ -1835,7 +1835,7 @@ END
         BOOST_CHECK_CLOSE(cs7.get(i).CF() / cs0.get(i).CF(), 0.8, 1.e-13);
     }
 
-    for (size_t i = 0; i < 3; ++i) {
+    for (std::size_t i = 0; i < 3; ++i) {
         BOOST_CHECK_CLOSE(cs5.get(i).CF() / cs0.get(i).CF(), 0.8, 1.e-13);
         BOOST_CHECK_CLOSE(cs6.get(i).CF() / cs0.get(i).CF(), 0.8, 1.e-13);
     }
@@ -2003,7 +2003,7 @@ DRSDT
 )";
 
     const auto& schedule = make_schedule(input);
-    size_t currentStep = 1;
+    std::size_t currentStep = 1;
     const auto& ovap = schedule[currentStep].oilvap();
 
     BOOST_CHECK_EQUAL(true,   ovap.getOption(0));
@@ -2034,7 +2034,7 @@ DRSDTCON
 /
 )";
     const auto& schedule = make_schedule(input);
-    size_t currentStep = 1;
+    std::size_t currentStep = 1;
     const auto& ovap = schedule[currentStep].oilvap();
 
     BOOST_CHECK_EQUAL(true,   ovap.getOption(0));
@@ -2077,7 +2077,7 @@ DRSDTR
 )";
 
     const auto& schedule = make_schedule(input);
-    size_t currentStep = 1;
+    std::size_t currentStep = 1;
     const auto& ovap = schedule[currentStep].oilvap();
     auto unitSystem =  UnitSystem::newMETRIC();
     for (int i = 0; i < 3; ++i) {
@@ -2159,7 +2159,7 @@ VAPPARS
     const auto& schedule = make_schedule(input);
     const OilVaporizationProperties& ovap0 = schedule[0].oilvap();
     BOOST_CHECK(ovap0.getType() == OilVaporizationProperties::OilVaporization::UNDEF);
-    size_t currentStep = 1;
+    std::size_t currentStep = 1;
     const OilVaporizationProperties& ovap = schedule[currentStep].oilvap();
     BOOST_CHECK(ovap.getType() == OilVaporizationProperties::OilVaporization::VAPPARS);
     double vap1 =  ovap.vap1();
@@ -6486,7 +6486,7 @@ BCPROP
 
     const auto& schedule = make_schedule(input);
     {
-        size_t currentStep = 0;
+        std::size_t currentStep = 0;
         const auto& bc = schedule[currentStep].bcprop;
         BOOST_CHECK_EQUAL(bc.size(), 2);
         const auto& bcface0 = bc[0];
@@ -6494,7 +6494,7 @@ BCPROP
     }
 
     {
-        size_t currentStep = 1;
+        std::size_t currentStep = 1;
         const auto& bc = schedule[currentStep].bcprop;
         BOOST_CHECK_EQUAL(bc.size(), 2);
         const auto& bcface0 = bc[0];
@@ -6527,7 +6527,7 @@ SOURCE
 
     const auto& schedule = make_schedule(input);
     {
-        size_t currentStep = 0;
+        std::size_t currentStep = 0;
         const auto& source = schedule[currentStep].source();
         BOOST_CHECK_EQUAL(source.size(), 1);  // num cells
         double rate11 = source.rate({0,0,0},Opm::SourceComponent::GAS);
@@ -6540,7 +6540,7 @@ SOURCE
     }
 
     {
-        size_t currentStep = 1;
+        std::size_t currentStep = 1;
         const auto& source = schedule[currentStep].source();
         BOOST_CHECK_EQUAL(source.size(), 2);  // num cells
         double rate21 = source.rate({0,0,0},Opm::SourceComponent::GAS);

--- a/tests/parser/SimpleTableTests.cpp
+++ b/tests/parser/SimpleTableTests.cpp
@@ -21,15 +21,15 @@
 
 #include <boost/test/unit_test.hpp>
 
-
 #include <opm/input/eclipse/EclipseState/Tables/ColumnSchema.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/SimpleTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableColumn.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableIndex.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableSchema.hpp>
 
-using namespace Opm;
+#include <cstddef>
 
+using namespace Opm;
 
 BOOST_AUTO_TEST_CASE( CreateTest ) {
     TableSchema schema;
@@ -51,7 +51,6 @@ BOOST_AUTO_TEST_CASE( CreateTest ) {
         const auto& col1 = table.getColumn( 0 );
         const auto& col2 = table.getColumn( 1 );
 
-
         BOOST_CHECK_EQUAL( col1[0] , 1 );
         BOOST_CHECK_EQUAL( col2[0] , 2 );
         BOOST_CHECK_EQUAL( col1[1] , 3 );
@@ -63,7 +62,6 @@ BOOST_AUTO_TEST_CASE( CreateTest ) {
 
     BOOST_CHECK_THROW( table.get("Name1" , 3) , std::invalid_argument);
     BOOST_CHECK_THROW( table.get(0 , 3) , std::invalid_argument);
-
 
     BOOST_CHECK_EQUAL( table.get("Name1" , 0) , 1 );
     BOOST_CHECK_EQUAL( table.get("Name1" , 1) , 3 );
@@ -80,7 +78,7 @@ BOOST_AUTO_TEST_CASE( CreateTest ) {
         auto exportCol = col.vectorCopy();
 
         BOOST_CHECK_EQUAL( col.size() , exportCol.size());
-        for (size_t i = 0; i < col.size(); i++)
+        for (std::size_t i = 0; i < col.size(); i++)
             BOOST_CHECK_EQUAL( col[i] , exportCol[i]);
     }
 }

--- a/tests/parser/TableColumnTests.cpp
+++ b/tests/parser/TableColumnTests.cpp
@@ -21,13 +21,13 @@
 
 #include <boost/test/unit_test.hpp>
 
-
 #include <opm/input/eclipse/EclipseState/Tables/TableIndex.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableColumn.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/ColumnSchema.hpp>
 
-using namespace Opm;
+#include <cstddef>
 
+using namespace Opm;
 
 BOOST_AUTO_TEST_CASE( CreateTest ) {
     ColumnSchema schema("COLUMN" , Table::STRICTLY_INCREASING , Table::DEFAULT_LINEAR );
@@ -50,17 +50,14 @@ BOOST_AUTO_TEST_CASE( CreateTest ) {
         std::vector<double> cp(column.size());
         std::ranges::copy(column, cp.begin());
 
-        for (size_t i = 0; i < column.size(); i++)
+        for (std::size_t i = 0; i < column.size(); i++)
             BOOST_CHECK_EQUAL( column[i] , cp[i] );
     }
 }
 
-
-
 BOOST_AUTO_TEST_CASE( TestDefault ) {
     ColumnSchema schema("COLUMN" , Table::STRICTLY_INCREASING , Table::DEFAULT_LINEAR );
     TableColumn column( schema );
-
 
     column.addDefault( "TableTested"  );
     column.addDefault( "TableTested"  );
@@ -72,7 +69,6 @@ BOOST_AUTO_TEST_CASE( TestDefault ) {
     BOOST_CHECK_EQUAL( column[0] , 10 );
     BOOST_CHECK( column.hasDefault( ) );
 }
-
 
 BOOST_AUTO_TEST_CASE( TestAscending ) {
     ColumnSchema schema("COLUMN" , Table::STRICTLY_INCREASING , Table::DEFAULT_LINEAR);
@@ -100,7 +96,6 @@ BOOST_AUTO_TEST_CASE( TestAscending ) {
     BOOST_CHECK( !column.hasDefault( ) );
 }
 
-
 BOOST_AUTO_TEST_CASE( TestWeaklyAscending ) {
     ColumnSchema schema("COLUMN" , Table::INCREASING  , Table::DEFAULT_LINEAR);
     TableColumn column( schema );
@@ -110,7 +105,6 @@ BOOST_AUTO_TEST_CASE( TestWeaklyAscending ) {
 
     BOOST_CHECK( !column.hasDefault( ) );
 }
-
 
 BOOST_AUTO_TEST_CASE( TestDescending ) {
     ColumnSchema schema("COLUMN" , Table::STRICTLY_DECREASING , Table::DEFAULT_LINEAR);
@@ -136,14 +130,12 @@ BOOST_AUTO_TEST_CASE( TestDescending ) {
     column.updateValue( 5,-15, "TableTested"  );
 }
 
-
 BOOST_AUTO_TEST_CASE( TestDEFAULT_NONE) {
     ColumnSchema schema("COLUMN" , Table::STRICTLY_DECREASING , Table::DEFAULT_NONE);
     TableColumn column( schema );
 
     BOOST_CHECK_THROW( column.addDefault( "TableTested" ) , std::invalid_argument );
 }
-
 
 BOOST_AUTO_TEST_CASE( Test_MIN_MAX) {
     ColumnSchema schema("COLUMN" , Table::RANDOM , Table::DEFAULT_LINEAR);
@@ -181,10 +173,8 @@ BOOST_AUTO_TEST_CASE( Test_IN_RANGE) {
     column.addValue(20, "TableTested" );
     BOOST_CHECK_THROW( column.inRange( 15 ) , std::invalid_argument );
 
-
     ColumnSchema schema2("COLUMN" , Table::INCREASING, Table::DEFAULT_LINEAR);
     TableColumn column2( schema2 );
-
 
     BOOST_CHECK_THROW( column2.inRange( 15 ) , std::invalid_argument );
     column2.addValue(10, "TableTested" );
@@ -200,8 +190,6 @@ BOOST_AUTO_TEST_CASE( Test_IN_RANGE) {
     column2.addDefault( "TableTested" );
     BOOST_CHECK_THROW( column2.inRange( 15 ) , std::invalid_argument );
 }
-
-
 
 BOOST_AUTO_TEST_CASE( Test_Table_Index ) {
     {
@@ -225,11 +213,9 @@ BOOST_AUTO_TEST_CASE( Test_Table_Index ) {
         /* Can not look up in column with defaults */
         BOOST_CHECK_THROW( column.lookup( 0.67 ) , std::invalid_argument );
 
-
         column.updateValue(1 , 20, "TableTested"  );
     }
 }
-
 
 BOOST_AUTO_TEST_CASE( Test_EVAL_INCREASING ) {
     ColumnSchema schema("COLUMN" , Table::INCREASING , Table::DEFAULT_LINEAR);
@@ -240,7 +226,6 @@ BOOST_AUTO_TEST_CASE( Test_EVAL_INCREASING ) {
     /* Out of range - constant end-point extrapolation , size = 1*/
     BOOST_CHECK_EQUAL( column.eval( column.lookup( -1 )) , 0 );
     BOOST_CHECK_EQUAL( column.eval( column.lookup(  1 )) , 0 );
-
 
     column.addValue(1, "TableTested" );
     column.addValue(2, "TableTested" );
@@ -259,7 +244,6 @@ BOOST_AUTO_TEST_CASE( Test_EVAL_INCREASING ) {
     BOOST_CHECK_EQUAL( column.eval( column.lookup( -1 )) , 0 );
     BOOST_CHECK_EQUAL( column.eval( column.lookup(  4 )) , 3 );
 }
-
 
 BOOST_AUTO_TEST_CASE( Test_EVAL_DECREASING ) {
     ColumnSchema schema("COLUMN" , Table::DECREASING , Table::DEFAULT_LINEAR);
@@ -284,9 +268,6 @@ BOOST_AUTO_TEST_CASE( Test_EVAL_DECREASING ) {
     BOOST_CHECK_EQUAL( column.eval( column.lookup(  4 )) , 3 );
 }
 
-
-
-
 BOOST_AUTO_TEST_CASE( Test_CONST_DEFAULT ) {
     ColumnSchema schema("COLUMN" , Table::DECREASING , 1.0);
     TableColumn column( schema );
@@ -297,7 +278,6 @@ BOOST_AUTO_TEST_CASE( Test_CONST_DEFAULT ) {
     BOOST_CHECK_EQUAL( column[0] , 1.0 );
     BOOST_CHECK_EQUAL( column[1] , 1.0 );
 }
-
 
 BOOST_AUTO_TEST_CASE( Test_LINEAR_DEFAULT ) {
     ColumnSchema argSchema("COLUMN" , Table::INCREASING , Table::DEFAULT_NONE);

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -275,14 +275,14 @@ BOOST_AUTO_TEST_CASE( CreateTablesWithJFunc ) {
          0.80, 0.65, 1.00, 0.90, 0.83, 0.50, 1.00, 1.00, 0.00};
 
 
-    for (size_t tab = 0; tab < swfnTab.size(); tab++) {
+    for (std::size_t tab = 0; tab < swfnTab.size(); tab++) {
         const auto& t = swfnTab.getTable(tab);
 
        //TODO uncomment BOOST_CHECK_THROW( t.getColumn("PCOW"), std::invalid_argument );
 
-        for (size_t c_idx = 0; c_idx < t.numColumns(); c_idx++) {
+        for (std::size_t c_idx = 0; c_idx < t.numColumns(); c_idx++) {
             const auto& col = t.getColumn(c_idx);
-            for (size_t i = 0; i < col.size(); i++) {
+            for (std::size_t i = 0; i < col.size(); i++) {
                 int idx = c_idx + i*3;
                 BOOST_CHECK_CLOSE( col[i], swfnDataVerbatim[idx], epsilon());
             }
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE( CreateTablesWithJFunc ) {
     //TODO uncommentBOOST_CHECK_THROW(tt.getPcowColumn(), std::invalid_argument);
 
     const auto& col = tt.getJFuncColumn();
-    for (size_t i = 0; i < col.size(); i++) {
+    for (std::size_t i = 0; i < col.size(); i++) {
         BOOST_CHECK_CLOSE(col[i], swfnDataVerbatim[i*3 + 2], epsilon());
     }
 

--- a/tests/parser/UnitTests.cpp
+++ b/tests/parser/UnitTests.cpp
@@ -29,6 +29,7 @@
 #include <opm/input/eclipse/Units/Units.hpp>
 
 #include <array>
+#include <cstddef>
 #include <memory>
 #include <ostream>
 #include <stdexcept>
@@ -232,7 +233,7 @@ BOOST_AUTO_TEST_CASE( VectorConvert ) {
     UnitSystem units = UnitSystem::newLAB();
 
     units.from_si( UnitSystem::measure::pressure , d0 );
-    for (size_t i = 0; i < d1.size(); i++)
+    for (std::size_t i = 0; i < d1.size(); i++)
         BOOST_CHECK_EQUAL( units.from_si( UnitSystem::measure::pressure , d1[i] ) , d0[i]);
 }
 

--- a/tests/parser/integration/BoxTest.cpp
+++ b/tests/parser/integration/BoxTest.cpp
@@ -23,13 +23,15 @@
 #include <boost/test/test_tools.hpp>
 #include <boost/version.hpp>
 
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/Box.hpp>
 
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <cstddef>
 #include <filesystem>
 
 using namespace Opm;
@@ -62,7 +64,7 @@ BOOST_AUTO_TEST_CASE( PERMX ) {
     const auto& permx = state.fieldProps().get_global_double( "PERMX" );
     const auto& permy = state.fieldProps().get_global_double( "PERMY" );
     const auto& permz = state.fieldProps().get_global_double( "PERMZ" );
-    size_t i, j, k;
+    std::size_t i, j, k;
     const EclipseGrid& grid = state.getInputGrid();
 
     for (k = 0; k < grid.getNZ(); k++) {
@@ -78,19 +80,17 @@ BOOST_AUTO_TEST_CASE( PERMX ) {
     }
 }
 
-
-
 BOOST_AUTO_TEST_CASE( PARSE_BOX_OK ) {
     EclipseState state = makeState( pathprefix() + "BOX/BOXTEST1" );
     const auto& satnum = state.fieldProps().get_global_int( "SATNUM" );
     {
-        size_t i, j, k;
+        std::size_t i, j, k;
         const EclipseGrid& grid = state.getInputGrid();
         for (k = 0; k < grid.getNZ(); k++) {
             for (j = 0; j < grid.getNY(); j++) {
                 for (i = 0; i < grid.getNX(); i++) {
 
-                    size_t g = i + j * grid.getNX() + k * grid.getNX() * grid.getNY();
+                    std::size_t g = i + j * grid.getNX() + k * grid.getNX() * grid.getNY();
                     if (i <= 1 && j <= 1 && k <= 1)
                         BOOST_CHECK_EQUAL( satnum[ g ], 10 );
                     else
@@ -106,14 +106,14 @@ BOOST_AUTO_TEST_CASE( PARSE_MULTIPLY_COPY ) {
     EclipseState state = makeState( pathprefix() + "BOX/BOXTEST1" );
     const auto& satnum = state.fieldProps().get_global_int( "SATNUM" );
     const auto& fipnum = state.fieldProps().get_global_int( "FIPNUM" );
-    size_t i, j, k;
+    std::size_t i, j, k;
     const EclipseGrid& grid = state.getInputGrid();
 
     for (k = 0; k < grid.getNZ(); k++) {
         for (j = 0; j < grid.getNY(); j++) {
             for (i = 0; i < grid.getNX(); i++) {
 
-                size_t g = grid.getGlobalIndex(i,j,k);
+                std::size_t g = grid.getGlobalIndex(i,j,k);
                 if (i <= 1 && j <= 1 && k <= 1)
                     BOOST_CHECK_EQUAL( 4 * satnum[g], fipnum[g] );
                 else
@@ -124,21 +124,18 @@ BOOST_AUTO_TEST_CASE( PARSE_MULTIPLY_COPY ) {
     }
 }
 
-
-
-
 BOOST_AUTO_TEST_CASE( EQUALS ) {
     EclipseState state = makeState( pathprefix() + "BOX/BOXTEST1" );
     const auto& pvtnum = state.fieldProps().get_global_int( "PVTNUM" );
     const auto& eqlnum = state.fieldProps().get_global_int( "EQLNUM" );
     const auto& poro   = state.fieldProps().get_global_double( "PORO" );
-    size_t i, j, k;
+    std::size_t i, j, k;
     const EclipseGrid& grid = state.getInputGrid();
 
     for (k = 0; k < grid.getNZ(); k++) {
         for (j = 0; j < grid.getNY(); j++) {
             for (i = 0; i < grid.getNX(); i++) {
-                size_t g = grid.getGlobalIndex(i,j,k);
+                std::size_t g = grid.getGlobalIndex(i,j,k);
 
                 BOOST_CHECK_EQUAL( pvtnum[g], k );
                 BOOST_CHECK_EQUAL( eqlnum[g], 77 + 2 * k );
@@ -147,7 +144,6 @@ BOOST_AUTO_TEST_CASE( EQUALS ) {
         }
     }
 }
-
 
 BOOST_AUTO_TEST_CASE( OPERATE ) {
     EclipseState state = makeState( pathprefix() + "BOX/BOXTEST1" );
@@ -161,7 +157,6 @@ BOOST_AUTO_TEST_CASE( OPERATE ) {
     BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,3)], 0.5 );   // MAXVALUE
     BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,4)], 1.5 );   // MINVALUE
 }
-
 
 BOOST_AUTO_TEST_CASE( CONSTRUCTOR_AND_UPDATE ) {
     auto deck = makeDeck( pathprefix() + "BOX/BOXTEST1" );

--- a/tests/parser/integration/EclipseGridCreateFromDeck.cpp
+++ b/tests/parser/integration/EclipseGridCreateFromDeck.cpp
@@ -18,19 +18,23 @@
 */
 
 #define BOOST_TEST_MODULE ScheduleIntegrationTests
-#include <math.h>
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
 #include <boost/version.hpp>
 
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <cstddef>
 #include <filesystem>
+
+#include <math.h>
 
 using namespace Opm;
 
@@ -55,7 +59,6 @@ BOOST_AUTO_TEST_CASE(CreateCPGrid) {
     BOOST_CHECK_EQUAL( 500U , grid.getNumActive() );
 }
 
-
 BOOST_AUTO_TEST_CASE(CreateCPActnumGrid) {
     Parser parser;
     std::filesystem::path scheduleFile(pathprefix() + "GRID/CORNERPOINT_ACTNUM.DATA");
@@ -68,7 +71,6 @@ BOOST_AUTO_TEST_CASE(CreateCPActnumGrid) {
     BOOST_CHECK_EQUAL(   5U , grid.getNZ( ));
     BOOST_CHECK_EQUAL( 100U , grid.getNumActive() );
 }
-
 
 BOOST_AUTO_TEST_CASE(ExportFromCPGridAllActive) {
     Parser parser;
@@ -83,9 +85,6 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridAllActive) {
     BOOST_CHECK_EQUAL( actnum.size() , 500U );
 }
 
-
-
-
 BOOST_AUTO_TEST_CASE(ExportFromCPGridACTNUM) {
     Parser parser;
     std::filesystem::path scheduleFile(pathprefix() + "GRID/CORNERPOINT_ACTNUM.DATA");
@@ -96,7 +95,7 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridACTNUM) {
     std::vector<double> coord;
     std::vector<double> zcorn;
     std::vector<int> actnum;
-    size_t volume = grid.getNX()*grid.getNY()*grid.getNZ();
+    std::size_t volume = grid.getNX()*grid.getNY()*grid.getNZ();
 
     coord = grid.getCOORD();
     BOOST_CHECK_EQUAL( coord.size() , (grid.getNX() + 1) * (grid.getNY() + 1) * 6);
@@ -111,9 +110,9 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridACTNUM) {
         const std::vector<int>& deckActnum = deck["ACTNUM"].back().getIntData();
         const std::vector<double>& deckZCORN = deck["ZCORN"].back().getSIDoubleData();
 
-        for (size_t i = 0; i < volume; i++) {
+        for (std::size_t i = 0; i < volume; i++) {
             BOOST_CHECK_EQUAL( deckActnum[i] , actnum[i]);
-            for (size_t j=0; j < 8; j++)
+            for (std::size_t j=0; j < 8; j++)
                 BOOST_CHECK_CLOSE( zcorn[i*8 + j] , deckZCORN[i*8 + j] , 0.0001);
         }
     }

--- a/tests/parser/integration/IntegrationTests.cpp
+++ b/tests/parser/integration/IntegrationTests.cpp
@@ -34,6 +34,7 @@
 
 #include <opm/input/eclipse/Parser/ParserEnums.hpp>
 
+#include <cstddef>
 #include <filesystem>
 
 using namespace Opm;
@@ -48,7 +49,7 @@ inline std::string pathprefix() {
 
 namespace {
 
-ParserKeyword createFixedSized(const std::string& kw , size_t size) {
+ParserKeyword createFixedSized(const std::string& kw , std::size_t size) {
     ParserKeyword pkw(kw, KeywordSize(size));
     return pkw;
 }
@@ -67,7 +68,7 @@ Parser createWWCTParser() {
     record.addItem(item);
     parserKeyword.addRecord( record );
 
-    auto summaryKeyword = createFixedSized("SUMMARY" , (size_t) 0);
+    auto summaryKeyword = createFixedSized("SUMMARY" , (std::size_t) 0);
 
     Parser parser;
     parser.addParserKeyword( std::move( parserKeyword ) );
@@ -155,7 +156,7 @@ static Parser createBPRParser() {
         bprRecord.addItem( ParserItem("K", ParserItem::itype::INT) );
         parserKeyword.addRecord( bprRecord );
     }
-    auto summaryKeyword = createFixedSized("SUMMARY" , (size_t) 0);
+    auto summaryKeyword = createFixedSized("SUMMARY" , (std::size_t) 0);
     Parser parser;
     parser.addParserKeyword( std::move( parserKeyword ) );
     parser.addParserKeyword( std::move( summaryKeyword ) );
@@ -200,7 +201,6 @@ BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_dataiscorrect) {
     BOOST_CHECK_EQUAL(3, record1.getItem("K").get< int >(0));
 }
 
-
 /***************** Testing non-recognized keywords ********************/
 BOOST_AUTO_TEST_CASE(parse_unknownkeyword_exceptionthrown) {
     Parser parser;
@@ -216,8 +216,6 @@ GRUDINT -- A wrong, or unknown keyword
   3 3 3 3 3 3 /
 /
 
-
-
 RADFIN4
  'NAME' 213 123 123 123 7 7 18 18 18 18 /
 )";
@@ -225,7 +223,6 @@ RADFIN4
 }
 
 /*********************Testing truncated (default) records ***************************/
-
 
 // Datafile contains 3 RADFIN4 keywords. One fully specified, one with 2 out of 11 items, and one with no items.
 BOOST_AUTO_TEST_CASE(parse_truncatedrecords_deckFilledWithDefaults) {

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE( END ) {
     std::string fileWithTitleKeyword = pathprefix() + "END/END1.txt";
     auto deck = parser.parseFile(fileWithTitleKeyword);
 
-    BOOST_CHECK_EQUAL(size_t(1), deck.size());
+    BOOST_CHECK_EQUAL(std::size_t(1), deck.size());
     BOOST_CHECK_EQUAL(true,  deck.hasKeyword("OIL"));
     BOOST_CHECK_EQUAL(false, deck.hasKeyword("GAS"));
     BOOST_CHECK_EQUAL(false, deck.hasKeyword("END"));
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE( ENDINC ) {
     std::string fileWithTitleKeyword(pathprefix() + "END/ENDINC1.txt");
     auto deck = parser.parseFile(fileWithTitleKeyword);
 
-    BOOST_CHECK_EQUAL(size_t(1), deck.size());
+    BOOST_CHECK_EQUAL(std::size_t(1), deck.size());
     BOOST_CHECK_EQUAL(true,  deck.hasKeyword("OIL"));
     BOOST_CHECK_EQUAL(false, deck.hasKeyword("GAS"));
     BOOST_CHECK_EQUAL(false, deck.hasKeyword("ENDINC"));
@@ -291,7 +291,7 @@ BOOST_AUTO_TEST_CASE( SGCWMIS ) {
     const auto& sgcwmis1 = sgcwmis.getRecord(1);
 
     // test number of columns
-    size_t ntmisc = miscible0.getItem(0).get< int >(0);
+    std::size_t ntmisc = miscible0.getItem(0).get< int >(0);
     Opm::SgcwmisTable sgcwmisTable0(sgcwmis0.getItem(0), 0);
     BOOST_CHECK_EQUAL(sgcwmisTable0.numColumns(),ntmisc);
 
@@ -1149,7 +1149,7 @@ BOOST_AUTO_TEST_CASE( TITLE ) {
 
     auto deck = parser.parseFile(fileWithTitleKeyword);
 
-    BOOST_CHECK_EQUAL(size_t(2), deck.size());
+    BOOST_CHECK_EQUAL(std::size_t(2), deck.size());
     BOOST_CHECK_EQUAL (true, deck.hasKeyword("TITLE"));
 
     const auto& titleKeyword = deck["TITLE"].back();
@@ -1173,12 +1173,12 @@ BOOST_AUTO_TEST_CASE( TOPS ) {
     BOOST_CHECK_EQUAL( grid.getNY() , 9 );
     BOOST_CHECK_EQUAL( grid.getNZ() , 2 );
 
-    for (size_t g=0; g < 9*9*2; g++)
+    for (std::size_t g=0; g < 9*9*2; g++)
         BOOST_CHECK_CLOSE( grid.getCellVolume( g ) , 400*300*10 , 0.1);
 
-    for (size_t k=0; k < grid.getNZ(); k++) {
-        for (size_t j=0; j < grid.getNY(); j++) {
-            for (size_t i=0; i < grid.getNX(); i++) {
+    for (std::size_t k=0; k < grid.getNZ(); k++) {
+        for (std::size_t j=0; j < grid.getNY(); j++) {
+            for (std::size_t i=0; i < grid.getNX(); i++) {
                 auto pos = grid.getCellCenter( i,j,k );
                 BOOST_CHECK_CLOSE( std::get<0>(pos) , i*400 + 200 , 0.10 );
                 BOOST_CHECK_CLOSE( std::get<1>(pos) , j*300 + 150 , 0.10 );

--- a/tests/parser/integration/parse_write.cpp
+++ b/tests/parser/integration/parse_write.cpp
@@ -17,15 +17,20 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <iostream>
-#include <sstream>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+#include <opm/input/eclipse/Python/Python.hpp>
+
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
 
 #include <opm/input/eclipse/Parser/Parser.hpp>
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#include <opm/input/eclipse/Python/Python.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <sstream>
 
 inline void loadDeck( const char * deck_file) {
     Opm::Parser parser;
@@ -45,7 +50,7 @@ inline void loadDeck( const char * deck_file) {
             std::exit( 1 );
         }
 
-        for (size_t index=0; index < deck.size(); index++) {
+        for (std::size_t index=0; index < deck.size(); index++) {
             const auto& kw1 = deck[index];
             const auto& kw2 = deck2[index];
 
@@ -59,7 +64,6 @@ inline void loadDeck( const char * deck_file) {
         }
     }
 }
-
 
 int main(int argc, char** argv) {
     for (int iarg = 1; iarg < argc; iarg++)

--- a/tests/test_EGrid.cpp
+++ b/tests/test_EGrid.cpp
@@ -29,13 +29,15 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <fstream>
 #include <initializer_list>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <math.h>
-#include <stdio.h>
 #include <tuple>
+
+#include <stdio.h>
 
 using Opm::EclIO::EGrid;
 
@@ -208,7 +210,7 @@ BOOST_AUTO_TEST_CASE(lgr_1)
     // cell 2,2,1 => zero based 1,1,0
     grid1.getCellCorners({1, 1, 0}, X, Y, Z);
 
-    for (size_t n = 0; n < 8; n++){
+    for (std::size_t n = 0; n < 8; n++){
         BOOST_REQUIRE_CLOSE(global_X_1_1_0[n], X[n], 1e-3);
         BOOST_REQUIRE_CLOSE(global_Y_1_1_0[n], Y[n], 1e-3);
         BOOST_REQUIRE_CLOSE(global_Z_1_1_0[n], Z[n], 1e-3);
@@ -227,7 +229,7 @@ BOOST_AUTO_TEST_CASE(lgr_1)
 
     BOOST_CHECK_EQUAL(nnc_list.size(), nnc_global_ref.size());
 
-    for (size_t n=0; n< nnc_list.size(); n++){
+    for (std::size_t n=0; n< nnc_list.size(); n++){
         BOOST_CHECK_EQUAL(std::get<0>(nnc_list[n]), std::get<0>(nnc_global_ref[n]));
         BOOST_CHECK_EQUAL(std::get<1>(nnc_list[n]), std::get<1>(nnc_global_ref[n]));
         BOOST_CHECK_EQUAL(std::get<2>(nnc_list[n]), std::get<2>(nnc_global_ref[n]));
@@ -256,7 +258,7 @@ BOOST_AUTO_TEST_CASE(lgr_1)
     // cell 2,3,1 => zero based 1,2,0
     lgr1.getCellCorners({1, 2, 0}, X, Y, Z);
 
-    for (size_t n = 0; n < 8; n++){
+    for (std::size_t n = 0; n < 8; n++){
         BOOST_REQUIRE_CLOSE(lgr1_X_1_2_0[n], X[n], 1e-3);
         BOOST_REQUIRE_CLOSE(lgr1_Y_1_2_0[n], Y[n], 1e-3);
         BOOST_REQUIRE_CLOSE(lgr1_Z_1_2_0[n], Z[n], 1e-3);
@@ -272,7 +274,7 @@ BOOST_AUTO_TEST_CASE(lgr_1)
 
     auto nnc_list_lgr1 = lgr1.get_nnc_ijk();
 
-    for (size_t n=0; n< nnc_list_lgr1.size(); n++){
+    for (std::size_t n=0; n< nnc_list_lgr1.size(); n++){
         BOOST_CHECK_EQUAL(std::get<0>(nnc_list_lgr1[n]), std::get<0>(nnc_lgr1_ref[n]));
         BOOST_CHECK_EQUAL(std::get<1>(nnc_list_lgr1[n]), std::get<1>(nnc_lgr1_ref[n]));
         BOOST_CHECK_EQUAL(std::get<2>(nnc_list_lgr1[n]), std::get<2>(nnc_lgr1_ref[n]));
@@ -302,7 +304,7 @@ BOOST_AUTO_TEST_CASE(lgr_1)
     // cell 5,2,1 => zero based 4,1,0
     lgr2.getCellCorners({4, 1, 0}, X, Y, Z);
 
-    for (size_t n = 0; n < 8; n++){
+    for (std::size_t n = 0; n < 8; n++){
         BOOST_CHECK_EQUAL(abs(lgr2_X_4_1_0[n]- X[n]) < 1e-3, true);
         BOOST_CHECK_EQUAL(abs(lgr2_Y_4_1_0[n]- Y[n]) < 1e-3, true);
         BOOST_CHECK_EQUAL(abs(lgr2_Z_4_1_0[n]- Z[n]) < 1e-3, true);
@@ -311,6 +313,6 @@ BOOST_AUTO_TEST_CASE(lgr_1)
     auto hostcells_ijk = lgr1.hostCellsIJK();
     auto hostcells_gind = lgr1.hostCellsGlobalIndex();
 
-    for (size_t n = 0; n < hostcells_gind.size(); n++)
+    for (std::size_t n = 0; n < hostcells_gind.size(); n++)
         BOOST_CHECK_EQUAL(grid1.ijk_from_global_index(hostcells_gind[n]) == hostcells_ijk[n], true);
 }

--- a/tests/test_ERft.cpp
+++ b/tests/test_ERft.cpp
@@ -27,6 +27,7 @@
 #include <opm/io/eclipse/EclOutput.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <fstream>
 #include <iostream>
 #include <math.h>
@@ -152,14 +153,14 @@ BOOST_AUTO_TEST_CASE(TestERft_1) {
     std::vector<float> vect2a = rft1.getRft<float>("PRESSURE", 3);
     BOOST_CHECK_EQUAL(vect2.size(), vect2a.size());
 
-    for (size_t t = 0; t < vect2.size(); t++){
+    for (std::size_t t = 0; t < vect2.size(); t++){
         BOOST_CHECK_EQUAL(vect2[t], vect2a[t]);
     }
 
     std::vector<std::string> vect3a = rft1.getRft<std::string>("WELLETC", 3);
     BOOST_CHECK_EQUAL(vect2.size(), vect2a.size());
 
-    for (size_t t = 0; t < vect3.size(); t++){
+    for (std::size_t t = 0; t < vect3.size(); t++){
         BOOST_CHECK_EQUAL(vect3[t], vect3a[t]);
     }
 

--- a/tests/test_ERst.cpp
+++ b/tests/test_ERst.cpp
@@ -18,28 +18,30 @@
 
 #include "config.h"
 
-#include <opm/io/eclipse/ERst.hpp>
-#include <opm/io/eclipse/EclFile.hpp>
-
 #define BOOST_TEST_MODULE Test EclIO
 #include <boost/test/unit_test.hpp>
 
+#include <opm/io/eclipse/EclFile.hpp>
 #include <opm/io/eclipse/EclOutput.hpp>
+#include <opm/io/eclipse/ERst.hpp>
 #include <opm/io/eclipse/OutputStream.hpp>
 
+#include <opm/common/utility/FileSystem.hpp>
+
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <iterator>
-#include <math.h>
+#include <numeric>
 #include <random>
-#include <stdio.h>
 #include <tuple>
 #include <type_traits>
-#include <numeric>
 
-#include <opm/common/utility/FileSystem.hpp>
+#include <math.h>
+#include <stdio.h>
 
 #include "tests/WorkArea.hpp"
 
@@ -111,7 +113,6 @@ BOOST_AUTO_TEST_CASE(TestERst_1) {
         false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
         false,false,false,false,false,false};
 
-
     std::vector<bool> ref_logih_25 = ref_logih_10;
 
     ERst rst1(testFile);
@@ -130,9 +131,8 @@ BOOST_AUTO_TEST_CASE(TestERst_1) {
     BOOST_CHECK_EQUAL(rst1.hasArray("PRESSURE", 5), true);
     BOOST_CHECK_EQUAL(rst1.hasArray("PRESSURE", 4), false);
 
-
     // try to get a list of vectors from non-existing report step, should throw exception
-    std::vector<std::tuple<std::string, eclArrType, int64_t>> rstArrays; // = rst1.listOfRstArrays(4);
+    std::vector<std::tuple<std::string, eclArrType, std::int64_t>> rstArrays; // = rst1.listOfRstArrays(4);
     BOOST_CHECK_THROW(rstArrays = rst1.listOfRstArrays(4), std::invalid_argument);
 
     // non exising report step number, should throw exception
@@ -231,7 +231,6 @@ BOOST_AUTO_TEST_CASE(TestERst_2) {
     // using API for ERst to read all array from a binary unified restart file1
     // Then write the data back to a new file and check that new file is identical with input file
 
-
     WorkArea work;
     work.copyIn(testFile);
     ERst rst1(testFile);
@@ -240,7 +239,7 @@ BOOST_AUTO_TEST_CASE(TestERst_2) {
 
         std::vector<int> seqnums = rst1.listOfReportStepNumbers();
 
-        for (size_t i = 0; i < seqnums.size(); i++) {
+        for (std::size_t i = 0; i < seqnums.size(); i++) {
             rst1.loadReportStepNumber(seqnums[i]);
             auto rstArrays = rst1.listOfRstArrays(seqnums[i]);
 
@@ -254,7 +253,6 @@ BOOST_AUTO_TEST_CASE(TestERst_2) {
 
     BOOST_CHECK_EQUAL(compare_files(testFile, outFile), true);
 }
-
 
 BOOST_AUTO_TEST_CASE(TestERst_3) {
 
@@ -285,7 +283,6 @@ BOOST_AUTO_TEST_CASE(TestERst_3) {
     }
     BOOST_CHECK_EQUAL(compare_files(testFile, outFile), true);
 }
-
 
 BOOST_AUTO_TEST_CASE(TestERst_4) {
 
@@ -319,7 +316,6 @@ BOOST_AUTO_TEST_CASE(TestERst_4) {
     BOOST_CHECK_EQUAL(pres1==pres3, true);
 }
 
-
 BOOST_AUTO_TEST_CASE(TestERst_5a) {
 
     std::string testRstFile = "LGR_TESTMOD.X0002";
@@ -335,7 +331,6 @@ BOOST_AUTO_TEST_CASE(TestERst_5a) {
     BOOST_CHECK_EQUAL(rst1.hasLGR("LGR1", 2), true);
     BOOST_CHECK_EQUAL(rst1.hasLGR("XXXX", 2), false);
 }
-
 
 BOOST_AUTO_TEST_CASE(TestERst_5b) {
 
@@ -389,12 +384,12 @@ BOOST_AUTO_TEST_CASE(TestERst_5b) {
     BOOST_CHECK_EQUAL(array_list_1.size(), ref_names_global.size());
     BOOST_CHECK_EQUAL(array_list_1.size(), ref_size_global.size());
 
-    for (size_t n = 0; n < array_list_1.size(); n++){
+    for (std::size_t n = 0; n < array_list_1.size(); n++){
         BOOST_CHECK_EQUAL(std::get<0>(array_list_1[n]), ref_names_global[n]);
         BOOST_CHECK_EQUAL(std::get<2>(array_list_1[n]), ref_size_global[n]);
     }
 
-    for (size_t index = 0; index < array_list_1.size(); index++){
+    for (std::size_t index = 0; index < array_list_1.size(); index++){
 
         std::string name = std::get<0>(array_list_1[index]);
 
@@ -440,12 +435,12 @@ BOOST_AUTO_TEST_CASE(TestERst_5b) {
     BOOST_CHECK_EQUAL(array_list_2.size(), ref_names_lgr1.size());
     BOOST_CHECK_EQUAL(array_list_2.size(), ref_size_lgr1.size());
 
-    for (size_t n = 0; n < array_list_2.size(); n++){
+    for (std::size_t n = 0; n < array_list_2.size(); n++){
         BOOST_CHECK_EQUAL(std::get<0>(array_list_2[n]), ref_names_lgr1[n]);
         BOOST_CHECK_EQUAL(std::get<2>(array_list_2[n]), ref_size_lgr1[n]);
     }
 
-    for (size_t index = 0; index < array_list_2.size(); index++){
+    for (std::size_t index = 0; index < array_list_2.size(); index++){
 
         std::string name = std::get<0>(array_list_2[index]);
 
@@ -489,12 +484,12 @@ BOOST_AUTO_TEST_CASE(TestERst_5b) {
     BOOST_CHECK_EQUAL(array_list_3.size(), ref_names_lgr2.size());
     BOOST_CHECK_EQUAL(array_list_3.size(), ref_size_lgr2.size());
 
-    for (size_t n = 0; n < array_list_2.size(); n++){
+    for (std::size_t n = 0; n < array_list_2.size(); n++){
         BOOST_CHECK_EQUAL(std::get<0>(array_list_3[n]), ref_names_lgr2[n]);
         BOOST_CHECK_EQUAL(std::get<2>(array_list_3[n]), ref_size_lgr2[n]);
     }
 
-    for (size_t index = 0; index < array_list_3.size(); index++){
+    for (std::size_t index = 0; index < array_list_3.size(); index++){
 
         std::string name = std::get<0>(array_list_3[index]);
 

--- a/tests/test_ESmry.cpp
+++ b/tests/test_ESmry.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -383,10 +384,10 @@ BOOST_AUTO_TEST_CASE(TestESmry_5) {
     std::vector<float> timeVect = smry1.get_at_rstep("TIME");
     std::vector<float> wopr_prod2 = smry1.get_at_rstep("WOPR:PROD-2");
 
-    for (size_t n = 0; n < timeVect.size() ; n ++)
+    for (std::size_t n = 0; n < timeVect.size() ; n ++)
         BOOST_CHECK_CLOSE(timeVect[n], report_timesteps[n], 1e-6);
 
-    for (size_t n = 0; n < wopr_prod2.size() ; n ++)
+    for (std::size_t n = 0; n < wopr_prod2.size() ; n ++)
         BOOST_CHECK_CLOSE(wopr_prod2[n], qoil_p2[n], 1e-6);
 }
 

--- a/tests/test_EclIO.cpp
+++ b/tests/test_EclIO.cpp
@@ -33,6 +33,7 @@
 #include <limits>
 #include <tuple>
 #include <cmath>
+#include <cstddef>
 #include <numeric>
 
 #include <math.h>
@@ -128,7 +129,7 @@ BOOST_AUTO_TEST_CASE(TestEclFile_X231)
     EclFile test1(filename);
     auto array = test1.get<int>(arrName);
 
-    for (size_t n = 0; n < 10; n++) {
+    for (std::size_t n = 0; n < 10; n++) {
         BOOST_CHECK_EQUAL(array[n], ivect[n]);
     }
 }
@@ -261,7 +262,7 @@ BOOST_AUTO_TEST_CASE(TestEclFile_IX)
 
     auto logih = file1.get<bool>("LOGIHEAD");
 
-    for (size_t n = 0 ; n < refLogihead.size(); n++)
+    for (std::size_t n = 0 ; n < refLogihead.size(); n++)
         BOOST_CHECK_EQUAL(refLogihead[n], logih[n]);
 }
 
@@ -429,7 +430,7 @@ BOOST_AUTO_TEST_CASE(TestEcl_Write_CHAR)
         EclFile file1(testFile1);
         std::vector<std::string> strList=file1.get<std::string>("TEST1");
 
-        for (size_t n = 0; n < refStrList1.size(); n++) {
+        for (std::size_t n = 0; n < refStrList1.size(); n++) {
             BOOST_CHECK(refStrList1[n] == strList[n]);
         }
 
@@ -447,7 +448,7 @@ BOOST_AUTO_TEST_CASE(TestEcl_Write_CHAR)
         EclFile file1(testFile1);
         std::vector<std::string> strList=file1.get<std::string>("TEST2");
 
-        for (size_t n = 0; n < refStrList2.size(); n++) {
+        for (std::size_t n = 0; n < refStrList2.size(); n++) {
             BOOST_CHECK(refStrList2[n] == strList[n]);
         }
 
@@ -466,7 +467,7 @@ BOOST_AUTO_TEST_CASE(TestEcl_Write_CHAR)
         EclFile file1(testFile1);
         std::vector<std::string> strList=file1.get<std::string>("TEST3");
 
-        for (size_t n = 0; n < refStrList1.size(); n++) {
+        for (std::size_t n = 0; n < refStrList1.size(); n++) {
             BOOST_CHECK(refStrList1[n] == strList[n]);
         }
 
@@ -485,7 +486,7 @@ BOOST_AUTO_TEST_CASE(TestEcl_Write_CHAR)
         EclFile file1(testFile2);
         std::vector<std::string> strList=file1.get<std::string>("TEST4");
 
-        for (size_t n = 0; n < refStrList1.size(); n++) {
+        for (std::size_t n = 0; n < refStrList1.size(); n++) {
             BOOST_CHECK(refStrList1[n] == strList[n]);
         }
 
@@ -503,7 +504,7 @@ BOOST_AUTO_TEST_CASE(TestEcl_Write_CHAR)
         EclFile file1(testFile2);
         std::vector<std::string> strList=file1.get<std::string>("TEST5");
 
-        for (size_t n = 0; n < refStrList2.size(); n++) {
+        for (std::size_t n = 0; n < refStrList2.size(); n++) {
             BOOST_CHECK(refStrList2[n] == strList[n]);
         }
 
@@ -522,7 +523,7 @@ BOOST_AUTO_TEST_CASE(TestEcl_Write_CHAR)
         EclFile file1(testFile2);
         std::vector<std::string> strList=file1.get<std::string>("TEST6");
 
-        for (size_t n = 0; n < refStrList1.size(); n++) {
+        for (std::size_t n = 0; n < refStrList1.size(); n++) {
             BOOST_CHECK(refStrList1[n] == strList[n]);
         }
 

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -54,6 +54,7 @@
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <fstream>
 #include <ios>
 #include <map>
@@ -124,7 +125,7 @@ void compareErtData(const std::vector< T > &src,
                     double tolerance ) {
     BOOST_REQUIRE_EQUAL(src.size(), dst.size());
 
-    for (size_t i = 0; i < src.size(); ++i)
+    for (std::size_t i = 0; i < src.size(); ++i)
         BOOST_CHECK_CLOSE(src[i], dst[i], tolerance);
 }
 

--- a/tests/test_ExtESmry.cpp
+++ b/tests/test_ExtESmry.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -367,7 +368,7 @@ BOOST_AUTO_TEST_CASE(TestESmry_3) {
     // fopt vector not present in base run, should get zeros as not
     // for time step 0, 1, ... 62
 
-    for (size_t n = 0; n < 63; n++)
+    for (std::size_t n = 0; n < 63; n++)
         BOOST_CHECK_EQUAL(fopt[n], 0.0);
 
     std::vector<float> fopt_rst_ref = { 3.19319e+07, 3.2234e+07, 3.25642e+07, 3.28804e+07, 3.32039e+07, 3.35138e+07,
@@ -380,6 +381,6 @@ BOOST_AUTO_TEST_CASE(TestESmry_3) {
             4.48504e+07, 4.50315e+07, 4.52109e+07, 4.53828e+07, 4.55587e+07, 4.57272e+07, 4.58995e+07 };
 
 
-    for (size_t n = 63; n < fopt.size(); n++)
+    for (std::size_t n = 63; n < fopt.size(); n++)
         BOOST_REQUIRE_CLOSE(fopt[n], fopt_rst_ref[n-63], 0.01);
 }

--- a/tests/test_GuideRate.cpp
+++ b/tests/test_GuideRate.cpp
@@ -37,11 +37,10 @@
 
 #include <opm/input/eclipse/Units/Units.hpp>
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <utility>
-
-#include <stddef.h>
 
 namespace {
     struct Setup
@@ -201,7 +200,7 @@ BOOST_AUTO_TEST_CASE(P1_First)
     const auto wgpp = 5.0;
     const auto wwpp = 0.1;
     const auto stm  = 0.0;
-    const auto rpt  = size_t{1};
+    const auto rpt  = std::size_t{1};
 
     cse.gr.updateGuideRateExpiration(stm, rpt);
     cse.gr.compute("P1", rpt, stm, wopp, wgpp, wwpp);
@@ -244,7 +243,7 @@ BOOST_AUTO_TEST_CASE(Erase)
     const auto wgpp = 5.0;
     const auto wwpp = 0.1;
     const auto stm  = 0.0;
-    const auto rpt  = size_t{1};
+    const auto rpt  = std::size_t{1};
 
     cse.gr.updateGuideRateExpiration(stm, rpt);
     // NOTE: The default guide rate for the production well P1 is computed based on the GUIDERAT keyword,
@@ -279,7 +278,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
         const auto wgpp = 5.0;
         const auto wwpp = 0.1;
         const auto stm  = 0.0;
-        const auto rpt  = size_t{1};
+        const auto rpt  = std::size_t{1};
 
         cse.gr.updateGuideRateExpiration(stm, rpt);
         cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
@@ -290,7 +289,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
         const auto wgpp = 50.0;
         const auto wwpp = 1.0;
         const auto stm  = 10.0*Opm::unit::second; // Before recalculation delay
-        const auto rpt  = size_t{1};
+        const auto rpt  = std::size_t{1};
 
         cse.gr.updateGuideRateExpiration(stm, rpt);
         cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
@@ -330,7 +329,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
         const auto wgpp = 50.0;
         const auto wwpp = 1.0;
         const auto stm  = 10.0*Opm::unit::day; // After recalculation delay
-        const auto rpt  = size_t{3};
+        const auto rpt  = std::size_t{3};
 
         cse.gr.updateGuideRateExpiration(stm, rpt);
         cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
@@ -372,7 +371,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
         const auto wgpp = 5.0;
         const auto wwpp = 0.1;
         const auto stm  = 0.0;
-        const auto rpt  = size_t{1};
+        const auto rpt  = std::size_t{1};
 
         cse.gr.updateGuideRateExpiration(stm, rpt);
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
@@ -383,7 +382,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
         const auto wgpp = 50.0;
         const auto wwpp = 1.0;
         const auto stm  = 10.0*Opm::unit::day;
-        const auto rpt  = size_t{3};
+        const auto rpt  = std::size_t{3};
 
         cse.gr.updateGuideRateExpiration(stm, rpt);
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
@@ -394,7 +393,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
         const auto wgpp = 100.0;
         const auto wwpp = 10.0;
         const auto stm  = 20.0*Opm::unit::day;
-        const auto rpt  = size_t{4};
+        const auto rpt  = std::size_t{4};
 
         cse.gr.updateGuideRateExpiration(stm, rpt);
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
@@ -442,7 +441,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
         const auto wgpp = 5.0;
         const auto wwpp = 0.1;
         const auto stm  = 0.0;
-        const auto rpt  = size_t{1};
+        const auto rpt  = std::size_t{1};
 
         cse.gr.updateGuideRateExpiration(stm, rpt);
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
@@ -453,7 +452,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
         const auto wgpp = 50.0;
         const auto wwpp = 1.0;
         const auto stm  = 10.0*Opm::unit::day;
-        const auto rpt  = size_t{3};
+        const auto rpt  = std::size_t{3};
 
         cse.gr.updateGuideRateExpiration(stm, rpt);
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
@@ -464,7 +463,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
         const auto wgpp = 100.0;
         const auto wwpp = 10.0;
         const auto stm  = 20.0*Opm::unit::day;
-        const auto rpt  = size_t{4};
+        const auto rpt  = std::size_t{4};
 
         cse.gr.updateGuideRateExpiration(stm, rpt);
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
@@ -512,7 +511,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
         const auto wgpp = 5.0;
         const auto wwpp = 0.1;
         const auto stm  = 0.0;
-        const auto rpt  = size_t{1};
+        const auto rpt  = std::size_t{1};
 
         cse.gr.updateGuideRateExpiration(stm, rpt);
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
@@ -523,7 +522,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
         const auto wgpp = 50.0;
         const auto wwpp = 1.0;
         const auto stm  = 10.0*Opm::unit::day;
-        const auto rpt  = size_t{3};
+        const auto rpt  = std::size_t{3};
 
         cse.gr.updateGuideRateExpiration(stm, rpt);
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
@@ -534,7 +533,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
         const auto wgpp = 100.0;
         const auto wwpp = 10.0;
         const auto stm  = 20.0*Opm::unit::day;
-        const auto rpt  = size_t{4};
+        const auto rpt  = std::size_t{4};
 
         cse.gr.updateGuideRateExpiration(stm, rpt);
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
@@ -684,7 +683,7 @@ BOOST_AUTO_TEST_CASE(POTN_has_and_get)
     const auto gas_pot = 3000.0;
     const auto wat_pot = 1000.0;
     const auto stm = 0.0; // simulation time
-    const auto rpt = size_t{1}; // report step
+    const auto rpt = std::size_t{1}; // report step
 
     // Before compute: group P should not have a guide rate
     BOOST_CHECK(!cse.gr.has("P"));
@@ -732,7 +731,7 @@ BOOST_AUTO_TEST_CASE(POTN_erase)
     const auto gas_pot = 3000.0;
     const auto wat_pot = 1000.0;
     const auto stm = 0.0; // simulation time
-    const auto rpt = size_t{1}; // report step
+    const auto rpt = std::size_t{1}; // report step
 
     cse.gr.updateGuideRateExpiration(stm, rpt);
     cse.gr.compute("P", rpt, stm, oil_pot, gas_pot, wat_pot);
@@ -752,7 +751,7 @@ BOOST_AUTO_TEST_CASE(POTN_updated_potentials)
     auto cse = case_potn_group();
 
     const auto stm1 = 0.0; // simulation time
-    const auto rpt = size_t{1}; // report step
+    const auto rpt = std::size_t{1}; // report step
 
     cse.gr.updateGuideRateExpiration(stm1, rpt);
     cse.gr.compute("P", rpt, stm1, /*oil_pot=*/6000.0, /*gas_pot=*/3000.0, /*wat_pot=*/1000.0);

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -25,11 +25,6 @@
 #include <boost/test/unit_test.hpp>
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
-#include <stdexcept>
-#include <iostream>
-#include <sstream>
-
-
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/LogBackend.hpp>
 #include <opm/common/OpmLog/CounterLog.hpp>
@@ -38,14 +33,17 @@
 #include <opm/common/OpmLog/LogUtil.hpp>
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 
-using namespace Opm;
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
 
+using namespace Opm;
 
 BOOST_AUTO_TEST_CASE(DoLogging) {
     OpmLog::addMessage(Log::MessageType::Warning , "Warning1");
     OpmLog::addMessage(Log::MessageType::Warning , "Warning2");
 }
-
 
 BOOST_AUTO_TEST_CASE(Test_Format) {
     BOOST_CHECK_EQUAL( "There is an error here?\nIn file /path/to/file, line 100\n" , Log::fileMessage(KeywordLocation("Keyword", "/path/to/file" , 100) , "There is an error here?"));
@@ -54,8 +52,6 @@ BOOST_AUTO_TEST_CASE(Test_Format) {
     BOOST_CHECK_EQUAL( "\nWarning: This is the warning" , Log::prefixMessage(Log::MessageType::Warning , "This is the warning"));
     BOOST_CHECK_EQUAL( "Info: This is the info" ,       Log::prefixMessage(Log::MessageType::Info , "This is the info"));
 }
-
-
 
 BOOST_AUTO_TEST_CASE(Test_Logger) {
     Logger logger;
@@ -78,7 +74,6 @@ BOOST_AUTO_TEST_CASE(Test_Logger) {
 
     BOOST_CHECK_EQUAL( log_stream.str() , "Warning\n");
 
-
     BOOST_CHECK_THROW( logger.getBackend<LogBackend>("No") , std::invalid_argument );
     {
         auto counter2 = logger.getBackend<CounterLog>("COUNTER");
@@ -98,11 +93,10 @@ BOOST_AUTO_TEST_CASE(Test_Logger) {
     }
 }
 
-
 BOOST_AUTO_TEST_CASE(LoggerAddTypes_PowerOf2) {
     Logger logger;
-    int64_t not_power_of2 = 13;
-    int64_t power_of2 = 4096;
+    std::int64_t not_power_of2 = 13;
+    std::int64_t power_of2 = 4096;
 
     BOOST_CHECK_THROW( logger.addMessageType( not_power_of2 , "Prefix") , std::invalid_argument);
     BOOST_CHECK_THROW( logger.enabledMessageType( not_power_of2 ) , std::invalid_argument);
@@ -112,16 +106,15 @@ BOOST_AUTO_TEST_CASE(LoggerAddTypes_PowerOf2) {
     BOOST_CHECK_EQUAL( false , logger.enabledMessageType( 2*power_of2 ));
 }
 
-
 class TestLog: public LogBackend {
 public:
-    explicit TestLog( int64_t messageMask ) : LogBackend( messageMask )
+    explicit TestLog( std::int64_t messageMask ) : LogBackend( messageMask )
     {
         m_defaultMessages = 0;
         m_specialMessages = 0;
     }
 
-    void addMessageUnconditionally(int64_t messageType , const std::string& /* message */) override
+    void addMessageUnconditionally(std::int64_t messageType , const std::string& /* message */) override
     {
         if (messageType & Log::DefaultMessageTypes)
             m_defaultMessages +=1;
@@ -140,7 +133,7 @@ public:
 
 BOOST_AUTO_TEST_CASE(LoggerMasksTypes) {
     Logger logger;
-    int64_t power_of2 = 4096;
+    std::int64_t power_of2 = 4096;
 
     std::shared_ptr<TestLog> testLog = std::make_shared<TestLog>(Log::DefaultMessageTypes + power_of2);
     logger.addBackend("TEST" , testLog);
@@ -158,10 +151,6 @@ BOOST_AUTO_TEST_CASE(LoggerMasksTypes) {
     logger.addMessage( power_of2 , "Passing through");
     BOOST_CHECK_EQUAL( testLog->m_specialMessages , 1 );
 }
-
-
-
-
 
 BOOST_AUTO_TEST_CASE(LoggerDefaultTypesEnabled) {
     Logger logger;
@@ -181,8 +170,8 @@ BOOST_AUTO_TEST_CASE( CounterLogTesting) {
     BOOST_CHECK_EQUAL(1U  , counter.numMessages( Log::MessageType::Note ));
 
     {
-        int64_t not_enabled = 4096;
-        int64_t not_power2  = 4095;
+        std::int64_t not_enabled = 4096;
+        std::int64_t not_power2  = 4095;
 
         BOOST_CHECK_EQUAL( 0U , counter.numMessages( not_enabled ));
         BOOST_CHECK_THROW( counter.numMessages( not_power2 ) , std::invalid_argument);
@@ -202,7 +191,6 @@ BOOST_AUTO_TEST_CASE(TestTimerLog) {
     std::cout << sstream.str() << std::endl;
 }
 
-
 /*****************************************************************/
 void initLogger(std::ostringstream& log_stream);
 
@@ -217,8 +205,6 @@ void initLogger(std::ostringstream& log_stream) {
     BOOST_CHECK_EQUAL( true , OpmLog::hasBackend("COUNTER"));
     BOOST_CHECK_EQUAL( true , OpmLog::hasBackend("STREAM"));
 }
-
-
 
 BOOST_AUTO_TEST_CASE(TestOpmLog) {
     std::ostringstream log_stream;
@@ -238,8 +224,6 @@ BOOST_AUTO_TEST_CASE(TestOpmLog) {
 
     BOOST_CHECK_EQUAL( log_stream.str() , "Warning\n");
 }
-
-
 
 BOOST_AUTO_TEST_CASE(TestHelperFunctions)
 {
@@ -265,8 +249,6 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
     BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Warning, "message"), AnsiTerminalColors::blue_strong + "message" + AnsiTerminalColors::none);
     BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Error, "message"), AnsiTerminalColors::red_strong + "message" + AnsiTerminalColors::none);
 }
-
-
 
 BOOST_AUTO_TEST_CASE(TestOpmLogWithColors)
 {
@@ -307,12 +289,8 @@ BOOST_AUTO_TEST_CASE(TestOpmLogWithColors)
         BOOST_CHECK_EQUAL( 1U , counter->numMessages(Log::MessageType::Bug) );
     }
 
-
     std::cout << log_stream.str() << std::endl;
 }
-
-
-
 
 BOOST_AUTO_TEST_CASE(TestOpmLogWithLimits)
 {
@@ -367,17 +345,12 @@ BOOST_AUTO_TEST_CASE(TestOpmLogWithLimits)
     std::cout << log_stream2.str() << std::endl;
 }
 
-
-
-
 BOOST_AUTO_TEST_CASE(TestsetupSimpleLog)
 {
     bool use_prefix = false;
     OpmLog::setupSimpleDefaultLogging(use_prefix);
     BOOST_CHECK_EQUAL(true, OpmLog::hasBackend("SimpleDefaultLog"));
 }
-
-
 
 BOOST_AUTO_TEST_CASE(TestFormat)
 {

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -757,12 +757,12 @@ BOOST_AUTO_TEST_CASE(test_RFT)
 
         std::vector<Opm::data::Connection> well1_comps(9);
         Opm::data::ConnectionFiltrate con_filtrate {0.1, 1, 3, 0.4, 1.e-9, 0.2, 0.05, 10.}; // values are not used in this test
-        for (size_t i = 0; i < 9; ++i) {
+        for (std::size_t i = 0; i < 9; ++i) {
             Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i), r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i, 1.2e3, 4.321, 0.0, 1.23, 0, con_filtrate};
             well1_comps[i] = std::move(well_comp);
         }
         std::vector<Opm::data::Connection> well2_comps(6);
-        for (size_t i = 0; i < 6; ++i) {
+        for (std::size_t i = 0; i < 6; ++i) {
             Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3), r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2, 0.15, 0.54321, 0.0, 0.98, 0, con_filtrate};
             well2_comps[i] = std::move(well_comp);
         }
@@ -882,7 +882,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
         const auto  start_time = schedule.posixStartTime();
         for (int counter = 0; counter < 2; counter++) {
             Opm::EclipseIO eclipseWriter( eclipseState, grid, schedule, summary_config );
-            for (size_t step = 0; step < schedule.size(); step++) {
+            for (std::size_t step = 0; step < schedule.size(); step++) {
                 const auto step_time = schedule.simTime(step);
 
                 Opm::data::Rates r1, r2;
@@ -896,12 +896,12 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
 
                 std::vector<Opm::data::Connection> well1_comps(9);
                 Opm::data::ConnectionFiltrate con_filtrate {0.1, 1, 3, 0.4, 1.e-9, 0.2, 0.05, 10.}; // values are not used in this test
-                for (size_t i = 0; i < 9; ++i) {
+                for (std::size_t i = 0; i < 9; ++i) {
                     Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i), r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i, 3.14e5, 0.1234, 0.0, 1.23, 0, con_filtrate};
                     well1_comps[i] = std::move(well_comp);
                 }
                 std::vector<Opm::data::Connection> well2_comps(6);
-                for (size_t i = 0; i < 6; ++i) {
+                for (std::size_t i = 0; i < 6; ++i) {
                     Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3), r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2, 355.113, 0.9876, 0.0, 0.98, 0, con_filtrate};
                     well2_comps[i] = std::move(well_comp);
                 }

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -65,6 +65,7 @@
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdlib>
 #include <ctime>
 #include <map>
@@ -799,7 +800,7 @@ BOOST_AUTO_TEST_CASE(ExtraData_content)
                 const std::vector<double> expected = {10,1,2,3};
 
                 BOOST_CHECK_EQUAL( rst_value.solution.has("NO") , false );
-                for (size_t i=0; i < expected.size(); i++)
+                for (std::size_t i=0; i < expected.size(); i++)
                     BOOST_CHECK_CLOSE(extraval[i], expected[i], 1e-5);
             }
         }

--- a/tests/test_Serialization.cpp
+++ b/tests/test_Serialization.cpp
@@ -162,6 +162,7 @@
 #include <opm/common/utility/Serializer.hpp>
 #include <opm/common/utility/MemPacker.hpp>
 
+#include <cstddef>
 #include <memory>
 #include <tuple>
 #include <utility>
@@ -173,10 +174,10 @@ namespace {
         Opm::Serialization::MemPacker packer;
         Opm::Serializer ser(packer);
         ser.pack(in);
-        const size_t pos1 = ser.position();
+        const std::size_t pos1 = ser.position();
         T out{};
         ser.unpack(out);
-        const size_t pos2 = ser.position();
+        const std::size_t pos2 = ser.position();
 
         return std::make_tuple(out, pos1, pos2);
     }
@@ -196,7 +197,6 @@ BOOST_AUTO_TEST_CASE(NAME) \
 
 #define TEST_FOR_TYPE(TYPE) \
     TEST_FOR_TYPE_NAMED(TYPE, TYPE)
-
 
 TEST_FOR_TYPE(Actdims)
 TEST_FOR_TYPE(Aqudims)

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -2494,14 +2494,14 @@ BOOST_AUTO_TEST_CASE(region_vars)
 
     {
         std::vector<double> values(10, 0.0);
-        for (size_t r=1; r <= 10; r++) {
+        for (std::size_t r=1; r <= 10; r++) {
             values[r - 1] = r *1.0;
         }
         region_values["RPR"] = values;
     }
     {
         std::vector<double> values(10, 0.0);
-        for (size_t r=1; r <= 10; r++) {
+        for (std::size_t r=1; r <= 10; r++) {
             values[r - 1] = r * r * 2.5;
         }
         region_values["RPRH"] = values;
@@ -2509,7 +2509,7 @@ BOOST_AUTO_TEST_CASE(region_vars)
     {
         double area = cfg.grid.getNX() * cfg.grid.getNY();
         std::vector<double> values(10, 0.0);
-        for (size_t r=1; r <= 10; r++) {
+        for (std::size_t r=1; r <= 10; r++) {
             if (r == 10)
                 area -= 1;
 
@@ -2520,7 +2520,7 @@ BOOST_AUTO_TEST_CASE(region_vars)
     {
         double area = cfg.grid.getNX() * cfg.grid.getNY();
         std::vector<double> values(10, 0.0);
-        for (size_t r=1; r <= 10; r++) {
+        for (std::size_t r=1; r <= 10; r++) {
             if (r == 10)
                 area -= 1;
 
@@ -2531,7 +2531,7 @@ BOOST_AUTO_TEST_CASE(region_vars)
     {
         double area = cfg.grid.getNX() * cfg.grid.getNY();
         std::vector<double> values(10, 0.0);
-        for (size_t r=1; r <= 10; r++) {
+        for (std::size_t r=1; r <= 10; r++) {
             if (r == 10)
                 area -= 1;
 
@@ -2542,7 +2542,7 @@ BOOST_AUTO_TEST_CASE(region_vars)
     {
         double area = cfg.grid.getNX() * cfg.grid.getNY();
         std::vector<double> values(10, 0.0);
-        for (size_t r=1; r <= 10; r++) {
+        for (std::size_t r=1; r <= 10; r++) {
             if (r == 10)
                 area -= 1;
 
@@ -2553,7 +2553,7 @@ BOOST_AUTO_TEST_CASE(region_vars)
     {
         double area = cfg.grid.getNX() * cfg.grid.getNY();
         std::vector<double> values(10, 0.0);
-        for (size_t r=1; r <= 10; r++) {
+        for (std::size_t r=1; r <= 10; r++) {
             if (r == 10)
                 area -= 1;
 
@@ -2564,7 +2564,7 @@ BOOST_AUTO_TEST_CASE(region_vars)
     {
         double area = cfg.grid.getNX() * cfg.grid.getNY();
         std::vector<double> values(10, 0.0);
-        for (size_t r=1; r <= 10; r++) {
+        for (std::size_t r=1; r <= 10; r++) {
             if (r == 10)
                 area -= 1;
 
@@ -2575,7 +2575,7 @@ BOOST_AUTO_TEST_CASE(region_vars)
     {
         double area = cfg.grid.getNX() * cfg.grid.getNY();
         std::vector<double> values(10, 0.0);
-        for (size_t r=1; r <= 10; r++) {
+        for (std::size_t r=1; r <= 10; r++) {
             if (r == 10)
                 area -= 1;
 
@@ -2630,7 +2630,7 @@ BOOST_AUTO_TEST_CASE(region_vars)
 
     UnitSystem units( UnitSystem::UnitType::UNIT_TYPE_METRIC );
 
-    for (size_t r=1; r <= 10; r++) {
+    for (std::size_t r=1; r <= 10; r++) {
         std::string rpr_key   = "RPR:"   + std::to_string( r );
         std::string rprh_key  = "RPRH:"  + std::to_string( r );
         std::string roip_key  = "ROIP:"  + std::to_string( r );

--- a/tests/test_cmp.cpp
+++ b/tests/test_cmp.cpp
@@ -22,9 +22,10 @@
 #define BOOST_TEST_MODULE FLOAT_CMP_TESTS
 #include <boost/test/unit_test.hpp>
 
-#include <stdexcept>
-
 #include <opm/common/utility/numeric/cmp.hpp>
+
+#include <cstddef>
+#include <stdexcept>
 
 using namespace Opm;
 
@@ -42,8 +43,6 @@ BOOST_AUTO_TEST_CASE(TestSCalarcmp) {
     BOOST_CHECK_EQUAL( false , cmp::scalar_equal<double>(1,0));
     BOOST_CHECK_EQUAL( false , cmp::scalar_equal<double>(0,1));
     BOOST_CHECK_EQUAL( false , cmp::scalar_equal<double>(-1,1));
-
-
 
     double v1,v2;
     /* Should be equal: */
@@ -67,7 +66,6 @@ BOOST_AUTO_TEST_CASE(TestSCalarcmp) {
         v1 = 0;
         v2 = 0.5 * abs_epsilon;
         BOOST_CHECK( cmp::scalar_equal<double>( v1 , v2));
-
 
         v1 = 1e7;
         v2 = 1e7 + 2*abs_epsilon;
@@ -110,7 +108,7 @@ BOOST_AUTO_TEST_CASE(TestSCalarcmp) {
 BOOST_AUTO_TEST_CASE(TestFloatcmp) {
     std::vector<float> v1;
     std::vector<float> v2;
-    for (size_t i =0; i < 10; i++) {
+    for (std::size_t i =0; i < 10; i++) {
         v1.push_back( i * 1.0 );
         v2.push_back( i * 1.0 );
     }

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -143,7 +143,7 @@ void verifyWellState(const std::string& rst_filename, const Opm::Schedule& sched
     //Verify number of active wells
     BOOST_CHECK_EQUAL( wellList.size(), static_cast<std::size_t>(intehead[16]));
 
-    for (size_t i=0; i< wellList.size(); i++) {
+    for (std::size_t i=0; i< wellList.size(); i++) {
 
         // Verify wellname
         BOOST_CHECK_EQUAL(zwel[i*3], ref_wellList[step][i]);
@@ -192,7 +192,7 @@ void verifyWellState(const std::string& rst_filename, const Opm::Schedule& sched
         BOOST_CHECK_EQUAL(ref_wellConn[step][i].size(), connections_set.size() );
 
 
-        for (size_t n=0; n< connections_set.size(); n++) {
+        for (std::size_t n=0; n< connections_set.size(); n++) {
             const auto& completion = connections_set.get(n);
 
             // Verify I, J and K indices for each connection
@@ -201,7 +201,7 @@ void verifyWellState(const std::string& rst_filename, const Opm::Schedule& sched
             BOOST_CHECK_EQUAL(completion.getJ()+1 , std::get<1>(ref_wellConn[step][i][n]));
             BOOST_CHECK_EQUAL(completion.getK()+1 , std::get<2>(ref_wellConn[step][i][n]));
 
-            size_t ind = i*ncwmax*niconz+n*niconz;
+            std::size_t ind = i*ncwmax*niconz+n*niconz;
 
             BOOST_CHECK_EQUAL(completion.getI()+1 , icon[ind+1]);
             BOOST_CHECK_EQUAL(completion.getJ()+1 , icon[ind+2]);


### PR DESCRIPTION
Modernize the codebase by replacing all bare C type aliases (`size_t`, `int64_t`, `uint64_t`, etc.) with their `std::`-qualified counterparts, making namespace usage explicit and consistent throughout.

## Changes

- **Type replacements** across 219 files in `opm/` and `tests/`:
  - `size_t` → `std::size_t` (~1600 occurrences)
  - `int64_t` → `std::int64_t` (~134 occurrences)
  - `uint64_t` → `std::uint64_t` (~32 occurrences)
  - `uint32_t` → `std::uint32_t`, `intptr_t` → `std::intptr_t` (handful each)

- **Headers added** where missing, placed in alphabetical order:
  - `#include <cstddef>` for `std::size_t` / `std::ptrdiff_t`
  - `#include <cstdint>` for fixed-width integer types

## Scope

- Types in comments and string/raw-string literals are left unchanged
- Vendored third-party code (`external/resinsight/`) is not touched
- Already-qualified `std::size_t` etc. are not duplicated

## Example

```cpp
// Before
size_t computeIndex(int64_t id, uint64_t offset);

// After
std::size_t computeIndex(std::int64_t id, std::uint64_t offset);
```

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> ## Objective
> 
> Replace all uses of "bare" type aliases (those in the global namespace) with their `std::` namespaced counterparts throughout the opm-common codebase. This modernizes the code and makes the namespace usage explicit and consistent.
> 
> ## Types to Replace
> 
> Replace the following bare types with their `std::` equivalents:
> 
> ### Fixed-width integer types (require `<cstdint>`)
> - `int8_t` → `std::int8_t`
> - `int16_t` → `std::int16_t`
> - `int32_t` → `std::int32_t`
> - `int64_t` → `std::int64_t`
> - `uint8_t` → `std::uint8_t`
> - `uint16_t` → `std::uint16_t`
> - `uint32_t` → `std::uint32_t`
> - `uint64_t` → `std::uint64_t`
> - `intptr_t` → `std::intptr_t`
> - `uintptr_t` → `std::uintptr_t`
> - `intmax_t` → `std::intmax_t`
> - `uintmax_t` → `std::uintmax_t`
> 
> ### Size and pointer difference types (require `<cstddef>`)
> - `size_t` → `std::size_t`
> - `ptrdiff_t` → `std::ptrdiff_t`
> 
> ## Requirements
> 
> 1. **Search comprehensively**: Find all occurrences of these bare types in:
>    - Function parameters
>    - Return types
>    - Variable declarations
>    - Type aliases/typedefs
>    - Template parameters
>    - Cast expressions
> 
> 2. **Preserve correct usage**: Do NOT change:
>    - Types already prefixed with `std::`
>    - Types that are custom type names that happen to match these names
>    - Types in comments (unless updating documentation to match code changes)
>    - Types in string literals
> 
> 3. **Add necessary headers**: When replacing types, ensure the appropriate header is included:
>    - Add `#include <cstdint>` when using `std::int*_t` or `std::uint*_t` types
>    - Add `#include <cstddef>` when using `std::size_t` or `std::ptrdiff_t`
>    - Place includes in alphabetical order with other system headers
>    - Avoid duplicate includes
> 
> 4. **Maintain code functionality**: Ensure all replacements maintain exact functional equivalence with the original code.
> 
> 5. **Handle edge cases properly**:
>    - Be careful with `size_t` in template contexts
>    - Preserve any `using` declarations that might exist
>    - Check for qualified usage (e.g., `::size_t` should become `std::size_t`)
> 
> ## Example Transformations
> 
> **Before:**
> ```cpp
> #include <vector>
> 
> size_t computeSize(const std::vector<int>& data) {
>     return data.size();
> }
> 
> void process(uint64_t id, int32_t value) {
>     // implementation
> }
> ```
> 
> **After:**
> ```cpp
> #include <cstddef>
> #include <cstdint>
> #include <vector>
> 
> std::size_t computeSize(const std::vector<int>& data) {
>     return data.size();
> }
> 
> void process(std::uint64_t id, std::int32_t value) {
>     // implementation
> }
> ```
> 
> ## Scope
> 
> - Focus on C++ source files (`.cpp`, `.hpp`, `.h`, `.cc`, `.hxx`, `.cxx`)
> - Make changes across the entire repository
> - Ensure consistency across all modified files
> 
> ## Testing Considerations
> 
> After making these changes, the code should:
> - Compile without errors
> - Maintain all existing functionality
> - Pass existing test suites
> 
> The following is the prior conversation context from the user's chat exploration (may be truncated):
> 
> User: Hi there,
> 
> The opm-common source base has been developed over a rather long time and some historical artifacts show up. In particular, there are numerous uses of "bare" size_t, int64_t and other type aliases for which we should use their "std" namespaced alternatives.
> 
> I'd like you to search the code base in bska/opm-common and replace all these "bare" types, i.e., in the global namespace, with their "std" counterparts. Please remember to also include the necessary headers when making such changes.
> 
> The end result of this work should be a pull request against the bska/opm-common repository fork.
> 
> Assistant: I'll create a pull request to replace bare type aliases with their `std::` counterparts throughout the opm-common codebase.
> 
> Assistant: I'm waiting for your approval to proceed with creating a pull request that will replace all bare type aliases (like `size_t`, `int64_t`, etc.) with their `std::` namespaced equivalents throughout the bska/opm-common repository.
> 
> 


</details>

---

<!-- START COPILOT CODING AGENT SUFFIX -->

*This pull request was created from Copilot chat.*
>

Agent-Logs-Url: https://github.com/bska/opm-common/sessions/d95e6a81-b15e-49f6-abc6-afccbffa3a07