### PR TITLE
Backport PR4571: [cmake] Search for OpenMP from the package configuration file

### DIFF
--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -15,7 +15,11 @@ if(TARGET opmcommon)
     find_package(Python3 COMPONENTS Development.Embed REQUIRED)
   endif()
 
-  if(opm-common_COMPILE_LIBS MATCHES dunecommon)
+  if(opm-common_LIBS MATCHES dunecommon)
     find_package(dune-common REQUIRED)
+  endif()
+
+  if(opm-common_LIBS MATCHES OpenMP::OpenMP)
+    find_package(OpenMP REQUIRED)
   endif()
 endif()


### PR DESCRIPTION
Allows opm-common to be used by programs that do not use the OPM specific build system at all.