### PR TITLE
GPU portability: add OPM_HOST_DEVICE/OPM_THROW and small fix BOFS

### DIFF
--- a/bin/genEvalSpecializations.py
+++ b/bin/genEvalSpecializations.py
@@ -87,6 +87,7 @@ specializationTemplate = \
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 {% if numDerivs == 0 %}\
 
@@ -344,8 +345,8 @@ public:
     template <class RhsValueType>
     OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType&, int)
     {
-        throw std::logic_error("Dynamically sized evaluations require that the number of "
-                               "derivatives is specified when creating an evaluation");
+        OPM_THROW(std::logic_error, "Dynamically sized evaluations require that the number of "
+                                    "derivatives is specified when creating an evaluation");
     }
 
     template <class RhsValueType>
@@ -491,10 +492,9 @@ public:
                 data_[i] = other.data_[i];
             return *this;
         }
-        throw std::logic_error(
-                "Cannot operate Evaluations with different number of derivatives "
-                "unless one of them has no derivatives"
-        );
+        OPM_THROW(std::logic_error,
+                  "Cannot operate Evaluations with different number of derivatives "
+                  "unless one of them has no derivatives");
 {% else %}\
         assert(size() == other.size());
 
@@ -547,10 +547,9 @@ public:
                 data_[i] -= other.data_[i];
             return *this;
         }
-        throw std::logic_error(
-                "Cannot operate Evaluations with different number of derivatives "
-                "unless one of them has no derivatives"
-        );
+        OPM_THROW(std::logic_error,
+                  "Cannot operate Evaluations with different number of derivatives "
+                  "unless one of them has no derivatives");
 {% else %}\
         assert(size() == other.size());
 
@@ -617,10 +616,9 @@ public:
             }
             return *this;
         }
-        throw std::logic_error(
-                "Cannot operate Evaluations with different number of derivatives "
-                "unless one of them has no derivatives"
-        );
+        OPM_THROW(std::logic_error,
+                  "Cannot operate Evaluations with different number of derivatives "
+                  "unless one of them has no derivatives");
 {% else %}\
         assert(size() == other.size());
 
@@ -714,10 +712,9 @@ public:
 
             return *this;
         }
-        throw std::logic_error(
-                "Cannot operate Evaluations with different number of derivatives "
-                "unless one of them has no derivatives"
-        );
+        OPM_THROW(std::logic_error,
+                  "Cannot operate Evaluations with different number of derivatives "
+                  "unless one of them has no derivatives");
 {% else %}\
         assert(size() == other.size());
 
@@ -1074,8 +1071,8 @@ public:
 
         if (size() == 0) {
             if (nVars < 0) {
-                throw std::logic_error("Cannot set derivative for a DynamicEvaluation initialized from a scalar "
-                                       "without specifying a positive number of derivatives");
+                OPM_THROW(std::logic_error, "Cannot set derivative for a DynamicEvaluation initialized from a scalar "
+                                            "without specifying a positive number of derivatives");
             }
 
             this->appendDerivativesToConstant(nVars);

--- a/opm/material/densead/DynamicEvaluation.hpp
+++ b/opm/material/densead/DynamicEvaluation.hpp
@@ -41,6 +41,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {
@@ -183,8 +184,8 @@ public:
     template <class RhsValueType>
     OPM_HOST_DEVICE static Evaluation createVariable(const RhsValueType&, int)
     {
-        throw std::logic_error("Dynamically sized evaluations require that the number of "
-                               "derivatives is specified when creating an evaluation");
+        OPM_THROW(std::logic_error, "Dynamically sized evaluations require that the number of "
+                                    "derivatives is specified when creating an evaluation");
     }
 
     template <class RhsValueType>
@@ -265,10 +266,9 @@ public:
                 data_[i] = other.data_[i];
             return *this;
         }
-        throw std::logic_error(
-                "Cannot operate Evaluations with different number of derivatives "
-                "unless one of them has no derivatives"
-        );
+        OPM_THROW(std::logic_error,
+                  "Cannot operate Evaluations with different number of derivatives "
+                  "unless one of them has no derivatives");
     }
 
     // add value from other to this values
@@ -306,10 +306,9 @@ public:
                 data_[i] -= other.data_[i];
             return *this;
         }
-        throw std::logic_error(
-                "Cannot operate Evaluations with different number of derivatives "
-                "unless one of them has no derivatives"
-        );
+        OPM_THROW(std::logic_error,
+                  "Cannot operate Evaluations with different number of derivatives "
+                  "unless one of them has no derivatives");
     }
 
     // subtract other's value from this values
@@ -361,10 +360,9 @@ public:
             }
             return *this;
         }
-        throw std::logic_error(
-                "Cannot operate Evaluations with different number of derivatives "
-                "unless one of them has no derivatives"
-        );
+        OPM_THROW(std::logic_error,
+                  "Cannot operate Evaluations with different number of derivatives "
+                  "unless one of them has no derivatives");
     }
 
     // m(c*u)' = c*u'
@@ -428,10 +426,9 @@ public:
 
             return *this;
         }
-        throw std::logic_error(
-                "Cannot operate Evaluations with different number of derivatives "
-                "unless one of them has no derivatives"
-        );
+        OPM_THROW(std::logic_error,
+                  "Cannot operate Evaluations with different number of derivatives "
+                  "unless one of them has no derivatives");
     }
 
     // divide value and derivatives by value of other
@@ -694,8 +691,8 @@ public:
 
         if (size() == 0) {
             if (nVars < 0) {
-                throw std::logic_error("Cannot set derivative for a DynamicEvaluation initialized from a scalar "
-                                       "without specifying a positive number of derivatives");
+                OPM_THROW(std::logic_error, "Cannot set derivative for a DynamicEvaluation initialized from a scalar "
+                                            "without specifying a positive number of derivatives");
             }
 
             this->appendDerivativesToConstant(nVars);

--- a/opm/material/densead/Evaluation.hpp
+++ b/opm/material/densead/Evaluation.hpp
@@ -41,6 +41,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 #if HAVE_DUNE_COMMON

--- a/opm/material/densead/Evaluation1.hpp
+++ b/opm/material/densead/Evaluation1.hpp
@@ -40,6 +40,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {

--- a/opm/material/densead/Evaluation10.hpp
+++ b/opm/material/densead/Evaluation10.hpp
@@ -40,6 +40,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {

--- a/opm/material/densead/Evaluation11.hpp
+++ b/opm/material/densead/Evaluation11.hpp
@@ -40,6 +40,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {

--- a/opm/material/densead/Evaluation12.hpp
+++ b/opm/material/densead/Evaluation12.hpp
@@ -40,6 +40,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {

--- a/opm/material/densead/Evaluation2.hpp
+++ b/opm/material/densead/Evaluation2.hpp
@@ -40,6 +40,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {

--- a/opm/material/densead/Evaluation3.hpp
+++ b/opm/material/densead/Evaluation3.hpp
@@ -40,6 +40,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {

--- a/opm/material/densead/Evaluation4.hpp
+++ b/opm/material/densead/Evaluation4.hpp
@@ -40,6 +40,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {

--- a/opm/material/densead/Evaluation5.hpp
+++ b/opm/material/densead/Evaluation5.hpp
@@ -40,6 +40,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {

--- a/opm/material/densead/Evaluation6.hpp
+++ b/opm/material/densead/Evaluation6.hpp
@@ -40,6 +40,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {

--- a/opm/material/densead/Evaluation7.hpp
+++ b/opm/material/densead/Evaluation7.hpp
@@ -40,6 +40,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {

--- a/opm/material/densead/Evaluation8.hpp
+++ b/opm/material/densead/Evaluation8.hpp
@@ -40,6 +40,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {

--- a/opm/material/densead/Evaluation9.hpp
+++ b/opm/material/densead/Evaluation9.hpp
@@ -40,6 +40,7 @@
 #include <iosfwd>
 #include <stdexcept>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm {

--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -43,12 +43,12 @@ OPM_GENERATE_HAS_MEMBER(pvtRegionIndex, ) // Creates 'HasMember_pvtRegionIndex<T
 
 template <class FluidState>
 OPM_HOST_DEVICE unsigned getPvtRegionIndex_(typename std::enable_if<HasMember_pvtRegionIndex<FluidState>::value,
-                                                    const FluidState&>::type fluidState)
+                                            const FluidState&>::type fluidState)
 { return fluidState.pvtRegionIndex(); }
 
 template <class FluidState>
 OPM_HOST_DEVICE unsigned getPvtRegionIndex_(typename std::enable_if<!HasMember_pvtRegionIndex<FluidState>::value,
-                                                    const FluidState&>::type)
+                                            const FluidState&>::type)
 { return 0; }
 
 OPM_GENERATE_HAS_MEMBER(invB, /*phaseIdx=*/0) // Creates 'HasMember_invB<T>'.
@@ -85,37 +85,37 @@ OPM_GENERATE_HAS_MEMBER(saltConcentration, ) // Creates 'HasMember_saltConcentra
 
 template <class FluidState>
 OPM_HOST_DEVICE auto getSaltConcentration_(typename std::enable_if<HasMember_saltConcentration<FluidState>::value,
-                                                    const FluidState&>::type fluidState)
+                                           const FluidState&>::type fluidState)
 { return fluidState.saltConcentration(); }
 
 template <class FluidState>
 OPM_HOST_DEVICE auto getSaltConcentration_(typename std::enable_if<!HasMember_saltConcentration<FluidState>::value,
-                                                    const FluidState&>::type)
+                                           const FluidState&>::type)
 { return 0.0; }
 
 OPM_GENERATE_HAS_MEMBER(saltSaturation, ) // Creates 'HasMember_saltSaturation<T>'.
 
 template <class FluidState>
 OPM_HOST_DEVICE auto getSaltSaturation_(typename std::enable_if<HasMember_saltSaturation<FluidState>::value,
-                                                    const FluidState&>::type fluidState)
+                                        const FluidState&>::type fluidState)
 { return fluidState.saltSaturation(); }
 
 
 template <class FluidState>
 OPM_HOST_DEVICE auto getSaltSaturation_(typename std::enable_if<!HasMember_saltSaturation<FluidState>::value,
-                                                    const FluidState&>::type)
+                                        const FluidState&>::type)
 { return 0.0; }
 
 OPM_GENERATE_HAS_MEMBER(solventSaturation, ) // Creates 'HasMember_solventSaturation<T>'.
 
 template <class FluidState>
 OPM_HOST_DEVICE auto getSolventSaturation_(typename std::enable_if<HasMember_solventSaturation<FluidState>::value,
-                                                    const FluidState&>::type fluidState)
+                                           const FluidState&>::type fluidState)
 { return fluidState.solventSaturation(); }
 
 template <class FluidState>
 OPM_HOST_DEVICE auto getSolventSaturation_(typename std::enable_if<!HasMember_solventSaturation<FluidState>::value,
-                                                    const FluidState&>::type)
+                                           const FluidState&>::type)
 { return 0.0; }
 
 /*!
@@ -804,7 +804,7 @@ public:
      *       usage we must avoid static, so making it a regular
      *       member function to simplify future refactoring.
      */
-    bool phaseIsActive(int phaseIdx) const
+    OPM_HOST_DEVICE bool phaseIsActive(int phaseIdx) const
     {
         return fluidSystem().phaseIsActive(phaseIdx);
     }

--- a/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem_macrotemplate.hpp
@@ -244,6 +244,14 @@ public:
     static FLUIDSYSTEM_CLASSNAME_NONSTATIC<Scalar, IndexTraits, StorageT>& getNonStaticInstance()
     {
         static FLUIDSYSTEM_CLASSNAME_NONSTATIC<Scalar, IndexTraits, StorageT> instance{FLUIDSYSTEM_CLASSNAME<Scalar, IndexTraits, Storage>()};
+        // Refresh the singleton from the current static fluid-system state.
+        // The static fluid system can be re-initialised (for example by a
+        // subsequent readDeck call) and the non-static instance must mirror
+        // the current static data, otherwise downstream consumers (e.g. the
+        // GPU intensive-quantities path) end up using stale PVT/density
+        // tables and produce results that no longer match the CPU side.
+        instance = FLUIDSYSTEM_CLASSNAME_NONSTATIC<Scalar, IndexTraits, StorageT>(
+            FLUIDSYSTEM_CLASSNAME<Scalar, IndexTraits, Storage>());
         return instance;
 
     }
@@ -692,7 +700,7 @@ public:
                 * waterPvt_.inverseFormationVolumeFactor(regionIdx, T, p, Rsw, saltConcentration);
         }
 
-        throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
+        OPM_THROW(std::logic_error, "Unhandled phase index " + std::to_string(phaseIdx));
     }
 
     /*!
@@ -804,7 +812,7 @@ public:
         }
         }
 
-        throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        OPM_THROW(std::logic_error, "Unhandled phase index " + std::to_string(phaseIdx));
     }
 
     /*!
@@ -902,7 +910,7 @@ public:
             const LhsEval Rsw(0.0);
             return waterPvt_.inverseFormationVolumeFactor(regionIdx, T, p, Rsw, saltConcentration);
         }
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        default: OPM_THROW(std::logic_error, "Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
 
@@ -910,7 +918,7 @@ public:
     STATIC_OR_DEVICE std::pair<LhsEval, LhsEval>
     inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState,
                                              unsigned phaseIdx,
-                                             unsigned regionIdx)
+                                             unsigned regionIdx) NOTHING_OR_CONST
     {
         switch (phaseIdx) {
         case oilPhaseIdx:
@@ -920,7 +928,7 @@ public:
         case waterPhaseIdx:
             return waterPvt_.inverseFormationVolumeFactorAndViscosity(fluidState, regionIdx);
         default:
-            throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+            OPM_THROW(std::logic_error, "Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
 
@@ -950,7 +958,7 @@ public:
         case oilPhaseIdx: return oilPvt_.saturatedInverseFormationVolumeFactor(regionIdx, T, p);
         case gasPhaseIdx: return gasPvt_.saturatedInverseFormationVolumeFactor(regionIdx, T, p);
         case waterPhaseIdx: return waterPvt_.saturatedInverseFormationVolumeFactor(regionIdx, T, p, saltConcentration);
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        default: OPM_THROW(std::logic_error, "Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
 
@@ -1073,7 +1081,7 @@ public:
             throw std::logic_error("Invalid phase index "+std::to_string(phaseIdx));
         }
 
-        throw std::logic_error("Unhandled phase or component index");
+        OPM_THROW(std::logic_error, "Unhandled phase or component index");
     }
 
     //! \copydoc BaseFluidSystem::viscosity
@@ -1205,9 +1213,9 @@ public:
             break;
 
         default:
-            throw std::logic_error {
-                "Phase index " + std::to_string(phaseIdx) + " does not support internal energy"
-            };
+            OPM_THROW(std::logic_error,
+                      "Phase index " + std::to_string(phaseIdx) +
+                      " does not support internal energy");
         }
 
         return internalMixingTotalEnergy<FluidState,LhsEval>(fluidState, phaseIdx, regionIdx)
@@ -1336,7 +1344,7 @@ public:
                 waterEnergy*referenceDensity(waterPhaseIdx, regionIdx)
                 * waterPvt_.inverseFormationVolumeFactor(regionIdx, T, p, Rsw, saltConcentration);
         }
-        throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
+        OPM_THROW(std::logic_error, "Unhandled phase index " + std::to_string(phaseIdx));
     }
 
 
@@ -1379,7 +1387,8 @@ public:
         case oilPhaseIdx: return 0.0;
         case gasPhaseIdx: return gasPvt_.saturatedWaterVaporizationFactor(regionIdx, T, p, saltConcentration);
         case waterPhaseIdx: return 0.0;
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        default:
+            OPM_THROW(std::logic_error, "Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
 
@@ -1408,7 +1417,7 @@ public:
         case gasPhaseIdx: return gasPvt_.saturatedOilVaporizationFactor(regionIdx, T, p, So, maxOilSaturation);
         case waterPhaseIdx: return waterPvt_.saturatedGasDissolutionFactor(regionIdx, T, p,
         BlackOil::template getSaltConcentration_<FluidState, LhsEval>(fluidState, regionIdx));
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        default: OPM_THROW(std::logic_error, "Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
 
@@ -1437,7 +1446,8 @@ public:
         case gasPhaseIdx: return gasPvt_.saturatedOilVaporizationFactor(regionIdx, T, p);
         case waterPhaseIdx: return waterPvt_.saturatedGasDissolutionFactor(regionIdx, T, p,
         BlackOil::template getSaltConcentration_<FluidState, LhsEval>(fluidState, regionIdx));
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        default:
+            OPM_THROW(std::logic_error, "Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
 
@@ -1488,7 +1498,7 @@ public:
         case waterPhaseIdx: return waterPvt_.saturationPressure(regionIdx, T,
         BlackOil::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
         BlackOil::template getSaltConcentration_<FluidState, LhsEval>(fluidState, regionIdx));
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        default: OPM_THROW(std::logic_error, "Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
 
@@ -1768,7 +1778,7 @@ public:
         case oilPhaseIdx: return oilPvt().diffusionCoefficient(T, p, compIdx);
         case gasPhaseIdx: return gasPvt().diffusionCoefficient(T, p, compIdx);
         case waterPhaseIdx: return waterPvt().diffusionCoefficient(T, p, compIdx, regionIdx);
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        default: OPM_THROW(std::logic_error, "Unhandled phase index " + std::to_string(phaseIdx));
         }
     }
     STATIC_OR_DEVICE void setEnergyEqualEnthalpy(bool enthalpy_eq_energy){

--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -199,15 +199,21 @@ public:
         return 0;
     }
 
+    /*! \brief Indicates whether this PVT object computes the water internal
+     *         energy via a thermal mixing model. \c BrineCo2Pvt always uses
+     *         the simple direct-internal-energy path, so returns \c false. */
+    OPM_HOST_DEVICE static constexpr bool mixingEnergy()
+    { return false; }
+
     /*!
      * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation internalEnergy(unsigned regionIdx,
-                              const Evaluation& temperature,
-                              const Evaluation& pressure,
-                              const Evaluation& Rs,
-                              const Evaluation& saltConcentration) const
+                                              const Evaluation& temperature,
+                                              const Evaluation& pressure,
+                                              const Evaluation& Rs,
+                                              const Evaluation& saltConcentration) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation salinity = salinityFromConcentration(regionIdx, temperature, pressure, saltConcentration);
@@ -223,9 +229,9 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation internalEnergy(unsigned regionIdx,
-                        const Evaluation& temperature,
-                        const Evaluation& pressure,
-                        const Evaluation& Rs) const
+                                              const Evaluation& temperature,
+                                              const Evaluation& pressure,
+                                              const Evaluation& Rs) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation xlCO2 = convertRsToXoG_(Rs,regionIdx);
@@ -241,9 +247,9 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation viscosity(unsigned regionIdx,
-                         const Evaluation& temperature,
-                         const Evaluation& pressure,
-                         const Evaluation& /*Rs*/) const
+                                         const Evaluation& temperature,
+                                         const Evaluation& pressure,
+                                         const Evaluation& /*Rs*/) const
     {
         //TODO: The viscosity does not yet depend on the composition
         return saturatedViscosity(regionIdx, temperature, pressure);
@@ -254,9 +260,9 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturatedViscosity(unsigned regionIdx,
-                                 const Evaluation& temperature,
-                                 const Evaluation& pressure,
-                                 const Evaluation& saltConcentration) const
+                                                  const Evaluation& temperature,
+                                                  const Evaluation& pressure,
+                                                  const Evaluation& saltConcentration) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation salinity = salinityFromConcentration(regionIdx, temperature, pressure, saltConcentration);
@@ -275,10 +281,10 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation viscosity(unsigned regionIdx,
-                         const Evaluation& temperature,
-                         const Evaluation& pressure,
-                         const Evaluation& /*Rsw*/,
-                         const Evaluation& saltConcentration) const
+                                         const Evaluation& temperature,
+                                         const Evaluation& pressure,
+                                         const Evaluation& /*Rsw*/,
+                                         const Evaluation& saltConcentration) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         //TODO: The viscosity does not yet depend on the composition
@@ -290,8 +296,8 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturatedViscosity(unsigned regionIdx,
-                                  const Evaluation& temperature,
-                                  const Evaluation& pressure) const
+                                                  const Evaluation& temperature,
+                                                  const Evaluation& pressure) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         if (enableEzrokhiViscosity_) {
@@ -311,9 +317,9 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturatedInverseFormationVolumeFactor(unsigned regionIdx,
-                                                     const Evaluation& temperature,
-                                                     const Evaluation& pressure,
-                                                     const Evaluation& saltconcentration) const
+                                                                     const Evaluation& temperature,
+                                                                     const Evaluation& pressure,
+                                                                     const Evaluation& saltconcentration) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation salinity = salinityFromConcentration(regionIdx, temperature,
@@ -328,10 +334,10 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation inverseFormationVolumeFactor(unsigned regionIdx,
-                                            const Evaluation& temperature,
-                                            const Evaluation& pressure,
-                                            const Evaluation& Rs,
-                                            const Evaluation& saltConcentration) const
+                                                            const Evaluation& temperature,
+                                                            const Evaluation& pressure,
+                                                            const Evaluation& Rs,
+                                                            const Evaluation& saltConcentration) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation salinity = salinityFromConcentration(regionIdx, temperature,
@@ -345,9 +351,9 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation inverseFormationVolumeFactor(unsigned regionIdx,
-                                            const Evaluation& temperature,
-                                            const Evaluation& pressure,
-                                            const Evaluation& Rs) const
+                                                            const Evaluation& temperature,
+                                                            const Evaluation& pressure,
+                                                            const Evaluation& Rs) const
     {
         return (1.0 - convertRsToXoG_(Rs,regionIdx)) * density(regionIdx, temperature, pressure,
                                                                Rs, Evaluation(salinity_[regionIdx]))
@@ -359,7 +365,7 @@ public:
      */
     template <class FluidState, class LhsEval = typename FluidState::ValueType>
     std::pair<LhsEval, LhsEval>
-    inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx)
+    OPM_HOST_DEVICE inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx) const
     {
         // Deal with the possibility that we are in a two-phase CO2STORE with OIL and GAS as phases.
         const bool waterIsActive = fluidState.phaseIsActive(FluidState::waterPhaseIdx);
@@ -380,8 +386,8 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturatedInverseFormationVolumeFactor(unsigned regionIdx,
-                                                     const Evaluation& temperature,
-                                                     const Evaluation& pressure) const
+                                                                     const Evaluation& temperature,
+                                                                     const Evaluation& pressure) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Evaluation rs_sat = rsSat(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx]));
@@ -398,8 +404,8 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturationPressure(unsigned /*regionIdx*/,
-                                  const Evaluation& /*temperature*/,
-                                  const Evaluation& /*Rs*/) const
+                                                  const Evaluation& /*temperature*/,
+                                                  const Evaluation& /*Rs*/) const
     {
 #if OPM_IS_INSIDE_DEVICE_FUNCTION
         assert(false && "Requested the saturation pressure for the brine-co2 pvt module. Not yet implemented.");
@@ -417,9 +423,9 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturationPressure(unsigned /*regionIdx*/,
-                                  const Evaluation& /*temperature*/,
-                                  const Evaluation& /*Rs*/,
-                                  const Evaluation& /*saltConcentration*/) const
+                                                  const Evaluation& /*temperature*/,
+                                                  const Evaluation& /*Rs*/,
+                                                  const Evaluation& /*saltConcentration*/) const
     {
 #if OPM_IS_INSIDE_DEVICE_FUNCTION
         assert(false && "Requested the saturation pressure for the brine-co2 pvt module. Not yet implemented.");
@@ -434,10 +440,10 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturatedGasDissolutionFactor(unsigned regionIdx,
-                                             const Evaluation& temperature,
-                                             const Evaluation& pressure,
-                                             const Evaluation& /*oilSaturation*/,
-                                             const Evaluation& /*maxOilSaturation*/) const
+                                                             const Evaluation& temperature,
+                                                             const Evaluation& pressure,
+                                                             const Evaluation& /*oilSaturation*/,
+                                                             const Evaluation& /*maxOilSaturation*/) const
     {
         //TODO support VAPPARS
         return rsSat(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx]));
@@ -448,9 +454,9 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturatedGasDissolutionFactor(unsigned regionIdx,
-                                             const Evaluation& temperature,
-                                             const Evaluation& pressure,
-                                             const Evaluation& saltConcentration) const
+                                                             const Evaluation& temperature,
+                                                             const Evaluation& pressure,
+                                                             const Evaluation& saltConcentration) const
     {
         const Evaluation salinity = salinityFromConcentration(regionIdx, temperature,
                                                               pressure, saltConcentration);
@@ -462,8 +468,8 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturatedGasDissolutionFactor(unsigned regionIdx,
-                                             const Evaluation& temperature,
-                                             const Evaluation& pressure) const
+                                                             const Evaluation& temperature,
+                                                             const Evaluation& pressure) const
     {
         return rsSat(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx]));
     }
@@ -503,9 +509,9 @@ public:
 
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation diffusionCoefficient(const Evaluation& temperature,
-                                    const Evaluation& pressure,
-                                    unsigned /*compIdx*/,
-                                    unsigned regionIdx = 0) const
+                                                    const Evaluation& pressure,
+                                                    unsigned /*compIdx*/,
+                                                    unsigned regionIdx = 0) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         // Diffusion coefficient of CO2 in pure water according to
@@ -535,10 +541,10 @@ public:
 
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation density(unsigned regionIdx,
-                       const Evaluation& temperature,
-                       const Evaluation& pressure,
-                       const Evaluation& Rs,
-                       const Evaluation& salinity) const
+                                       const Evaluation& temperature,
+                                       const Evaluation& pressure,
+                                       const Evaluation& Rs,
+                                       const Evaluation& salinity) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Evaluation xlCO2 = convertXoGToxoG_(convertRsToXoG_(Rs,regionIdx), salinity);
@@ -553,9 +559,9 @@ public:
 
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation rsSat(unsigned regionIdx,
-                     const Evaluation& temperature,
-                     const Evaluation& pressure,
-                     const Evaluation& salinity) const
+                                     const Evaluation& temperature,
+                                     const Evaluation& pressure,
+                                     const Evaluation& salinity) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         if (!enableDissolution_) {
@@ -585,7 +591,7 @@ public:
 private:
     template <class LhsEval>
     OPM_HOST_DEVICE LhsEval ezrokhiExponent_(const LhsEval& temperature,
-                             const ContainerT& ezrokhiCoeff) const
+                                             const ContainerT& ezrokhiCoeff) const
     {
         const LhsEval& tempC = temperature - 273.15;
         return ezrokhiCoeff[0] + tempC * (ezrokhiCoeff[1] + ezrokhiCoeff[2] * tempC);
@@ -593,9 +599,9 @@ private:
 
     template <class LhsEval>
     OPM_HOST_DEVICE LhsEval liquidDensity_(const LhsEval& T,
-                           const LhsEval& pl,
-                           const LhsEval& xlCO2,
-                           const LhsEval& salinity) const
+                                           const LhsEval& pl,
+                                           const LhsEval& xlCO2,
+                                           const LhsEval& salinity) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         Valgrind::CheckDefined(T);
@@ -718,9 +724,9 @@ private:
 
     template <class LhsEval>
     OPM_HOST_DEVICE LhsEval liquidEnthalpyBrineCO2_(const LhsEval& T,
-                                    const LhsEval& p,
-                                    const LhsEval& salinity,
-                                    const LhsEval& X_CO2_w) const
+                                                    const LhsEval& p,
+                                                    const LhsEval& salinity,
+                                                    const LhsEval& X_CO2_w) const
     {
         if (liquidMixType_ == Co2StoreConfig::LiquidMixingType::NONE
             && saltMixType_ == Co2StoreConfig::SaltMixingType::NONE)
@@ -807,9 +813,9 @@ private:
 
     template <class LhsEval>
     OPM_HOST_DEVICE const LhsEval salinityFromConcentration(unsigned regionIdx,
-                                            const LhsEval&T,
-                                            const LhsEval& P,
-                                            const LhsEval& saltConcentration) const
+                                                            const LhsEval&T,
+                                                            const LhsEval& P,
+                                                            const LhsEval& saltConcentration) const
     {
         if (enableSaltConcentration_) {
             // Convert concentration [kg/m³] to mass fraction [kg_salt/kg_solution].

--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -130,9 +130,9 @@ public:
      * \brief Initialize the reference densities of all fluids for a given PVT region
      */
     OPM_HOST_DEVICE void setReferenceDensities(unsigned regionIdx,
-                               Scalar rhoRefBrine,
-                               Scalar rhoRefGas,
-                               Scalar /*rhoRefWater*/);
+                                               Scalar rhoRefBrine,
+                                               Scalar rhoRefGas,
+                                               Scalar /*rhoRefWater*/);
 
     /*!
      * \brief Specify whether the PVT model should consider that the water component can
@@ -169,15 +169,21 @@ public:
     OPM_HOST_DEVICE Scalar hVap(unsigned ) const
     { return 0.0;  }
 
+    /*! \brief Indicates whether this PVT object computes the gas internal
+     *         energy via a thermal mixing model. \c Co2GasPvt always uses
+     *         the simple direct-internal-energy path, so returns \c false. */
+    OPM_HOST_DEVICE static constexpr bool mixingEnergy()
+    { return false; }
+
     /*!
      * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation internalEnergy(unsigned regionIdx,
-                        const Evaluation& temperature,
-                        const Evaluation& pressure,
-                        const Evaluation& rv,
-                        const Evaluation& rvw) const
+                                              const Evaluation& temperature,
+                                              const Evaluation& pressure,
+                                              const Evaluation& rv,
+                                              const Evaluation& rvw) const
     {
         OPM_TIMEBLOCK_LOCAL(internalEnergy, Subsystem::PvtProps);
         if (gastype_ == Co2StoreConfig::GasMixingType::NONE) {
@@ -203,10 +209,10 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation viscosity(unsigned regionIdx,
-                         const Evaluation& temperature,
-                         const Evaluation& pressure,
-                         const Evaluation& /*Rv*/,
-                         const Evaluation& /*Rvw*/) const
+                                         const Evaluation& temperature,
+                                         const Evaluation& pressure,
+                                         const Evaluation& /*Rv*/,
+                                         const Evaluation& /*Rvw*/) const
     { return saturatedViscosity(regionIdx, temperature, pressure); }
 
     /*!
@@ -214,8 +220,8 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturatedViscosity(unsigned /*regionIdx*/,
-                                  const Evaluation& temperature,
-                                  const Evaluation& pressure) const
+                                                  const Evaluation& temperature,
+                                                  const Evaluation& pressure) const
     {
         OPM_TIMEBLOCK_LOCAL(saturatedViscosity, Subsystem::PvtProps);
         // Neglects impact of vaporized water on the visosity
@@ -227,10 +233,10 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation inverseFormationVolumeFactor(unsigned regionIdx,
-                                            const Evaluation& temperature,
-                                            const Evaluation& pressure,
-                                            const Evaluation& rv,
-                                            const Evaluation& rvw) const
+                                                            const Evaluation& temperature,
+                                                            const Evaluation& pressure,
+                                                            const Evaluation& rv,
+                                                            const Evaluation& rvw) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         if (!enableVaporization_) {
@@ -254,8 +260,8 @@ public:
      * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
      */
     template <class FluidState, class LhsEval = typename FluidState::ValueType>
-    std::pair<LhsEval, LhsEval>
-    inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx)
+    OPM_HOST_DEVICE std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx) const
     {
         const LhsEval& T = decay<LhsEval>(fluidState.temperature(FluidState::gasPhaseIdx));
         const LhsEval& p = decay<LhsEval>(fluidState.pressure(FluidState::gasPhaseIdx));
@@ -270,8 +276,8 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturatedInverseFormationVolumeFactor(unsigned regionIdx,
-                                                     const Evaluation& temperature,
-                                                     const Evaluation& pressure) const
+                                                                     const Evaluation& temperature,
+                                                                     const Evaluation& pressure) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation rvw = rvwSat_(regionIdx, temperature, pressure,
@@ -289,8 +295,8 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturationPressure(unsigned /*regionIdx*/,
-                                  const Evaluation& /*temperature*/,
-                                  const Evaluation& /*Rvw*/) const
+                                                  const Evaluation& /*temperature*/,
+                                                  const Evaluation& /*Rvw*/) const
     { return 0.0; /* not implemented */ }
 
     /*!
@@ -298,8 +304,8 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturatedWaterVaporizationFactor(unsigned regionIdx,
-                                              const Evaluation& temperature,
-                                              const Evaluation& pressure) const
+                                                                const Evaluation& temperature,
+                                                                const Evaluation& pressure) const
     { return rvwSat_(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx])); }
 
     /*!
@@ -307,9 +313,9 @@ public:
     */
     template <class Evaluation = Scalar>
     OPM_HOST_DEVICE Evaluation saturatedWaterVaporizationFactor(unsigned regionIdx,
-                                              const Evaluation& temperature,
-                                              const Evaluation& pressure,
-                                              const Evaluation& saltConcentration) const
+                                                                const Evaluation& temperature,
+                                                                const Evaluation& pressure,
+                                                                const Evaluation& saltConcentration) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         const Evaluation salinity = salinityFromConcentration(temperature, pressure,
@@ -322,10 +328,10 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturatedOilVaporizationFactor(unsigned regionIdx,
-                                              const Evaluation& temperature,
-                                              const Evaluation& pressure,
-                                              const Evaluation& /*oilSaturation*/,
-                                              const Evaluation& /*maxOilSaturation*/) const
+                                                              const Evaluation& temperature,
+                                                              const Evaluation& pressure,
+                                                              const Evaluation& /*oilSaturation*/,
+                                                              const Evaluation& /*maxOilSaturation*/) const
     { return rvwSat_(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx])); }
 
     /*!
@@ -333,14 +339,14 @@ public:
      */
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturatedOilVaporizationFactor(unsigned regionIdx,
-                                              const Evaluation& temperature,
-                                              const Evaluation& pressure) const
+                                                              const Evaluation& temperature,
+                                                              const Evaluation& pressure) const
     { return rvwSat_(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx])); }
 
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation diffusionCoefficient(const Evaluation& temperature,
-                                    const Evaluation& pressure,
-                                    unsigned /*compIdx*/) const
+                                                    const Evaluation& pressure,
+                                                    unsigned /*compIdx*/) const
     {
         return BinaryCoeffBrineCO2::gasDiffCoeff(co2Tables, temperature, pressure, extrapolate);
     }
@@ -397,9 +403,9 @@ private:
 
     template <class LhsEval>
     OPM_HOST_DEVICE LhsEval rvwSat_(unsigned regionIdx,
-                    const LhsEval& temperature,
-                    const LhsEval& pressure,
-                    const LhsEval& salinity) const
+                                    const LhsEval& temperature,
+                                    const LhsEval& pressure,
+                                    const LhsEval& salinity) const
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::PvtProps);
         if (!enableVaporization_) {
@@ -475,7 +481,7 @@ private:
 
     template <class LhsEval>
     OPM_HOST_DEVICE const LhsEval salinityFromConcentration(const LhsEval&T, const LhsEval& P,
-                                            const LhsEval& saltConcentration) const
+                                                            const LhsEval& saltConcentration) const
     { return saltConcentration/H2O::liquidDensity(T, P, true); }
 
     ContainerT brineReferenceDensity_{};

--- a/opm/material/fluidsystems/blackoilpvt/NullOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/NullOilPvt.hpp
@@ -101,6 +101,14 @@ public:
         return 0.0;
     }
 
+    // Combined formation volume factor and viscosity
+    template <class FluidState, class LhsEval = typename FluidState::ValueType>
+    OPM_HOST_DEVICE std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& /*fluidState*/, unsigned /*regionIdx*/) const
+    {
+        return { LhsEval(1.0), LhsEval(0.0) };
+    }
+
     template <class Evaluation>
     OPM_HOST_DEVICE Evaluation saturatedViscosity(unsigned /*regionIdx*/,
                                                   const Evaluation& /*temperature*/,


### PR DESCRIPTION
- Add OPM_HOST_DEVICE annotations and convert raw `throw` sites to OPM_THROW in Evaluation, DynamicEvaluation, BlackOilFluidState, BlackOilFluidSystem and the BrineCo2/Co2Gas/NullOil PVT classes.
- Refresh BlackOilFluidSystem_macrotemplate's getNonStaticInstance() so the non-static singleton mirrors the current static state after every getInstance() call (fixes stale PVT/density tables seen by the GPU intensive-quantities path).
- Add a small `mixingEnergy()` constexpr probe and an `inverseFormationVolumeFactorAndViscosity` helper used by GPU code.
- Update bin/genEvalSpecializations.py so generated Evaluation*.hpp pick up ErrorMacros.hpp.