### PR TITLE
Support More General UDT Names

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQEnums.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQEnums.cpp
@@ -307,7 +307,7 @@ UDQVarType targetType(const std::string& keyword)
         return UDQVarType::NONE;
     }
 
-    if (keyword.substr(0,3) == "TU_") {
+    if (keyword.starts_with("TU")) {
         return UDQVarType::TABLE_LOOKUP;
     }
 

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -704,6 +704,7 @@ BOOST_AUTO_TEST_CASE(ENUM_CONVERSION) {
     BOOST_CHECK(UDQ::targetType("RBHP") == UDQVarType::REGION_VAR);
     BOOST_CHECK(UDQ::targetType("ABHP") == UDQVarType::AQUIFER_VAR);
     BOOST_CHECK(UDQ::targetType("SBHP") == UDQVarType::SEGMENT_VAR);
+    BOOST_CHECK(UDQ::targetType("TUPOLEV") == UDQVarType::TABLE_LOOKUP);
 
     BOOST_REQUIRE_THROW( UDQ::actionType("INVALID_ACTION"), std::invalid_argument);
     BOOST_CHECK(UDQ::actionType("DEFINE") == UDQAction::DEFINE );

--- a/tests/parser/UDTTests.cpp
+++ b/tests/parser/UDTTests.cpp
@@ -213,3 +213,35 @@ UDT
     BOOST_CHECK_THROW(Schedule schedule(deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>()),
                       Opm::OpmInputError);
 }
+
+BOOST_AUTO_TEST_CASE(UseUDT_In_UDQ)
+{
+    const auto deck = Parser{}.parseString(R"(RUNSPEC
+UDTDIMS
+  1 10 10 1 /
+SCHEDULE
+UDT
+ 'TUFBHP' 1 /
+ 'LC'  100.0  500.0 / -- FOPR values
+       100.0  180.0 / -- WBHP values
+/
+/
+
+UDQ
+ASSIGN WU_WBHP 0 /
+DEFINE WU_WBHP0 WU_WBHP /
+DEFINE WU_WBHP (TUFBHP[WOPR] UMIN WBHP) UMIN WU_WBHP0 /
+/
+)");
+
+    const auto runspec = Runspec { deck };
+    const auto table = TableManager { deck };
+
+    auto grid = EclipseGrid { 10, 10, 10 };
+
+    const auto fp = FieldPropsManager {
+        deck, Phases{true, true, true}, grid, table
+    };
+
+    BOOST_CHECK_NO_THROW(Schedule schedule(deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>()));
+}


### PR DESCRIPTION
The original implementation would recognise user-defined tables (UDTs) named `TU_*`.  This commit also recognises UDT names without an underscore as the third character, such as `TUFBHP`.