### PR TITLE
Rptrst norst

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -543,6 +543,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/test_RegionSetMatcher.cpp
   tests/test_Restart.cpp
   tests/test_RestartFileView.cpp
+  tests/test_NORST.cpp
   tests/test_RestartLGR.cpp
   tests/test_restartwellinfo.cpp
   tests/test_RFT.cpp
@@ -711,6 +712,7 @@ list(APPEND TEST_DATA_FILES
   tests/BASE.UNRST
   tests/BASE_SIM.DATA
   tests/BASE_SIM_THPRES.DATA
+  tests/NORST_SIM.DATA
   tests/CARFIN-COLUMN.EGRID
   tests/CARFIN-DOUBLE.EGRID
   tests/CARFIN-NESTED.EGRID

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -544,6 +544,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/test_RegionSetMatcher.cpp
   tests/test_Restart.cpp
   tests/test_RestartFileView.cpp
+  tests/test_NORST.cpp
   tests/test_RestartLGR.cpp
   tests/test_restartwellinfo.cpp
   tests/test_RFT.cpp
@@ -712,6 +713,7 @@ list(APPEND TEST_DATA_FILES
   tests/BASE.UNRST
   tests/BASE_SIM.DATA
   tests/BASE_SIM_THPRES.DATA
+  tests/NORST_SIM.DATA
   tests/CARFIN-COLUMN.EGRID
   tests/CARFIN-DOUBLE.EGRID
   tests/CARFIN-NESTED.EGRID

--- a/opm/input/eclipse/Schedule/RSTConfig.cpp
+++ b/opm/input/eclipse/Schedule/RSTConfig.cpp
@@ -84,7 +84,7 @@ namespace {
                 "KRG",        // 13
                 "PORO",       // 14
                 "NOGRAD",     // 15
-                "NORST",      // 16 NORST - not supported
+                "NORST",      // 16 NORST - graphics-only restart file control
                 "SAVE",       // 17
                 "SFREQ",      // 18 SFREQ=?? - not supported
                 "ALLPROPS",   // 19
@@ -297,6 +297,13 @@ namespace {
         }
     }
 
+    // Extract NORST value from mnemonics (for graphics-only restart files)
+    std::optional<int>
+    extractNORST(std::map<std::string, int>& mnemonics)
+    {
+        return extract(mnemonics, "NORST");
+    }
+
 } // Anonymous namespace
 
 // ---------------------------------------------------------------------------
@@ -379,6 +386,7 @@ RSTConfig RSTConfig::serializationTestObject()
     rst_config.compositional = false;
     rst_config.keywords = {{"S1", 1}, {"S2", 2}};
     rst_config.solution_only_keywords = { "FIP" };
+    rst_config.norst = 2;
 
     return rst_config;
 }
@@ -392,6 +400,7 @@ bool RSTConfig::operator==(const RSTConfig& other) const
         && (this->save == other.save)
         && (this->compositional == other.compositional)
         && (this->solution_only_keywords == other.solution_only_keywords)
+        && (this->norst == other.norst)
         ;
 }
 
@@ -445,6 +454,11 @@ void RSTConfig::handleRPTRST(const DeckKeyword&  keyword,
 
     this->update_schedule(basic_freq);
 
+    // Extract NORST for graphics-only restart file control
+    auto mnemonics_copy = mnemonics;
+    const auto norst = extractNORST(mnemonics_copy);
+    update_optional(this->norst, norst);
+
     for (const auto& [kw, num] : mnemonics) {
         // Insert_or_assign() to overwrite existing 'kw' elements.
         this->keywords.insert_or_assign(kw, num);
@@ -459,6 +473,11 @@ void RSTConfig::handleRPTRSTSOLUTION(const DeckKeyword&  keyword,
 
     update_optional(this->basic, basic_freq.first);
     update_optional(this->freq, basic_freq.second);
+
+    // Extract NORST for graphics-only restart file control
+    auto mnemonics_copy = mnemonics;
+    const auto norst = extractNORST(mnemonics_copy);
+    update_optional(this->norst, norst);
 
     for (const auto& [kw, num] : mnemonics) {
         // Insert_or_assign() to overwrite existing 'kw' elements.

--- a/opm/input/eclipse/Schedule/RSTConfig.cpp
+++ b/opm/input/eclipse/Schedule/RSTConfig.cpp
@@ -456,8 +456,8 @@ void RSTConfig::handleRPTRST(const DeckKeyword&  keyword,
 
     // Extract NORST for graphics-only restart file control
     auto mnemonics_copy = mnemonics;
-    const auto norst = extractNORST(mnemonics_copy);
-    update_optional(this->norst, norst);
+    const auto norst_value = extractNORST(mnemonics_copy);
+    update_optional(this->norst, norst_value);
 
     for (const auto& [kw, num] : mnemonics) {
         // Insert_or_assign() to overwrite existing 'kw' elements.
@@ -476,8 +476,8 @@ void RSTConfig::handleRPTRSTSOLUTION(const DeckKeyword&  keyword,
 
     // Extract NORST for graphics-only restart file control
     auto mnemonics_copy = mnemonics;
-    const auto norst = extractNORST(mnemonics_copy);
-    update_optional(this->norst, norst);
+    const auto norst_value = extractNORST(mnemonics_copy);
+    update_optional(this->norst, norst_value);
 
     for (const auto& [kw, num] : mnemonics) {
         // Insert_or_assign() to overwrite existing 'kw' elements.

--- a/opm/input/eclipse/Schedule/RSTConfig.hpp
+++ b/opm/input/eclipse/Schedule/RSTConfig.hpp
@@ -188,12 +188,19 @@
   files, which are suitable for visualization but cannot be used for
   restarting simulations. When NORST > 0:
 
-  NORST = 1: Excludes arrays not required for visualization (e.g.,
-             hysteresis arrays).
+  NORST = 1: The restart file does not contain arrays that are required for restarting
+             but are not normally needed for graphical output. Example: hysteresis arrays
+             (if present in the simulation) are omitted. All standard solution arrays
+             (pressure, saturations, dissolved gas, etc.) and well arrays are included.
+             This gives a reasonably compact file that still allows well results to be
+             visualized.
 
-  NORST = 2: Excludes well arrays; keeps only essential data including
-             SEQNUM, INTEHEAD, IWEL, XWEL, ZWEL, XCON, and solution
-             arrays (PRESSURE, SWAT, SGAS, RS, RV, etc.).
+  NORST = 2: The restart file further excludes all well arrays (IWEL, XWEL, ZWEL, XCON, and
+             any other well‑related arrays). In a standard black‑oil simulation, the file
+             then contains only: the main solution arrays (PRESSURE, SWAT, SGAS, RS) and any
+             additional arrays requested by other restart controls (e.g., RPTRST). This produces
+             the smallest possible restart file, suitable for fast loading of reservoir‑wide
+             properties.
 
   Graphics-only restart files are marked internally and will fail if
   used in a restart attempt.
@@ -232,28 +239,28 @@ public:
     static RSTConfig first(const RSTConfig& src);
     static RSTConfig serializationTestObject();
 
-     template<class Serializer>
-     void serializeOp(Serializer& serializer)
-     {
-         serializer(write_rst_file);
-         serializer(keywords);
-         serializer(basic);
-         serializer(freq);
-         serializer(save);
-         serializer(compositional);
-         serializer(this->solution_only_keywords);
-         serializer(norst);
-     }
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(write_rst_file);
+        serializer(keywords);
+        serializer(basic);
+        serializer(freq);
+        serializer(save);
+        serializer(compositional);
+        serializer(this->solution_only_keywords);
+        serializer(norst);
+    }
 
-     bool operator==(const RSTConfig& other) const;
+    bool operator==(const RSTConfig& other) const;
 
-     std::optional<bool> write_rst_file{};
-     std::map<std::string, int> keywords{};
-     std::optional<int> basic{};
-     std::optional<int> freq{};
-     bool save { false };
-     bool compositional { false };
-     std::optional<int> norst{};  // Graphics-only restart file control
+    std::optional<bool> write_rst_file{};
+    std::map<std::string, int> keywords{};
+    std::optional<int> basic{};
+    std::optional<int> freq{};
+    bool save { false };
+    bool compositional { false };
+    std::optional<int> norst{};  // Graphics-only restart file control
 
 private:
     std::unordered_set<std::string> solution_only_keywords{};

--- a/opm/input/eclipse/Schedule/RSTConfig.hpp
+++ b/opm/input/eclipse/Schedule/RSTConfig.hpp
@@ -174,11 +174,29 @@
 
 
 
-  What is not supported?
-  ----------------------
+   What is not supported?
+   ----------------------
 
-  The SAVE keyword is not supported in OPM at all, this implies that
-  the SAVE and SFREQ mneomics are not supported.
+   The SAVE keyword is not supported in OPM at all, this implies that
+   the SAVE and SFREQ mneomics are not supported.
+
+
+   Graphics-Only Restart Files (NORST)
+   -----------------------------------
+
+   The NORST mnemonic controls the generation of graphics-only restart
+   files, which are suitable for visualization but cannot be used for
+   restarting simulations. When NORST > 0:
+
+   NORST = 1: Excludes arrays not required for visualization (e.g.,
+              hysteresis arrays).
+
+   NORST = 2: Excludes well arrays; keeps only essential data including
+              SEQNUM, INTEHEAD, IWEL, XWEL, ZWEL, XCON, and solution
+              arrays (PRESSURE, SWAT, SGAS, RS, RV, etc.).
+
+   Graphics-only restart files are marked internally and will fail if
+   used in a restart attempt.
 */
 
 #include <map>
@@ -214,26 +232,28 @@ public:
     static RSTConfig first(const RSTConfig& src);
     static RSTConfig serializationTestObject();
 
-    template<class Serializer>
-    void serializeOp(Serializer& serializer)
-    {
-        serializer(write_rst_file);
-        serializer(keywords);
-        serializer(basic);
-        serializer(freq);
-        serializer(save);
-        serializer(compositional);
-        serializer(this->solution_only_keywords);
-    }
+     template<class Serializer>
+     void serializeOp(Serializer& serializer)
+     {
+         serializer(write_rst_file);
+         serializer(keywords);
+         serializer(basic);
+         serializer(freq);
+         serializer(save);
+         serializer(compositional);
+         serializer(this->solution_only_keywords);
+         serializer(norst);
+     }
 
-    bool operator==(const RSTConfig& other) const;
+     bool operator==(const RSTConfig& other) const;
 
-    std::optional<bool> write_rst_file{};
-    std::map<std::string, int> keywords{};
-    std::optional<int> basic{};
-    std::optional<int> freq{};
-    bool save { false };
-    bool compositional { false };
+     std::optional<bool> write_rst_file{};
+     std::map<std::string, int> keywords{};
+     std::optional<int> basic{};
+     std::optional<int> freq{};
+     bool save { false };
+     bool compositional { false };
+     std::optional<int> norst{};  // Graphics-only restart file control
 
 private:
     std::unordered_set<std::string> solution_only_keywords{};

--- a/opm/input/eclipse/Schedule/RSTConfig.hpp
+++ b/opm/input/eclipse/Schedule/RSTConfig.hpp
@@ -174,29 +174,29 @@
 
 
 
-   What is not supported?
-   ----------------------
+  What is not supported?
+  ----------------------
 
-   The SAVE keyword is not supported in OPM at all, this implies that
-   the SAVE and SFREQ mneomics are not supported.
+  The SAVE keyword is not supported in OPM at all, this implies that
+  the SAVE and SFREQ mneomics are not supported.
 
 
-   Graphics-Only Restart Files (NORST)
-   -----------------------------------
+  Graphics-Only Restart Files (NORST)
+  -----------------------------------
 
-   The NORST mnemonic controls the generation of graphics-only restart
-   files, which are suitable for visualization but cannot be used for
-   restarting simulations. When NORST > 0:
+  The NORST mnemonic controls the generation of graphics-only restart
+  files, which are suitable for visualization but cannot be used for
+  restarting simulations. When NORST > 0:
 
-   NORST = 1: Excludes arrays not required for visualization (e.g.,
-              hysteresis arrays).
+  NORST = 1: Excludes arrays not required for visualization (e.g.,
+             hysteresis arrays).
 
-   NORST = 2: Excludes well arrays; keeps only essential data including
-              SEQNUM, INTEHEAD, IWEL, XWEL, ZWEL, XCON, and solution
-              arrays (PRESSURE, SWAT, SGAS, RS, RV, etc.).
+  NORST = 2: Excludes well arrays; keeps only essential data including
+             SEQNUM, INTEHEAD, IWEL, XWEL, ZWEL, XCON, and solution
+             arrays (PRESSURE, SWAT, SGAS, RS, RV, etc.).
 
-   Graphics-only restart files are marked internally and will fail if
-   used in a restart attempt.
+  Graphics-only restart files are marked internally and will fail if
+  used in a restart attempt.
 */
 
 #include <map>

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -131,7 +131,6 @@ Opm::Well::Status status_from_int(const int int_value)
     case Value::Stop: return Opm::Well::Status::STOP;
     case Value::Open: return Opm::Well::Status::OPEN;
     case Value::Auto: return Opm::Well::Status::AUTO;
-    case Value::Undefined: return Opm::Well::Status::SHUT;
     default:
         throw std::logic_error {
             fmt::format("integer value: {} could not be "

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -131,6 +131,7 @@ Opm::Well::Status status_from_int(const int int_value)
     case Value::Stop: return Opm::Well::Status::STOP;
     case Value::Open: return Opm::Well::Status::OPEN;
     case Value::Auto: return Opm::Well::Status::AUTO;
+    case Value::Undefined: return Opm::Well::Status::SHUT;
     default:
         throw std::logic_error {
             fmt::format("integer value: {} could not be "

--- a/opm/io/eclipse/RestartFileView.cpp
+++ b/opm/io/eclipse/RestartFileView.cpp
@@ -161,13 +161,20 @@ public:
     bool valid() const
     { return rst_file_.operator bool(); }
 
+    // Returns true if all header arrays are present (INTEHEAD, LOGIHEAD, DOUBHEAD)
+    bool hasHeaderArrays() const
+    {
+        return this->hasKeyword<int>("INTEHEAD")
+            && this->hasKeyword<bool>("LOGIHEAD")
+            && this->hasKeyword<double>("DOUBHEAD");
+    }
+
     // Detect graphics-only restart (NORST >= 2).
     // ZGRP is always written in full restarts (even for FIELD group).
     // In case SWEL is omitted while IWEL is present, that is also a graphics-only indicator.
+    // Only valid if all header arrays are present.
     bool isGraphicsOnly() const
     {
-        // Not a valid restart file — not a graphics-only file either.
-        if (!this->hasKeyword<int>("INTEHEAD")) { return false; }
         // ZGRP absent in a valid file: graphics-only indicator.
         if (!this->hasKeyword<std::string>("ZGRP")) { return true; }
         // In case ZGRP is present but SWEL is omitted: graphics-only indicator.
@@ -292,6 +299,11 @@ const std::vector<double>& Opm::EclIO::RestartFileView::doubhead() const
 bool Opm::EclIO::RestartFileView::valid() const
 {
     return this->pImpl_->valid();
+}
+
+bool Opm::EclIO::RestartFileView::hasHeaderArrays() const
+{
+    return this->pImpl_->hasHeaderArrays();
 }
 
 bool Opm::EclIO::RestartFileView::isGraphicsOnly() const

--- a/opm/io/eclipse/RestartFileView.cpp
+++ b/opm/io/eclipse/RestartFileView.cpp
@@ -161,6 +161,14 @@ public:
     bool valid() const
     { return rst_file_.operator bool(); }
 
+    // IWEL is always written when wells exist; SWEL is skipped for NORST >= 2.
+    // A file with wells (IWEL present) but no SWEL is a graphics-only restart.
+    bool isGraphicsOnly() const
+    {
+        return this->hasKeyword<int>("IWEL") &&
+               !this->hasKeyword<float>("SWEL");
+    }
+
 private:
     using RstFile = std::shared_ptr<ERst>;
 
@@ -279,6 +287,11 @@ const std::vector<double>& Opm::EclIO::RestartFileView::doubhead() const
 bool Opm::EclIO::RestartFileView::valid() const
 {
     return this->pImpl_->valid();
+}
+
+bool Opm::EclIO::RestartFileView::isGraphicsOnly() const
+{
+    return this->pImpl_->isGraphicsOnly();
 }
 
 template <typename ElmType>

--- a/opm/io/eclipse/RestartFileView.cpp
+++ b/opm/io/eclipse/RestartFileView.cpp
@@ -161,12 +161,17 @@ public:
     bool valid() const
     { return rst_file_.operator bool(); }
 
-    // IWEL is always written when wells exist; SWEL is skipped for NORST >= 2.
-    // A file with wells (IWEL present) but no SWEL is a graphics-only restart.
+    // Detect graphics-only restart (NORST >= 2).
+    // ZGRP is always written in full restarts (even for FIELD group).
+    // In case SWEL is omitted while IWEL is present, that is also a graphics-only indicator.
     bool isGraphicsOnly() const
     {
-        return this->hasKeyword<int>("IWEL") &&
-               !this->hasKeyword<float>("SWEL");
+        // Not a valid restart file — not a graphics-only file either.
+        if (!this->hasKeyword<int>("INTEHEAD")) { return false; }
+        // ZGRP absent in a valid file: graphics-only indicator.
+        if (!this->hasKeyword<std::string>("ZGRP")) { return true; }
+        // In case ZGRP is present but SWEL is omitted: graphics-only indicator.
+        return this->hasKeyword<int>("IWEL") && !this->hasKeyword<float>("SWEL");
     }
 
 private:

--- a/opm/io/eclipse/RestartFileView.hpp
+++ b/opm/io/eclipse/RestartFileView.hpp
@@ -62,6 +62,7 @@ public:
     const std::vector<double>& doubhead() const;
 
     bool valid() const;
+    bool isGraphicsOnly() const;
 
 private:
     class Implementation;

--- a/opm/io/eclipse/RestartFileView.hpp
+++ b/opm/io/eclipse/RestartFileView.hpp
@@ -62,6 +62,7 @@ public:
     const std::vector<double>& doubhead() const;
 
     bool valid() const;
+    bool hasHeaderArrays() const;
     bool isGraphicsOnly() const;
 
 private:

--- a/opm/io/eclipse/rst/state.cpp
+++ b/opm/io/eclipse/rst/state.cpp
@@ -705,6 +705,16 @@ RstState RstState::load(std::shared_ptr<EclIO::RestartFileView> rstView,
                         const Parser&                           parser,
                         const ::Opm::EclipseGrid*               grid)
 {
+    if (rstView->isGraphicsOnly()) {
+        throw std::runtime_error {
+            fmt::format("Cannot load state from a graphics-only restart file "
+                        "(report step {}). This file was written with NORST >= 2 "
+                        "and is missing arrays required for simulation restart. "
+                        "Please use a standard restart file instead.",
+                        rstView->reportStep())
+        };
+    }
+
     RstState state(rstView, runspec, grid);
 
     // At minimum we need any applicable constraint data for FIELD.  Load

--- a/opm/io/eclipse/rst/state.cpp
+++ b/opm/io/eclipse/rst/state.cpp
@@ -720,6 +720,16 @@ RstState RstState::load(std::shared_ptr<EclIO::RestartFileView> rstView,
                         const Parser&                           parser,
                         const ::Opm::EclipseGrid*               grid)
 {
+    if (rstView->isGraphicsOnly()) {
+        throw std::runtime_error {
+            fmt::format("Cannot load state from a graphics-only restart file "
+                        "(report step {}). This file was written with NORST >= 2 "
+                        "and is missing arrays required for simulation restart. "
+                        "Please use a standard restart file instead.",
+                        rstView->reportStep())
+        };
+    }
+
     RstState state(rstView, runspec, grid);
 
     // At minimum we need any applicable constraint data for FIELD.  Load

--- a/opm/io/eclipse/rst/state.cpp
+++ b/opm/io/eclipse/rst/state.cpp
@@ -722,9 +722,9 @@ RstState RstState::load(std::shared_ptr<EclIO::RestartFileView> rstView,
 {
     if (rstView->isGraphicsOnly()) {
         throw std::runtime_error {
-            fmt::format("Cannot load state from a graphics-only restart file "
-                        "(report step {}). This file was written with NORST >= 2 "
-                        "and is missing arrays required for simulation restart. "
+            fmt::format("Cannot restart from restart file "
+                        "report step {}): the file appears to be graphics-only "
+                        "or is missing well arrays required for simulation restart. "
                         "Please use a standard restart file instead.",
                         rstView->reportStep())
         };

--- a/opm/io/eclipse/rst/state.cpp
+++ b/opm/io/eclipse/rst/state.cpp
@@ -707,9 +707,9 @@ RstState RstState::load(std::shared_ptr<EclIO::RestartFileView> rstView,
 {
     if (rstView->isGraphicsOnly()) {
         throw std::runtime_error {
-            fmt::format("Cannot load state from a graphics-only restart file "
-                        "(report step {}). This file was written with NORST >= 2 "
-                        "and is missing arrays required for simulation restart. "
+            fmt::format("Cannot restart from restart file "
+                        "report step {}): the file appears to be graphics-only "
+                        "or is missing well arrays required for simulation restart. "
                         "Please use a standard restart file instead.",
                         rstView->reportStep())
         };

--- a/opm/output/eclipse/LoadRestart.cpp
+++ b/opm/output/eclipse/LoadRestart.cpp
@@ -1636,9 +1636,9 @@ namespace Opm::RestartIO  {
 
         if (rst_view->isGraphicsOnly()) {
             throw std::runtime_error {
-                fmt::format("Cannot restart from graphics-only restart file '{}' "
-                            "(report step {}). This file was written with NORST >= 2 "
-                            "and is missing well arrays required for simulation restart. "
+                fmt::format("Cannot restart from restart file '{}' "
+                            "report step {}): the file appears to be graphics-only "
+                            "or is missing well arrays required for simulation restart. "
                             "Please use a standard restart file instead.",
                             filename, report_step)
             };

--- a/opm/output/eclipse/LoadRestart.cpp
+++ b/opm/output/eclipse/LoadRestart.cpp
@@ -1634,6 +1634,14 @@ namespace Opm::RestartIO  {
         auto rst_view = std::make_shared<Opm::EclIO::RestartFileView>
             (std::make_shared<Opm::EclIO::ERst>(filename), report_step);
 
+        // Check for missing headers first
+        if (!rst_view->hasHeaderArrays()) {
+            throw std::runtime_error {
+                fmt::format("Restart file '{}' report step {} is missing required header arrays (INTEHEAD/LOGIHEAD/DOUBHEAD)",
+                            filename, report_step)
+            };
+        }
+
         if (rst_view->isGraphicsOnly()) {
             throw std::runtime_error {
                 fmt::format("Cannot restart from restart file '{}' "

--- a/opm/output/eclipse/LoadRestart.cpp
+++ b/opm/output/eclipse/LoadRestart.cpp
@@ -1634,6 +1634,16 @@ namespace Opm::RestartIO  {
         auto rst_view = std::make_shared<Opm::EclIO::RestartFileView>
             (std::make_shared<Opm::EclIO::ERst>(filename), report_step);
 
+        if (rst_view->isGraphicsOnly()) {
+            throw std::runtime_error {
+                fmt::format("Cannot restart from graphics-only restart file '{}' "
+                            "(report step {}). This file was written with NORST >= 2 "
+                            "and is missing well arrays required for simulation restart. "
+                            "Please use a standard restart file instead.",
+                            filename, report_step)
+            };
+        }
+
         auto xr = restoreSOLUTION(solution_keys, grid.getNumActive(), *rst_view);
         xr.convertToSI(es.getUnits());
 

--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -397,11 +397,9 @@ namespace {
         // NORST logic:
         //  - NORST=0: Full well and connection data
         //  - NORST=1: Geometry only (IWEL/XWEL/ZWEL, XCON)
-        //  - NORST=2: No well data, solution vectors only
-        if (norst_value <= 1)
-        {
-            rstFile.write("IWEL", wellData.getIWell());
-        }
+        //  - NORST=2: No well-data but (IWEL/ZWEL) still available for plotting wells, and solution vectors only
+
+        rstFile.write("IWEL", wellData.getIWell());
 
         if (norst_value == 0) {
             rstFile.write("SWEL", wellData.getSWell());
@@ -410,8 +408,9 @@ namespace {
         if (norst_value <= 1)
         {
             rstFile.write("XWEL", wellData.getXWell());
-            rstFile.write("ZWEL", wellData.getZWell());
         }
+
+        rstFile.write("ZWEL", wellData.getZWell());
 
         if (norst_value == 0)
         {
@@ -452,10 +451,7 @@ namespace {
         wellData.captureDeclaredWellDataLGR(schedule, grid, tracers, sim_step, action_state, wtest_state, sumState, ih, lgr_tag);
         wellData.captureDynamicWellDataLGR(schedule, tracers, sim_step, wells, sumState,lgr_tag);
 
-        if (norst_value <= 1)
-        {
-            rstFile.write("IWEL", wellData.getIWell());
-        }
+        rstFile.write("IWEL", wellData.getIWell());
 
         if (norst_value == 0)
         {
@@ -465,8 +461,9 @@ namespace {
         if (norst_value <= 1)
         {
             rstFile.write("XWEL", wellData.getXWell());
-            rstFile.write("ZWEL", wellData.getZWell());
         }
+
+        rstFile.write("ZWEL", wellData.getZWell());
 
         if (norst_value == 0)
         {

--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -165,6 +165,7 @@ namespace {
                 const EclipseState&           es,
                 EclIO::OutputStream::Restart& rstFile)
     {
+        const int norst_value = schedule[sim_step].rst_config().norst.value_or(0);
         // write INTEHEAD to restart file
         auto ih = Helpers::
             createInteHead(es, grid, schedule, simTime,
@@ -173,20 +174,24 @@ namespace {
 
         rstFile.write("INTEHEAD", ih);
 
-        // write LOGIHEAD to restart file
-        if (report_step == 0) {
-            rstFile.write("LOGIHEAD", Helpers::createLogiHead(es));
-        }
-        else {
-            rstFile.write("LOGIHEAD", Helpers::createLogiHead(es, schedule[report_step - 1]));
+        // LOGIHEAD and DOUBHEAD are only written for full restarts (NORST=0).
+        if (norst_value == 0) {
+            // write LOGIHEAD to restart file
+            if (report_step == 0) {
+                rstFile.write("LOGIHEAD", Helpers::createLogiHead(es));
+            }
+            else {
+                rstFile.write("LOGIHEAD", Helpers::createLogiHead(es, schedule[report_step - 1]));
+            }
         }
 
-        // write DOUBHEAD to restart file
-        const auto dh = Helpers::createDoubHead(es, schedule,
-                                                sim_step, report_step,
-                                                simTime, next_step_size);
-        rstFile.write("DOUBHEAD", dh);
-
+        if (norst_value == 0) {
+            // write DOUBHEAD to restart file
+            const auto dh = Helpers::createDoubHead(es, schedule,
+                                                    sim_step, report_step,
+                                                    simTime, next_step_size);
+            rstFile.write("DOUBHEAD", dh);
+        }
         // return the inteHead vector
         return ih;
     }
@@ -382,21 +387,34 @@ namespace {
                    const Opm::WellTestState&     wtest_state,
                    const Opm::SummaryState&      sumState,
                    const std::vector<int>&       ih,
-                   EclIO::OutputStream::Restart& rstFile,
-                   const int                     norst = 0)
+                   const int                     norst_value,
+                   EclIO::OutputStream::Restart& rstFile)
     {
         auto wellData = Helpers::AggregateWellData(ih);
         wellData.captureDeclaredWellData(schedule, grid, tracers, sim_step, action_state, wtest_state, sumState, ih);
         wellData.captureDynamicWellData(schedule, tracers, sim_step, wells, sumState);
 
-        rstFile.write("IWEL", wellData.getIWell());
-        if (norst < 2) {
+        // NORST logic:
+        //  - NORST=0: Full well and connection data
+        //  - NORST=1: Geometry only (IWEL/XWEL/ZWEL, XCON)
+        //  - NORST=2: No well data, solution vectors only
+        if (norst_value <= 1)
+        {
+            rstFile.write("IWEL", wellData.getIWell());
+        }
+
+        if (norst_value == 0) {
             rstFile.write("SWEL", wellData.getSWell());
         }
-        rstFile.write("XWEL", wellData.getXWell());
-        rstFile.write("ZWEL", wellData.getZWell());
 
-        if (norst < 2) {
+        if (norst_value <= 1)
+        {
+            rstFile.write("XWEL", wellData.getXWell());
+            rstFile.write("ZWEL", wellData.getZWell());
+        }
+
+        if (norst_value == 0)
+        {
             auto wListData = Helpers::AggregateWListData(ih);
             wListData.captureDeclaredWListData(schedule, sim_step, ih);
             rstFile.write("ZWLS", wListData.getZWls());
@@ -407,11 +425,14 @@ namespace {
         connectionData.captureDeclaredConnData(schedule, grid, schedule.getUnits(),
                                                wells, sumState, sim_step);
 
-        if (norst < 2) {
+        if (norst_value == 0) {
             rstFile.write("ICON", connectionData.getIConn());
             rstFile.write("SCON", connectionData.getSConn());
         }
-        rstFile.write("XCON", connectionData.getXConn());
+
+        if (norst_value <= 1) {
+            rstFile.write("XCON", connectionData.getXConn());
+        }
     }
 
     void writeWellLGR(int                           sim_step,
@@ -423,6 +444,7 @@ namespace {
                       const Opm::WellTestState&     wtest_state,
                       const Opm::SummaryState&      sumState,
                       const std::vector<int>&       ih,
+                      const int                     norst_value,
                       EclIO::OutputStream::Restart& rstFile,
                       const std::string&            lgr_tag)
     {
@@ -430,15 +452,27 @@ namespace {
         wellData.captureDeclaredWellDataLGR(schedule, grid, tracers, sim_step, action_state, wtest_state, sumState, ih, lgr_tag);
         wellData.captureDynamicWellDataLGR(schedule, tracers, sim_step, wells, sumState,lgr_tag);
 
-        rstFile.write("IWEL", wellData.getIWell());
-        rstFile.write("SWEL", wellData.getSWell());
-        rstFile.write("XWEL", wellData.getXWell());
-        rstFile.write("ZWEL", wellData.getZWell());
+        if (norst_value <= 1)
+        {
+            rstFile.write("IWEL", wellData.getIWell());
+        }
 
+        if (norst_value == 0)
+        {
+            rstFile.write("SWEL", wellData.getSWell());
+        }
 
-        // write LGWEL
-        rstFile.write("LGWEL", wellData.getLGWell());
+        if (norst_value <= 1)
+        {
+            rstFile.write("XWEL", wellData.getXWell());
+            rstFile.write("ZWEL", wellData.getZWell());
+        }
 
+        if (norst_value == 0)
+        {
+            // write LGWEL
+            rstFile.write("LGWEL", wellData.getLGWell());
+        }
         // wListData for LGR is currently not supported.
         // the following code is left here for future reference.
         // auto wListData = Helpers::AggregateWListData(ih);
@@ -450,11 +484,17 @@ namespace {
         auto connectionData = Helpers::AggregateConnectionData(ih);
         connectionData.captureDeclaredConnDataLGR(schedule, grid, schedule.getUnits(),
                                                      wells, sumState, sim_step, lgr_tag);
-
-        rstFile.write("ICON", connectionData.getIConn());
-        rstFile.write("SCON", connectionData.getSConn());
-        rstFile.write("XCON", connectionData.getXConn());
+        if (norst_value == 0)
+        {
+            rstFile.write("ICON", connectionData.getIConn());
+            rstFile.write("SCON", connectionData.getSConn());
         }
+
+        if (norst_value <= 1)
+        {
+            rstFile.write("XCON", connectionData.getXConn());
+        }
+    }
 
     void writeAnalyticAquiferData(const Helpers::AggregateAquiferData& aquiferData,
                                   EclIO::OutputStream::Restart&        rstFile)
@@ -525,13 +565,15 @@ namespace {
                           std::optional<Helpers::AggregateAquiferData>& aquiferData,
                           EclIO::OutputStream::Restart&                 rstFile)
     {
-        const int norst = schedule[sim_step].rst_config().norst.value_or(0);
-
-        writeGroup(sim_step, schedule.getUnits(), schedule, sumState, inteHD, rstFile);
+        const int norst_value = schedule[sim_step].rst_config().norst.value_or(0);
+        if (norst_value == 0)
+        {
+            writeGroup(sim_step, schedule.getUnits(), schedule, sumState, inteHD, rstFile);
+        }
 
         // Write network data if the network option is used and network defined
         const auto& network = schedule[sim_step].network();
-        if (network.active())
+        if (network.active() && norst_value == 0)
         {
             writeNetwork(es, sim_step, schedule.getUnits(), schedule, sumState, inteHD, rstFile);
         }
@@ -545,26 +587,30 @@ namespace {
                                     [&schedule, sim_step](const std::string& well)
                                     { return schedule.getWell(well, sim_step).isMultiSegment(); });
 
-            // MSW data is well-specific detail; skip for graphics-only restart (NORST=2)
-            if (haveMSW && norst < 2) {
+            // MSW data is well-structure specific and not written for
+            // reduced (NORST=1) or graphics-only (NORST=2) restarts.
+            if (haveMSW && norst_value == 0) {
                 writeMSWData(sim_step, schedule.getUnits(), schedule, grid,
                              sumState, wellSol, inteHD, rstFile);
             }
 
             writeWell(sim_step, grid, schedule, es.tracer(), wellSol,
-                      action_state, wtest_state, sumState, inteHD, rstFile, norst);
+                      action_state, wtest_state, sumState, inteHD, norst_value, rstFile);
         }
 
-        if (const auto& aqCfg = es.aquifer();
-            aqCfg.active() && aquiferData.has_value())
+        if (norst_value == 0)
         {
-            updateAndWriteAquiferData(es,
-                                      schedule[sim_step],
-                                      aquDynData,
-                                      sumState,
-                                      schedule.getUnits(),
-                                      aquiferData.value(),
-                                      rstFile);
+            if (const auto& aqCfg = es.aquifer();
+                aqCfg.active() && aquiferData.has_value())
+            {
+                updateAndWriteAquiferData(es,
+                                          schedule[sim_step],
+                                          aquDynData,
+                                          sumState,
+                                          schedule.getUnits(),
+                                          aquiferData.value(),
+                                          rstFile);
+            }
         }
     }
 
@@ -580,11 +626,15 @@ namespace {
                              EclIO::OutputStream::Restart&                 rstFile,
                              const std::string&                            lgr_tag)
     {
-        writeGroupLGR(sim_step, schedule.getUnits(), schedule, sumState, inteHD, rstFile, lgr_tag);
+        const int norst_value = schedule[sim_step].rst_config().norst.value_or(0);
 
+        if (norst_value == 0)
+        {
+            writeGroupLGR(sim_step, schedule.getUnits(), schedule, sumState, inteHD, rstFile, lgr_tag);
+        }
         // Write network data if the network option is used and network defined
         const auto& network = schedule[sim_step].network();
-        if (network.active())
+        if (network.active() && norst_value == 0)
         {
             writeNetwork(es, sim_step, schedule.getUnits(), schedule, sumState, inteHD, rstFile);
         }
@@ -612,7 +662,7 @@ namespace {
             }
 
             writeWellLGR(sim_step, grid, schedule, es.tracer(), wellSol,
-                         action_state, wtest_state, sumState, inteHD, rstFile, lgr_tag);
+                         action_state, wtest_state, sumState, inteHD, norst_value, rstFile, lgr_tag);
         }
         // Write aquifer data if the aquifer option for LGR.
         // At the moment LGR and Aquifers are not supported.
@@ -841,16 +891,22 @@ namespace {
                             int                           sim_step,
                             const bool                    ecl_compatible_rst,
                             const std::vector<int>&       inteHD,
+                            const int                     norst_value,
                             EclIO::OutputStream::Restart& rstFile,
                             WriteDorF                     writeDorF,
                             WriteInt                      writeInt,
                             WriteDouble                   writeDouble)
-    {        // Use writeDorF, writeInt, and writeDouble as provided.
-
-        writeUDQ(report_step, sim_step, schedule, udq_state, inteHD, rstFile);
-        writeExtraVectors(value, writeDouble);
-        if (! ecl_compatible_rst) {
-            writeExtendedSolutionVectors(value, writeDorF, writeInt);
+    {
+        // UDQ state, ACTIONX, and extra solution vectors
+        // are only valid for full restarts (NORST=0).
+        if (norst_value == 0)
+        {
+            // Use writeDorF, writeInt, and writeDouble as provided.
+            writeUDQ(report_step, sim_step, schedule, udq_state, inteHD, rstFile);
+            writeExtraVectors(value, writeDouble);
+            if (! ecl_compatible_rst) {
+                writeExtendedSolutionVectors(value, writeDorF, writeInt);
+            }
         }
     }
 
@@ -866,6 +922,7 @@ namespace {
                            EclIO::OutputStream::Restart& rstFile,
                            const bool                    is_lgr_grid = false)
     {
+        const int norst_value = schedule[sim_step].rst_config().norst.value_or(0);
         auto writeDorF = [&rstFile, write_double = write_double_arg]
             (const std::string& key, const std::vector<double>& data)
         {
@@ -898,10 +955,9 @@ namespace {
 
         if (!is_lgr_grid) {
             writeSolutionExtra(value, schedule, udq_state, report_step, sim_step,
-                ecl_compatible_rst, inteHD, rstFile,
+                ecl_compatible_rst, inteHD, norst_value, rstFile,
                 writeDorF, writeInt, writeDouble);
         }
-
     }
 
     //  Writes the solution for Global grids
@@ -1009,6 +1065,7 @@ namespace {
                                                 bool write_double, EclIO::OutputStream::Restart& rstFile, const std::vector<RestartValue>& values,
                                                 std::optional<Helpers::AggregateAquiferData>& aquiferData)
     {
+        const int norst_value = schedule[sim_step].rst_config().norst.value_or(0);
         const auto inteHD =
         writeHeader(report_step, sim_step, nextStepSize(values[0]),
                     seconds_elapsed, schedule, grid, es, rstFile);
@@ -1019,12 +1076,14 @@ namespace {
                         values[0].aquifer, aquiferData, rstFile);
         }
 
-        writeActionx(report_step, sim_step, schedule, action_state, sumState, rstFile);
-
+        if (norst_value == 0)
+        {
+            writeActionx(report_step, sim_step, schedule, action_state, sumState, rstFile);
+        }
         writeSolution(values[0], es, schedule, udqState, report_step, sim_step,
                     ecl_compatible_rst, write_double, inteHD, rstFile);
 
-        if (! ecl_compatible_rst) {
+        if (! ecl_compatible_rst && norst_value == 0) {
             writeExtraData(values[0].extra, rstFile);
         }
 
@@ -1106,6 +1165,7 @@ void save(EclIO::OutputStream::Restart&                 rstFile,
     const auto inteHD =
         writeHeader(report_step, sim_step, nextStepSize(value),
                     seconds_elapsed, schedule, grid, es, rstFile);
+    const int norst_value = schedule[sim_step].rst_config().norst.value_or(0);
 
     if (report_step > 0) {
         writeDynamicData(sim_step, grid, es, schedule, value.wells,
@@ -1113,12 +1173,15 @@ void save(EclIO::OutputStream::Restart&                 rstFile,
                          value.aquifer, aquiferData, rstFile);
     }
 
-    writeActionx(report_step, sim_step, schedule, action_state, sumState, rstFile);
+    if (norst_value == 0)
+    {
+        writeActionx(report_step, sim_step, schedule, action_state, sumState, rstFile);
+    }
 
     writeSolution(value, es, schedule, udqState, report_step, sim_step,
                   ecl_compatible_rst, write_double, inteHD, rstFile);
 
-    if (! ecl_compatible_rst) {
+    if (! ecl_compatible_rst && norst_value == 0) {
         writeExtraData(value.extra, rstFile);
     }
 

--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -382,29 +382,35 @@ namespace {
                    const Opm::WellTestState&     wtest_state,
                    const Opm::SummaryState&      sumState,
                    const std::vector<int>&       ih,
-                   EclIO::OutputStream::Restart& rstFile)
+                   EclIO::OutputStream::Restart& rstFile,
+                   const int                     norst = 0)
     {
         auto wellData = Helpers::AggregateWellData(ih);
         wellData.captureDeclaredWellData(schedule, grid, tracers, sim_step, action_state, wtest_state, sumState, ih);
         wellData.captureDynamicWellData(schedule, tracers, sim_step, wells, sumState);
 
         rstFile.write("IWEL", wellData.getIWell());
-        rstFile.write("SWEL", wellData.getSWell());
+        if (norst < 2) {
+            rstFile.write("SWEL", wellData.getSWell());
+        }
         rstFile.write("XWEL", wellData.getXWell());
         rstFile.write("ZWEL", wellData.getZWell());
 
-        auto wListData = Helpers::AggregateWListData(ih);
-        wListData.captureDeclaredWListData(schedule, sim_step, ih);
-
-        rstFile.write("ZWLS", wListData.getZWls());
-        rstFile.write("IWLS", wListData.getIWls());
+        if (norst < 2) {
+            auto wListData = Helpers::AggregateWListData(ih);
+            wListData.captureDeclaredWListData(schedule, sim_step, ih);
+            rstFile.write("ZWLS", wListData.getZWls());
+            rstFile.write("IWLS", wListData.getIWls());
+        }
 
         auto connectionData = Helpers::AggregateConnectionData(ih);
         connectionData.captureDeclaredConnData(schedule, grid, schedule.getUnits(),
                                                wells, sumState, sim_step);
 
-        rstFile.write("ICON", connectionData.getIConn());
-        rstFile.write("SCON", connectionData.getSConn());
+        if (norst < 2) {
+            rstFile.write("ICON", connectionData.getIConn());
+            rstFile.write("SCON", connectionData.getSConn());
+        }
         rstFile.write("XCON", connectionData.getXConn());
     }
 
@@ -519,6 +525,8 @@ namespace {
                           std::optional<Helpers::AggregateAquiferData>& aquiferData,
                           EclIO::OutputStream::Restart&                 rstFile)
     {
+        const int norst = schedule[sim_step].rst_config().norst.value_or(0);
+
         writeGroup(sim_step, schedule.getUnits(), schedule, sumState, inteHD, rstFile);
 
         // Write network data if the network option is used and network defined
@@ -537,13 +545,14 @@ namespace {
                                     [&schedule, sim_step](const std::string& well)
                                     { return schedule.getWell(well, sim_step).isMultiSegment(); });
 
-            if (haveMSW) {
+            // MSW data is well-specific detail; skip for graphics-only restart (NORST=2)
+            if (haveMSW && norst < 2) {
                 writeMSWData(sim_step, schedule.getUnits(), schedule, grid,
                              sumState, wellSol, inteHD, rstFile);
             }
 
             writeWell(sim_step, grid, schedule, es.tracer(), wellSol,
-                      action_state, wtest_state, sumState, inteHD, rstFile);
+                      action_state, wtest_state, sumState, inteHD, rstFile, norst);
         }
 
         if (const auto& aqCfg = es.aquifer();

--- a/opm/output/eclipse/VectorItems/well.hpp
+++ b/opm/output/eclipse/VectorItems/well.hpp
@@ -224,10 +224,11 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             };*/
 
             enum Status : int {
-                Shut = -1000,
-                Stop = 0,
-                Open = 1,
-                Auto = 3,
+                Shut      = -1000,
+                Stop      = 0,
+                Open      = 1,
+                Auto      = 3,
+                Undefined = -987, // Well defined but never opened at this step.
             };
 
             namespace WGrupCon {

--- a/opm/output/eclipse/VectorItems/well.hpp
+++ b/opm/output/eclipse/VectorItems/well.hpp
@@ -228,7 +228,6 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
                 Stop      = 0,
                 Open      = 1,
                 Auto      = 3,
-                Undefined = -987, // Well defined but never opened at this step.
             };
 
             namespace WGrupCon {

--- a/tests/NORST_SIM.DATA
+++ b/tests/NORST_SIM.DATA
@@ -1,0 +1,68 @@
+RUNSPEC
+OIL
+GAS
+WATER
+DISGAS
+VAPOIL
+UNIFOUT
+UNIFIN
+DIMENS
+ 10 10 10 /
+
+START             -- 0
+1 NOV 1979 /
+
+WELLDIMS
+   6      3       1      6
+/
+
+GRID
+DXV
+10*0.25 /
+DYV
+10*0.25 /
+DZV
+10*0.25 /
+TOPS
+100*0.25 /
+
+PORO
+1000*0.2 /
+PERMX
+1000*1 /
+PERMY
+1000*0.1 /
+PERMZ
+1000*0.01 /
+
+SOLUTION
+
+
+SCHEDULE
+RPTRST
+ 'BASIC=2' 'NORST=2' /
+
+WELSPECS
+      'OP_1'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  /
+      'OP_2'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  /
+/
+COMPDAT
+      'OP_1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+      'OP_2'  9  9   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 /
+/
+WCONPROD
+      'OP_1' 'OPEN' 'ORAT' 20000  4* 1000 /
+/
+WCONINJE
+      'OP_2' 'GAS' 'OPEN' 'RATE' 100 200 400 /
+/
+
+DATES             -- 1
+ 20  JAN 2011 /
+/
+
+DATES             -- 2
+ 15  JUN 2013 /
+/
+
+END

--- a/tests/test_NORST.cpp
+++ b/tests/test_NORST.cpp
@@ -1,0 +1,196 @@
+/*
+  Copyright 2026 SINTEF Digital.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE NORST_Test
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/io/eclipse/ERst.hpp>
+#include <opm/io/eclipse/OutputStream.hpp>
+#include <opm/io/eclipse/RestartFileView.hpp>
+
+#include <opm/output/eclipse/AggregateAquiferData.hpp>
+#include <opm/output/eclipse/RestartIO.hpp>
+#include <opm/output/eclipse/RestartValue.hpp>
+#include <opm/output/data/Cells.hpp>
+#include <opm/output/data/Groups.hpp>
+#include <opm/output/data/Wells.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Python/Python.hpp>
+#include <opm/input/eclipse/Schedule/Action/State.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
+
+#include <opm/common/utility/TimeService.hpp>
+
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <tests/WorkArea.hpp>
+
+namespace {
+
+struct Setup
+{
+    Opm::EclipseState es;
+    const Opm::EclipseGrid& grid;
+    Opm::Schedule schedule;
+    Opm::SummaryConfig summary_config;
+
+    explicit Setup(const std::string& path)
+        : Setup { Opm::Parser{}.parseFile(path) }
+    {}
+
+    explicit Setup(const Opm::Deck& deck)
+        : es             { deck }
+        , grid           { es.getInputGrid() }
+        , schedule       { deck, es, std::make_shared<Opm::Python>() }
+        , summary_config { deck, schedule, es.fieldProps(), es.aquifer() }
+    {
+        es.getIOConfig().setEclCompatibleRST(false);
+    }
+};
+
+std::unique_ptr<Opm::EclIO::RestartFileView>
+openRestart(const std::string& filename, const int report_step)
+{
+    auto rst = std::make_shared<Opm::EclIO::ERst>(filename);
+    return std::make_unique<Opm::EclIO::RestartFileView>(std::move(rst), report_step);
+}
+
+Opm::data::Solution makeSolution(const int numCells)
+{
+    using measure = Opm::UnitSystem::measure;
+
+    auto sol = Opm::data::Solution {
+        { "PRESSURE", Opm::data::CellData { measure::pressure, {}, Opm::data::TargetType::RESTART_SOLUTION } },
+        { "SWAT",     Opm::data::CellData { measure::identity, {}, Opm::data::TargetType::RESTART_SOLUTION } },
+    };
+
+    sol.data<double>("PRESSURE").assign(numCells, 250.0);
+    sol.data<double>("SWAT").assign(numCells, 0.3);
+
+    return sol;
+}
+
+void writeRestartFile(const Setup&       setup,
+                      const std::string& outputDir,
+                      const std::string& caseName)
+{
+    namespace OS = Opm::EclIO::OutputStream;
+
+    const auto seqnum      = 1;
+    const auto numCells    = setup.grid.getNumActive();
+    auto       aquiferData = std::optional<Opm::RestartIO::Helpers::AggregateAquiferData>{};
+    auto       action_state = Opm::Action::State{};
+    auto       wtest_state  = Opm::WellTestState{};
+    auto       sumState     = Opm::SummaryState{ Opm::TimeService::now(), 0.0 };
+    const auto udqState     = Opm::UDQState{ 1 };
+
+    Opm::RestartValue restartValue { makeSolution(numCells), {}, {}, {} };
+
+    auto rstFile = OS::Restart {
+        OS::ResultSet{ outputDir, caseName }, seqnum,
+        OS::Formatted{ false }, OS::Unified{ true }
+    };
+
+    Opm::RestartIO::save(rstFile, seqnum, 100.0,
+                         restartValue,
+                         setup.es, setup.grid, setup.schedule,
+                         action_state, wtest_state,
+                         sumState, udqState,
+                         aquiferData, false);
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(NORST)
+
+// A standard full restart file must not be flagged as graphics-only.
+BOOST_AUTO_TEST_CASE(isGraphicsOnly_Full_Restart_Returns_False)
+{
+    const auto rst = openRestart("SPE1_TESTCASE.UNRST", 10);
+    BOOST_CHECK_MESSAGE(!rst->isGraphicsOnly(),
+        "Full restart file must not be detected as graphics-only");
+}
+
+// OPM-written NORST=0 restart must not be flagged as graphics-only.
+BOOST_AUTO_TEST_CASE(isGraphicsOnly_OPM_NORST0_Returns_False)
+{
+    WorkArea work_area("test_NORST0");
+    work_area.copyIn("BASE_SIM.DATA");
+
+    const Setup setup { "BASE_SIM.DATA" };
+    writeRestartFile(setup, work_area.currentWorkingDirectory(), "BASE_SIM");
+
+    const auto rst = openRestart("BASE_SIM.UNRST", 1);
+    BOOST_CHECK_MESSAGE(!rst->isGraphicsOnly(),
+        "NORST=0 restart must not be detected as graphics-only");
+}
+
+// OPM-written NORST=2 restart must be flagged as graphics-only.
+BOOST_AUTO_TEST_CASE(isGraphicsOnly_OPM_NORST2_Returns_True)
+{
+    WorkArea work_area("test_NORST2");
+    work_area.copyIn("NORST_SIM.DATA");
+
+    const Setup setup { "NORST_SIM.DATA" };
+    writeRestartFile(setup, work_area.currentWorkingDirectory(), "NORST_SIM");
+
+    const auto rst = openRestart("NORST_SIM.UNRST", 1);
+    BOOST_CHECK_MESSAGE(rst->isGraphicsOnly(),
+        "NORST=2 restart must be detected as graphics-only");
+}
+
+// Loading a graphics-only restart must throw a descriptive error.
+BOOST_AUTO_TEST_CASE(Load_Throws_On_Graphics_Only)
+{
+    WorkArea work_area("test_NORST_load");
+    work_area.copyIn("NORST_SIM.DATA");
+
+    const Setup setup { "NORST_SIM.DATA" };
+    writeRestartFile(setup, work_area.currentWorkingDirectory(), "NORST_SIM");
+
+    Opm::Action::State action_state;
+    auto sumState = Opm::SummaryState { Opm::TimeService::now(), 0.0 };
+
+    const std::vector<Opm::RestartKey> solution_keys {
+        { "PRESSURE", Opm::UnitSystem::measure::pressure },
+    };
+
+    BOOST_CHECK_THROW(
+        Opm::RestartIO::load("NORST_SIM.UNRST", 1,
+                             action_state, sumState,
+                             solution_keys,
+                             setup.es, setup.grid, setup.schedule, {}),
+        std::runtime_error
+    );
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds full support for the Eclipse NORST keyword, enabling the generation of graphics‑only restart files (NORST=1) and minimal restart files (NORST=2). The implementation respects the required array exclusion rules, reducing the amount of output data while keeping the restart file usable for its intended purpose.

**Key changes: Array filtering based on NORST value:**
1.  **NORST = 0** (full restart) – all arrays are written as before.
2.   **NORST = 1** (graphics‑only) – only INTEHEAD, solution vectors, SEQNUM, and basic well/connection geometry (IWEL, XWEL, ZWEL, XCON) are written. All other arrays (LOGIHEAD, DOUBHEAD, group/network/MSW data, UDQ, Actionx, aquifers, detailed well arrays SWEL/ICON/SCON/LGWEL, well lists, extra vectors, etc.) are excluded.
3. **NORST = 2** (minimal) – only INTEHEAD and solution vectors are written; no well‑related arrays are output.
