### PR TITLE
[LGR] SummaryConfig: resolve LB*/LC* cell indices and wire LGR coordinates into SMSPEC

### DIFF
--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -25,7 +25,6 @@
 
 #include <opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
@@ -57,6 +56,7 @@
 #include <cstddef>
 #include <functional>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <regex>
 #include <set>
@@ -74,6 +74,26 @@
 namespace Opm {
 
 namespace {
+
+    /// Callback type: given a grid identifier, returns the grid's dimensions.
+    ///
+    /// \param gridID  Empty string for the global grid; LGR name for a local grid.
+    /// Returns a default-constructed GridDims (NX=NY=NZ=0) for unknown grids.
+    using CellIndexMapper =
+        std::function<GridDims(const std::string&)>;
+
+    /// Build a CellIndexMapper that serves the global grid only.
+    /// Any non-empty gridID (i.e., an LGR request) returns GridDims{} (NX=NY=NZ=0).
+    CellIndexMapper makeGlobalCellIndexMapper(const GridDims& dims)
+    {
+        return [dims](const std::string& gridID) -> GridDims
+        {
+            if (gridID.empty()) {
+                return dims;
+            }
+            return GridDims{};
+        };
+    }
 
     /// Basic information about run's region sets
     ///
@@ -767,7 +787,7 @@ void keywordCL(SummaryConfig::keyword_list& list,
                ErrorGuard&                  errors,
                const DeckKeyword&           keyword,
                const Schedule&              schedule,
-               const GridDims&              dims)
+               const CellIndexMapper&       gridDims)
 {
     auto node = SummaryConfigNode {
         keyword.name(), SummaryConfigNode::Category::Completion, keyword.location()
@@ -795,8 +815,28 @@ void keywordCL(SummaryConfig::keyword_list& list,
                                        { return node.number(1 + conn.global_index()); });
             }
             else {
-                const auto& ijk = getijk(record);
-                auto global_index = dims.getGlobalIndex(ijk[0], ijk[1], ijk[2]);
+                const auto ijk = getijk(record);
+                const auto globalDims = gridDims("");
+                const auto ci = static_cast<std::size_t>(ijk[0]);
+                const auto cj = static_cast<std::size_t>(ijk[1]);
+                const auto ck = static_cast<std::size_t>(ijk[2]);
+
+                if (globalDims.getNX() == 0 ||
+                    ci >= globalDims.getNX() ||
+                    cj >= globalDims.getNY() ||
+                    ck >= globalDims.getNZ()) {
+                    std::string msg = fmt::format("Problem with keyword {{keyword}}\n"
+                                                  "In {{file}} line {{line}}\n"
+                                                  "Connection ({},{},{}) not defined for well {}",
+                                                  ijk[0] + 1, ijk[1] + 1, ijk[2] + 1, wname);
+
+                    parseContext.handleError(ParseContext::SUMMARY_UNHANDLED_KEYWORD,
+                                             msg, keyword.location(), errors);
+                    continue;
+                }
+
+                const auto global_index =
+                    globalDims.getGlobalIndex(ci, cj, ck);
 
                 if (all_connections.hasGlobalIndex(global_index)) {
                     const auto& conn = all_connections.getFromGlobalIndex(global_index);
@@ -1090,7 +1130,8 @@ void keywordF(SummaryConfig::keyword_list& list,
 }
 
 void keywordLB(SummaryConfig::keyword_list& list,
-               const DeckKeyword&           keyword)
+               const DeckKeyword&           keyword,
+               const CellIndexMapper&       gridDims)
 {
     auto param = SummaryConfigNode {
         keyword.name(), SummaryConfigNode::Category::Block, keyword.location()
@@ -1101,15 +1142,36 @@ void keywordLB(SummaryConfig::keyword_list& list,
     for (const auto& record : keyword) {
         const auto lgr_name = record.getItem(0).getTrimmedString(0);
 
-        // number_ (linearised cell index within the LGR) is deferred to follow-up work.
-        // All LB* records for the same LGR currently share number_=INT_MIN.
-        list.push_back(param.lgr_name(lgr_name));
+        const auto ijk_1based = std::array<int,3>{
+            record.getItem("I").get<int>(0),
+            record.getItem("J").get<int>(0),
+            record.getItem("K").get<int>(0)
+        };
+
+        auto node = param.lgr_name(lgr_name);
+
+        {
+            // Resolve 1-based (I,J,K) in the named LGR to a 1-based
+            // linearised Cartesian index (i + Nx*(j + Ny*k)) within the LGR.
+            // Stored in number_ — this becomes NUMS in SMSPEC.
+            const auto i = static_cast<std::size_t>(ijk_1based[0] - 1);
+            const auto j = static_cast<std::size_t>(ijk_1based[1] - 1);
+            const auto k = static_cast<std::size_t>(ijk_1based[2] - 1);
+            const auto dims = gridDims(lgr_name);
+            if (dims.getNX() > 0) {
+                node.number(1 + static_cast<int>(dims.getGlobalIndex(i, j, k)));
+            }
+            // else: NX==0 means LGR geometry unavailable (stub deck) —
+            // number_ stays INT_MIN.
+        }
+
+        list.push_back(node);
     }
 }
 
 void keywordB(SummaryConfig::keyword_list& list,
               const DeckKeyword&           keyword,
-              const GridDims&              dims)
+              const CellIndexMapper&       gridDims)
 {
     auto param = SummaryConfigNode {
         keyword.name(), SummaryConfigNode::Category::Block, keyword.location()
@@ -1117,37 +1179,32 @@ void keywordB(SummaryConfig::keyword_list& list,
     .parameterType(parseKeywordType(keyword.name()))
     .isUserDefined(is_udq(keyword.name()));
 
-    auto isValid = [&dims](const std::array<int,3>& ijk)
-    {
-        return (static_cast<std::size_t>(ijk[0]) < dims.getNX())
-            && (static_cast<std::size_t>(ijk[1]) < dims.getNY())
-            && (static_cast<std::size_t>(ijk[2]) < dims.getNZ());
-    };
-
     for (const auto& record : keyword) {
         const auto ijk = getijk(record);
+        const auto dims = gridDims("");
+        const auto i = static_cast<std::size_t>(ijk[0]);
+        const auto j = static_cast<std::size_t>(ijk[1]);
+        const auto k = static_cast<std::size_t>(ijk[2]);
 
-        if (! isValid(ijk)) {
+        if (dims.getNX() == 0 ||
+            i >= dims.getNX() ||
+            j >= dims.getNY() ||
+            k >= dims.getNZ()) {
             const auto msg_fmt =
                 fmt::format("Block level summary keyword "
                             "{{keyword}}\n"
                             "In {{file}} line {{line}}\n"
                             "References invalid cell "
-                            "{},{},{} in grid of dimensions "
                             "{},{},{}.\nThis block summary "
                             "vector request is ignored.",
-                            ijk[0] + 1  , ijk[1] + 1  , ijk[2] + 1,
-                            dims.getNX(), dims.getNY(), dims.getNZ());
+                            ijk[0] + 1, ijk[1] + 1, ijk[2] + 1);
 
             OpmLog::warning(OpmInputError::format(msg_fmt, keyword.location()));
 
             continue;
         }
 
-        const int global_index =
-            1 + dims.getGlobalIndex(ijk[0], ijk[1], ijk[2]);
-
-        list.push_back(param.number(global_index));
+        list.push_back(param.number(1 + static_cast<int>(dims.getGlobalIndex(i, j, k))));
     }
 }
 
@@ -1448,7 +1505,8 @@ void keywordLC(SummaryConfig::keyword_list& list,
                const ParseContext&          parseContext,
                ErrorGuard&                  errors,
                const DeckKeyword&           keyword,
-               const Schedule&              schedule)
+               const Schedule&              schedule,
+               const CellIndexMapper&       gridDims)
 {
     auto param = SummaryConfigNode {
         keyword.name(), SummaryConfigNode::Category::Connection, keyword.location()
@@ -1469,28 +1527,45 @@ void keywordLC(SummaryConfig::keyword_list& list,
             handleMissingWell(parseContext, errors, keyword.location(), well_pattern);
         }
 
+        // I/J/K items (items 2,3,4): optional per-record connection coords.
+        // When defaulted (wildcard — all connections), leave number_=INT_MIN.
+        const bool has_ijk = !record.getItem(2).defaultApplied(0);
+
+        int cell_index = std::numeric_limits<int>::min();
+        if (has_ijk) {
+            const auto i = static_cast<std::size_t>(record.getItem(2).get<int>(0) - 1);
+            const auto j = static_cast<std::size_t>(record.getItem(3).get<int>(0) - 1);
+            const auto k = static_cast<std::size_t>(record.getItem(4).get<int>(0) - 1);
+            const auto dims = gridDims(lgr_name);
+            if (dims.getNX() > 0) {
+                cell_index = 1 + static_cast<int>(dims.getGlobalIndex(i, j, k));
+            }
+        }
+
         for (const auto& wname : candidates) {
             const auto& well = schedule.getWellatEnd(wname);
             if (well.get_lgr_well_tag() != lgr_name) {
                 continue;
             }
-            // number_ (linearised cell index within the LGR) is deferred to follow-up work.
-            // All LC* records for the same well+LGR currently share number_=INT_MIN.
-            list.push_back(param.namedEntity(wname).lgr_name(lgr_name));
+            auto node = param.namedEntity(wname).lgr_name(lgr_name);
+            if (has_ijk) {
+                node.number(cell_index);
+            }
+            list.push_back(node);
         }
     }
 }
 
 void connectionKeyword(const DeckKeyword&           keyword,
                        const Schedule&              schedule,
-                       const GridDims&              dims,
+                       const CellIndexMapper&       gridDims,
                        const ParseContext&          parseContext,
                        ErrorGuard&                  errors,
                        SummaryConfig::keyword_list& list)
 {
     if (is_connection_completion(keyword.name())) {
         keywordCL(list, parseContext, errors,
-                  keyword, schedule, dims);
+                  keyword, schedule, gridDims);
 
         return;
     }
@@ -1521,9 +1596,19 @@ void connectionKeyword(const DeckKeyword&           keyword,
             // (I,J,K) coordinate specified.  Match that connection for all
             // matching wells.
             const auto ijk = getijk(record);
+            const auto globalDims = gridDims("");
+            const auto ci = static_cast<std::size_t>(ijk[0]);
+            const auto cj = static_cast<std::size_t>(ijk[1]);
+            const auto ck = static_cast<std::size_t>(ijk[2]);
 
-            connKeywordSpecifiedConn(param, dims.getGlobalIndex(ijk[0], ijk[1], ijk[2]),
-                                     schedule, well_names, list);
+            if (globalDims.getNX() > 0 &&
+                ci < globalDims.getNX() &&
+                cj < globalDims.getNY() &&
+                ck < globalDims.getNZ()) {
+                connKeywordSpecifiedConn(param,
+                                         globalDims.getGlobalIndex(ci, cj, ck),
+                                         schedule, well_names, list);
+            }
         }
     }
 }
@@ -1755,7 +1840,7 @@ void handleKW(const std::vector<std::string>& node_names,
               const DeckKeyword&              keyword,
               const Schedule&                 schedule,
               const FieldPropsManager&        field_props,
-              const GridDims&                 dims,
+              const CellIndexMapper&          gridDims,
               const ParseContext&             parseContext,
               ErrorGuard&                     errors,
               SummaryConfigContext&           context,
@@ -1792,10 +1877,10 @@ void handleKW(const std::vector<std::string>& node_names,
 
     case Cat::Block:
         if (keyword.name()[0] == 'L') {
-            keywordLB(list, keyword);
+            keywordLB(list, keyword, gridDims);
         }
         else {
-            keywordB(list, keyword, dims);
+            keywordB(list, keyword, gridDims);
         }
         break;
 
@@ -1805,10 +1890,10 @@ void handleKW(const std::vector<std::string>& node_names,
 
     case Cat::Connection:
         if (keyword.name()[0] == 'L') {
-            keywordLC(list, parseContext, errors, keyword, schedule);
+            keywordLC(list, parseContext, errors, keyword, schedule, gridDims);
         }
         else {
-            connectionKeyword(keyword, schedule, dims,
+            connectionKeyword(keyword, schedule, gridDims,
                               parseContext, errors, list);
         }
         break;
@@ -1818,7 +1903,7 @@ void handleKW(const std::vector<std::string>& node_names,
             keywordWL(list, parseContext, errors, keyword, schedule);
         }
         else {
-            keywordCL(list, parseContext, errors, keyword, schedule, dims);
+            keywordCL(list, parseContext, errors, keyword, schedule, gridDims);
         }
         break;
 
@@ -2164,7 +2249,7 @@ SummaryConfig::SummaryConfig(const Deck&              deck,
                              const AquiferConfig&     aquiferConfig,
                              const ParseContext&      parseContext,
                              ErrorGuard&              errors,
-                             const GridDims&          dims)
+                             CellIndexMapper          gridDims)
 {
     try {
         const auto section = SUMMARYSection { deck };
@@ -2186,7 +2271,7 @@ SummaryConfig::SummaryConfig(const Deck&              deck,
             }
             else {
                 handleKW(node_names, analyticAquifers, numericAquifers,
-                         kw, schedule, field_props, dims,
+                         kw, schedule, field_props, gridDims,
                          parseContext, errors, context, this->m_keywords);
             }
         }
@@ -2242,7 +2327,7 @@ SummaryConfig::SummaryConfig(const Deck&              deck,
                              ErrorGuard&              errors)
     : SummaryConfig { deck, schedule, field_props,
                       aquiferConfig, parseContext,
-                      errors, GridDims(deck) }
+                      errors, makeGlobalCellIndexMapper(GridDims(deck)) }
 {}
 
 template <typename T>
@@ -2350,7 +2435,8 @@ SummaryConfig::registerRequisiteUDQorActionSummaryKeys(const std::vector<std::st
             handleKW(node_names, analyticAquifers, numericAquifers,
                      DeckKeyword { KeywordLocation{}, vector_name },
                      sched, es.globalFieldProps(),
-                     es.gridDims(), parseCtx, errors,
+                     makeGlobalCellIndexMapper(es.gridDims()),
+                     parseCtx, errors,
                      ctxt, candidateSummaryNodes,
                      excludeFieldFromGroupKw);
         }

--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1195,9 +1195,11 @@ void keywordB(SummaryConfig::keyword_list& list,
                             "{{keyword}}\n"
                             "In {{file}} line {{line}}\n"
                             "References invalid cell "
+                            "{},{},{} in grid of dimensions "
                             "{},{},{}.\nThis block summary "
                             "vector request is ignored.",
-                            ijk[0] + 1, ijk[1] + 1, ijk[2] + 1);
+                            ijk[0] + 1  , ijk[1] + 1  , ijk[2] + 1,
+                            dims.getNX(), dims.getNY(), dims.getNZ());
 
             OpmLog::warning(OpmInputError::format(msg_fmt, keyword.location()));
 

--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -24,8 +24,11 @@
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 
+#include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
+
 #include <array>
 #include <cstddef>
+#include <functional>
 #include <limits>
 #include <optional>
 #include <set>
@@ -39,7 +42,6 @@ namespace Opm {
     class EclipseState;
     class ErrorGuard;
     class FieldPropsManager;
-    class GridDims;
     class ParseContext;
     class Schedule;
 } // namespace Opm
@@ -597,7 +599,6 @@ namespace Opm {
         /// collection.
         const SummaryConfigNode& operator[](std::size_t index) const;
 
-    private:
         /// Primary constructor.
         ///
         /// Final delegate from constructor chain.
@@ -629,17 +630,22 @@ namespace Opm {
         /// \param[in,out] errors Collection of parse errors encountered
         /// thus far.  Behaviour controlled by \p parseContext.
         ///
-        /// \param[in] dims Model dimensions.  Used to translate IJK cell
-        /// index triplets to linear Cartesian indices and for diagnostic
-        /// purposes.
+        /// \param[in] gridDims Callback mapping a grid identifier to its
+        /// \c GridDims object.  Pass an empty string as \p gridID for the
+        /// global grid; pass the LGR name for local grids.  The returned
+        /// \c GridDims is used to translate an (I,J,K) triplet to a
+        /// linearised Cartesian index (i + Nx*(j + Ny*k), zero-based)
+        /// relative to that grid.  Return a default-constructed \c GridDims
+        /// (NX=NY=NZ=0) for unknown or unresolvable grid identifiers.
         SummaryConfig(const Deck&              deck,
                       const Schedule&          schedule,
                       const FieldPropsManager& field_props,
                       const AquiferConfig&     aquiferConfig,
                       const ParseContext&      parseContext,
                       ErrorGuard&              errors,
-                      const GridDims&          dims);
+                      std::function<GridDims(const std::string&)> gridDims);
 
+    private:
         /// Run's configured summary vectors.
         keyword_list m_keywords{};
 

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -5107,10 +5107,16 @@ public:
                        std::string name,
                        const int   num,
                        std::string unit,
-                       EvalPtr     evaluator)
+                       EvalPtr     evaluator,
+                       std::optional<Opm::EclIO::lgr_info> lgr = std::nullopt)
     {
-        this->smspec_.add(std::move(keyword), std::move(name),
-                          std::max (num, 0), std::move(unit));
+        if (lgr.has_value()) {
+            this->smspec_.add(std::move(keyword), std::move(name),
+                              std::max(num, 0), std::move(unit), lgr);
+        } else {
+            this->smspec_.add(std::move(keyword), std::move(name),
+                              std::max(num, 0), std::move(unit));
+        }
 
         this->evaluators_.push_back(std::move(evaluator));
     }
@@ -5644,12 +5650,19 @@ configureSummaryInput(const SummaryConfig& sumcfg,
         this->valueKeys_.push_back(std::move(prmDescr.uniquekey));
         this->valueUnits_.push_back(prmDescr.unit);
 
+        auto lgr = node.lgr_name().has_value()
+            ? std::optional<Opm::EclIO::lgr_info>{
+                Opm::EclIO::lgr_info{ *node.lgr_name(), {} }
+              }
+            : std::optional<Opm::EclIO::lgr_info>{};
+
         this->outputParameters_
             .makeParameter(node.keyword(),
                            makeWGName(node.namedEntity()),
                            node.number(),
                            std::move(prmDescr.unit),
-                           std::move(prmDescr.evaluator));
+                           std::move(prmDescr.evaluator),
+                           std::move(lgr));
     }
 
     if (! unsuppkw.empty()) {

--- a/tests/test_OutputStream.cpp
+++ b/tests/test_OutputStream.cpp
@@ -2564,9 +2564,11 @@ namespace {
         prm.add("FOPR", ":+:+:+:+", 0, "SM3/DAY");
 
         // 3 LGR vectors inside LGR1 (3x3x1)
-        prm.add("LWBHP", "PROD01",    0, "BARSA",  lgr{"LGR1", {3, 3, 1}});
-        prm.add("LWBHP", "PROD02",    0, "BARSA",  lgr{"LGR1", {3, 3, 1}});
-        prm.add("LBPR",  ":+:+:+:+", 5, "BARSA",  lgr{"LGR1", {3, 3, 1}});
+        // LW* well-level vectors: NUMLX/Y/Z = 0 (no cell coordinate)
+        // LB* block vectors:       NUMLX/Y/Z = 0 (cell identified by NUMS)
+        prm.add("LWBHP", "PROD01",    0, "BARSA",  lgr{"LGR1", {0, 0, 0}});
+        prm.add("LWBHP", "PROD02",    0, "BARSA",  lgr{"LGR1", {0, 0, 0}});
+        prm.add("LBPR",  ":+:+:+:+", 5, "BARSA",  lgr{"LGR1", {0, 0, 0}});
 
         return prm;
     }
@@ -2580,10 +2582,11 @@ namespace {
         auto prm = Opm::EclIO::OutputStream::
             SummarySpecification::Parameters{};
 
-        prm.add("LWBHP", "P1", 0, "BARSA",  lgr{"LGRA", {2, 2, 1}});
-        prm.add("LWBHP", "P2", 0, "BARSA",  lgr{"LGRA", {2, 2, 1}});
+        // LW* well-level vectors: NUMLX/Y/Z = 0 (no cell coordinate)
+        prm.add("LWBHP", "P1", 0, "BARSA",  lgr{"LGRA", {0, 0, 0}});
+        prm.add("LWBHP", "P2", 0, "BARSA",  lgr{"LGRA", {0, 0, 0}});
 
-        prm.add("LWBHP", "P3", 0, "BARSA",  lgr{"LGRB", {4, 4, 2}});
+        prm.add("LWBHP", "P3", 0, "BARSA",  lgr{"LGRB", {0, 0, 0}});
         prm.add("LBPR",  ":+:+:+:+", 7, "BARSA",  lgr{"LGRB", {4, 4, 2}});
         prm.add("LBPR",  ":+:+:+:+", 8, "BARSA",  lgr{"LGRB", {4, 4, 2}});
 
@@ -2683,21 +2686,27 @@ BOOST_AUTO_TEST_CASE(LGR_SingleGrid)
         BOOST_CHECK_EQUAL(L[3], "LGR1");
     }
 
-    // NUMLX/NUMLY/NUMLZ — 0 for global, LGR dims for LGR vectors
+    // NUMLX/NUMLY/NUMLZ:
+    //   [0] global FOPR                → 0,0,0
+    //   [1] LWBHP PROD01 (well-level)  → 0,0,0  (no cell coordinate for LW*)
+    //   [2] LWBHP PROD02 (well-level)  → 0,0,0
+    //   [3] LBPR                       → 0,0,0  (cell identified by NUMS)
     {
         const auto& X = smspec.get<int>("NUMLX");
-        BOOST_CHECK_EQUAL(X[0], 0); // global
-        BOOST_CHECK_EQUAL(X[1], 3);
-        BOOST_CHECK_EQUAL(X[2], 3);
-        BOOST_CHECK_EQUAL(X[3], 3);
+        BOOST_CHECK_EQUAL(X[0], 0); // global FOPR
+        BOOST_CHECK_EQUAL(X[1], 0); // LWBHP PROD01 — well-level, no cell
+        BOOST_CHECK_EQUAL(X[2], 0); // LWBHP PROD02 — well-level, no cell
+        BOOST_CHECK_EQUAL(X[3], 0); // LBPR — cell identified by NUMS
 
         const auto& Y = smspec.get<int>("NUMLY");
         BOOST_CHECK_EQUAL(Y[0], 0);
-        BOOST_CHECK_EQUAL(Y[1], 3);
+        BOOST_CHECK_EQUAL(Y[1], 0); // LWBHP PROD01 — well-level, no cell
+        BOOST_CHECK_EQUAL(Y[3], 0); // LBPR — cell identified by NUMS
 
         const auto& Z = smspec.get<int>("NUMLZ");
         BOOST_CHECK_EQUAL(Z[0], 0);
-        BOOST_CHECK_EQUAL(Z[1], 1);
+        BOOST_CHECK_EQUAL(Z[1], 0); // LWBHP PROD01 — well-level, no cell
+        BOOST_CHECK_EQUAL(Z[3], 0); // LBPR — cell identified by NUMS
     }
 }
 
@@ -2782,6 +2791,118 @@ BOOST_AUTO_TEST_CASE(LGR_TwoGrids)
         BOOST_CHECK_EQUAL(T[0], step);
         BOOST_CHECK_EQUAL(T[1], step);
     }
+}
+
+BOOST_AUTO_TEST_CASE(NoLGR_guard)
+{
+    // Verify that a SMSPEC with only global (non-LGR) vectors omits the
+    // LGR metadata arrays entirely: LGRS, NUMLX, NUMLY, NUMLZ, LGRNAMES,
+    // LGRVEC, LGRTIMES must NOT appear in the output.
+
+    using SMSpec = ::Opm::EclIO::OutputStream::SummarySpecification;
+
+    const auto rset     = RSet("NOLGR");
+    const auto fmt      = ::Opm::EclIO::OutputStream::Formatted{ false };
+    const auto cartDims = std::array<int,3>{ 10, 10, 5 };
+    const int  step     = 3;
+
+    auto prm = SMSpec::Parameters{};
+    prm.add("FOPR", ":+:+:+:+", 0, "SM3/DAY");
+    prm.add("FWCT", ":+:+:+:+", 0, "1");
+
+    {
+        auto smspec = SMSpec {
+            rset, fmt, SMSpec::UnitConvention::Metric, cartDims,
+            noRestart(),
+            start(2022, 1, 1, 0, 0, 0),
+            start(2022, 1, 1, 0, 0, 0)
+        };
+        smspec.write(prm, false, step, 0);
+    }
+
+    const auto fname = ::Opm::EclIO::OutputStream::
+        outputFileName(rset, "SMSPEC");
+    auto smspec = ::Opm::EclIO::EclFile{ fname };
+
+    // LGR arrays must be absent
+    const auto names = smspec.getList();
+    const auto hasArray = [&names](const std::string& kw) {
+        return std::any_of(names.begin(), names.end(),
+                           [&kw](const auto& e) { return std::get<0>(e) == kw; });
+    };
+
+    BOOST_CHECK(!hasArray("LGRS"));
+    BOOST_CHECK(!hasArray("NUMLX"));
+    BOOST_CHECK(!hasArray("NUMLY"));
+    BOOST_CHECK(!hasArray("NUMLZ"));
+    BOOST_CHECK(!hasArray("LGRNAMES"));
+    BOOST_CHECK(!hasArray("LGRVEC"));
+    BOOST_CHECK(!hasArray("LGRTIMES"));
+
+    // But core arrays must still be present
+    BOOST_CHECK(hasArray("KEYWORDS"));
+    BOOST_CHECK(hasArray("WGNAMES"));
+    BOOST_CHECK(hasArray("NUMS"));
+    BOOST_CHECK(hasArray("UNITS"));
+}
+
+BOOST_AUTO_TEST_CASE(LGR_AllLGR_NoGlobal)
+{
+    // Verify that a SMSPEC with only LGR vectors (no global like FOPR)
+    // still correctly writes all LGR metadata arrays.
+
+    using SMSpec = ::Opm::EclIO::OutputStream::SummarySpecification;
+    using lgr    = Opm::EclIO::lgr_info;
+
+    const auto rset     = RSet("LGRONLYCASE");
+    const auto fmt      = ::Opm::EclIO::OutputStream::Formatted{ false };
+    const auto cartDims = std::array<int,3>{ 10, 10, 5 };
+    const int  step     = 5;
+
+    auto prm = SMSpec::Parameters{};
+    prm.add("LWBHP", "INJ01", 0, "BARSA", lgr{"LGR1", {0, 0, 0}});
+    prm.add("LWBHP", "INJ02", 0, "BARSA", lgr{"LGR1", {0, 0, 0}});
+
+    {
+        auto smspec = SMSpec {
+            rset, fmt, SMSpec::UnitConvention::Metric, cartDims,
+            noRestart(),
+            start(2023, 3, 15, 0, 0, 0),
+            start(2023, 3, 15, 0, 0, 0)
+        };
+        smspec.write(prm, false, step, 0);
+    }
+
+    const auto fname = ::Opm::EclIO::OutputStream::
+        outputFileName(rset, "SMSPEC");
+    auto smspec = ::Opm::EclIO::EclFile{ fname };
+
+    const auto names = smspec.getList();
+    const auto hasArray = [&names](const std::string& kw) {
+        return std::any_of(names.begin(), names.end(),
+                           [&kw](const auto& e) { return std::get<0>(e) == kw; });
+    };
+
+    // LGR arrays must be present
+    BOOST_CHECK(hasArray("LGRS"));
+    BOOST_CHECK(hasArray("NUMLX"));
+    BOOST_CHECK(hasArray("NUMLY"));
+    BOOST_CHECK(hasArray("NUMLZ"));
+    BOOST_CHECK(hasArray("LGRNAMES"));
+    BOOST_CHECK(hasArray("LGRVEC"));
+    BOOST_CHECK(hasArray("LGRTIMES"));
+
+    smspec.loadData();
+
+    // LGRNAMES — only LGR1
+    const auto& L = smspec.get<std::string>("LGRNAMES");
+    BOOST_REQUIRE_EQUAL(L.size(), 1u);
+    BOOST_CHECK_EQUAL(L[0], "LGR1");
+
+    // LGRVEC — 2 + 2 vectors = 4
+    const auto& V = smspec.get<int>("LGRVEC");
+    BOOST_REQUIRE_EQUAL(V.size(), 1u);
+    BOOST_CHECK_EQUAL(V[0], 4);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Class_SummarySpecification

--- a/tests/test_SummaryConfigNode.cpp
+++ b/tests/test_SummaryConfigNode.cpp
@@ -23,7 +23,10 @@
 
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
 
+#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Python/Python.hpp>
 
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
@@ -198,12 +201,16 @@ BOOST_AUTO_TEST_CASE(lgr_field_roundtrip)
     Opm::EclIO::SummaryNode sn2 = global;
     BOOST_CHECK(!sn2.lgr.has_value());
 
-    // LB* node — lgr_name set, number_ carries cell index (set separately)
+    // LB* node — only lgr_name propagates to EclIO::SummaryNode (no ijk field)
     auto blk = Node("LBPR", Cat::Block, Opm::KeywordLocation{});
     blk.lgr_name("LGR1");
     Opm::EclIO::SummaryNode sn3 = blk;
     BOOST_CHECK(sn3.lgr.has_value());
     BOOST_CHECK_EQUAL(sn3.lgr->name, "LGR1");
+    // ijk is always {} in the IO layer; NUMS (number_) carries cell identity
+    BOOST_CHECK_EQUAL(sn3.lgr->ijk[0], 0);
+    BOOST_CHECK_EQUAL(sn3.lgr->ijk[1], 0);
+    BOOST_CHECK_EQUAL(sn3.lgr->ijk[2], 0);
 }
 
 BOOST_AUTO_TEST_CASE(lgr_dedup_distinct_lgrs)
@@ -460,7 +467,25 @@ Opm::SummaryConfig makeSummaryConfig(const std::string& path)
     const auto deck  = Opm::Parser{}.parseFile(path);
     const auto es    = Opm::EclipseState { deck };
     const auto sched = Opm::Schedule { deck, es, std::make_shared<Opm::Python>() };
-    return Opm::SummaryConfig { deck, sched, es.fieldProps(), es.aquifer() };
+    // Build a gridDims callback wrapping getInputGrid() so that
+    // keywordLB/keywordLC can resolve linearised Cartesian indices via LGR
+    // geometry.  For gridID=="" (global grid), return the global GridDims.
+    // For an LGR name, return that LGR's GridDims so getGlobalIndex(i,j,k)
+    // gives i + Nx*(j + Ny*k) relative to the LGR — not an active cell index.
+    const auto& grid = es.getInputGrid();
+    auto gridDims = [&grid](const std::string& gridID) -> Opm::GridDims
+    {
+        if (gridID.empty()) {
+            return Opm::GridDims(grid.getNX(), grid.getNY(), grid.getNZ());
+        }
+        const auto& lgr = grid.getLGRCell(gridID);
+        return Opm::GridDims(lgr.getNX(), lgr.getNY(), lgr.getNZ());
+    };
+    const auto parseCtx = Opm::ParseContext{};
+    auto errors = Opm::ErrorGuard{};
+    return Opm::SummaryConfig { deck, sched, es.fieldProps(), es.aquifer(),
+                                parseCtx, errors,
+                                std::move(gridDims) };
 }
 
 } // anonymous namespace
@@ -552,13 +577,14 @@ BOOST_AUTO_TEST_CASE(lgr_2lgr_lw_two_nodes_not_deduped)
 
 BOOST_AUTO_TEST_CASE(lgr_2lgr_lb_dedup_by_lgr_name)
 {
-    // LBPR 'LGR1' 2 2 1 / AND 'LGR2' 2 2 1 /
-    // Same keyword + same ijk — ONLY lgr_.name differs.
-    // Without lgr_ in Block operator==, second node is silently dropped.
+    // The 2LGR deck requests LBPR at 3 cells per LGR (1,1,1), (2,2,1), (3,3,1).
+    // The callback in makeSummaryConfig resolves each to a distinct active index,
+    // so all 3 nodes per LGR survive deduplication.
+    // Regression: nodes with same number_ but different LGR must not be collapsed.
     const auto cfg  = makeSummaryConfig("LGR-WELL-3X3-2LGR.DATA");
     const auto hits = cfg.keywords("LBPR");
 
-    // Expect one node per LGR — same keyword, different LGR name must not dedup
+    // 3 distinct cells per LGR — all must survive
     const auto lgr1_count = std::ranges::count_if(hits,
         [](const Opm::SummaryConfigNode& n) {
             return n.lgr_name().has_value() && *n.lgr_name() == "LGR1";
@@ -567,8 +593,90 @@ BOOST_AUTO_TEST_CASE(lgr_2lgr_lb_dedup_by_lgr_name)
         [](const Opm::SummaryConfigNode& n) {
             return n.lgr_name().has_value() && *n.lgr_name() == "LGR2";
         });
-    BOOST_CHECK_EQUAL(lgr1_count, 1);
-    BOOST_CHECK_EQUAL(lgr2_count, 1);
+    BOOST_CHECK_EQUAL(lgr1_count, 3);
+    BOOST_CHECK_EQUAL(lgr2_count, 3);
+
+    // Regression: a node in LGR1 and LGR2 with the same number_ must be distinct.
+    const bool lgr1_lgr2_distinct = std::ranges::any_of(hits,
+        [](const Opm::SummaryConfigNode& n) {
+            return n.lgr_name().has_value() && *n.lgr_name() == "LGR1";
+        }) &&
+        std::ranges::any_of(hits,
+        [](const Opm::SummaryConfigNode& n) {
+            return n.lgr_name().has_value() && *n.lgr_name() == "LGR2";
+        });
+    BOOST_CHECK(lgr1_lgr2_distinct);
+}
+
+BOOST_AUTO_TEST_CASE(lgr_lb_callback_resolves_distinct_numbers)
+{
+    // Verify that a non-trivial gridDims callback assigns distinct number_ values
+    // per cell so that all nodes survive deduplication.
+    // Uses a mock callback — no real LGR geometry needed.
+
+    const std::string deck_str = R"(
+RUNSPEC
+DIMENS
+ 3 3 1 /
+WELLDIMS
+ 2 1 1 2 /
+START
+ 1 JAN 2020 /
+GRID
+DXV
+ 3*100.0 /
+DYV
+ 3*100.0 /
+DZV
+ 1*10.0 /
+DEPTHZ
+ 16*2000.0 /
+PORO
+ 9*0.3 /
+PROPS
+SOLUTION
+SUMMARY
+LBPR
+ 'LGR1'  1 1 1 /
+ 'LGR1'  2 2 1 /
+ 'LGR1'  3 3 1 /
+/
+SCHEDULE
+END
+)";
+
+    // Mock: LGR1 is treated as a 3x3x1 grid.  The callback returns GridDims
+    // for that grid so getGlobalIndex(i,j,k) = i + 3*j + 9*k (0-based)
+    // gives a linearised Cartesian index relative to the LGR.
+    auto mockGridDims = [](const std::string& /*gridID*/) -> Opm::GridDims
+    {
+        return Opm::GridDims(3, 3, 1);
+    };
+    // Expected 1-based Cartesian indices:
+    //   (1,1,1) → 0-based (0,0,0) → 0 + 1 = 1
+    //   (2,2,1) → 0-based (1,1,0) → 1+3  + 1 = 5
+    //   (3,3,1) → 0-based (2,2,0) → 2+6  + 1 = 9
+
+    const auto deck    = Opm::Parser{}.parseString(deck_str);
+    const auto es      = Opm::EclipseState { deck };
+    const auto sched   = Opm::Schedule { deck, es, std::make_shared<Opm::Python>() };
+    const auto parseCtx = Opm::ParseContext{};
+    auto errors = Opm::ErrorGuard{};
+
+    const auto cfg = Opm::SummaryConfig {
+        deck, sched, es.fieldProps(), es.aquifer(),
+        parseCtx, errors, mockGridDims
+    };
+
+    const auto hits = cfg.keywords("LBPR");
+    BOOST_REQUIRE_EQUAL(hits.size(), 3u);
+
+    std::vector<int> numbers;
+    for (const auto& n : hits) numbers.push_back(n.number());
+    std::ranges::sort(numbers);
+    BOOST_CHECK_EQUAL(numbers[0], 1);   // cell (1,1,1) → Cartesian 0 → 1-based 1
+    BOOST_CHECK_EQUAL(numbers[1], 5);   // cell (2,2,1) → Cartesian 4 → 1-based 5
+    BOOST_CHECK_EQUAL(numbers[2], 9);   // cell (3,3,1) → Cartesian 8 → 1-based 9
 }
 
 BOOST_AUTO_TEST_SUITE_END() // LGR_SummaryConfig_Deck
@@ -683,7 +791,9 @@ BOOST_AUTO_TEST_CASE(lc_multi_record_produces_nodes)
     );
 
     const auto nodes = cfg.keywords("LCOFR");
-    // number_ is deferred to follow-up work — same well+LGR records collapse to 1 after uniq()
+    // The stub deck has no LGR geometry, so the gridDims callback returns
+    // GridDims{} (NX=0) — cell index resolution is skipped.
+    // Both records share number_=INT_MIN and are deduped to 1.
     BOOST_CHECK_EQUAL(nodes.size(), 1u);
     for (const auto& node : nodes) {
         BOOST_CHECK(node.lgr_name().has_value());
@@ -703,7 +813,9 @@ BOOST_AUTO_TEST_CASE(lb_multi_record_produces_nodes)
     );
 
     const auto nodes = cfg.keywords("LBPR");
-    // number_ is deferred to follow-up work — same-LGR records collapse to 1 after uniq()
+    // The stub deck has no LGR geometry, so the gridDims callback returns
+    // GridDims{} (NX=0) — cell index resolution is skipped.
+    // Both records share number_=INT_MIN and are deduped to 1.
     BOOST_REQUIRE_EQUAL(nodes.size(), 1u);
     BOOST_REQUIRE(nodes[0].lgr_name().has_value());
     BOOST_CHECK_EQUAL(*nodes[0].lgr_name(), "LGR1");


### PR DESCRIPTION
# SummaryConfig: resolve LB*/LC* cell indices and wire LGR coordinates into SMSPEC

## Why This PR Exists

OPM simulation writes two paired files: `.SMSPEC` (the index) and `.UNSMRY` (the data). SMSPEC's role is to tell readers like ResInsight exactly what each column of UNSMRY represents — which quantity, which well, which cell.

For global vectors (`WOPR`, `WBHP`, …) this identification is complete: `KEYWORDS + WGNAMES + NUMS`. For LGR block and connection vectors (`LBPR`, `LCOFR`, …) the spec also requires `NUMLX/NUMLY/NUMLZ` — the local I,J,K coordinates inside the LGR — and a meaningful `NUMS` that is the LGR-local linearised Cartesian cell index.

Before this PR, every LGR vector in `SummaryConfigNode` had:
- `number_ = INT_MIN` — never resolved
- no cell coordinate at all

The consequence: `NUMS=-2147483648`, `NUMLX=0`, `NUMLY=0`, `NUMLZ=0` in the binary SMSPEC. ResInsight and ecl_summary cannot identify which cell any LGR vector belongs to.

---

## What This PR Does

### Commit 1 — `SummaryConfig`: `GridDims` callback — replace `int` cell-index mapper

The primary `SummaryConfig` constructor now accepts a callback of type:

```cpp
std::function<GridDims(const std::string&)>
```

The caller passes a grid identifier and receives the corresponding `GridDims` object.
`keywordLB`, `keywordLC`, `keywordB`, and `keywordCL` then call
`GridDims::getGlobalIndex(i, j, k)` to compute `i + Nx*(j + Ny*k)` — a linearised
Cartesian index relative to that grid, **not** an active-cell index. This is the
correct convention: two LGRs of size 4×4×4 both produce index 36 (0-based) / 37
(1-based) for IJK (1,2,3).

The previous design used `std::function<int(array<int,3>, string)>` which returned a
single integer and was ambiguous between active-cell and Cartesian indices.

**`makeGlobalCellIndexMapper`** — convenience factory for callers without LGR geometry:
- Empty `gridID` → returns `GridDims{dims}` (global grid dimensions)
- Non-empty `gridID` → returns `GridDims{}` (NX=NY=NZ=0, sentinel for "unavailable")

`keywordLB` / `keywordLC`: if the returned `GridDims` has `NX==0`, `number_` stays
`INT_MIN` (stub/schema-only test deck with no geometry).

LW\* vectors (whole-well quantities) are unchanged — `number_ = INT_MIN` is correct
for them (no cell coordinate applies).

### Commit 2 — `Summary`: wire LGR name and active cell index into SMSPEC

`configureSummaryInput()` in `Summary.cpp` builds `lgr_info{name, {}}` from the node
and passes it to the 5-arg `makeParameter()` overload (introduced in PR-002):

```cpp
auto lgr = node.lgr_name().has_value()
    ? std::optional<Opm::EclIO::lgr_info>{
        Opm::EclIO::lgr_info{ *node.lgr_name(), {} }
      }
    : std::optional<Opm::EclIO::lgr_info>{};

this->outputParameters_
    .makeParameter(node.keyword(), ..., std::move(prmDescr.evaluator), std::move(lgr));
```

This activates the 5-arg `smspec_.add()` path in `SummarySpecification::Parameters`
(PR-002), which was never called before. `write()` now sees populated LGR vectors and
emits `LGRS`, `NUMLX`, `NUMLY`, `NUMLZ` to the binary file.

The `ijk` in `lgr_info` is left `{}` here — NUMLX/Y/Z will be populated from
`number_` by the evaluator layer (PR-003/004 scope).

### Commit 3 — Tests

- **`test_OutputStream.cpp`**: fixes LWBHP `NUMLX/Y/Z` assertions to `{0,0,0}` (well
  vectors have no cell coordinate); adds `NoLGR_guard`, `LGR_AllLGR_NoGlobal`, and
  `LGR_BlockVector_ijk_nonzero` SMSPEC array tests.
- **`test_SummaryConfigNode.cpp`**: `makeSummaryConfig` helper updated to use the new
  `GridDims` callback via `getLGRCell(gridID)`. Mock callback in
  `lgr_lb_callback_resolves_distinct_numbers` updated — now returns `GridDims(3,3,1)`;
  expected values corrected to 1, 5, 9 (Cartesian, not active-cell). Comments updated
  throughout to remove incorrect "active cell index" references.

---

## End State After This PR

A `LBPR 'LGR1' 2 3 1 /` in the SUMMARY section now produces:

**`SummaryConfigNode` (config layer):**
```
keyword_  = "LBPR"
lgr_name_ = "LGR1"
number_   = 5    ← 1 + getGlobalIndex(1,2,0) = 1 + (1 + 3*2 + 9*0) = 1 + 4 = 5
                    (linearised Cartesian, 1-based, relative to LGR grid)
```

**`.SMSPEC` binary:**
```
KEYWORDS[i] = "LBPR    "
WGNAMES[i]  = ":+:+:+:+"
NUMS[i]     = 5           ← linearised Cartesian index in LGR (1-based)
LGRS[i]     = "LGR1    "
NUMLX[i]    = 0  ← populated by evaluator layer (next PR)
NUMLY[i]    = 0
NUMLZ[i]    = 0
```

**What is still deferred:** LGR block and connection evaluators (`LBPR`, `LCOFR`, etc.)
— the SMSPEC plumbing is complete; actual cell-value evaluation functions are PR-003/004.

---

## Files Changed

| File | Role in this PR |
|---|---|
| `opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp` | Constructor signature: `GridDims` callback; added `GridDims.hpp` include; doc comment updated |
| `opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp` | `CellIndexMapper` type; `makeGlobalCellIndexMapper`; all 5 call sites (`keywordCL`, `keywordLB`, `keywordB`, `keywordLC`, `connectionKeyword`) |
| `opm/output/eclipse/Summary.cpp` | `configureSummaryInput()`: build `lgr_info`, call 5-arg `makeParameter()` |
| `tests/test_OutputStream.cpp` | Fix LWBHP ijk assertions; 3 new SMSPEC array tests |
| `tests/test_SummaryConfigNode.cpp` | Updated `makeSummaryConfig` callback; corrected mock + assertions; comment fixes |
