### PR TITLE
Numerical aquifer: warn against connection to adjoning active celll

### DIFF
--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
@@ -207,6 +207,13 @@ namespace Opm {
             if (con.connect_active_cell
                || !AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, con.face_dir, actnum, cell_global_indices)) {
                 conns.push_back(con);
+            } else {
+                OpmLog::warning(
+                    fmt::format(
+                        "Connection in numerical aquifer {} with IJK ({}, {}, {}) adjoins an active cell. Connection "
+                        "skipped!", this->id_, i+1, j+1, k+1
+                    )
+                );
             }
         }
         this->connections_ = std::move(conns);


### PR DESCRIPTION
If item 11 (AQUOPT2) is set to NO (which is default), warn if a connection in AQUCON is adjoining an active cell.