### PR TITLE
[LGR] OutputStream: add LGR coordinate arrays to SMSPEC output

### DIFF
--- a/opm/common/utility/String.cpp
+++ b/opm/common/utility/String.cpp
@@ -144,6 +144,7 @@ template std::string ltrim_copy(const std::string&);
 template std::string rtrim_copy(const std::string&);
 template std::string trim_copy(const std::string&);
 template std::string trim_copy(const EclIO::PaddedOutputString<4>&);
+template std::string trim_copy(const EclIO::PaddedOutputString<8>&);
 
 template std::string& uppercase(const std::string&,std::string&);
 template std::string& uppercase(const std::string_view&,std::string&);

--- a/opm/io/eclipse/OutputStream.cpp
+++ b/opm/io/eclipse/OutputStream.cpp
@@ -21,6 +21,7 @@
 #include <opm/io/eclipse/OutputStream.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/String.hpp>
 
 #include <opm/io/eclipse/EclOutput.hpp>
 #include <opm/io/eclipse/ERst.hpp>
@@ -33,6 +34,7 @@
 #include <fstream>
 #include <iomanip>
 #include <ios>
+#include <map>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
@@ -753,6 +755,39 @@ Parameters::add(const std::string& keyword,
     this->units   .emplace_back(unit);
 }
 
+void
+Opm::EclIO::OutputStream::SummarySpecification::
+Parameters::add(const std::string&                          keyword,
+                const std::string&                          wgname,
+                const int                                   num,
+                const std::string&                          unit,
+                const std::optional<Opm::EclIO::lgr_info>& lgr)
+{
+    this->add(keyword, wgname, num, unit);
+
+    if (lgr.has_value()) {
+        if (this->lgrs.empty()) {
+            // First LGR vector — backfill all prior non-LGR entries with blanks/zeros.
+            const auto n = this->keywords.size() - 1;
+            this->lgrs .resize(n);
+            this->numlx.resize(n, 0);
+            this->numly.resize(n, 0);
+            this->numlz.resize(n, 0);
+        }
+        this->lgrs  .emplace_back(lgr->name);
+        this->numlx .push_back(lgr->ijk[0]);
+        this->numly .push_back(lgr->ijk[1]);
+        this->numlz .push_back(lgr->ijk[2]);
+    } else if (!this->lgrs.empty()) {
+        // LGR arrays already started — keep alignment for this non-LGR entry.
+        this->lgrs  .emplace_back();
+        this->numlx .push_back(0);
+        this->numly .push_back(0);
+        this->numlz .push_back(0);
+    }
+    // else: pure non-LGR run — nothing to do.
+}
+
 Opm::EclIO::OutputStream::SummarySpecification::
 SummarySpecification(const ResultSet&            rset,
                      const Formatted&            fmt,
@@ -824,15 +859,61 @@ SummarySpecification::write(const Parameters& params,
     smspec.write("KEYWORDS", params.keywords);
     smspec.write("WGNAMES",  params.wgnames);
     smspec.write("NUMS",     params.nums);
+
+    // LGR metadata arrays — written only when at least one LGR vector is present.
+    // Eclipse reference order: NUMS → LGRS → NUMLX → NUMLY → NUMLZ → UNITS → STARTDAT
+    //                          → LGRNAMES → LGRVEC → LGRTIMES
+    // params.lgrs is non-empty iff at least one LGR-aware add() was called.
+    const bool has_lgr = !params.lgrs.empty();
+
+    if (has_lgr) {
+        smspec.write("LGRS",  params.lgrs);
+        smspec.write("NUMLX", params.numlx);
+        smspec.write("NUMLY", params.numly);
+        smspec.write("NUMLZ", params.numlz);
+    }
+
     smspec.write("UNITS",    params.units);
 
     smspec.write("STARTDAT", makeStartDate(this->startDate_));
+
+    if (has_lgr) {
+        this->writeLgrMetadata(params, currentStep);
+    }
 
     // Create and write RUNTIMEI
     smspec.write("RUNTIMEI", makeRuntimei(simulationFinished, this->restartStep_,
                                           currentStep, this->computeStart_, basic));
 
     this->flushStream();
+}
+
+void
+Opm::EclIO::OutputStream::SummarySpecification::
+writeLgrMetadata(const Parameters& params, const int currentStep)
+{
+    auto& smspec = this->stream();
+    auto lgrCounts = std::map<std::string, int>{};
+    for (const auto& lgr : params.lgrs) {
+        const auto name = trim_copy(lgr);
+        if (!name.empty()) {
+            ++lgrCounts[name];
+        }
+    }
+
+    auto lgrNames = std::vector<PaddedOutputString<8>>{};
+    auto lgrVec   = std::vector<int>{};
+    lgrNames.reserve(lgrCounts.size());
+    lgrVec  .reserve(lgrCounts.size());
+
+    for (const auto& [lgrName, lgrCount] : lgrCounts) {
+        lgrNames.emplace_back(lgrName);
+        lgrVec  .push_back(lgrCount + 2); // +2 for implicit TIME and YEARS per LGR
+    }
+
+    smspec.write("LGRNAMES", lgrNames);
+    smspec.write("LGRVEC",   lgrVec);
+    smspec.write("LGRTIMES", std::vector<int>(lgrCounts.size(), currentStep));
 }
 
 void Opm::EclIO::OutputStream::SummarySpecification::rewindStream()

--- a/opm/io/eclipse/OutputStream.hpp
+++ b/opm/io/eclipse/OutputStream.hpp
@@ -22,12 +22,14 @@
 #define OPM_IO_OUTPUTSTREAM_HPP_INCLUDED
 
 #include <opm/io/eclipse/PaddedOutputString.hpp>
+#include <opm/io/eclipse/SummaryNode.hpp>
 #include <opm/common/utility/TimeService.hpp>
 
 #include <array>
 #include <chrono>
 #include <ios>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -401,6 +403,12 @@ namespace Opm { namespace EclIO { namespace OutputStream {
                      const int          num,
                      const std::string& unit);
 
+            void add(const std::string&                          keyword,
+                     const std::string&                          wgname,
+                     const int                                   num,
+                     const std::string&                          unit,
+                     const std::optional<Opm::EclIO::lgr_info>& lgr);
+
             friend class SummarySpecification;
 
         private:
@@ -408,6 +416,10 @@ namespace Opm { namespace EclIO { namespace OutputStream {
             std::vector<PaddedOutputString<8>> wgnames{};
             std::vector<int>                   nums{};
             std::vector<PaddedOutputString<8>> units{};
+            std::vector<PaddedOutputString<8>> lgrs{};
+            std::vector<int>                   numlx{};
+            std::vector<int>                   numly{};
+            std::vector<int>                   numlz{};
         };
 
         explicit SummarySpecification(const ResultSet&            rset,
@@ -450,6 +462,7 @@ namespace Opm { namespace EclIO { namespace OutputStream {
 
         void rewindStream();
         void flushStream();
+        void writeLgrMetadata(const Parameters& params, int currentStep);
 
         EclOutput& stream();
     };

--- a/tests/test_OutputStream.cpp
+++ b/tests/test_OutputStream.cpp
@@ -2546,4 +2546,242 @@ BOOST_AUTO_TEST_CASE(Formatted_Restarted)
     }
 }
 
+// -----------------------------------------------------------------------
+// LGR SMSPEC array tests — verify array ordering and values per Eclipse ref
+// -----------------------------------------------------------------------
+
+namespace {
+    // Build Parameters with one LGR ("LGR1", 3x3x1) containing 3 vectors
+    // plus one global vector (FOPR). Reference: 1LGR case.
+    Opm::EclIO::OutputStream::SummarySpecification::Parameters
+    lgrParameters_1LGR()
+    {
+        using lgr = Opm::EclIO::lgr_info;
+        auto prm = Opm::EclIO::OutputStream::
+            SummarySpecification::Parameters{};
+
+        // Global vector — no LGR
+        prm.add("FOPR", ":+:+:+:+", 0, "SM3/DAY");
+
+        // 3 LGR vectors inside LGR1 (3x3x1)
+        prm.add("LWBHP", "PROD01",    0, "BARSA",  lgr{"LGR1", {3, 3, 1}});
+        prm.add("LWBHP", "PROD02",    0, "BARSA",  lgr{"LGR1", {3, 3, 1}});
+        prm.add("LBPR",  ":+:+:+:+", 5, "BARSA",  lgr{"LGR1", {3, 3, 1}});
+
+        return prm;
+    }
+
+    // Build Parameters with two LGRs ("LGRA" 2x2x1, "LGRB" 4x4x2),
+    // 2 vectors in LGRA and 3 vectors in LGRB. Reference: 2LGR case.
+    Opm::EclIO::OutputStream::SummarySpecification::Parameters
+    lgrParameters_2LGR()
+    {
+        using lgr = Opm::EclIO::lgr_info;
+        auto prm = Opm::EclIO::OutputStream::
+            SummarySpecification::Parameters{};
+
+        prm.add("LWBHP", "P1", 0, "BARSA",  lgr{"LGRA", {2, 2, 1}});
+        prm.add("LWBHP", "P2", 0, "BARSA",  lgr{"LGRA", {2, 2, 1}});
+
+        prm.add("LWBHP", "P3", 0, "BARSA",  lgr{"LGRB", {4, 4, 2}});
+        prm.add("LBPR",  ":+:+:+:+", 7, "BARSA",  lgr{"LGRB", {4, 4, 2}});
+        prm.add("LBPR",  ":+:+:+:+", 8, "BARSA",  lgr{"LGRB", {4, 4, 2}});
+
+        return prm;
+    }
+} // Anonymous
+
+BOOST_AUTO_TEST_CASE(LGR_SingleGrid)
+{
+    // Verify that for a single LGR the SMSPEC output contains:
+    //   KEYWORDS → WGNAMES → NUMS → LGRS → NUMLX → NUMLY → NUMLZ
+    //   → UNITS → STARTDAT → LGRNAMES → LGRVEC → LGRTIMES → RUNTIMEI
+    // And that LGRVEC = 2 + count(vectors in that LGR) = 2+3 = 5.
+
+    using SMSpec = ::Opm::EclIO::OutputStream::SummarySpecification;
+
+    const auto rset     = RSet("LGR1CASE");
+    const auto fmt      = ::Opm::EclIO::OutputStream::Formatted{ false };
+    const auto cartDims = std::array<int,3>{ 10, 10, 5 };
+    const int  step     = 7;
+
+    {
+        auto smspec = SMSpec {
+            rset, fmt, SMSpec::UnitConvention::Metric, cartDims,
+            noRestart(),
+            start(2020, 1, 1, 0, 0, 0),
+            start(2020, 1, 1, 0, 0, 0)
+        };
+
+        smspec.write(lgrParameters_1LGR(), false, step, 0);
+    }
+
+    const auto fname = ::Opm::EclIO::OutputStream::
+        outputFileName(rset, "SMSPEC");
+
+    auto smspec = ::Opm::EclIO::EclFile{ fname };
+
+    {
+        const auto vectors        = smspec.getList();
+        const auto expect_vectors = std::vector<Opm::EclIO::EclFile::EclEntry>{
+            { "INTEHEAD", Opm::EclIO::eclArrType::INTE, 2  },
+            { "RESTART",  Opm::EclIO::eclArrType::CHAR, 9  },
+            { "DIMENS",   Opm::EclIO::eclArrType::INTE, 6  },
+            { "KEYWORDS", Opm::EclIO::eclArrType::CHAR, 4  },
+            { "WGNAMES",  Opm::EclIO::eclArrType::CHAR, 4  },
+            { "NUMS",     Opm::EclIO::eclArrType::INTE, 4  },
+            { "LGRS",     Opm::EclIO::eclArrType::CHAR, 4  },
+            { "NUMLX",    Opm::EclIO::eclArrType::INTE, 4  },
+            { "NUMLY",    Opm::EclIO::eclArrType::INTE, 4  },
+            { "NUMLZ",    Opm::EclIO::eclArrType::INTE, 4  },
+            { "UNITS",    Opm::EclIO::eclArrType::CHAR, 4  },
+            { "STARTDAT", Opm::EclIO::eclArrType::INTE, 6  },
+            { "LGRNAMES", Opm::EclIO::eclArrType::CHAR, 1  },
+            { "LGRVEC",   Opm::EclIO::eclArrType::INTE, 1  },
+            { "LGRTIMES", Opm::EclIO::eclArrType::INTE, 1  },
+            { "RUNTIMEI", Opm::EclIO::eclArrType::INTE, 50 },
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),
+                                      expect_vectors.begin(),
+                                      expect_vectors.end());
+    }
+
+    smspec.loadData();
+
+    // LGRNAMES — unique sorted non-blank LGR names
+    {
+        const auto& L = smspec.get<std::string>("LGRNAMES");
+        const auto  expect = std::vector<std::string>{ "LGR1" };
+        BOOST_CHECK_EQUAL_COLLECTIONS(L.begin(), L.end(),
+                                      expect.begin(), expect.end());
+    }
+
+    // LGRVEC — 2 (TIME+YEARS in ROOT.LGR) + 3 vectors = 5
+    {
+        const auto& V = smspec.get<int>("LGRVEC");
+        const auto  expect = std::vector<int>{ 5 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(V.begin(), V.end(),
+                                      expect.begin(), expect.end());
+    }
+
+    // LGRTIMES — currentStep per LGR
+    {
+        const auto& T = smspec.get<int>("LGRTIMES");
+        const auto  expect = std::vector<int>{ step };
+        BOOST_CHECK_EQUAL_COLLECTIONS(T.begin(), T.end(),
+                                      expect.begin(), expect.end());
+    }
+
+    // LGRS — blank for global FOPR, "LGR1" for the 3 LGR vectors
+    {
+        const auto& L = smspec.get<std::string>("LGRS");
+        BOOST_CHECK_EQUAL(L.size(), 4u);
+        BOOST_CHECK_EQUAL(L[0], ""); // FOPR is global
+        BOOST_CHECK_EQUAL(L[1], "LGR1");
+        BOOST_CHECK_EQUAL(L[2], "LGR1");
+        BOOST_CHECK_EQUAL(L[3], "LGR1");
+    }
+
+    // NUMLX/NUMLY/NUMLZ — 0 for global, LGR dims for LGR vectors
+    {
+        const auto& X = smspec.get<int>("NUMLX");
+        BOOST_CHECK_EQUAL(X[0], 0); // global
+        BOOST_CHECK_EQUAL(X[1], 3);
+        BOOST_CHECK_EQUAL(X[2], 3);
+        BOOST_CHECK_EQUAL(X[3], 3);
+
+        const auto& Y = smspec.get<int>("NUMLY");
+        BOOST_CHECK_EQUAL(Y[0], 0);
+        BOOST_CHECK_EQUAL(Y[1], 3);
+
+        const auto& Z = smspec.get<int>("NUMLZ");
+        BOOST_CHECK_EQUAL(Z[0], 0);
+        BOOST_CHECK_EQUAL(Z[1], 1);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(LGR_TwoGrids)
+{
+    // Verify LGRVEC and LGRTIMES for two LGRs:
+    //   LGRA: 2 vectors → LGRVEC[0] = 2+2 = 4
+    //   LGRB: 3 vectors → LGRVEC[1] = 2+3 = 5
+    // LGRTIMES: {step, step} for both LGRs.
+
+    using SMSpec = ::Opm::EclIO::OutputStream::SummarySpecification;
+
+    const auto rset     = RSet("LGR2CASE");
+    const auto fmt      = ::Opm::EclIO::OutputStream::Formatted{ false };
+    const auto cartDims = std::array<int,3>{ 20, 20, 5 };
+    const int  step     = 13;
+
+    {
+        auto smspec = SMSpec {
+            rset, fmt, SMSpec::UnitConvention::Metric, cartDims,
+            noRestart(),
+            start(2021, 6, 1, 0, 0, 0),
+            start(2021, 6, 1, 0, 0, 0)
+        };
+
+        smspec.write(lgrParameters_2LGR(), false, step, 0);
+    }
+
+    const auto fname = ::Opm::EclIO::OutputStream::
+        outputFileName(rset, "SMSPEC");
+
+    auto smspec = ::Opm::EclIO::EclFile{ fname };
+
+    {
+        const auto vectors        = smspec.getList();
+        const auto expect_vectors = std::vector<Opm::EclIO::EclFile::EclEntry>{
+            { "INTEHEAD", Opm::EclIO::eclArrType::INTE, 2  },
+            { "RESTART",  Opm::EclIO::eclArrType::CHAR, 9  },
+            { "DIMENS",   Opm::EclIO::eclArrType::INTE, 6  },
+            { "KEYWORDS", Opm::EclIO::eclArrType::CHAR, 5  },
+            { "WGNAMES",  Opm::EclIO::eclArrType::CHAR, 5  },
+            { "NUMS",     Opm::EclIO::eclArrType::INTE, 5  },
+            { "LGRS",     Opm::EclIO::eclArrType::CHAR, 5  },
+            { "NUMLX",    Opm::EclIO::eclArrType::INTE, 5  },
+            { "NUMLY",    Opm::EclIO::eclArrType::INTE, 5  },
+            { "NUMLZ",    Opm::EclIO::eclArrType::INTE, 5  },
+            { "UNITS",    Opm::EclIO::eclArrType::CHAR, 5  },
+            { "STARTDAT", Opm::EclIO::eclArrType::INTE, 6  },
+            { "LGRNAMES", Opm::EclIO::eclArrType::CHAR, 2  },
+            { "LGRVEC",   Opm::EclIO::eclArrType::INTE, 2  },
+            { "LGRTIMES", Opm::EclIO::eclArrType::INTE, 2  },
+            { "RUNTIMEI", Opm::EclIO::eclArrType::INTE, 50 },
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),
+                                      expect_vectors.begin(),
+                                      expect_vectors.end());
+    }
+
+    smspec.loadData();
+
+    // LGRNAMES — sorted: LGRA before LGRB
+    {
+        const auto& L = smspec.get<std::string>("LGRNAMES");
+        BOOST_CHECK_EQUAL(L.size(), 2u);
+        BOOST_CHECK_EQUAL(L[0], "LGRA");
+        BOOST_CHECK_EQUAL(L[1], "LGRB");
+    }
+
+    // LGRVEC — LGRA: 2+2=4, LGRB: 2+3=5
+    {
+        const auto& V = smspec.get<int>("LGRVEC");
+        BOOST_REQUIRE_EQUAL(V.size(), 2u);
+        BOOST_CHECK_EQUAL(V[0], 4); // LGRA
+        BOOST_CHECK_EQUAL(V[1], 5); // LGRB
+    }
+
+    // LGRTIMES — both LGRs at same currentStep
+    {
+        const auto& T = smspec.get<int>("LGRTIMES");
+        BOOST_REQUIRE_EQUAL(T.size(), 2u);
+        BOOST_CHECK_EQUAL(T[0], step);
+        BOOST_CHECK_EQUAL(T[1], step);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Class_SummarySpecification


### PR DESCRIPTION
# [LGR] OutputStream: add LGR coordinate arrays to SMSPEC output

## Summary

Extend `SummarySpecification::Parameters` and `write()` to carry and emit the
LGR-related SMSPEC arrays required by the Eclipse file format specification
(FileFormatsReferenceManual pp. 9–11).

This is the **file-format layer** of LGR summary vector support. It makes
the SMSPEC index file conformant for simulations with LGR vectors, enabling
ResInsight, `ecl_summary`, and `opm-data` to correctly identify and read
LGR summary columns.

## Background

PR #5140 added `lgr_name_` to `SummaryConfigNode`. PR #5143 added parsing
of `LW*`/`LC*`/`LB*` keywords in `SummaryConfig`. This PR adds the
corresponding file-format output so the produced `.SMSPEC` file contains the
required LGR metadata arrays.

## Changes

### `opm/io/eclipse/OutputStream.hpp`

- Add `#include <opm/io/eclipse/SummaryNode.hpp>` and `#include <optional>`
- Add 4 new parallel fields to `Parameters`: `lgrs`, `numlx`, `numly`, `numlz`
- Declare new 5-arg `add()` overload accepting `std::optional<lgr_info>`
- Declare private `writeLgrMetadata(EclOutput&, const Parameters&, int)` on
  `SummarySpecification`

### `opm/io/eclipse/OutputStream.cpp`

**`Parameters::add()` (4-arg):** Unchanged — pushes only to `keywords`,
`wgnames`, `nums`, `units`. Zero overhead for non-LGR runs; the LGR parallel
arrays are never touched.

**`Parameters::add()` (5-arg, new):** Lazily initialises the LGR arrays on
first LGR call. If `lgrs` is currently empty, all previously added global
entries are backfilled with blank/zero values to restore alignment, then the
real LGR values are appended. Subsequent LGR calls append directly. Non-LGR
calls after the first LGR entry push blank/zero to maintain alignment. This
ensures `params.lgrs.empty()` is the single authoritative test for "no LGR
vectors in this run".

**`SummarySpecification::write()`:**

1. After `NUMS` (before `UNITS`): writes `LGRS`/`NUMLX`/`NUMLY`/`NUMLZ`
   when `!params.lgrs.empty()`.
2. After `STARTDAT`: calls `writeLgrMetadata()`.

SMSPEC output for non-LGR runs is **bit-identical to before**.

**`writeLgrMetadata()` (new private member):** Computes and writes
`LGRNAMES`, `LGRVEC`, `LGRTIMES` in a single pass using
`std::map<string,int>` (naturally sorted, counted). Uses `trim_copy()` from
`opm/common/utility/String.hpp` to convert `PaddedOutputString<8>` keys.
`LGRVEC[i]` = vector count for LGR `i` + 2, accounting for the implicit
`TIME` and `YEARS` entries Eclipse writes per LGR root.

### `opm/common/utility/String.cpp`

Add explicit instantiation of `trim_copy<PaddedOutputString<8>>` (previously
only `<4>` was instantiated).

### `tests/test_OutputStream.cpp`

Two new test cases:

- **`LGR_SingleGrid`** — 1 LGR (`LGR1`), 3 LGR vectors + 1 global (`FOPR`).
  Verifies full SMSPEC array layout, `LGRS` content, `NUMLX`/`NUMLY`/`NUMLZ`,
  `LGRNAMES=["LGR1"]`, `LGRVEC=[5]`, `LGRTIMES=[step]`.
- **`LGR_TwoGrids`** — 2 LGRs (`LGRA`, `LGRB`), 2+3 LGR vectors.
  Verifies sorted `LGRNAMES=["LGRA","LGRB"]`, `LGRVEC=[4,5]`, `LGRTIMES=[step,step]`.



