### PR TITLE
Define RFT Segment Arrays for Non-Flowing Wells

### DIFF
--- a/opm/output/eclipse/WriteRFT.cpp
+++ b/opm/output/eclipse/WriteRFT.cpp
@@ -462,7 +462,7 @@ namespace {
         explicit PLTSegmentPhaseVelocity(const std::size_t nseg = 0);
 
         void addSegment(const ::Opm::UnitSystem&    usys,
-                        const ::Opm::data::Segment& segSol);
+                        const ::Opm::data::Segment* segSol);
 
     private:
         [[nodiscard]] Opm::UnitSystem::measure oilUnit() const override
@@ -480,18 +480,25 @@ namespace {
     {}
 
     void PLTSegmentPhaseVelocity::addSegment(const ::Opm::UnitSystem&    usys,
-                                             const ::Opm::data::Segment& segSol)
+                                             const ::Opm::data::Segment* segSol)
     {
-        using Ix = ::Opm::data::SegmentPhaseQuantity::Item;
+        if (segSol == nullptr) {
+            this->addOil  (usys, 0.0);
+            this->addGas  (usys, 0.0);
+            this->addWater(usys, 0.0);
+        }
+        else {
+            using Ix = ::Opm::data::SegmentPhaseQuantity::Item;
 
-        auto velocityValue = [&segSol](const Ix i)
-        {
-            return segSol.velocity.has(i) ? -segSol.velocity.get(i) : 0.0;
-        };
+            auto velocityValue = [&vel = segSol->velocity](const Ix i)
+            {
+                return vel.has(i) ? -vel.get(i) : 0.0;
+            };
 
-        this->addOil  (usys, velocityValue(Ix::Oil));
-        this->addGas  (usys, velocityValue(Ix::Gas));
-        this->addWater(usys, velocityValue(Ix::Water));
+            this->addOil  (usys, velocityValue(Ix::Oil));
+            this->addGas  (usys, velocityValue(Ix::Gas));
+            this->addWater(usys, velocityValue(Ix::Water));
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -502,7 +509,7 @@ namespace {
         explicit PLTSegmentPhaseHoldupFraction(const std::size_t nseg = 0);
 
         void addSegment(const ::Opm::UnitSystem&    usys,
-                        const ::Opm::data::Segment& segSol);
+                        const ::Opm::data::Segment* segSol);
 
     private:
         [[nodiscard]] Opm::UnitSystem::measure oilUnit() const override
@@ -520,18 +527,26 @@ namespace {
     {}
 
     void PLTSegmentPhaseHoldupFraction::addSegment(const ::Opm::UnitSystem&    usys,
-                                                   const ::Opm::data::Segment& segSol)
+                                                   const ::Opm::data::Segment* segSol)
     {
-        using Ix = ::Opm::data::SegmentPhaseQuantity::Item;
+        if (segSol == nullptr) {
+            // Note: HF oil = 1 when not flowing.
+            this->addOil  (usys, 1.0);
+            this->addGas  (usys, 0.0);
+            this->addWater(usys, 0.0);
+        }
+        else {
+            using Ix = ::Opm::data::SegmentPhaseQuantity::Item;
 
-        auto holdupValue = [&segSol](const Ix i)
-        {
-            return segSol.holdup.has(i) ? segSol.holdup.get(i) : 0.0;
-        };
+            auto holdupValue = [&hf = segSol->holdup](const Ix i)
+            {
+                return hf.has(i) ? hf.get(i) : 0.0;
+            };
 
-        this->addOil  (usys, holdupValue(Ix::Oil));
-        this->addGas  (usys, holdupValue(Ix::Gas));
-        this->addWater(usys, holdupValue(Ix::Water));
+            this->addOil  (usys, holdupValue(Ix::Oil));
+            this->addGas  (usys, holdupValue(Ix::Gas));
+            this->addWater(usys, holdupValue(Ix::Water));
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -542,7 +557,7 @@ namespace {
         explicit PLTSegmentPhaseViscosity(const std::size_t nseg = 0);
 
         void addSegment(const ::Opm::UnitSystem&    usys,
-                        const ::Opm::data::Segment& segSol);
+                        const ::Opm::data::Segment* segSol);
 
     private:
         [[nodiscard]] Opm::UnitSystem::measure oilUnit() const override
@@ -560,18 +575,25 @@ namespace {
     {}
 
     void PLTSegmentPhaseViscosity::addSegment(const ::Opm::UnitSystem&    usys,
-                                              const ::Opm::data::Segment& segSol)
+                                              const ::Opm::data::Segment* segSol)
     {
-        using Ix = ::Opm::data::SegmentPhaseQuantity::Item;
+        if (segSol == nullptr) {
+            this->addOil  (usys, 0.0);
+            this->addGas  (usys, 0.0);
+            this->addWater(usys, 0.0);
+        }
+        else {
+            using Ix = ::Opm::data::SegmentPhaseQuantity::Item;
 
-        auto viscosityValue = [&segSol](const Ix i)
-        {
-            return segSol.viscosity.has(i) ? segSol.viscosity.get(i) : 0.0;
-        };
+            auto viscosityValue = [&mu = segSol->viscosity](const Ix i)
+            {
+                return mu.has(i) ? mu.get(i) : 0.0;
+            };
 
-        this->addOil  (usys, viscosityValue(Ix::Oil));
-        this->addGas  (usys, viscosityValue(Ix::Gas));
-        this->addWater(usys, viscosityValue(Ix::Water));
+            this->addOil  (usys, viscosityValue(Ix::Oil));
+            this->addGas  (usys, viscosityValue(Ix::Gas));
+            this->addWater(usys, viscosityValue(Ix::Water));
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -1170,7 +1192,7 @@ namespace {
         void addSegment(const ::Opm::UnitSystem&    usys,
                         const ::Opm::WellSegments&  segments,
                         const ::Opm::Segment&       segment,
-                        const ::Opm::data::Segment& segSol);
+                        const ::Opm::data::Segment* segSol);
 
         void recordPhysicalLocation(const ::Opm::UnitSystem&   usys,
                                     const ::Opm::WellSegments& segments,
@@ -1182,7 +1204,7 @@ namespace {
                                      const ::Opm::Segment& segment);
 
         void recordDynamicState(const ::Opm::UnitSystem&    usys,
-                                const ::Opm::data::Segment& segSol);
+                                const ::Opm::data::Segment* segSol);
 
         void recordAutoICDTypeProperties(const ::Opm::UnitSystem& usys,
                                          const ::Opm::Segment& segment);
@@ -1262,12 +1284,13 @@ namespace {
         const auto& xseg = wellSol.segments;
 
         for (const auto& segment : segments) {
-            auto segSolPos = xseg.find(segment.segmentNumber());
-            if (segSolPos == xseg.end()) {
-                continue;
-            }
+            const auto segSolPos = xseg.find(segment.segmentNumber());
 
-            this->addSegment(usys, segments, segment, segSolPos->second);
+            const auto* segSol = (segSolPos == xseg.end())
+                ? nullptr
+                : &segSolPos->second;
+
+            this->addSegment(usys, segments, segment, segSol);
         }
 
         if (this->nSeg() > std::size_t{0}) {
@@ -1308,7 +1331,7 @@ namespace {
     void SegmentRecord::addSegment(const ::Opm::UnitSystem&   usys,
                                    const ::Opm::WellSegments& segments,
                                    const ::Opm::Segment&      segment,
-                                   const Opm::data::Segment&  segSol)
+                                   const Opm::data::Segment*  segSol)
     {
         this->recordPhysicalLocation(usys, segments, segment);
         this->recordSegmentConnectivity(segment);
@@ -1355,11 +1378,7 @@ namespace {
     void SegmentRecord::recordSegmentProperties(const ::Opm::UnitSystem& usys,
                                                 const ::Opm::Segment&    segment)
     {
-        using TypeProperties = void(SegmentRecord::*)
-            (const ::Opm::UnitSystem& usys,
-             const ::Opm::Segment&    segment);
-
-        static const auto handlers = std::array<TypeProperties, 4> {
+        static const auto handlers = std::array {
             &SegmentRecord::recordRegularTypeProperties,
             &SegmentRecord::recordSpiralICDTypeProperties,
             &SegmentRecord::recordAutoICDTypeProperties,
@@ -1377,13 +1396,27 @@ namespace {
     }
 
     void SegmentRecord::recordDynamicState(const ::Opm::UnitSystem&    usys,
-                                           const ::Opm::data::Segment& segSol)
+                                           const ::Opm::data::Segment* segSol)
     {
-        using M = ::Opm::UnitSystem::measure;
-        using SegPress = ::Opm::data::SegmentPressures::Value;
+        {
+            using M = ::Opm::UnitSystem::measure;
+            using SegPress = ::Opm::data::SegmentPressures::Value;
 
-        this->pressure_.push_back(usys.from_si(M::pressure, segSol.pressures[SegPress::Pressure]));
-        this->rate_.addConnection(usys, segSol.rates);
+            const auto segpress = (segSol == nullptr)
+                ? 0.0
+                : segSol->pressures[SegPress::Pressure];
+
+            this->pressure_.push_back(usys.from_si(M::pressure, segpress));
+        }
+
+        {
+            const auto& rates = (segSol == nullptr)
+                ? ::Opm::data::Rates{}
+                : segSol->rates;
+
+            this->rate_.addConnection(usys, rates);
+        }
+
         this->velocity_.addSegment(usys, segSol);
         this->holdup_fraction_.addSegment(usys, segSol);
         this->viscosity_.addSegment(usys, segSol);

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -4356,11 +4356,28 @@ END
         return xw;
     }
 
+    ::Opm::data::Well wellSol_P1_NoSegFlow(const ::Opm::EclipseGrid& grid)
+    {
+        auto xw = ::Opm::data::Well{};
+        xw.connections = connRes_P1(grid);
+
+        return xw;
+    }
+
     ::Opm::data::Wells wellSol(const ::Opm::EclipseGrid& grid)
     {
         auto xw = ::Opm::data::Wells{};
 
         xw["P1"] = wellSol_P1(grid);
+
+        return xw;
+    }
+
+    ::Opm::data::Wells wellSol_NoSegFlow(const ::Opm::EclipseGrid& grid)
+    {
+        auto xw = ::Opm::data::Wells{};
+
+        xw["P1"] = wellSol_P1_NoSegFlow(grid);
 
         return xw;
     }
@@ -4385,6 +4402,38 @@ END
 
             ::Opm::RftIO::write(reportStep, elapsed, model.es.getUnits(),
                                 grid, model.sched, wellSol(grid), rftFile);
+        }
+
+        const auto rft = ::Opm::EclIO::ERft {
+            ::Opm::EclIO::OutputStream::outputFileName(rset, "RFT")
+        };
+
+        return SegmentResults {
+            rft, "P1", RftDate{ 2000, 1, 2 }
+        };
+    }
+
+    SegmentResults readWriteSegmentRFTDataNoSegFlow(std::function<Opm::Deck()> dataSet = &segmentDataSet,
+                                                    const std::string&         caseName = "TESTSEG_NOFLOW")
+    {
+        using RftDate = ::Opm::EclIO::ERft::RftDate;
+
+        const auto rset  = RSet { caseName };
+        const auto model = Setup{ dataSet() };
+
+        {
+            auto rftFile = ::Opm::EclIO::OutputStream::RFT {
+                rset, ::Opm::EclIO::OutputStream::Formatted  { false },
+                ::Opm::EclIO::OutputStream::RFT::OpenExisting{ false }
+            };
+
+            const auto  reportStep = 1;
+            const auto  elapsed    = model.sched.seconds(reportStep);
+            const auto& grid       = model.es.getInputGrid();
+
+            ::Opm::RftIO::write(reportStep, elapsed, model.es.getUnits(),
+                                grid, model.sched, wellSol_NoSegFlow(grid),
+                                rftFile);
         }
 
         const auto rft = ::Opm::EclIO::ERft {
@@ -4728,6 +4777,198 @@ BOOST_AUTO_TEST_CASE(Valve)
     BOOST_CHECK_CLOSE(xSEG.icd_setting( 9), 6.0e-5f / dfltArea(0.102f), 1.0e-5f);
     BOOST_CHECK_CLOSE(xSEG.icd_setting(10), 0.5f                      , 1.0e-5f);
     BOOST_CHECK_CLOSE(xSEG.icd_setting(11), 0.5f                      , 1.0e-5f);
+}
+
+BOOST_AUTO_TEST_CASE(Segment_Pressure_NoFlow)
+{
+    const auto xSEG = readWriteSegmentRFTDataNoSegFlow();
+
+    BOOST_REQUIRE_EQUAL(xSEG.numSegments(), std::size_t{11});
+
+    BOOST_CHECK_CLOSE(xSEG.pressure( 1), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.pressure( 2), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.pressure( 3), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.pressure( 4), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.pressure( 5), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.pressure( 6), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.pressure( 7), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.pressure( 8), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.pressure( 9), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.pressure(10), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.pressure(11), 0.0f, 1.0e-5f);
+}
+
+BOOST_AUTO_TEST_CASE(Segment_Phase_Rates_NoFlow)
+{
+    const auto xSEG = readWriteSegmentRFTDataNoSegFlow();
+
+    BOOST_REQUIRE_EQUAL(xSEG.numSegments(), std::size_t{11});
+
+    BOOST_CHECK_CLOSE(xSEG.orat( 1), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.orat( 2), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.orat( 3), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.orat( 4), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.orat( 5), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.orat( 6), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.orat( 7), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.orat( 8), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.orat( 9), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.orat(10), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.orat(11), 0.0f, 1.0e-5f);
+
+    BOOST_CHECK_CLOSE(xSEG.grat( 1), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.grat( 2), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.grat( 3), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.grat( 4), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.grat( 5), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.grat( 6), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.grat( 7), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.grat( 8), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.grat( 9), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.grat(10), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.grat(11), 0.0f, 1.0e-5f);
+
+    BOOST_CHECK_CLOSE(xSEG.wrat( 1), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wrat( 2), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wrat( 3), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wrat( 4), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wrat( 5), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wrat( 6), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wrat( 7), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wrat( 8), 0.0f, 1.1e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wrat( 9), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wrat(10), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wrat(11), 0.0f, 1.0e-5f);
+}
+
+BOOST_AUTO_TEST_CASE(Segment_Phase_Velocity_NoFlow)
+{
+    const auto xSEG = readWriteSegmentRFTDataNoSegFlow();
+
+    BOOST_REQUIRE_EQUAL(xSEG.numSegments(), std::size_t{11});
+
+    BOOST_CHECK_CLOSE(xSEG.ovel( 1), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovel( 2), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovel( 3), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovel( 4), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovel( 5), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovel( 6), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovel( 7), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovel( 8), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovel( 9), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovel(10), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovel(11), 0.0f, 1.0e-5f);
+
+    BOOST_CHECK_CLOSE(xSEG.wvel( 1), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvel( 2), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvel( 3), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvel( 4), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvel( 5), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvel( 6), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvel( 7), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvel( 8), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvel( 9), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvel(10), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvel(11), 0.0f, 1.0e-5f);
+
+    BOOST_CHECK_CLOSE(xSEG.gvel( 1), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvel( 2), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvel( 3), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvel( 4), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvel( 5), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvel( 6), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvel( 7), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvel( 8), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvel( 9), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvel(10), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvel(11), 0.0f, 1.0e-5f);
+}
+
+BOOST_AUTO_TEST_CASE(Segment_Phase_Holdup_Fractions_NoFlow)
+{
+    const auto xSEG = readWriteSegmentRFTDataNoSegFlow();
+
+    BOOST_REQUIRE_EQUAL(xSEG.numSegments(), std::size_t{11});
+
+    // Note: No-flow segments => oil HF = 1.
+    BOOST_CHECK_CLOSE(xSEG.hf_o( 1), 1.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_o( 2), 1.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_o( 3), 1.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_o( 4), 1.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_o( 5), 1.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_o( 6), 1.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_o( 7), 1.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_o( 8), 1.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_o( 9), 1.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_o(10), 1.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_o(11), 1.0f, 1.0e-5f);
+
+    BOOST_CHECK_CLOSE(xSEG.hf_w( 1), 0.0f, 3.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_w( 2), 0.0f, 2.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_w( 3), 0.0f, 2.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_w( 4), 0.0f, 2.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_w( 5), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_w( 6), 0.0f, 2.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_w( 7), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_w( 8), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_w( 9), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_w(10), 0.0f, 2.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_w(11), 0.0f, 1.0e-5f);
+
+    BOOST_CHECK_CLOSE(xSEG.hf_g( 1), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_g( 2), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_g( 3), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_g( 4), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_g( 5), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_g( 6), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_g( 7), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_g( 8), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_g( 9), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_g(10), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.hf_g(11), 0.0f, 1.0e-5f);
+}
+
+BOOST_AUTO_TEST_CASE(Segment_Phase_Viscosity_NoFlow)
+{
+    const auto xSEG = readWriteSegmentRFTDataNoSegFlow();
+
+    BOOST_REQUIRE_EQUAL(xSEG.numSegments(), std::size_t{11});
+
+    BOOST_CHECK_CLOSE(xSEG.ovis( 1), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovis( 2), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovis( 3), 0.0f, 1.2e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovis( 4), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovis( 5), 0.0f, 1.1e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovis( 6), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovis( 7), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovis( 8), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovis( 9), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovis(10), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.ovis(11), 0.0f, 1.0e-5f);
+
+    BOOST_CHECK_CLOSE(xSEG.wvis( 1), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvis( 2), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvis( 3), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvis( 4), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvis( 5), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvis( 6), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvis( 7), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvis( 8), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvis( 9), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvis(10), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.wvis(11), 0.0f, 1.0e-5f);
+
+    BOOST_CHECK_CLOSE(xSEG.gvis( 1), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvis( 2), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvis( 3), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvis( 4), 0.0f, 1.2e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvis( 5), 0.0f, 1.2e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvis( 6), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvis( 7), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvis( 8), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvis( 9), 0.0f, 1.0e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvis(10), 0.0f, 1.1e-5f);
+    BOOST_CHECK_CLOSE(xSEG.gvis(11), 0.0f, 1.0e-5f);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // SegmentData


### PR DESCRIPTION
Previously, we would not define any dynamic segment arrays such as `SEGPRES` if the well was not flowing (no dynamic segment results). This commit amends the logic slightly by filling in zeroes for the segments that are not flowing.  The only exception is the holdup fraction for oil, which we more or less arbitrarily define as one in this case.