### PR TITLE
Removing warning: EQUIL: invalid value '1' for item 10

### DIFF
--- a/opm/input/eclipse/share/keywords/000_Eclipse100/E/EQUIL
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/E/EQUIL
@@ -74,7 +74,6 @@
       "item": 10,
       "name": "COMP_INIT_TYPE",
       "value_type": "INT",
-      "default": 1,
       "comment": "This item is ECLIPSE300 specific"
     },
     {


### PR DESCRIPTION
In master running flow:
```bash
Warning: Unsupported keywords or keyword items:
EQUIL: invalid value '1' for item 10
  In file: SPE1CASE1.DATA, line 254
  EQUIL(COMP_INIT_TYPE): compositional option not used, should be defaulted
```

Either we remove the default value, or the warning message in opm-simulators.