### PR TITLE
Honour per-cell salt concentration in CO2STORE fugacity/enthalpy

### DIFF
--- a/opm/input/eclipse/share/keywords/000_Eclipse100/S/SALT
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/S/SALT
@@ -3,6 +3,9 @@
   "sections": [
     "SOLUTION"
   ],
+  "requires": [
+    "BRINE"
+  ],
   "size": 1,
   "items": [
     {

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/S/SALTVD
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/S/SALTVD
@@ -4,6 +4,9 @@
   "sections": [
     "SOLUTION"
   ],
+  "requires": [
+    "BRINE"
+  ],
   "size": {
     "keyword": "EQLDIMS",
     "item": "NTEQUL"

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/S/SALINITY
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/S/SALINITY
@@ -4,7 +4,8 @@
     "PROPS"
   ],
   "prohibits": [
-    "SALTMF"
+    "SALTMF",
+    "BRINE"
   ],
   "size": 1,
   "items": [

--- a/tests/parser/SaltTableTests.cpp
+++ b/tests/parser/SaltTableTests.cpp
@@ -52,6 +52,9 @@ inline std::string prefix() {
 
 BOOST_AUTO_TEST_CASE( Brine ) {
     const char *deckData =
+        "BRINE\n"
+        "/\n"
+        "\n"
         "TABDIMS\n"
         "1 1/\n"
         "\n"


### PR DESCRIPTION
  ## Summary                                                                                                                                                                         
                                                                
  When the BRINE phase is active in CO2STORE, `BrineCo2Pvt` uses per-cell salt concentration (from `SALTVD`/`SALT`) for dissolution, diffusion, and viscosity. However,              
  `BrineCO2FluidSystem::fugacityCoefficient()` and `enthalpy()` unconditionally use the static `Brine_IAPWS::salinity` (set from the `SALINITY` keyword scalar). This creates a
  silent thermodynamic inconsistency.                                                                                                                                                
                                                                
  Three failure modes:
  1. **BRINE + SALINITY, no SALTVD** — fugacity sees SALINITY value, dissolution sees salt=0 (silent fresh-water solubility)
  2. **BRINE + SALTVD, no SALINITY** — dissolution sees per-cell, fugacity sees 0 (opposite inconsistency)                                                                           
  3. **BRINE + SALINITY + SALTVD** — always inconsistent unless SALTVD is uniform and equals SALINITY                                                                                
                                                                                                                                                                                     
  ## Changes                                                                                                                                                                         
                                                                                                                                                                                     
  - `BlackOilFluidSystem.cpp` — gate CO2STORE molar-mass initialization on BRINE phase: use salinity=0 when BRINE active (per-cell correction at runtime)                            
  - `BrineCO2FluidSystem.hpp` — `fugacityCoefficient()` and `enthalpy()` detect `saltConcentration()` on the FluidState via `constexpr if (requires {...})` and convert to mass
  fraction using one-iteration Batzle-Wang with `BrineDynamic::liquidDensity`; fall back to `Brine_IAPWS::salinity` for non-BRINE FluidStates                                        
  - `BrineCo2Pvt.cpp` — parser-time warning when BRINE + SALINITY without SALTVD/SALT
                                                                                                                                                                                     
  ## Testing                                                                                                                                                                         
                                                                                                                                                                                     
  - 7 direct fugacity assertions: salt=5 kg/m³ gives φ=44.4, salt=200 kg/m³ gives φ=90.7 (salting-out direction correct: higher salt → higher φ → lower CO₂ solubility); fallback    
  path unchanged; salt=0 matches fallback                       
  - Simulation: BRINE+SALTVD runs with +0.00% mass balance and active dissolution                                                                                                    
  - Warning fires when BRINE+SALINITY without SALTVD; does NOT fire when SALTVD is present                                                                                           
  - Full ctest: 251/252 pass                                                                                                                                                         
  - Cross-compiler: g++-13.3 and g++-14.2                                                                                                                                            
             
  ## Recommended usage                                                                                                                                                               
                                                                                                                                                                                     
  | Configuration | When to use | After this PR |                                                                                                                                    
  |---|---|---|                                                 
  | `CO2STORE` + `SALINITY` (no `BRINE`) | Simple models, uniform salinity per PVT region | Fugacity and dissolution both use the SALINITY scalar — consistent ✓ |                   
  | `CO2STORE` + `BRINE` + `SALTVD` | Full physics, per-cell salinity gradient | Fugacity and dissolution both use per-cell salt from SALTVD — consistent ✓ |                        
  | `CO2STORE` + `BRINE` + `SALT` | Full physics, per-cell from field property | Same as SALTVD — consistent ✓ |                                                                     
  | `CO2STORE` + `BRINE` + `SALINITY` (no `SALTVD`/`SALT`) | **Avoid** — warning emitted | Per-cell salt defaults to 0; SALINITY value is ignored. Use SALTVD or SALT instead |      
                                                                                                                                                                                     
  **Rule of thumb:** If you activate `BRINE`, always initialise per-cell salt via `SALTVD` or `SALT`. The `SALINITY` keyword is for non-BRINE CO2STORE models only.
                                                                                                                                                                        
  ## Context                                                    

  Third follow-up from #5097 review. Independent of the per-region SALINITY PR (uses `config.salinity() > 0.0` for warning trigger, not `numSalinityRegions()`).  