### PR TITLE
NVCC requires seeing DatumDepth classes

### DIFF
--- a/opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.hpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.hpp
@@ -119,7 +119,14 @@ namespace Opm {
             serializer(this->datum_);
         }
 
-    private:
+#ifdef __NVCC__
+        // NVCC struggles with the std::variant in this class and requires
+        // that the nested classes are public. This workaround should
+        // be avoided if a better fix is found.
+        public:
+#else
+        private:
+#endif
         /// Neither DATUM* nor EQUIL specified => datum depth = 0
         class Zero
         {
@@ -380,6 +387,7 @@ namespace Opm {
                               std::vector<double>::difference_type ix) const;
         };
 
+    private:
         /// Datum depth implementation object.
         std::variant<Zero, Global, DefaultRegion, UserDefined> datum_{};
     };


### PR DESCRIPTION
NVCC struggles with some template instantiations when the nested classes are private.
When compiling with NVCC I have then made these public instead, which is not really a nice solution but I think it will be quite harmless.

Required for getting https://github.com/OPM/opm-simulators/pull/7042/ to compile without worse workarounds in opm-simulators.