### PR TITLE
Explicitly Identify Header Files in Library File Set

### DIFF
--- a/cmake/Modules/OpmTargets.cmake
+++ b/cmake/Modules/OpmTargets.cmake
@@ -91,7 +91,8 @@ function(opm_add_library)
     target_sources(${PARAM_TARGET}
       PRIVATE
       FILE_SET
-      HEADERS
+        HEADERS
+      FILES
         ${PARAM_HEADERS}
     )
   endif()


### PR DESCRIPTION
We need to explicitly pass the "FILES" parameter in order to distinguish file names from any other argument in `target_sources`.