### PR TITLE
Tabulated1DFunction and Ecl* materials: parameterise storage for GPU copy

### DIFF
--- a/opm/material/common/Tabulated1DFunction.cpp
+++ b/opm/material/common/Tabulated1DFunction.cpp
@@ -28,8 +28,8 @@
 
 namespace Opm {
 
-template<class Scalar>
-void Tabulated1DFunction<Scalar>::
+template<class Scalar, template <class> class Storage>
+void Tabulated1DFunction<Scalar, Storage>::
 printCSV(Scalar xi0, Scalar xi1, unsigned k, std::ostream& os) const
 {
     Scalar x0 = std::min(xi0, xi1);

--- a/opm/material/common/Tabulated1DFunction.hpp
+++ b/opm/material/common/Tabulated1DFunction.hpp
@@ -28,6 +28,8 @@
 #define OPM_TABULATED_1D_FUNCTION_HPP
 
 #include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/VectorWithDefaultAllocator.hpp>
+#include <opm/common/utility/gpuDecorators.hpp>
 #include <opm/material/densead/Math.hpp>
 
 #include <algorithm>
@@ -45,17 +47,32 @@ struct SegmentIndex {
 /*!
  * \brief Implements a linearly interpolated scalar function that depends on one
  *        variable.
+ *
+ * The samples are stored in a templated \c Storage container so the
+ * same class can be used both on the CPU (\c VectorWithDefaultAllocator)
+ * and on the GPU (\c GpuBuffer for owning device memory and \c GpuView
+ * for a non-owning device-side view usable from a kernel).
  */
-template <class Scalar>
+template <class Scalar, template <class> class Storage = ::Opm::VectorWithDefaultAllocator>
 class Tabulated1DFunction
 {
 public:
+    using ValueVector = Storage<Scalar>;
+
     /*!
      * \brief Default constructor for a piecewise linear function.
      *
      * To specfiy the acutal curve, use one of the set() methods.
      */
-    Tabulated1DFunction()
+    OPM_HOST_DEVICE Tabulated1DFunction() = default;
+
+    /*!
+     * \brief Construct directly from sample-value containers. Mainly used to
+     *        build GPU instantiations from device-resident buffers/views.
+     */
+    OPM_HOST_DEVICE Tabulated1DFunction(ValueVector xValues, ValueVector yValues)
+        : xValues_(std::move(xValues))
+        , yValues_(std::move(yValues))
     {}
 
     /*!
@@ -212,44 +229,50 @@ public:
     /*!
      * \brief Returns the number of sampling points.
      */
-    size_t numSamples() const
+    OPM_HOST_DEVICE size_t numSamples() const
     { return xValues_.size(); }
 
     /*!
      * \brief Return the x value of the leftmost sampling point.
      */
-    Scalar xMin() const
+    OPM_HOST_DEVICE Scalar xMin() const
     { return xValues_[0]; }
 
     /*!
      * \brief Return the x value of the rightmost sampling point.
      */
-    Scalar xMax() const
+    OPM_HOST_DEVICE Scalar xMax() const
     { return xValues_[numSamples() - 1]; }
 
     /*!
      * \brief Return the x value of the a sample point with a given index.
      */
-    Scalar xAt(size_t i) const
+    OPM_HOST_DEVICE Scalar xAt(size_t i) const
     { return xValues_[i]; }
 
-    const std::vector<Scalar>& xValues() const
+    OPM_HOST_DEVICE const ValueVector& xValues() const
     { return xValues_; }
 
-    const std::vector<Scalar>& yValues() const
+    OPM_HOST_DEVICE const ValueVector& yValues() const
+    { return yValues_; }
+
+    ValueVector& xValuesMutable()
+    { return xValues_; }
+
+    ValueVector& yValuesMutable()
     { return yValues_; }
 
     /*!
      * \brief Return the value of the a sample point with a given index.
      */
-    Scalar valueAt(size_t i) const
+    OPM_HOST_DEVICE Scalar valueAt(size_t i) const
     { return yValues_[i]; }
 
     /*!
      * \brief Return true iff the given x is in range [x1, xn].
      */
     template <class Evaluation>
-    bool applies(const Evaluation& x) const
+    OPM_HOST_DEVICE bool applies(const Evaluation& x) const
     { return xValues_[0] <= x && x <= xValues_[numSamples() - 1]; }
 
     /*!
@@ -262,14 +285,14 @@ public:
      *                    failed assertation.
      */
     template <class Evaluation>
-    Evaluation eval(const Evaluation& x, bool extrapolate = false) const
+    OPM_HOST_DEVICE Evaluation eval(const Evaluation& x, bool extrapolate = false) const
     {
         SegmentIndex segIdx = findSegmentIndex(x, extrapolate);
         return eval(x, segIdx);
     }
 
     template <class Evaluation>
-    Evaluation eval(const Evaluation& x, SegmentIndex segIdxIn) const
+    OPM_HOST_DEVICE Evaluation eval(const Evaluation& x, SegmentIndex segIdxIn) const
     {
         size_t segIdx = segIdxIn.value;
         Scalar x0 = xValues_[segIdx];
@@ -429,14 +452,15 @@ public:
     */
     void printCSV(Scalar xi0, Scalar xi1, unsigned k, std::ostream& os) const;
 
-    bool operator==(const Tabulated1DFunction<Scalar>& data) const {
+    bool operator==(const Tabulated1DFunction<Scalar, Storage>& data) const {
         return xValues_ == data.xValues_ &&
                yValues_ == data.yValues_;
     }
 
     template <class Evaluation>
-    SegmentIndex findSegmentIndex(const Evaluation& x, bool extrapolate = false) const
+    OPM_HOST_DEVICE SegmentIndex findSegmentIndex(const Evaluation& x, bool extrapolate = false) const
     {
+#if !OPM_IS_INSIDE_DEVICE_FUNCTION
         if (!isfinite(x)) {
             throw std::runtime_error("We can not search for extrapolation/interpolation "
                                      "segment in an 1D table for non-finite value " +
@@ -454,6 +478,9 @@ public:
                                    std::to_string(numSamples()) +
                                    " sampling points");
         }
+#else
+        (void)extrapolate;
+#endif
 
         if (x <= xValues_[1])
             return SegmentIndex{0};
@@ -471,6 +498,7 @@ public:
                     lowerIdx = pivotIdx;
             }
 
+#if !OPM_IS_INSIDE_DEVICE_FUNCTION
             if (xValues_[lowerIdx] > x || x > xValues_[lowerIdx + 1]) {
                 std::string msg = "Problematic interpolation/extrapolation "
                                   "segment is found for the input value " +
@@ -499,6 +527,7 @@ public:
                 OpmLog::debug(msg);
                 throw std::runtime_error(msg);
             }
+#endif
             return SegmentIndex{lowerIdx};
         }
     }
@@ -554,14 +583,14 @@ private:
      */
     struct ComparatorX_
     {
-        explicit ComparatorX_(const std::vector<Scalar>& x)
+        explicit ComparatorX_(const ValueVector& x)
             : x_(x)
         {}
 
         bool operator ()(size_t idxA, size_t idxB) const
         { return x_.at(idxA) < x_.at(idxB); }
 
-        const std::vector<Scalar>& x_;
+        const ValueVector& x_;
     };
 
     /*!
@@ -582,7 +611,7 @@ private:
         std::ranges::sort(idxVector, cmp);
 
         // reorder the sample points
-        std::vector<Scalar> tmpX(n), tmpY(n);
+        ValueVector tmpX(n), tmpY(n);
         for (size_t i = 0; i < idxVector.size(); ++ i) {
             tmpX[i] = xValues_[idxVector[i]];
             tmpY[i] = yValues_[idxVector[i]];
@@ -614,8 +643,8 @@ private:
         yValues_.resize(nSamples);
     }
 
-    std::vector<Scalar> xValues_;
-    std::vector<Scalar> yValues_;
+    ValueVector xValues_;
+    ValueVector yValues_;
 };
 
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -29,6 +29,7 @@
 
 #include <opm/common/TimingMacros.hpp>
 
+#include <opm/common/utility/gpuDecorators.hpp>
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/Valgrind.hpp>
 #include <opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp>
@@ -134,9 +135,9 @@ public:
      * \param state The fluid state
      */
     template <class ContainerT, class FluidState, class ...Args>
-    static void capillaryPressures(ContainerT& values,
-                                   const Params& params,
-                                   const FluidState& state)
+    OPM_HOST_DEVICE static void capillaryPressures(ContainerT& values,
+                                                   const Params& params,
+                                                   const FluidState& state)
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
@@ -261,8 +262,8 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation, class ...Args>
-    static Evaluation pcgn(const Params& params,
-                           const FluidState& fs)
+    OPM_HOST_DEVICE static Evaluation pcgn(const Params& params,
+                                           const FluidState& fs)
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         // Maximum attainable oil saturation is 1-SWL.
@@ -280,8 +281,8 @@ public:
      * \f]
      */
     template <class FluidState, class Evaluation, class ...Args>
-    static Evaluation pcnw(const Params& params,
-                           const FluidState& fs)
+    OPM_HOST_DEVICE static Evaluation pcnw(const Params& params,
+                                           const FluidState& fs)
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const auto Sw = decay<Evaluation>(fs.saturation(waterPhaseIdx));
@@ -345,9 +346,9 @@ public:
      * technical description.
      */
     template <class ContainerT, class FluidState, class ...Args>
-    static void relativePermeabilities(ContainerT& values,
-                                       const Params& params,
-                                       const FluidState& fluidState)
+    OPM_HOST_DEVICE static void relativePermeabilities(ContainerT& values,
+                                                       const Params& params,
+                                                       const FluidState& fluidState)
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
@@ -361,8 +362,8 @@ public:
      * \brief The relative permeability of the gas phase.
      */
     template <class FluidState, class Evaluation, class ...Args>
-    static Evaluation krg(const Params& params,
-                          const FluidState& fluidState)
+    OPM_HOST_DEVICE static Evaluation krg(const Params& params,
+                                          const FluidState& fluidState)
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         // Maximum attainable oil saturation is 1-SWL.
@@ -374,8 +375,8 @@ public:
      * \brief The relative permeability of the wetting phase.
      */
     template <class FluidState, class Evaluation, class ...Args>
-    static Evaluation krw(const Params& params,
-                          const FluidState& fluidState)
+    OPM_HOST_DEVICE static Evaluation krw(const Params& params,
+                                          const FluidState& fluidState)
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const Evaluation sw = decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
@@ -386,8 +387,8 @@ public:
      * \brief The relative permeability of the non-wetting (i.e., oil) phase.
      */
     template <class FluidState, class Evaluation, class ...Args>
-    static Evaluation krn(const Params& params,
-                          const FluidState& fluidState)
+    OPM_HOST_DEVICE static Evaluation krn(const Params& params,
+                                          const FluidState& fluidState)
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const Scalar Swco = params.Swl();
@@ -425,8 +426,8 @@ public:
      * \brief The relative permeability of oil in oil/gas system.
      */
     template <class Evaluation, class FluidState, class ...Args>
-    static Evaluation relpermOilInOilGasSystem(const Params& params,
-                                               const FluidState& fluidState)
+    OPM_HOST_DEVICE static Evaluation relpermOilInOilGasSystem(const Params& params,
+                                                               const FluidState& fluidState)
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const Evaluation sw =
@@ -443,8 +444,8 @@ public:
      * \brief The relative permeability of oil in oil/water system.
      */
     template <class Evaluation, class FluidState, class ...Args>
-    static Evaluation relpermOilInOilWaterSystem(const Params& params,
-                                                 const FluidState& fluidState)
+    OPM_HOST_DEVICE static Evaluation relpermOilInOilWaterSystem(const Params& params,
+                                                                 const FluidState& fluidState)
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         const Evaluation sw =

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
@@ -29,6 +29,7 @@
 
 #include <memory>
 
+#include <opm/common/utility/gpuDecorators.hpp>
 #include <opm/material/common/EnsureFinalized.hpp>
 
 namespace Opm {
@@ -55,20 +56,20 @@ public:
     /*!
      * \brief The default constructor.
      */
-    EclDefaultMaterialParams()
+    OPM_HOST_DEVICE EclDefaultMaterialParams()
     {
     }
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.
      */
-    const GasOilParams& gasOilParams() const
+    OPM_HOST_DEVICE const GasOilParams& gasOilParams() const
     { EnsureFinalized::check(); return gasOilParams_; }
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.
      */
-    GasOilParams& gasOilParams()
+    OPM_HOST_DEVICE GasOilParams& gasOilParams()
     { EnsureFinalized::check(); return gasOilParams_; }
 
     /*!
@@ -80,13 +81,13 @@ public:
     /*!
      * \brief The parameter object for the oil-water twophase law.
      */
-    const OilWaterParams& oilWaterParams() const
+    OPM_HOST_DEVICE const OilWaterParams& oilWaterParams() const
     { EnsureFinalized::check(); return oilWaterParams_; }
 
     /*!
      * \brief The parameter object for the oil-water twophase law.
      */
-    OilWaterParams& oilWaterParams()
+    OPM_HOST_DEVICE OilWaterParams& oilWaterParams()
     { EnsureFinalized::check(); return oilWaterParams_; }
 
     /*!
@@ -112,7 +113,7 @@ public:
     /*!
      * \brief Return the saturation of "connate" water.
      */
-    Scalar Swl() const
+    OPM_HOST_DEVICE Scalar Swl() const
     { EnsureFinalized::check(); return Swl_; }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
@@ -27,6 +27,8 @@
 #ifndef OPM_ECL_EPS_CONFIG_HPP
 #define OPM_ECL_EPS_CONFIG_HPP
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 #include <string>
 
 namespace Opm {
@@ -62,7 +64,7 @@ public:
     /*!
      * \brief Returns whether saturation scaling is enabled.
      */
-    bool enableSatScaling() const
+    OPM_HOST_DEVICE bool enableSatScaling() const
     { return enableSatScaling_; }
 
     /*!
@@ -76,7 +78,7 @@ public:
      * \brief Returns whether three point saturation scaling is enabled for the relative
      *        permeabilities.
      */
-    bool enableThreePointKrSatScaling() const
+    OPM_HOST_DEVICE bool enableThreePointKrSatScaling() const
     { return enableThreePointKrSatScaling_; }
 
     /*!
@@ -88,7 +90,7 @@ public:
     /*!
      * \brief Returns whether relative permeability scaling is enabled for the wetting phase.
      */
-    bool enableKrwScaling() const
+    OPM_HOST_DEVICE bool enableKrwScaling() const
     { return enableKrwScaling_; }
 
     /*!
@@ -102,7 +104,7 @@ public:
      * \brief Whether or not three-point relative permeability value scaling
      * is enabled for the wetting phase (KRWR + KRW).
      */
-    bool enableThreePointKrwScaling() const
+    OPM_HOST_DEVICE bool enableThreePointKrwScaling() const
     { return this->enableThreePointKrwScaling_; }
 
     /*!
@@ -116,7 +118,7 @@ public:
      * \brief Whether or not three-point relative permeability value scaling
      * is enabled for the non-wetting phase (e.g., KRORW + KRO).
      */
-    bool enableThreePointKrnScaling() const
+    OPM_HOST_DEVICE bool enableThreePointKrnScaling() const
     { return this->enableThreePointKrnScaling_; }
 
     /*!
@@ -128,7 +130,7 @@ public:
     /*!
      * \brief Returns whether relative permeability scaling is enabled for the non-wetting phase.
      */
-    bool enableKrnScaling() const
+    OPM_HOST_DEVICE bool enableKrnScaling() const
     { return enableKrnScaling_; }
 
     /*!
@@ -140,7 +142,7 @@ public:
     /*!
      * \brief Returns whether capillary pressure scaling is enabled.
      */
-    bool enablePcScaling() const
+    OPM_HOST_DEVICE bool enablePcScaling() const
     { return enablePcScaling_; }
 
     /*!
@@ -160,7 +162,7 @@ public:
      * the normal capillary pressure scaling and the value of enablePcScaling() does not
      * matter anymore.
      */
-    bool enableLeverettScaling() const
+    OPM_HOST_DEVICE bool enableLeverettScaling() const
     { return enableLeverettScaling_; }
 
     /*!

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -27,6 +27,8 @@
 #ifndef OPM_ECL_EPS_SCALING_POINTS_HPP
 #define OPM_ECL_EPS_SCALING_POINTS_HPP
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 #include <array>
 #include <vector>
 
@@ -166,7 +168,7 @@ public:
     /*!
      * \brief Returns the points used for capillary pressure saturation scaling
      */
-    const std::array<Scalar, 3>& saturationPcPoints() const
+    OPM_HOST_DEVICE const std::array<Scalar, 3>& saturationPcPoints() const
     { return saturationPcPoints_; }
 
     /*!
@@ -178,7 +180,7 @@ public:
     /*!
      * \brief Returns the points used for wetting phase relperm saturation scaling
      */
-    const std::array<Scalar, 3>& saturationKrwPoints() const
+    OPM_HOST_DEVICE const std::array<Scalar, 3>& saturationKrwPoints() const
     { return saturationKrwPoints_; }
 
     /*!
@@ -190,7 +192,7 @@ public:
     /*!
      * \brief Returns the points used for non-wetting phase relperm saturation scaling
      */
-    const std::array<Scalar, 3>& saturationKrnPoints() const
+    OPM_HOST_DEVICE const std::array<Scalar, 3>& saturationKrnPoints() const
     { return saturationKrnPoints_; }
 
     /*!
@@ -202,7 +204,7 @@ public:
     /*!
      * \brief Returns the maximum capillary pressure
      */
-    Scalar maxPcnw() const
+    OPM_HOST_DEVICE Scalar maxPcnw() const
     { return maxPcnwOrLeverettFactor_; }
 
     /*!
@@ -214,7 +216,7 @@ public:
     /*!
      * \brief Returns the Leverett scaling factor for capillary pressure
      */
-    Scalar leverettFactor() const
+    OPM_HOST_DEVICE Scalar leverettFactor() const
     { return maxPcnwOrLeverettFactor_; }
 
     /*!
@@ -228,7 +230,7 @@ public:
      * \brief Returns wetting-phase relative permeability at residual
      * saturation of non-wetting phase.
      */
-    Scalar krwr() const
+    OPM_HOST_DEVICE Scalar krwr() const
     { return this->Krwr_; }
 
     /*!
@@ -240,7 +242,7 @@ public:
     /*!
      * \brief Returns the maximum wetting phase relative permeability
      */
-    Scalar maxKrw() const
+    OPM_HOST_DEVICE Scalar maxKrw() const
     { return maxKrw_; }
 
     /*!
@@ -254,7 +256,7 @@ public:
      * \brief Returns non-wetting phase relative permeability at residual
      * saturation of wetting phase.
      */
-    Scalar krnr() const
+    OPM_HOST_DEVICE Scalar krnr() const
     { return this->Krnr_; }
 
     /*!
@@ -266,7 +268,7 @@ public:
     /*!
      * \brief Returns the maximum wetting phase relative permeability
      */
-    Scalar maxKrn() const
+    OPM_HOST_DEVICE Scalar maxKrn() const
     { return maxKrn_; }
 
     void print() const;

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
@@ -29,6 +29,8 @@
 
 #include "EclEpsTwoPhaseLawParams.hpp"
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 #include <algorithm>
 #include <cstddef>
 #include <type_traits>
@@ -147,7 +149,7 @@ public:
     }
 
     template <class Evaluation, class ...Args>
-    static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& SwScaled)
+    OPM_HOST_DEVICE static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& SwScaled)
     {
         const Evaluation SwUnscaled = scaledToUnscaledSatPc(params, SwScaled);
         const Evaluation pcUnscaled = EffLaw::template twoPhaseSatPcnw<Evaluation, Args...>(params.effectiveLawParams(), SwUnscaled);
@@ -219,7 +221,7 @@ public:
     }
 
     template <class Evaluation, class ...Args>
-    static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& SwScaled)
+    OPM_HOST_DEVICE static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& SwScaled)
     {
         const Evaluation SwUnscaled = scaledToUnscaledSatKrw(params, SwScaled);
         const Evaluation krwUnscaled = EffLaw::template twoPhaseSatKrw<Evaluation, Args...>(params.effectiveLawParams(), SwUnscaled);
@@ -244,7 +246,7 @@ public:
     }
 
     template <class Evaluation, class ...Args>
-    static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& SwScaled)
+    OPM_HOST_DEVICE static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& SwScaled)
     {
         const Evaluation SwUnscaled = scaledToUnscaledSatKrn(params, SwScaled);
         const Evaluation krnUnscaled = EffLaw::template twoPhaseSatKrn<Evaluation, Args...>(params.effectiveLawParams(), SwUnscaled);
@@ -265,7 +267,7 @@ public:
      * The effective saturation is then feed into the "raw" capillary pressure law.
      */
     template <class Evaluation>
-    static Evaluation scaledToUnscaledSatPc(const Params& params, const Evaluation& SwScaled)
+    OPM_HOST_DEVICE static Evaluation scaledToUnscaledSatPc(const Params& params, const Evaluation& SwScaled)
     {
         if (!params.config().enableSatScaling())
             return SwScaled;
@@ -278,7 +280,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation unscaledToScaledSatPc(const Params& params, const Evaluation& SwUnscaled)
+    OPM_HOST_DEVICE static Evaluation unscaledToScaledSatPc(const Params& params, const Evaluation& SwUnscaled)
     {
         if (!params.config().enableSatScaling())
             return SwUnscaled;
@@ -295,7 +297,7 @@ public:
      *        relperm of the wetting phase.
      */
     template <class Evaluation>
-    static Evaluation scaledToUnscaledSatKrw(const Params& params, const Evaluation& SwScaled)
+    OPM_HOST_DEVICE static Evaluation scaledToUnscaledSatKrw(const Params& params, const Evaluation& SwScaled)
     {
         if (!params.config().enableSatScaling())
             return SwScaled;
@@ -313,7 +315,7 @@ public:
     }
 
     template <class Evaluation>
-    static Evaluation unscaledToScaledSatKrw(const Params& params, const Evaluation& SwUnscaled)
+    OPM_HOST_DEVICE static Evaluation unscaledToScaledSatKrw(const Params& params, const Evaluation& SwUnscaled)
     {
         if (!params.config().enableSatScaling())
             return SwUnscaled;
@@ -335,7 +337,7 @@ public:
      *        relperm of the non-wetting phase.
      */
     template <class Evaluation>
-    static Evaluation scaledToUnscaledSatKrn(const Params& params, const Evaluation& SwScaled)
+    OPM_HOST_DEVICE static Evaluation scaledToUnscaledSatKrn(const Params& params, const Evaluation& SwScaled)
     {
         if (!params.config().enableSatScaling())
             return SwScaled;
@@ -352,7 +354,7 @@ public:
 
 
     template <class Evaluation>
-    static Evaluation unscaledToScaledSatKrn(const Params& params, const Evaluation& SwUnscaled)
+    OPM_HOST_DEVICE static Evaluation unscaledToScaledSatKrn(const Params& params, const Evaluation& SwUnscaled)
     {
         if (!params.config().enableSatScaling())
             return SwUnscaled;
@@ -371,9 +373,9 @@ public:
 
 private:
     template <class Evaluation, class PointsContainer>
-    static Evaluation scaledToUnscaledSatTwoPoint_(const Evaluation& scaledSat,
-                                                   const PointsContainer& unscaledSats,
-                                                   const PointsContainer& scaledSats)
+    OPM_HOST_DEVICE static Evaluation scaledToUnscaledSatTwoPoint_(const Evaluation& scaledSat,
+                                                                   const PointsContainer& unscaledSats,
+                                                                   const PointsContainer& scaledSats)
     {
         return
             unscaledSats[0]
@@ -382,9 +384,9 @@ private:
     }
 
     template <class Evaluation, class PointsContainer>
-    static Evaluation unscaledToScaledSatTwoPoint_(const Evaluation& unscaledSat,
-                                                   const PointsContainer& unscaledSats,
-                                                   const PointsContainer& scaledSats)
+    OPM_HOST_DEVICE static Evaluation unscaledToScaledSatTwoPoint_(const Evaluation& unscaledSat,
+                                                                   const PointsContainer& unscaledSats,
+                                                                   const PointsContainer& scaledSats)
     {
         return
             scaledSats[0]
@@ -393,9 +395,9 @@ private:
     }
 
     template <class Evaluation, class PointsContainer>
-    static Evaluation scaledToUnscaledSatThreePoint_(const Evaluation& scaledSat,
-                                                     const PointsContainer& unscaledSats,
-                                                     const PointsContainer& scaledSats)
+    OPM_HOST_DEVICE static Evaluation scaledToUnscaledSatThreePoint_(const Evaluation& scaledSat,
+                                                                     const PointsContainer& unscaledSats,
+                                                                     const PointsContainer& scaledSats)
     {
         using UnscaledSat = std::remove_cv_t<std::remove_reference_t<decltype(unscaledSats[0])>>;
 
@@ -433,9 +435,9 @@ private:
     }
 
     template <class Evaluation, class PointsContainer>
-    static Evaluation unscaledToScaledSatThreePoint_(const Evaluation& unscaledSat,
-                                                     const PointsContainer& unscaledSats,
-                                                     const PointsContainer& scaledSats)
+    OPM_HOST_DEVICE static Evaluation unscaledToScaledSatThreePoint_(const Evaluation& unscaledSat,
+                                                                     const PointsContainer& unscaledSats,
+                                                                     const PointsContainer& scaledSats)
     {
         using ScaledSat = std::remove_cv_t<std::remove_reference_t<decltype(scaledSats[0])>>;
 
@@ -473,7 +475,7 @@ private:
      * \brief Scale the capillary pressure according to the given parameters
      */
     template <class Evaluation>
-    static Evaluation unscaledToScaledPcnw_(const Params& params, const Evaluation& unscaledPcnw)
+    OPM_HOST_DEVICE static Evaluation unscaledToScaledPcnw_(const Params& params, const Evaluation& unscaledPcnw)
     {
         if (params.config().enableLeverettScaling()) {
             Scalar alpha = params.scaledPoints().leverettFactor();
@@ -496,7 +498,7 @@ private:
     }
 
     template <class Evaluation>
-    static Evaluation scaledToUnscaledPcnw_(const Params& params, const Evaluation& scaledPcnw)
+    OPM_HOST_DEVICE static Evaluation scaledToUnscaledPcnw_(const Params& params, const Evaluation& scaledPcnw)
     {
         if (params.config().enableLeverettScaling()) {
             Scalar alpha = params.scaledPoints().leverettFactor();
@@ -522,9 +524,9 @@ private:
      * \brief Scale the wetting phase relative permeability of a phase according to the given parameters
      */
     template <class Evaluation>
-    static Evaluation unscaledToScaledKrw_(const Evaluation& SwScaled,
-                                           const Params& params,
-                                           const Evaluation& unscaledKrw)
+    OPM_HOST_DEVICE static Evaluation unscaledToScaledKrw_(const Evaluation& SwScaled,
+                                                           const Params& params,
+                                                           const Evaluation& unscaledKrw)
     {
         const auto& cfg = params.config();
 
@@ -582,7 +584,7 @@ private:
     }
 
     template <class Evaluation>
-    static Evaluation scaledToUnscaledKrw_(const Params& params, const Evaluation& scaledKrw)
+    OPM_HOST_DEVICE static Evaluation scaledToUnscaledKrw_(const Params& params, const Evaluation& scaledKrw)
     {
         if (!params.config().enableKrwScaling())
             return scaledKrw;
@@ -595,9 +597,9 @@ private:
      * \brief Scale the non-wetting phase relative permeability of a phase according to the given parameters
      */
     template <class Evaluation>
-    static Evaluation unscaledToScaledKrn_(const Evaluation& SwScaled,
-                                           const Params& params,
-                                           const Evaluation& unscaledKrn)
+    OPM_HOST_DEVICE static Evaluation unscaledToScaledKrn_(const Evaluation& SwScaled,
+                                                           const Params& params,
+                                                           const Evaluation& unscaledKrn)
     {
         const auto& cfg = params.config();
 
@@ -660,7 +662,7 @@ private:
     }
 
     template <class Evaluation>
-    static Evaluation scaledToUnscaledKrn_(const Params& params, const Evaluation& scaledKrn)
+    OPM_HOST_DEVICE static Evaluation scaledToUnscaledKrn_(const Params& params, const Evaluation& scaledKrn)
     {
         if (!params.config().enableKrnScaling())
             return scaledKrn;

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
@@ -30,6 +30,8 @@
 #include "EclEpsConfig.hpp"
 #include "EclEpsScalingPoints.hpp"
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 #include <memory>
 #include <cassert>
 
@@ -80,7 +82,7 @@ public:
     /*!
      * \brief Returns the endpoint scaling configuration object.
      */
-    const EclEpsConfig& config() const
+    OPM_HOST_DEVICE const EclEpsConfig& config() const
     { return config_; }
 
     /*!
@@ -92,7 +94,7 @@ public:
     /*!
      * \brief Returns the scaling points which are seen by the nested material law
      */
-    const ScalingPoints& unscaledPoints() const
+    OPM_HOST_DEVICE const ScalingPoints& unscaledPoints() const
     { return *unscaledPoints_; }
 
     /*!
@@ -104,7 +106,7 @@ public:
     /*!
      * \brief Returns the scaling points which are seen by the physical model
      */
-    const ScalingPoints& scaledPoints() const
+    OPM_HOST_DEVICE const ScalingPoints& scaledPoints() const
     { return scaledPoints_; }
 
     /*!
@@ -137,7 +139,7 @@ public:
     /*!
      * \brief Returns the parameter object for the effective/nested material law.
      */
-    const EffLawParams& effectiveLawParams() const
+    OPM_HOST_DEVICE const EffLawParams& effectiveLawParams() const
     { return *effectiveLawParams_; }
 
     template<class Serializer>

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -30,6 +30,7 @@
 #include <opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp>
 
 #include <opm/common/TimingMacros.hpp>
+#include <opm/common/utility/gpuDecorators.hpp>
 
 #include <opm/material/common/Valgrind.hpp>
 #include <opm/material/common/MathToolbox.hpp>
@@ -142,9 +143,9 @@ public:
      */
 
     template <class ContainerT, class FluidState, class ...Args>
-    static void capillaryPressures(ContainerT& values,
-                                   const Params& params,
-                                   const FluidState& fluidState)
+    OPM_HOST_DEVICE static void capillaryPressures(ContainerT& values,
+                                                   const Params& params,
+                                                   const FluidState& fluidState)
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
@@ -380,9 +381,9 @@ public:
      * technical description.
      */
     template <class ContainerT, class FluidState, class ...Args>
-    static void relativePermeabilities(ContainerT& values,
-                                       const Params& params,
-                                       const FluidState& fluidState)
+    OPM_HOST_DEVICE static void relativePermeabilities(ContainerT& values,
+                                                       const Params& params,
+                                                       const FluidState& fluidState)
     {
         OPM_TIMEFUNCTION_LOCAL(Subsystem::SatProps);
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
@@ -29,15 +29,13 @@
 
 #include <memory>
 
+#include <opm/common/utility/gpuDecorators.hpp>
 #include <opm/material/common/EnsureFinalized.hpp>
 
-namespace Opm {
+namespace Opm
+{
 
-enum class EclTwoPhaseApproach {
-    GasOil,
-    OilWater,
-    GasWater
-};
+enum class EclTwoPhaseApproach { GasOil, OilWater, GasWater };
 
 /*!
  * \brief Implementation for the parameters required by the material law for two-phase
@@ -45,87 +43,128 @@ enum class EclTwoPhaseApproach {
  *
  * Essentially, this class just stores the two parameter objects for
  * the twophase capillary pressure laws.
+ *
+ * The \c StoragePolicy template parameter selects how the per-sub-law
+ * parameter objects are stored. By default they are heap-allocated and
+ * referenced through std::shared_ptr; instantiations targeting the GPU may
+ * pass an inline-storage policy such as \c Opm::gpuistl::ValueAsPointer so
+ * that the resulting object is trivially copyable to the device.
  */
-template<class Traits, class GasOilParamsT, class OilWaterParamsT, class GasWaterParamsT>
+template <class Traits,
+          class GasOilParamsT,
+          class OilWaterParamsT,
+          class GasWaterParamsT,
+          template <class> class StoragePolicy = std::shared_ptr>
 class EclTwoPhaseMaterialParams : public EnsureFinalized
 {
     using Scalar = typename Traits::Scalar;
     enum { numPhases = 3 };
+
 public:
-    using EnsureFinalized :: finalize;
+    using EnsureFinalized::finalize;
 
     using GasOilParams = GasOilParamsT;
     using OilWaterParams = OilWaterParamsT;
     using GasWaterParams = GasWaterParamsT;
 
+    using GasOilParamsStorage = StoragePolicy<GasOilParams>;
+    using OilWaterParamsStorage = StoragePolicy<OilWaterParams>;
+    using GasWaterParamsStorage = StoragePolicy<GasWaterParams>;
+
     /*!
      * \brief The default constructor.
      */
-    EclTwoPhaseMaterialParams()
+    OPM_HOST_DEVICE EclTwoPhaseMaterialParams() = default;
+
+    OPM_HOST_DEVICE void setApproach(EclTwoPhaseApproach newApproach)
     {
+        approach_ = newApproach;
     }
 
-    void setApproach(EclTwoPhaseApproach newApproach)
-    { approach_ = newApproach; }
-
-    EclTwoPhaseApproach approach() const
-    { return approach_; }
-
-    /*!
-     * \brief The parameter object for the gas-oil twophase law.
-     */
-    const GasOilParams& gasOilParams() const
-    { EnsureFinalized::check(); return *gasOilParams_; }
+    OPM_HOST_DEVICE EclTwoPhaseApproach approach() const
+    {
+        return approach_;
+    }
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.
      */
-    GasOilParams& gasOilParams()
-    { EnsureFinalized::check(); return *gasOilParams_; }
+    OPM_HOST_DEVICE const GasOilParams& gasOilParams() const
+    {
+        EnsureFinalized::check();
+        return *gasOilParams_;
+    }
+
+    /*!
+     * \brief The parameter object for the gas-oil twophase law.
+     */
+    OPM_HOST_DEVICE GasOilParams& gasOilParams()
+    {
+        EnsureFinalized::check();
+        return *gasOilParams_;
+    }
 
     /*!
      * \brief Set the parameter object for the gas-oil twophase law.
      */
-    void setGasOilParams(std::shared_ptr<GasOilParams> val)
-    { gasOilParams_ = val; }
+    OPM_HOST_DEVICE void setGasOilParams(GasOilParamsStorage val)
+    {
+        gasOilParams_ = std::move(val);
+    }
 
     /*!
      * \brief The parameter object for the oil-water twophase law.
      */
-    const OilWaterParams& oilWaterParams() const
-    { EnsureFinalized::check(); return *oilWaterParams_; }
+    OPM_HOST_DEVICE const OilWaterParams& oilWaterParams() const
+    {
+        EnsureFinalized::check();
+        return *oilWaterParams_;
+    }
 
     /*!
      * \brief The parameter object for the oil-water twophase law.
      */
-    OilWaterParams& oilWaterParams()
-    { EnsureFinalized::check(); return *oilWaterParams_; }
+    OPM_HOST_DEVICE OilWaterParams& oilWaterParams()
+    {
+        EnsureFinalized::check();
+        return *oilWaterParams_;
+    }
 
     /*!
      * \brief Set the parameter object for the oil-water twophase law.
      */
-    void setOilWaterParams(std::shared_ptr<OilWaterParams> val)
-    { oilWaterParams_ = val; }
-
-  /*!
-     * \brief The parameter object for the gas-water twophase law.
-     */
-    const GasWaterParams& gasWaterParams() const
-    { EnsureFinalized::check(); return *gasWaterParams_; }
+    OPM_HOST_DEVICE void setOilWaterParams(OilWaterParamsStorage val)
+    {
+        oilWaterParams_ = std::move(val);
+    }
 
     /*!
      * \brief The parameter object for the gas-water twophase law.
      */
-    GasWaterParams& gasWaterParams()
-    { EnsureFinalized::check(); return *gasWaterParams_; }
+    OPM_HOST_DEVICE const GasWaterParams& gasWaterParams() const
+    {
+        EnsureFinalized::check();
+        return *gasWaterParams_;
+    }
+
+    /*!
+     * \brief The parameter object for the gas-water twophase law.
+     */
+    OPM_HOST_DEVICE GasWaterParams& gasWaterParams()
+    {
+        EnsureFinalized::check();
+        return *gasWaterParams_;
+    }
 
     /*!
      * \brief Set the parameter object for the gas-water twophase law.
      */
-    void setGasWaterParams(std::shared_ptr<GasWaterParams> val)
-    { gasWaterParams_ = val; }
+    OPM_HOST_DEVICE void setGasWaterParams(GasWaterParamsStorage val)
+    {
+        gasWaterParams_ = std::move(val);
+    }
 
-    template<class Serializer>
+    template <class Serializer>
     void serializeOp(Serializer& serializer)
     {
         // This is for restart serialization.
@@ -135,14 +174,16 @@ public:
         serializer(*gasWaterParams_);
     }
 
-    void setSwl(Scalar) {}
+    void setSwl(Scalar)
+    {
+    }
 
 private:
-    EclTwoPhaseApproach approach_{EclTwoPhaseApproach::GasOil};
+    EclTwoPhaseApproach approach_ {EclTwoPhaseApproach::GasOil};
 
-    std::shared_ptr<GasOilParams> gasOilParams_;
-    std::shared_ptr<OilWaterParams> oilWaterParams_;
-    std::shared_ptr<GasWaterParams> gasWaterParams_;
+    GasOilParamsStorage gasOilParams_ {};
+    OilWaterParamsStorage oilWaterParams_ {};
+    GasWaterParamsStorage gasWaterParams_ {};
 };
 
 } // namespace Opm

--- a/opm/material/thermal/EclSpecrockLaw.hpp
+++ b/opm/material/thermal/EclSpecrockLaw.hpp
@@ -29,6 +29,8 @@
 
 #include "EclSpecrockLawParams.hpp"
 
+#include <opm/common/utility/gpuDecorators.hpp>
+
 namespace Opm
 {
 
@@ -51,7 +53,7 @@ public:
      * \brief Given a fluid state, compute the volumetric internal energy of the rock [W/m^3].
      */
     template <class FluidState, class Evaluation = typename FluidState::ValueType>
-    static Evaluation solidInternalEnergy(const Params& params, const FluidState& fluidState)
+    OPM_HOST_DEVICE static Evaluation solidInternalEnergy(const Params& params, const FluidState& fluidState)
     {
         const auto& T = fluidState.temperature(/*phaseIdx=*/0);
         return params.internalEnergyFunction().eval(T, /*extrapolate=*/true);

--- a/opm/material/thermal/EclSpecrockLawParams.hpp
+++ b/opm/material/thermal/EclSpecrockLawParams.hpp
@@ -27,29 +27,55 @@
 #ifndef OPM_ECL_SPECROCK_LAW_PARAMS_HPP
 #define OPM_ECL_SPECROCK_LAW_PARAMS_HPP
 
+#include <opm/common/utility/VectorWithDefaultAllocator.hpp>
+#include <opm/common/utility/gpuDecorators.hpp>
+#include <opm/common/utility/gpuistl_if_available.hpp>
+
 #include <opm/material/common/EnsureFinalized.hpp>
 #include <opm/material/common/Tabulated1DFunction.hpp>
 
 #include <cassert>
+#include <utility>
 
 namespace Opm {
 
 /*!
  * \brief The default implementation of a parameter object for the
  *        ECL thermal law based on SPECROCK.
+ *
+ * The internal-energy table is stored in a templated \c Storage
+ * container so the same class can be used both on the CPU
+ * (\c VectorWithDefaultAllocator) and on the GPU (\c GpuBuffer for
+ * owning device memory and \c GpuView for a non-owning view usable
+ * from a kernel).
  */
-template <class ScalarT>
+template <class ScalarT, template <class> class Storage = ::Opm::VectorWithDefaultAllocator>
 class EclSpecrockLawParams : public EnsureFinalized
 {
-    using InternalEnergyFunction = Tabulated1DFunction<ScalarT>;
+    using InternalEnergyFunction = Tabulated1DFunction<ScalarT, Storage>;
 
 public:
     using Scalar = ScalarT;
 
-    EclSpecrockLawParams(const EclSpecrockLawParams&) = default;
+    OPM_HOST_DEVICE EclSpecrockLawParams() = default;
 
-    EclSpecrockLawParams()
-    { }
+    OPM_HOST_DEVICE explicit EclSpecrockLawParams(InternalEnergyFunction internalEnergyFunction)
+        : internalEnergyFunction_(std::move(internalEnergyFunction))
+    {
+        EnsureFinalized::finalize();
+    }
+
+    /*!
+     * \brief Construct directly from temperature and internal-energy storage
+     *        containers (used by the GPU thermal-law manager).
+     */
+    OPM_HOST_DEVICE EclSpecrockLawParams(Storage<Scalar> temperatureSamples,
+                                         Storage<Scalar> internalEnergySamples)
+        : internalEnergyFunction_(std::move(temperatureSamples),
+                                  std::move(internalEnergySamples))
+    {
+        EnsureFinalized::finalize();
+    }
 
     /*!
      * \brief Specify the volumetric internal energy of rock via heat capacities.
@@ -85,6 +111,17 @@ public:
     }
 
     /*!
+     * \brief Set the temperature/internal-energy sample table directly. Marks
+     *        the object as finalized.
+     */
+    template <class Container>
+    void setSamples(const Container& temperature, const Container& internalEnergy)
+    {
+        internalEnergyFunction_.setXYContainers(temperature, internalEnergy);
+        EnsureFinalized::finalize();
+    }
+
+    /*!
      * \brief Return the function which maps temparature to the rock's volumetric
      *        internal energy
      *
@@ -92,13 +129,51 @@ public:
      * linear heat capacity, the real function is quadratic, but the difference should be
      * negligible.)
      */
-    const InternalEnergyFunction& internalEnergyFunction() const
+    OPM_HOST_DEVICE const InternalEnergyFunction& internalEnergyFunction() const
     { EnsureFinalized::check(); return internalEnergyFunction_; }
+
+    InternalEnergyFunction& internalEnergyFunctionMutable()
+    { return internalEnergyFunction_; }
+
+    /*! \brief Convenience accessors for the per-region sample tables used by
+     *         the GPU thermal-law manager. */
+    OPM_HOST_DEVICE const auto& temperatureSamples() const
+    { return internalEnergyFunction_.xValues(); }
+
+    OPM_HOST_DEVICE const auto& internalEnergySamples() const
+    { return internalEnergyFunction_.yValues(); }
 
 private:
     InternalEnergyFunction internalEnergyFunction_;
 };
 
 } // namespace Opm
+
+#if HAVE_CUDA
+namespace Opm::gpuistl {
+
+template <class ScalarT>
+::Opm::EclSpecrockLawParams<ScalarT, GpuBuffer>
+copy_to_gpu(const ::Opm::EclSpecrockLawParams<ScalarT>& cpu)
+{
+    using GpuFunction = ::Opm::Tabulated1DFunction<ScalarT, GpuBuffer>;
+    return ::Opm::EclSpecrockLawParams<ScalarT, GpuBuffer>(
+        GpuFunction(GpuBuffer<ScalarT>(cpu.temperatureSamples()),
+                    GpuBuffer<ScalarT>(cpu.internalEnergySamples())));
+}
+
+template <class ScalarT>
+::Opm::EclSpecrockLawParams<ScalarT, GpuView>
+make_view(::Opm::EclSpecrockLawParams<ScalarT, GpuBuffer>& gpuBuffers)
+{
+    auto& f = gpuBuffers.internalEnergyFunctionMutable();
+    using ViewFunction = ::Opm::Tabulated1DFunction<ScalarT, GpuView>;
+    return ::Opm::EclSpecrockLawParams<ScalarT, GpuView>(
+        ViewFunction(GpuView<ScalarT>(f.xValuesMutable().data(), f.xValuesMutable().size()),
+                     GpuView<ScalarT>(f.yValuesMutable().data(), f.yValuesMutable().size())));
+}
+
+} // namespace Opm::gpuistl
+#endif // HAVE_CUDA
 
 #endif

--- a/opm/material/thermal/EclThconrLaw.hpp
+++ b/opm/material/thermal/EclThconrLaw.hpp
@@ -29,6 +29,7 @@
 
 #include "EclThconrLawParams.hpp"
 
+#include <opm/common/utility/gpuDecorators.hpp>
 #include <opm/material/densead/Math.hpp>
 
 namespace Opm
@@ -52,13 +53,13 @@ public:
      *        medium.
      */
     template <class FluidState, class Evaluation = typename FluidState::ValueType>
-    static Evaluation thermalConductivity(const Params& params,
-                                          const FluidState& fluidState)
+    OPM_HOST_DEVICE static Evaluation thermalConductivity(const Params& params,
+                                                          const FluidState& fluidState)
     {
         // THCONR + THCONSF approach.
         Scalar lambdaRef = params.referenceTotalThermalConductivity();
-        static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
-        if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
+        constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
+        if (fluidState.fluidSystem().phaseIsActive(gasPhaseIdx)) {
             Scalar alpha = params.dTotalThermalConductivity_dSg();
             const Evaluation& Sg = decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
             return lambdaRef*(1.0 - alpha*Sg);

--- a/opm/material/thermal/EclThconrLawParams.hpp
+++ b/opm/material/thermal/EclThconrLawParams.hpp
@@ -27,6 +27,7 @@
 #ifndef OPM_ECL_THCONR_LAW_PARAMS_HPP
 #define OPM_ECL_THCONR_LAW_PARAMS_HPP
 
+#include <opm/common/utility/gpuDecorators.hpp>
 #include <opm/material/common/EnsureFinalized.hpp>
 
 namespace Opm {
@@ -41,10 +42,9 @@ class EclThconrLawParams : public EnsureFinalized
 public:
     using Scalar = ScalarT;
 
-    EclThconrLawParams(const EclThconrLawParams&) = default;
+    OPM_HOST_DEVICE EclThconrLawParams(const EclThconrLawParams&) = default;
 
-    EclThconrLawParams()
-    { }
+    OPM_HOST_DEVICE EclThconrLawParams() = default;
 
     /*!
      * \brief Set the total thermal conductivity [J/m^2 / (K/m)] of at Sg = 0
@@ -55,7 +55,7 @@ public:
     /*!
      * \brief The total thermal conductivity [J/m^2 / (K/m)] of at Sg = 0
      */
-    Scalar referenceTotalThermalConductivity() const
+    OPM_HOST_DEVICE Scalar referenceTotalThermalConductivity() const
     { EnsureFinalized::check(); return referenceTotalThermalConductivity_; }
 
     /*!
@@ -67,7 +67,7 @@ public:
     /*!
      * \brief The gas saturation dependence of thermal conductivity [-]
      */
-    Scalar dTotalThermalConductivity_dSg() const
+    OPM_HOST_DEVICE Scalar dTotalThermalConductivity_dSg() const
     { EnsureFinalized::check(); return dTotalThermalConductivity_dSg_; }
 
 private:


### PR DESCRIPTION
Adds a `Storage` template parameter to Tabulated1DFunction and the Ecl*material/thermal parameter classes (EclDefaultMaterial(Params), EclEpsConfig, EclEpsScalingPoints, EclEpsTwoPhaseLaw(Params),  EclTwoPhaseMaterial(Params), EclSpecrockLaw(Params), EclThconrLaw(Params)),  together with `copy_to_gpu` / `make_view` helpers, so the same parameter objects can live on both host and device. CPU code paths are preserved.