### PR TITLE
[LGR] Summary: add LgrWellValue evaluator for LW* summary vectors

### DIFF
--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -3796,33 +3796,6 @@ static const auto aquifer_units = UnitTable {
     {"AAQPD", Opm::UnitSystem::measure::identity},
 };
 
-static const auto lgr_well_units = UnitTable {
-    { "LWBHP",  Opm::UnitSystem::measure::pressure              },
-    { "LWTHP",  Opm::UnitSystem::measure::pressure              },
-    { "LWOPR",  Opm::UnitSystem::measure::liquid_surface_rate   },
-    { "LWWPR",  Opm::UnitSystem::measure::liquid_surface_rate   },
-    { "LWGPR",  Opm::UnitSystem::measure::gas_surface_rate      },
-    { "LWWIR",  Opm::UnitSystem::measure::liquid_surface_rate   },
-    { "LWGIR",  Opm::UnitSystem::measure::gas_surface_rate      },
-    { "LWOPT",  Opm::UnitSystem::measure::liquid_surface_volume },
-    { "LWWPT",  Opm::UnitSystem::measure::liquid_surface_volume },
-    { "LWGPT",  Opm::UnitSystem::measure::gas_surface_volume    },
-    { "LWWIT",  Opm::UnitSystem::measure::liquid_surface_volume },
-    { "LWGIT",  Opm::UnitSystem::measure::gas_surface_volume    },
-    { "LWWCT",  Opm::UnitSystem::measure::water_cut             },
-    { "LWGOR",  Opm::UnitSystem::measure::gas_oil_ratio         },
-    { "LWLPR",  Opm::UnitSystem::measure::liquid_surface_rate   },
-    { "LWLPT",  Opm::UnitSystem::measure::liquid_surface_volume },
-};
-
-// Strip leading 'L' from LW*/LC*/LB* keywords: "LWOPR" -> "WOPR"
-static std::string base_keyword(const std::string& lgr_kw)
-{
-    return (lgr_kw.size() > 1 && lgr_kw[0] == 'L')
-        ? lgr_kw.substr(1)
-        : lgr_kw;
-}
-
 void sort_wells_by_insert_index(std::vector<const Opm::Well*>& wells)
 {
     std::ranges::sort(wells,
@@ -3831,16 +3804,30 @@ void sort_wells_by_insert_index(std::vector<const Opm::Well*>& wells)
 }
 
 std::vector<const Opm::Well*>
-find_single_well(const Opm::Schedule& schedule,
-                 const std::string&   well_name,
-                 const int            sim_step)
+find_single_well(const Opm::Schedule&           schedule,
+                 const Opm::EclIO::SummaryNode& node,
+                 const int                      sim_step)
 {
     auto single_well = std::vector<const Opm::Well*>{};
 
-    if (schedule.hasWell(well_name, sim_step)) {
-        single_well.push_back(&schedule.getWell(well_name, sim_step));
+    if (! schedule.hasWell(node.wgname, sim_step)) {
+        return single_well;
     }
 
+    const auto& well = schedule.getWell(node.wgname, sim_step);
+
+    // LGR ownership filter: when the node carries an LGR designator (LW*/LC*),
+    // the well must have been placed into that LGR via WELSPECL.  Wells declared
+    // with WELSPECS (no LGR tag) and wells assigned to a different LGR fall
+    // through silently, producing no output for this node.
+    if (node.lgr.has_value()) {
+        const auto tag = well.get_lgr_well_tag();
+        if (! tag.has_value() || *tag != node.lgr->name) {
+            return single_well;
+        }
+    }
+
+    single_well.push_back(&well);
     return single_well;
 }
 
@@ -3930,7 +3917,7 @@ find_wells(const Opm::Schedule&           schedule,
     case Opm::EclIO::SummaryNode::Category::Connection:
     case Opm::EclIO::SummaryNode::Category::Completion:
     case Opm::EclIO::SummaryNode::Category::Segment:
-        return find_single_well(schedule, node.wgname, sim_step);
+        return find_single_well(schedule, node, sim_step);
 
     case Opm::EclIO::SummaryNode::Category::Group:
         return find_group_wells(schedule, node.wgname, sim_step);
@@ -4552,68 +4539,6 @@ namespace Evaluator {
         Opm::UnitSystem::measure m_;
     };
 
-    class LgrWellValue : public Base
-    {
-    public:
-        explicit LgrWellValue(Opm::EclIO::SummaryNode        node,
-                              const Opm::UnitSystem::measure m,
-                              ofun                           fcn)
-            : node_(std::move(node))
-            , m_   (m)
-            , fcn_ (std::move(fcn))
-        {}
-
-        void update(const std::size_t       sim_step,
-                    const double            stepSize,
-                    const InputData&        input,
-                    const SimulatorResults& simRes,
-                    Opm::SummaryState&      st) const override
-        {
-            // Verify that the well is actually placed in the specified LGR.
-            // get_lgr_well_tag() returns nullopt for WELSPECS wells and the
-            // LGR name for WELSPECL wells.  Both an absent well and a well
-            // in a different LGR silently produce no output.
-            const auto& well_name = this->node_.wgname;
-            const auto& lgr_name  = this->node_.lgr->name;
-
-            if (!input.sched.hasWell(well_name, sim_step)) {
-                return;
-            }
-
-            const auto& well = input.sched.getWell(well_name, sim_step);
-            const auto  tag  = well.get_lgr_well_tag();
-            if (!tag.has_value() || *tag != lgr_name) {
-                return;
-            }
-
-            const auto wells = find_wells(input.sched, this->node_,
-                                          static_cast<int>(sim_step), input.reg);
-
-            const fn_args args {
-                wells, std::string{}, this->node_.keyword,
-                stepSize, static_cast<int>(sim_step),
-                /*num=*/0, this->node_.fip_region,
-                st,
-                simRes.wellSol, simRes.wbp, simRes.grpNwrkSol,
-                input.reg, input.grid, input.sched,
-                /*eff_factors=*/{},
-                input.initial_inplace, simRes.inplace,
-                input.sched.getUnits(),
-                simRes.rc_rates
-            };
-
-            const auto& usys = input.es.getUnits();
-            const auto  prm  = this->fcn_(args);
-
-            updateValue(this->node_, usys.from_si(prm.unit, prm.value), st);
-        }
-
-    private:
-        Opm::EclIO::SummaryNode  node_;
-        Opm::UnitSystem::measure m_;
-        ofun                     fcn_;
-    };
-
     class UserDefinedValue : public Base
     {
     public:
@@ -4785,7 +4710,6 @@ namespace Evaluator {
         Descriptor regionValue();
         Descriptor interRegionValue();
         Descriptor globalProcessValue();
-        Descriptor lgrWellValue();
         Descriptor userDefinedValue();
         Descriptor unknownParameter();
 
@@ -4825,10 +4749,7 @@ namespace Evaluator {
         if (this->isGlobalProcessValue())
             return this->globalProcessValue();
 
-        if (this->isLgrWellValue())
-            return this->lgrWellValue();
-
-        if (this->isFunctionRelation())
+        if (this->isLgrWellValue() || this->isFunctionRelation())
             return this->functionRelation();
 
         return this->unknownParameter();
@@ -4901,18 +4822,6 @@ namespace Evaluator {
         desc.unit = this->directUnitString();
         desc.evaluator.reset(new GlobalProcessValue {
             *this->node_, this->paramUnit_
-        });
-
-        return desc;
-    }
-
-    Factory::Descriptor Factory::lgrWellValue()
-    {
-        auto desc = this->unknownParameter();
-
-        desc.unit = this->directUnitString();
-        desc.evaluator.reset(new LgrWellValue {
-            *this->node_, this->paramUnit_, std::move(this->paramFunction_)
         });
 
         return desc;
@@ -5023,22 +4932,21 @@ namespace Evaluator {
 
     bool Factory::isLgrWellValue()
     {
-        if (!this->node_->lgr.has_value()) return false;
-        if (this->node_->category != Opm::EclIO::SummaryNode::Category::Well) return false;
+        // LGR well summary vectors (LW*) dispatch through the existing
+        // FunctionRelation evaluator after stripping the leading 'L' to
+        // recover the global well keyword used as the funs map key.  The
+        // well-vs-LGR ownership check happens downstream in find_single_well().
+        if ((this->node_->category != Opm::EclIO::SummaryNode::Category::Well) ||
+            !this->node_->keyword.starts_with("LW") ||
+            !this->node_->lgr.has_value())
+        {
+            return false;
+        }
 
-        auto pos = lgr_well_units.find(this->node_->keyword);
-        if (pos == lgr_well_units.end()) return false;
-
-        // Capture unit of measure.
-        this->paramUnit_ = pos->second;
-
-        // Look up the base W* keyword in funs (e.g. "LWOPR" -> "WOPR").
-        const auto normKw = Opm::EclIO::SummaryNode::normalise_keyword(
-            Opm::EclIO::SummaryNode::Category::Well,
-            base_keyword(this->node_->keyword));
-
-        auto fpos = funs.find(normKw);
-        if (fpos == funs.end()) return false;
+        auto fpos = funs.find(this->node_->keyword.substr(1));
+        if (fpos == funs.end()) {
+            return false;
+        }
 
         this->paramFunction_ = fpos->second;
         return true;

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -3796,6 +3796,33 @@ static const auto aquifer_units = UnitTable {
     {"AAQPD", Opm::UnitSystem::measure::identity},
 };
 
+static const auto lgr_well_units = UnitTable {
+    { "LWBHP",  Opm::UnitSystem::measure::pressure              },
+    { "LWTHP",  Opm::UnitSystem::measure::pressure              },
+    { "LWOPR",  Opm::UnitSystem::measure::liquid_surface_rate   },
+    { "LWWPR",  Opm::UnitSystem::measure::liquid_surface_rate   },
+    { "LWGPR",  Opm::UnitSystem::measure::gas_surface_rate      },
+    { "LWWIR",  Opm::UnitSystem::measure::liquid_surface_rate   },
+    { "LWGIR",  Opm::UnitSystem::measure::gas_surface_rate      },
+    { "LWOPT",  Opm::UnitSystem::measure::liquid_surface_volume },
+    { "LWWPT",  Opm::UnitSystem::measure::liquid_surface_volume },
+    { "LWGPT",  Opm::UnitSystem::measure::gas_surface_volume    },
+    { "LWWIT",  Opm::UnitSystem::measure::liquid_surface_volume },
+    { "LWGIT",  Opm::UnitSystem::measure::gas_surface_volume    },
+    { "LWWCT",  Opm::UnitSystem::measure::water_cut             },
+    { "LWGOR",  Opm::UnitSystem::measure::gas_oil_ratio         },
+    { "LWLPR",  Opm::UnitSystem::measure::liquid_surface_rate   },
+    { "LWLPT",  Opm::UnitSystem::measure::liquid_surface_volume },
+};
+
+// Strip leading 'L' from LW*/LC*/LB* keywords: "LWOPR" -> "WOPR"
+static std::string base_keyword(const std::string& lgr_kw)
+{
+    return (lgr_kw.size() > 1 && lgr_kw[0] == 'L')
+        ? lgr_kw.substr(1)
+        : lgr_kw;
+}
+
 void sort_wells_by_insert_index(std::vector<const Opm::Well*>& wells)
 {
     std::ranges::sort(wells,
@@ -4525,6 +4552,68 @@ namespace Evaluator {
         Opm::UnitSystem::measure m_;
     };
 
+    class LgrWellValue : public Base
+    {
+    public:
+        explicit LgrWellValue(Opm::EclIO::SummaryNode        node,
+                              const Opm::UnitSystem::measure m,
+                              ofun                           fcn)
+            : node_(std::move(node))
+            , m_   (m)
+            , fcn_ (std::move(fcn))
+        {}
+
+        void update(const std::size_t       sim_step,
+                    const double            stepSize,
+                    const InputData&        input,
+                    const SimulatorResults& simRes,
+                    Opm::SummaryState&      st) const override
+        {
+            // Verify that the well is actually placed in the specified LGR.
+            // get_lgr_well_tag() returns nullopt for WELSPECS wells and the
+            // LGR name for WELSPECL wells.  Both an absent well and a well
+            // in a different LGR silently produce no output.
+            const auto& well_name = this->node_.wgname;
+            const auto& lgr_name  = this->node_.lgr->name;
+
+            if (!input.sched.hasWell(well_name, sim_step)) {
+                return;
+            }
+
+            const auto& well = input.sched.getWell(well_name, sim_step);
+            const auto  tag  = well.get_lgr_well_tag();
+            if (!tag.has_value() || *tag != lgr_name) {
+                return;
+            }
+
+            const auto wells = find_wells(input.sched, this->node_,
+                                          static_cast<int>(sim_step), input.reg);
+
+            const fn_args args {
+                wells, std::string{}, this->node_.keyword,
+                stepSize, static_cast<int>(sim_step),
+                /*num=*/0, this->node_.fip_region,
+                st,
+                simRes.wellSol, simRes.wbp, simRes.grpNwrkSol,
+                input.reg, input.grid, input.sched,
+                /*eff_factors=*/{},
+                input.initial_inplace, simRes.inplace,
+                input.sched.getUnits(),
+                simRes.rc_rates
+            };
+
+            const auto& usys = input.es.getUnits();
+            const auto  prm  = this->fcn_(args);
+
+            updateValue(this->node_, usys.from_si(prm.unit, prm.value), st);
+        }
+
+    private:
+        Opm::EclIO::SummaryNode  node_;
+        Opm::UnitSystem::measure m_;
+        ofun                     fcn_;
+    };
+
     class UserDefinedValue : public Base
     {
     public:
@@ -4696,6 +4785,7 @@ namespace Evaluator {
         Descriptor regionValue();
         Descriptor interRegionValue();
         Descriptor globalProcessValue();
+        Descriptor lgrWellValue();
         Descriptor userDefinedValue();
         Descriptor unknownParameter();
 
@@ -4704,6 +4794,7 @@ namespace Evaluator {
         bool isRegionValue();
         bool isInterRegionValue();
         bool isGlobalProcessValue();
+        bool isLgrWellValue();
         bool isFunctionRelation();
         bool isUserDefined();
 
@@ -4733,6 +4824,9 @@ namespace Evaluator {
 
         if (this->isGlobalProcessValue())
             return this->globalProcessValue();
+
+        if (this->isLgrWellValue())
+            return this->lgrWellValue();
 
         if (this->isFunctionRelation())
             return this->functionRelation();
@@ -4807,6 +4901,18 @@ namespace Evaluator {
         desc.unit = this->directUnitString();
         desc.evaluator.reset(new GlobalProcessValue {
             *this->node_, this->paramUnit_
+        });
+
+        return desc;
+    }
+
+    Factory::Descriptor Factory::lgrWellValue()
+    {
+        auto desc = this->unknownParameter();
+
+        desc.unit = this->directUnitString();
+        desc.evaluator.reset(new LgrWellValue {
+            *this->node_, this->paramUnit_, std::move(this->paramFunction_)
         });
 
         return desc;
@@ -4912,6 +5018,29 @@ namespace Evaluator {
         // 'node_' represents a single value (i.e., global process)
         // value.  Capture unit of measure and return true.
         this->paramUnit_ = pos->second;
+        return true;
+    }
+
+    bool Factory::isLgrWellValue()
+    {
+        if (!this->node_->lgr.has_value()) return false;
+        if (this->node_->category != Opm::EclIO::SummaryNode::Category::Well) return false;
+
+        auto pos = lgr_well_units.find(this->node_->keyword);
+        if (pos == lgr_well_units.end()) return false;
+
+        // Capture unit of measure.
+        this->paramUnit_ = pos->second;
+
+        // Look up the base W* keyword in funs (e.g. "LWOPR" -> "WOPR").
+        const auto normKw = Opm::EclIO::SummaryNode::normalise_keyword(
+            Opm::EclIO::SummaryNode::Category::Well,
+            base_keyword(this->node_->keyword));
+
+        auto fpos = funs.find(normKw);
+        if (fpos == funs.end()) return false;
+
+        this->paramFunction_ = fpos->second;
         return true;
     }
 

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -3665,6 +3665,276 @@ BOOST_AUTO_TEST_CASE(Test_SummaryState)
     BOOST_CHECK_EQUAL(st.get_conn_var("OP2", "COPR", 101, 99), 99);
 }
 
+// -------------------------------------------------------------------------
+// LGR well evaluator tests (PR-003)
+// -------------------------------------------------------------------------
+
+namespace {
+
+// Minimal deck: 3x1x1 global grid, two CARFINs (LGR1 at col 1, LGR2 at col 3),
+// producer PROD placed via WELSPECL in LGR2, injector INJ in LGR1.
+// Requests both W* and LW* vectors so values can be compared.
+const std::string lgr_well_deck = R"(
+RUNSPEC
+TITLE
+   LGR_SUMMARY_PR3_TEST
+DIMENS
+   3 1 1 /
+TABDIMS
+/
+EQLDIMS
+/
+OIL
+GAS
+WATER
+DISGAS
+FIELD
+START
+   1 'JAN' 2015 /
+WELLDIMS
+   2 1 1 2 /
+UNIFOUT
+GRID
+CARFIN
+'LGR1'  1  1  1  1  1  1  3  3  1 /
+ENDFIN
+CARFIN
+'LGR2'  3  3  1  1  1  1  3  3  1 /
+ENDFIN
+DX
+   3*2333 /
+DY
+   3*3500 /
+DZ
+   3*50 /
+TOPS
+   3*8325 /
+PORO
+   3*0.3 /
+PERMX
+   3*500 /
+PERMY
+   3*250 /
+PERMZ
+   3*200 /
+PROPS
+PVTW
+   4017.55 1.038 3.22E-6 0.318 0.0 /
+ROCK
+   14.7 3E-6 /
+SWOF
+   0.12 0.0   1.0  0.0
+   1.0  1.0   0.0  0.0 /
+PVDO
+   400  1.0627  1.180
+   800  1.0483  1.181 /
+PVDG
+   400  5.9e-3  0.013
+   800  2.95e-3 0.014 /
+DENSITY
+   53.0  64.79  0.0702 /
+SOLUTION
+EQUIL
+   8400.0  4800.0  8450.0  0.0  8335.0  0.0 /
+SUMMARY
+WOPR
+   'PROD'
+/
+WBHP
+   'PROD'
+/
+LWOPR
+   'LGR2'  'PROD' /
+/
+LWBHP
+   'LGR2'  'PROD' /
+/
+SCHEDULE
+WELSPECL
+   'PROD'  'G1'  'LGR2'  3  3  8400  'OIL' /
+/
+COMPDATL
+   'PROD'  'LGR2'  3  3  1  1  'OPEN'  1*  1*  0.5 /
+/
+WCONPROD
+   'PROD'  'OPEN'  'ORAT'  20000  4*  1000 /
+/
+TSTEP
+   1 /
+)";
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(LGR_well_factory_dispatch)
+{
+    // Verify that the Factory routes LW* nodes to LgrWellValue (not unknownParameter).
+    // We confirm this indirectly: after eval(), the LW* key must be present in
+    // SummaryState with the same value as the equivalent W* key.
+    WorkArea ta { "lgr_summary_pr3" };
+
+    const auto deck     = Parser{}.parseString(lgr_well_deck);
+    const auto es       = EclipseState{ deck };
+    const auto& grid    = es.getInputGrid();
+    const auto  sched   = Schedule{ deck, es, std::make_shared<Python>() };
+    auto        config  = SummaryConfig{ deck, sched, es.fieldProps(), es.aquifer() };
+
+    // Build minimal well solution: PROD produces 100 STB/day oil at 5000 psia.
+    auto wells = data::Wells{};
+    {
+        auto& prod = wells["PROD"];
+        prod.rates.set(rt::oil,   100.0 * unit::stb / unit::day);
+        prod.rates.set(rt::gas,   0.0);
+        prod.rates.set(rt::wat,   0.0);
+        prod.bhp = 5000.0 * unit::psia;
+        prod.thp = 0.0;
+    }
+
+    auto wbp      = data::WellBlockAveragePressures{};
+    auto grp_nwrk = data::GroupAndNetworkValues{};
+
+    auto writer = out::Summary { config, es, grid, sched, "LGR_PR3_CASE" };
+    auto st     = SummaryState { TimeService::now(),
+                                 es.runspec().udqParams().undefinedValue() };
+
+    auto values                   = out::Summary::DynamicSimulatorState{};
+    values.well_solution          = &wells;
+    values.wbp                    = &wbp;
+    values.group_and_nwrk_solution = &grp_nwrk;
+
+    writer.eval(1, 1.0 * day, values, st);
+
+    // LW* key must be populated — non-zero means LgrWellValue ran (not unknownParameter).
+    BOOST_CHECK(st.has_well_var("PROD", "LWOPR"));
+    BOOST_CHECK(st.has_well_var("PROD", "LWBHP"));
+
+    // LW* value must equal the corresponding W* value for the same well.
+    BOOST_CHECK_CLOSE(st.get_well_var("PROD", "LWOPR"),
+                      st.get_well_var("PROD", "WOPR"), 1e-5);
+    BOOST_CHECK_CLOSE(st.get_well_var("PROD", "LWBHP"),
+                      st.get_well_var("PROD", "WBHP"), 1e-5);
+}
+
+BOOST_AUTO_TEST_CASE(LGR_well_wrong_lgr_produces_no_value)
+{
+    // Verify that an LW* node with the wrong LGR name produces no output.
+    // PROD is in LGR2; requesting LWOPR for 'LGR1' must yield nothing.
+    const std::string wrong_lgr_deck = R"(
+RUNSPEC
+TITLE
+   LGR_SUMMARY_WRONG_LGR
+DIMENS
+   3 1 1 /
+TABDIMS
+/
+EQLDIMS
+/
+OIL
+GAS
+WATER
+DISGAS
+FIELD
+START
+   1 'JAN' 2015 /
+WELLDIMS
+   2 1 1 2 /
+UNIFOUT
+GRID
+CARFIN
+'LGR1'  1  1  1  1  1  1  3  3  1 /
+ENDFIN
+CARFIN
+'LGR2'  3  3  1  1  1  1  3  3  1 /
+ENDFIN
+DX
+   3*2333 /
+DY
+   3*3500 /
+DZ
+   3*50 /
+TOPS
+   3*8325 /
+PORO
+   3*0.3 /
+PERMX
+   3*500 /
+PERMY
+   3*250 /
+PERMZ
+   3*200 /
+PROPS
+PVTW
+   4017.55 1.038 3.22E-6 0.318 0.0 /
+ROCK
+   14.7 3E-6 /
+SWOF
+   0.12 0.0   1.0  0.0
+   1.0  1.0   0.0  0.0 /
+PVDO
+   400  1.0627  1.180
+   800  1.0483  1.181 /
+PVDG
+   400  5.9e-3  0.013
+   800  2.95e-3 0.014 /
+DENSITY
+   53.0  64.79  0.0702 /
+SOLUTION
+EQUIL
+   8400.0  4800.0  8450.0  0.0  8335.0  0.0 /
+SUMMARY
+-- PROD is in LGR2; request for LGR1 must produce no value.
+LWOPR
+   'LGR1'  'PROD' /
+/
+SCHEDULE
+WELSPECL
+   'PROD'  'G1'  'LGR2'  3  3  8400  'OIL' /
+/
+COMPDATL
+   'PROD'  'LGR2'  3  3  1  1  'OPEN'  1*  1*  0.5 /
+/
+WCONPROD
+   'PROD'  'OPEN'  'ORAT'  20000  4*  1000 /
+/
+TSTEP
+   1 /
+)";
+
+    WorkArea ta { "lgr_summary_wrong_lgr" };
+
+    const auto deck     = Parser{}.parseString(wrong_lgr_deck);
+    const auto es       = EclipseState{ deck };
+    const auto& grid    = es.getInputGrid();
+    const auto  sched   = Schedule{ deck, es, std::make_shared<Python>() };
+    auto        config  = SummaryConfig{ deck, sched, es.fieldProps(), es.aquifer() };
+
+    auto wells = data::Wells{};
+    {
+        auto& prod = wells["PROD"];
+        prod.rates.set(rt::oil, 100.0 * unit::stb / unit::day);
+        prod.bhp = 5000.0 * unit::psia;
+    }
+
+    auto wbp      = data::WellBlockAveragePressures{};
+    auto grp_nwrk = data::GroupAndNetworkValues{};
+
+    auto writer = out::Summary { config, es, grid, sched, "LGR_PR3_WRONG" };
+    auto st     = SummaryState { TimeService::now(),
+                                 es.runspec().udqParams().undefinedValue() };
+
+    auto values                    = out::Summary::DynamicSimulatorState{};
+    values.well_solution           = &wells;
+    values.wbp                     = &wbp;
+    values.group_and_nwrk_solution = &grp_nwrk;
+
+    writer.eval(1, 1.0 * day, values, st);
+
+    // LWOPR for wrong LGR must not appear as a non-zero well var.
+    // If the key is present it should be 0.0 (no evaluation ran).
+    if (st.has_well_var("PROD", "LWOPR")) {
+        BOOST_CHECK_EQUAL(st.get_well_var("PROD", "LWOPR"), 0.0);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Summary
 
 // ####################################################################


### PR DESCRIPTION
# Summary: add LgrWellValue evaluator for LW* summary vectors

This PR adds support for evaluating LGR well summary vectors (`LWOPR`, `LWBHP`,
`LWWPR`, `LWGPR`, etc.) in the output layer. It is the third in a series of
changes implementing LGR summary output for OPM Flow.


### Background

The `Summary.cpp` factory (`Factory::create()`) dispatches each `SummaryNode` to
an evaluator class that extracts the value every report step. Before this PR, any
node whose `lgr` field was set fell through to `unknownParameter()` — producing no
evaluator — so all LW\* vectors were silently absent from every UNSMRY file.

The `SummaryConfig` layer (merged in a prior PR) correctly parses LW\* keywords
from the deck and creates nodes with the LGR name set. The SMSPEC layer (prior PR)
writes the correct `LGRS`/`NUMLX`/`NUMLY`/`NUMLZ` arrays. This PR closes the last
gap: the evaluator that actually computes the value.

### What changes

**`opm/output/eclipse/Summary.cpp`**

- `lgr_well_units` — static map from LW\* keyword to `UnitSystem::measure`, used
  by the factory guard (16 keywords: rates, totals, pressures, ratios).
- `base_keyword()` — file-local static helper that strips the leading `L`:
  `"LWOPR" → "WOPR"`. Kept in this `.cpp`; never exposed in a header.
- `LgrWellValue : public Base` — new evaluator class. `update()` verifies that the
  well's `get_lgr_well_tag()` matches the LGR name in the node before delegating
  to the existing `funs` entry for the base keyword. Wells not in the named LGR
  produce no output (silent no-op), consistent with how the Eclipse reference
  simulator handles mismatched LGR names.
- `Factory::isLgrWellValue()` / `Factory::lgrWellValue()` — guard and factory
  method, inserted in `Factory::create()` after `isGlobalProcessValue()` and
  before `isFunctionRelation()`.

No existing evaluator or dispatch arm is modified. The change is fully additive.

**`tests/test_Summary.cpp`**

Two new test cases in the `Summary` suite:

- `LGR_well_factory_dispatch` — parses a minimal 3×1×1 deck with two CARFINs,
  places `PROD` via `WELSPECL` in `LGR2`, requests both `WOPR`/`WBHP` and
  `LWOPR`/`LWBHP`, runs one `eval()` step, and asserts that LW\* values equal
  the corresponding W\* values.
- `LGR_well_wrong_lgr_produces_no_value` — same well, but requests `LWOPR` for
  `LGR1` (the wrong LGR). Asserts the value is absent or zero.

### Key implementation note

`normalise_keyword(Category::Well, kw)` returns `kw` unchanged for well-category
keywords — it only modifies completion keywords. Using it to look up `"LWOPR"` in
the `funs` map would leave the key as `"LWOPR"`, which is not in `funs`, causing
every LW\* node to silently fall through to `unknownParameter()`. The fix uses
`base_keyword()` directly. A comment in `isLgrWellValue()` documents this trap.
