### PR TITLE
Reservoir coupling: Add slave group target update API

### DIFF
--- a/opm/input/eclipse/Schedule/Group/Group.cpp
+++ b/opm/input/eclipse/Schedule/Group/Group.cpp
@@ -775,6 +775,7 @@ const Group::GroupType& Group::getGroupType() const
 bool Group::isProductionGroup() const
 {
     return this->hasType(GroupType::PRODUCTION)
+        || this->m_is_slave_production_group
         || (this->m_gpmaint.has_value() &&
             this->m_gpmaint->flow_target() == GPMaint::FlowTarget::RESV_PROD);
 }
@@ -782,6 +783,7 @@ bool Group::isProductionGroup() const
 bool Group::isInjectionGroup() const
 {
     return this->hasType(GroupType::INJECTION)
+        || this->m_is_slave_injection_group
         || (this->m_gpmaint.has_value() &&
             this->m_gpmaint->flow_target() != GPMaint::FlowTarget::RESV_PROD);
 }
@@ -1540,6 +1542,8 @@ bool Group::operator==(const Group& data) const
         && (this->injection_properties == data.injection_properties)
         && (this->m_gpmaint == data.m_gpmaint)
         && (this->productionProperties() == data.productionProperties())
+        && (this->m_is_slave_production_group == data.m_is_slave_production_group)
+        && (this->m_is_slave_injection_group == data.m_is_slave_injection_group)
         ;
 }
 

--- a/opm/input/eclipse/Schedule/Group/Group.hpp
+++ b/opm/input/eclipse/Schedule/Group/Group.hpp
@@ -306,6 +306,16 @@ public:
     bool isInjectionGroup() const;
     void setProductionGroup();
     void setInjectionGroup();
+
+    /// Mark this group as a reservoir coupling slave group that receives
+    /// production targets from the master.  Makes isProductionGroup()
+    /// return true without requiring a GCONPROD entry in the slave deck.
+    void setSlaveProductionGroup() { this->m_is_slave_production_group = true; }
+
+    /// Mark this group as a reservoir coupling slave group that receives
+    /// injection targets from the master.  Makes isInjectionGroup()
+    /// return true without requiring a GCONINJE entry in the slave deck.
+    void setSlaveInjectionGroup() { this->m_is_slave_injection_group = true; }
     double getGroupEfficiencyFactor(bool network = false) const;
     bool useEfficiencyInNetwork() const;
 
@@ -389,6 +399,8 @@ public:
         serializer(production_properties);
         serializer(m_topup_phase);
         serializer(m_gpmaint);
+        serializer(m_is_slave_production_group);
+        serializer(m_is_slave_injection_group);
     }
 
 private:
@@ -414,6 +426,12 @@ private:
     std::optional<Phase> m_topup_phase{};
     std::optional<GPMaint> m_gpmaint{};
     std::optional<std::string> m_choke_group{};
+
+    // Reservoir coupling: slave groups receiving master targets.
+    // These flags make isProductionGroup()/isInjectionGroup() return true
+    // without requiring GCONPROD/GCONINJE in the slave deck.
+    bool m_is_slave_production_group{false};
+    bool m_is_slave_injection_group{false};
 };
 
 Group::GroupType operator |(Group::GroupType lhs, Group::GroupType rhs);

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -3067,6 +3067,115 @@ void Schedule::dump_deck(std::ostream& os) const
     this->m_sched_deck.dump_deck(os, this->getUnits());
 }
 
+void Schedule::updateSlaveGroupProductionTarget(const std::size_t report_step,
+                                                const std::string& group_name,
+                                                const Group::ProductionCMode cmode,
+                                                const double target)
+{
+    auto grp = this->snapshots[report_step].groups(group_name);
+
+    // Build production properties that make the group behave like it has GCONPROD.
+    // We use the group's existing production properties as a base (in case the slave
+    // deck already has GCONPROD entries), and update only the fields relevant to
+    // the master's target.
+    auto production = grp.productionProperties();
+    production.cmode = cmode;
+    // Note: available_group_control is not overwritten here.  It defaults to
+    // true in GroupProductionProperties, and if the slave deck has GCONPROD
+    // with a different value, we preserve the user's setting.
+
+    // Set the target for the active control mode and register it as a control.
+    // The group_limit_action for the active mode is set to RATE so that when the
+    // constraint is exceeded, the well rates are scaled down proportionally (the
+    // default NONE action would do nothing).
+    switch (cmode) {
+    case Group::ProductionCMode::ORAT:
+        production.oil_target = UDAValue(target);
+        production.production_controls |= static_cast<int>(Group::ProductionCMode::ORAT);
+        production.group_limit_action.oil = Group::ExceedAction::RATE;
+        break;
+    case Group::ProductionCMode::WRAT:
+        production.water_target = UDAValue(target);
+        production.production_controls |= static_cast<int>(Group::ProductionCMode::WRAT);
+        production.group_limit_action.water = Group::ExceedAction::RATE;
+        break;
+    case Group::ProductionCMode::GRAT:
+        production.gas_target = UDAValue(target);
+        production.production_controls |= static_cast<int>(Group::ProductionCMode::GRAT);
+        production.group_limit_action.gas = Group::ExceedAction::RATE;
+        break;
+    case Group::ProductionCMode::LRAT:
+        production.liquid_target = UDAValue(target);
+        production.production_controls |= static_cast<int>(Group::ProductionCMode::LRAT);
+        production.group_limit_action.liquid = Group::ExceedAction::RATE;
+        break;
+    case Group::ProductionCMode::RESV:
+        production.resv_target = UDAValue(target);
+        production.production_controls |= static_cast<int>(Group::ProductionCMode::RESV);
+        // For RESV, the group_limit_action is always  RATE.
+        break;
+    default:
+        break;
+    }
+
+    // updateProduction() sets the group type to PRODUCTION and stores
+    // the production properties.
+    grp.updateProduction(production);
+    this->snapshots[report_step].groups.update(std::move(grp));
+}
+
+void Schedule::updateSlaveGroupInjectionTarget(const std::size_t report_step,
+                                               const std::string& group_name,
+                                               const Phase phase,
+                                               const Group::InjectionCMode cmode,
+                                               const double target)
+{
+    auto grp = this->snapshots[report_step].groups(group_name);
+
+    // Build injection properties that make the group behave like it has GCONINJE.
+    // Use existing properties for this phase as a base (in case the slave deck
+    // already has GCONINJE entries), otherwise create new ones.
+    auto injection = grp.hasInjectionControl(phase)
+        ? grp.injectionProperties(phase)
+        : Group::GroupInjectionProperties{group_name, phase, this->m_static.m_unit_system};
+
+    injection.cmode = cmode;
+    // Note: available_group_control is not overwritten here.  It defaults to
+    // true in GroupInjectionProperties, and if the slave deck has GCONINJE
+    // with a different value, we preserve the user's setting.
+
+    // Set the target for the active control mode and register it as a control.
+    // Note: in reservoir coupling, the master always sends RATE mode (the numeric
+    // value is already a surface rate for all modes).  The RESV/REIN/VREP cases
+    // are included for completeness but are not expected to be reached in practice.
+    // See RescoupConstraintsCalculator.cpp for details.
+    switch (cmode) {
+    case Group::InjectionCMode::RATE:
+        injection.surface_max_rate = UDAValue(target);
+        injection.injection_controls |= static_cast<int>(Group::InjectionCMode::RATE);
+        break;
+    case Group::InjectionCMode::RESV:
+        injection.resv_max_rate = UDAValue(target);
+        injection.injection_controls |= static_cast<int>(Group::InjectionCMode::RESV);
+        break;
+    case Group::InjectionCMode::REIN:
+        injection.target_reinj_fraction = UDAValue(target);
+        injection.injection_controls |= static_cast<int>(Group::InjectionCMode::REIN);
+        break;
+    case Group::InjectionCMode::VREP:
+        injection.target_void_fraction = UDAValue(target);
+        injection.injection_controls |= static_cast<int>(Group::InjectionCMode::VREP);
+        break;
+    default:
+        break;
+    }
+
+    // updateInjection() sets the group type to INJECTION and stores
+    // the injection properties for this phase.
+    grp.updateInjection(injection);
+    this->snapshots[report_step].groups.update(std::move(grp));
+}
+
 std::ostream& operator<<(std::ostream& os, const Schedule& sched)
 {
     sched.dump_deck(os);

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -3067,113 +3067,24 @@ void Schedule::dump_deck(std::ostream& os) const
     this->m_sched_deck.dump_deck(os, this->getUnits());
 }
 
-void Schedule::updateSlaveGroupProductionTarget(const std::size_t report_step,
-                                                const std::string& group_name,
-                                                const Group::ProductionCMode cmode,
-                                                const double target)
+void Schedule::markSlaveProductionGroup(const std::size_t report_step,
+                                        const std::string& group_name)
 {
     auto grp = this->snapshots[report_step].groups(group_name);
-
-    // Build production properties that make the group behave like it has GCONPROD.
-    // We use the group's existing production properties as a base (in case the slave
-    // deck already has GCONPROD entries), and update only the fields relevant to
-    // the master's target.
-    auto production = grp.productionProperties();
-    production.cmode = cmode;
-    // Note: available_group_control is not overwritten here.  It defaults to
-    // true in GroupProductionProperties, and if the slave deck has GCONPROD
-    // with a different value, we preserve the user's setting.
-
-    // Set the target for the active control mode and register it as a control.
-    // The group_limit_action for the active mode is set to RATE so that when the
-    // constraint is exceeded, the well rates are scaled down proportionally (the
-    // default NONE action would do nothing).
-    switch (cmode) {
-    case Group::ProductionCMode::ORAT:
-        production.oil_target = UDAValue(target);
-        production.production_controls |= static_cast<int>(Group::ProductionCMode::ORAT);
-        production.group_limit_action.oil = Group::ExceedAction::RATE;
-        break;
-    case Group::ProductionCMode::WRAT:
-        production.water_target = UDAValue(target);
-        production.production_controls |= static_cast<int>(Group::ProductionCMode::WRAT);
-        production.group_limit_action.water = Group::ExceedAction::RATE;
-        break;
-    case Group::ProductionCMode::GRAT:
-        production.gas_target = UDAValue(target);
-        production.production_controls |= static_cast<int>(Group::ProductionCMode::GRAT);
-        production.group_limit_action.gas = Group::ExceedAction::RATE;
-        break;
-    case Group::ProductionCMode::LRAT:
-        production.liquid_target = UDAValue(target);
-        production.production_controls |= static_cast<int>(Group::ProductionCMode::LRAT);
-        production.group_limit_action.liquid = Group::ExceedAction::RATE;
-        break;
-    case Group::ProductionCMode::RESV:
-        production.resv_target = UDAValue(target);
-        production.production_controls |= static_cast<int>(Group::ProductionCMode::RESV);
-        // For RESV, the group_limit_action is always  RATE.
-        break;
-    default:
-        break;
+    if (!grp.isProductionGroup()) {
+        grp.setSlaveProductionGroup();
+        this->snapshots[report_step].groups.update(std::move(grp));
     }
-
-    // updateProduction() sets the group type to PRODUCTION and stores
-    // the production properties.
-    grp.updateProduction(production);
-    this->snapshots[report_step].groups.update(std::move(grp));
 }
 
-void Schedule::updateSlaveGroupInjectionTarget(const std::size_t report_step,
-                                               const std::string& group_name,
-                                               const Phase phase,
-                                               const Group::InjectionCMode cmode,
-                                               const double target)
+void Schedule::markSlaveInjectionGroup(const std::size_t report_step,
+                                       const std::string& group_name)
 {
     auto grp = this->snapshots[report_step].groups(group_name);
-
-    // Build injection properties that make the group behave like it has GCONINJE.
-    // Use existing properties for this phase as a base (in case the slave deck
-    // already has GCONINJE entries), otherwise create new ones.
-    auto injection = grp.hasInjectionControl(phase)
-        ? grp.injectionProperties(phase)
-        : Group::GroupInjectionProperties{group_name, phase, this->m_static.m_unit_system};
-
-    injection.cmode = cmode;
-    // Note: available_group_control is not overwritten here.  It defaults to
-    // true in GroupInjectionProperties, and if the slave deck has GCONINJE
-    // with a different value, we preserve the user's setting.
-
-    // Set the target for the active control mode and register it as a control.
-    // Note: in reservoir coupling, the master always sends RATE mode (the numeric
-    // value is already a surface rate for all modes).  The RESV/REIN/VREP cases
-    // are included for completeness but are not expected to be reached in practice.
-    // See RescoupConstraintsCalculator.cpp for details.
-    switch (cmode) {
-    case Group::InjectionCMode::RATE:
-        injection.surface_max_rate = UDAValue(target);
-        injection.injection_controls |= static_cast<int>(Group::InjectionCMode::RATE);
-        break;
-    case Group::InjectionCMode::RESV:
-        injection.resv_max_rate = UDAValue(target);
-        injection.injection_controls |= static_cast<int>(Group::InjectionCMode::RESV);
-        break;
-    case Group::InjectionCMode::REIN:
-        injection.target_reinj_fraction = UDAValue(target);
-        injection.injection_controls |= static_cast<int>(Group::InjectionCMode::REIN);
-        break;
-    case Group::InjectionCMode::VREP:
-        injection.target_void_fraction = UDAValue(target);
-        injection.injection_controls |= static_cast<int>(Group::InjectionCMode::VREP);
-        break;
-    default:
-        break;
+    if (!grp.isInjectionGroup()) {
+        grp.setSlaveInjectionGroup();
+        this->snapshots[report_step].groups.update(std::move(grp));
     }
-
-    // updateInjection() sets the group type to INJECTION and stores
-    // the injection properties for this phase.
-    grp.updateInjection(injection);
-    this->snapshots[report_step].groups.update(std::move(grp));
 }
 
 std::ostream& operator<<(std::ostream& os, const Schedule& sched)

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -502,6 +502,44 @@ namespace Opm {
         friend std::ostream& operator<<(std::ostream& os, const Schedule& sched);
         void dump_deck(std::ostream& os) const;
 
+        /// Set up production properties on a slave group so that it behaves
+        /// as if it has a GCONPROD entry.
+        ///
+        /// In reservoir coupling, slave groups may not have GCONPROD in the
+        /// slave deck (the master provides the production target at runtime).
+        /// This method creates a synthetic GroupProductionProperties entry so
+        /// that the existing group constraint enforcement mechanisms
+        /// (checkGroupHigherConstraints, getWellGroupTargetProducer, etc.)
+        /// recognize the group as a production group and apply the target.
+        ///
+        /// \param[in] report_step  0-based report step index.
+        /// \param[in] group_name   Slave group name (e.g. "PLAT-A").
+        /// \param[in] cmode        Production control mode (e.g. ORAT).
+        /// \param[in] target       Production target in SI units (sm3/s).
+        void updateSlaveGroupProductionTarget(std::size_t report_step,
+            const std::string& group_name,
+            Group::ProductionCMode cmode,
+            double target);
+
+        /// Set up injection properties on a slave group so that it behaves
+        /// as if it has a GCONINJE entry.
+        ///
+        /// Mirrors updateSlaveGroupProductionTarget() for the injection side.
+        /// Creates a synthetic GroupInjectionProperties entry so that the
+        /// existing constraint enforcement mechanisms recognize the group as
+        /// an injection group and apply the master's target.
+        ///
+        /// \param[in] report_step  0-based report step index.
+        /// \param[in] group_name   Slave group name.
+        /// \param[in] phase        Injection phase (WATER, GAS, or OIL).
+        /// \param[in] cmode        Injection control mode (e.g. RATE, RESV).
+        /// \param[in] target       Injection target in SI units (sm3/s or rm3/s).
+        void updateSlaveGroupInjectionTarget(std::size_t report_step,
+            const std::string& group_name,
+            Phase phase,
+            Group::InjectionCMode cmode,
+            double target);
+
     private:
         friend class HandlerContext;
 

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -502,43 +502,13 @@ namespace Opm {
         friend std::ostream& operator<<(std::ostream& os, const Schedule& sched);
         void dump_deck(std::ostream& os) const;
 
-        /// Set up production properties on a slave group so that it behaves
-        /// as if it has a GCONPROD entry.
-        ///
-        /// In reservoir coupling, slave groups may not have GCONPROD in the
-        /// slave deck (the master provides the production target at runtime).
-        /// This method creates a synthetic GroupProductionProperties entry so
-        /// that the existing group constraint enforcement mechanisms
-        /// (checkGroupHigherConstraints, getWellGroupTargetProducer, etc.)
-        /// recognize the group as a production group and apply the target.
-        ///
-        /// \param[in] report_step  0-based report step index.
-        /// \param[in] group_name   Slave group name (e.g. "PLAT-A").
-        /// \param[in] cmode        Production control mode (e.g. ORAT).
-        /// \param[in] target       Production target in SI units (sm3/s).
-        void updateSlaveGroupProductionTarget(std::size_t report_step,
-            const std::string& group_name,
-            Group::ProductionCMode cmode,
-            double target);
+        /// Mark a slave group as receiving production targets from the master.
+        /// Makes isProductionGroup() return true without GCONPROD.
+        void markSlaveProductionGroup(std::size_t report_step, const std::string& group_name);
 
-        /// Set up injection properties on a slave group so that it behaves
-        /// as if it has a GCONINJE entry.
-        ///
-        /// Mirrors updateSlaveGroupProductionTarget() for the injection side.
-        /// Creates a synthetic GroupInjectionProperties entry so that the
-        /// existing constraint enforcement mechanisms recognize the group as
-        /// an injection group and apply the master's target.
-        ///
-        /// \param[in] report_step  0-based report step index.
-        /// \param[in] group_name   Slave group name.
-        /// \param[in] phase        Injection phase (WATER, GAS, or OIL).
-        /// \param[in] cmode        Injection control mode (e.g. RATE, RESV).
-        /// \param[in] target       Injection target in SI units (sm3/s or rm3/s).
-        void updateSlaveGroupInjectionTarget(std::size_t report_step,
-            const std::string& group_name,
-            Phase phase,
-            Group::InjectionCMode cmode,
-            double target);
+        /// Mark a slave group as receiving injection targets from the master.
+        /// Makes isInjectionGroup() return true without GCONINJE.
+        void markSlaveInjectionGroup(std::size_t report_step, const std::string& group_name);
 
     private:
         friend class HandlerContext;

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -1314,3 +1314,114 @@ GCONPROD
 
     BOOST_CHECK(sched[0].has_gpmaint());
 }
+
+// ============================================================
+// Tests for reservoir coupling Schedule update methods
+// ============================================================
+
+BOOST_AUTO_TEST_CASE(UpdateSlaveGroupProductionTarget)
+{
+    // Create a schedule with a group that has NO GCONPROD
+    auto sched = create_schedule(R"(
+START
+31 AUG 1993 /
+SCHEDULE
+GRUPTREE
+  'PLAT-A' 'FIELD' /
+/
+TSTEP
+  1 /
+)");
+
+    const auto report_step_idx = 0;
+    const auto& grp_before = sched.getGroup("PLAT-A", report_step_idx);
+    BOOST_CHECK(!grp_before.isProductionGroup());
+    BOOST_CHECK(!grp_before.has_control(Group::ProductionCMode::ORAT));
+
+    // Simulate what reservoir coupling does: set a production target
+    const double target_si = 9200.0 / 86400.0;  // 9200 SM3/day in SI
+    sched.updateSlaveGroupProductionTarget(report_step_idx, "PLAT-A",
+        Group::ProductionCMode::ORAT, target_si);
+
+    const auto& grp_after = sched.getGroup("PLAT-A", report_step_idx);
+    BOOST_CHECK(grp_after.isProductionGroup());
+    BOOST_CHECK(grp_after.has_control(Group::ProductionCMode::ORAT));
+
+    // Verify target value
+    SummaryState st(TimeService::now(), 0.0);
+    const auto controls = grp_after.productionControls(st);
+    BOOST_CHECK_CLOSE(controls.oil_target, target_si, 1e-10);
+}
+
+BOOST_AUTO_TEST_CASE(UpdateSlaveGroupProductionTarget_PreservesExisting)
+{
+    // Create a schedule where the group already has GCONPROD
+    auto sched = create_schedule(R"(
+START
+31 AUG 1993 /
+SCHEDULE
+GRUPTREE
+  'PLAT-A' 'FIELD' /
+/
+GCONPROD
+  'PLAT-A' 'ORAT' 5000 /
+/
+TSTEP
+  1 /
+)");
+
+    const auto report_step_idx = 0;
+    const auto& grp_before = sched.getGroup("PLAT-A", report_step_idx);
+    BOOST_CHECK(grp_before.isProductionGroup());
+    BOOST_CHECK(grp_before.has_control(Group::ProductionCMode::ORAT));
+
+    // Override with a master target
+    const double new_target_si = 3000.0 / 86400.0;
+    sched.updateSlaveGroupProductionTarget(report_step_idx, "PLAT-A",
+        Group::ProductionCMode::ORAT, new_target_si);
+
+    const auto& grp_after = sched.getGroup("PLAT-A", report_step_idx);
+    BOOST_CHECK(grp_after.isProductionGroup());
+
+    SummaryState st(TimeService::now(), 0.0);
+    const auto controls = grp_after.productionControls(st);
+    BOOST_CHECK_CLOSE(controls.oil_target, new_target_si, 1e-10);
+}
+
+BOOST_AUTO_TEST_CASE(UpdateSlaveGroupInjectionTarget)
+{
+    // Create a schedule with a group that has NO GCONINJE
+    auto sched = create_schedule(R"(
+START
+31 AUG 1993 /
+SCHEDULE
+GRUPTREE
+  'PLAT-A' 'FIELD' /
+/
+TSTEP
+  1 /
+)");
+
+    const auto report_step_idx = 0;
+    const auto& grp_before = sched.getGroup("PLAT-A", report_step_idx);
+    BOOST_CHECK(!grp_before.isInjectionGroup());
+    BOOST_CHECK(!grp_before.hasInjectionControl(Phase::WATER));
+
+    // Simulate what reservoir coupling does: set an injection target
+    const double target_si = 5000.0 / 86400.0;  // 5000 SM3/day in SI
+    sched.updateSlaveGroupInjectionTarget(report_step_idx, "PLAT-A",
+        Phase::WATER, Group::InjectionCMode::RATE, target_si);
+
+    const auto& grp_after = sched.getGroup("PLAT-A", report_step_idx);
+    BOOST_CHECK(grp_after.isInjectionGroup());
+    BOOST_CHECK(grp_after.hasInjectionControl(Phase::WATER));
+
+    // Verify the raw stored value.  Note: we don't check via injectionControls()
+    // because it applies eval_group_uda_rate() which does a unit conversion that
+    // assumes the value is in deck units.  In reservoir coupling, the target is
+    // already in SI and is used directly by getInjectionGroupTarget(), it
+    // bypasses injectionControls().
+    const auto& inj_props = grp_after.injectionProperties(Phase::WATER);
+    BOOST_CHECK_CLOSE(inj_props.surface_max_rate.get<double>(), target_si, 1e-10);
+    BOOST_CHECK(inj_props.cmode == Group::InjectionCMode::RATE);
+}

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -1319,9 +1319,8 @@ GCONPROD
 // Tests for reservoir coupling Schedule update methods
 // ============================================================
 
-BOOST_AUTO_TEST_CASE(UpdateSlaveGroupProductionTarget)
+BOOST_AUTO_TEST_CASE(MarkSlaveProductionGroup)
 {
-    // Create a schedule with a group that has NO GCONPROD
     auto sched = create_schedule(R"(
 START
 31 AUG 1993 /
@@ -1333,64 +1332,19 @@ TSTEP
   1 /
 )");
 
-    const auto report_step_idx = 0;
-    const auto& grp_before = sched.getGroup("PLAT-A", report_step_idx);
+    const auto& grp_before = sched.getGroup("PLAT-A", 0);
     BOOST_CHECK(!grp_before.isProductionGroup());
-    BOOST_CHECK(!grp_before.has_control(Group::ProductionCMode::ORAT));
 
-    // Simulate what reservoir coupling does: set a production target
-    const double target_si = 9200.0 / 86400.0;  // 9200 SM3/day in SI
-    sched.updateSlaveGroupProductionTarget(report_step_idx, "PLAT-A",
-        Group::ProductionCMode::ORAT, target_si);
+    sched.markSlaveProductionGroup(0, "PLAT-A");
 
-    const auto& grp_after = sched.getGroup("PLAT-A", report_step_idx);
+    const auto& grp_after = sched.getGroup("PLAT-A", 0);
     BOOST_CHECK(grp_after.isProductionGroup());
-    BOOST_CHECK(grp_after.has_control(Group::ProductionCMode::ORAT));
-
-    // Verify target value
-    SummaryState st(TimeService::now(), 0.0);
-    const auto controls = grp_after.productionControls(st);
-    BOOST_CHECK_CLOSE(controls.oil_target, target_si, 1e-10);
+    // No GCONPROD -> has_control should still be false
+    BOOST_CHECK(!grp_after.has_control(Group::ProductionCMode::ORAT));
 }
 
-BOOST_AUTO_TEST_CASE(UpdateSlaveGroupProductionTarget_PreservesExisting)
+BOOST_AUTO_TEST_CASE(MarkSlaveInjectionGroup)
 {
-    // Create a schedule where the group already has GCONPROD
-    auto sched = create_schedule(R"(
-START
-31 AUG 1993 /
-SCHEDULE
-GRUPTREE
-  'PLAT-A' 'FIELD' /
-/
-GCONPROD
-  'PLAT-A' 'ORAT' 5000 /
-/
-TSTEP
-  1 /
-)");
-
-    const auto report_step_idx = 0;
-    const auto& grp_before = sched.getGroup("PLAT-A", report_step_idx);
-    BOOST_CHECK(grp_before.isProductionGroup());
-    BOOST_CHECK(grp_before.has_control(Group::ProductionCMode::ORAT));
-
-    // Override with a master target
-    const double new_target_si = 3000.0 / 86400.0;
-    sched.updateSlaveGroupProductionTarget(report_step_idx, "PLAT-A",
-        Group::ProductionCMode::ORAT, new_target_si);
-
-    const auto& grp_after = sched.getGroup("PLAT-A", report_step_idx);
-    BOOST_CHECK(grp_after.isProductionGroup());
-
-    SummaryState st(TimeService::now(), 0.0);
-    const auto controls = grp_after.productionControls(st);
-    BOOST_CHECK_CLOSE(controls.oil_target, new_target_si, 1e-10);
-}
-
-BOOST_AUTO_TEST_CASE(UpdateSlaveGroupInjectionTarget)
-{
-    // Create a schedule with a group that has NO GCONINJE
     auto sched = create_schedule(R"(
 START
 31 AUG 1993 /
@@ -1402,26 +1356,13 @@ TSTEP
   1 /
 )");
 
-    const auto report_step_idx = 0;
-    const auto& grp_before = sched.getGroup("PLAT-A", report_step_idx);
+    const auto& grp_before = sched.getGroup("PLAT-A", 0);
     BOOST_CHECK(!grp_before.isInjectionGroup());
-    BOOST_CHECK(!grp_before.hasInjectionControl(Phase::WATER));
 
-    // Simulate what reservoir coupling does: set an injection target
-    const double target_si = 5000.0 / 86400.0;  // 5000 SM3/day in SI
-    sched.updateSlaveGroupInjectionTarget(report_step_idx, "PLAT-A",
-        Phase::WATER, Group::InjectionCMode::RATE, target_si);
+    sched.markSlaveInjectionGroup(0, "PLAT-A");
 
-    const auto& grp_after = sched.getGroup("PLAT-A", report_step_idx);
+    const auto& grp_after = sched.getGroup("PLAT-A", 0);
     BOOST_CHECK(grp_after.isInjectionGroup());
-    BOOST_CHECK(grp_after.hasInjectionControl(Phase::WATER));
-
-    // Verify the raw stored value.  Note: we don't check via injectionControls()
-    // because it applies eval_group_uda_rate() which does a unit conversion that
-    // assumes the value is in deck units.  In reservoir coupling, the target is
-    // already in SI and is used directly by getInjectionGroupTarget(), it
-    // bypasses injectionControls().
-    const auto& inj_props = grp_after.injectionProperties(Phase::WATER);
-    BOOST_CHECK_CLOSE(inj_props.surface_max_rate.get<double>(), target_si, 1e-10);
-    BOOST_CHECK(inj_props.cmode == Group::InjectionCMode::RATE);
+    // No GCONINJE -> hasInjectionControl should still be false
+    BOOST_CHECK(!grp_after.hasInjectionControl(Phase::WATER));
 }


### PR DESCRIPTION
Builds on #5101. See also companion PR https://github.com/OPM/opm-simulators/pull/6983

- **Add `Schedule::updateSlaveGroupProductionTarget()`**:  creates synthetic `GroupProductionProperties` on a slave group so that `isProductionGroup()` returns true and the existing constraint enforcement mechanisms (checkGroupHigherConstraints, getWellGroupTargetProducer, etc.) apply the master's production target
- **Add `Schedule::updateSlaveGroupInjectionTarget()`**: same for injection: creates synthetic `GroupInjectionProperties` so that `isInjectionGroup()` returns true and injection targets are enforced
- **Add unit tests** for both production and injection target updates, as well as for `updateSatelliteProduction()` and `updateSatelliteInjection()` from the previous PR #5101.

### Background

In reservoir coupling, slave groups may not have `GCONPROD` or `GCONINJE` in the slave deck. The master provides targets at runtime via MPI. Without synthetic group properties, the group constraint enforcement code skips these groups because `isProductionGroup()` / `isInjectionGroup()` returns false.

### Design decisions

- **`available_group_control` is not overwritten** — it defaults to `true` in the constructors and is preserved from existing properties if the slave deck has `GCONPROD`/`GCONINJE`. This respects user settings and `GRUPSLAV` filter flag semantics.
- **Injection always uses RATE mode** in practice — the master converts all injection modes (REIN, VREP, RESV) to RATE before sending to the slave, since the slave lacks the master's schedule data needed to evaluate derived modes. The RESV/REIN/VREP cases are included for completeness.
- **`group_limit_action` is set to RATE** for production targets so that when the constraint is exceeded, well rates are scaled down proportionally (the default NONE action would do nothing).

### Companion PR

- **opm-simulators**: https://github.com/OPM/opm-simulators/pull/6983 : calls these methods from `ReservoirCouplingSlaveReportStep::updateSlaveGroupTargetsInSchedule()` after receiving master constraints
