### PR TITLE
Container for multicomponent salt

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -567,6 +567,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/test_RPTConfig.cpp
   tests/test_rst.cpp
   tests/test_rst_netbalan.cpp
+  tests/test_SaltArray.cpp
   tests/test_ScheduleGrid.cpp
   tests/test_SegmentMatcher.cpp
   tests/test_makeMSWellFromStandardWell.cpp
@@ -907,6 +908,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/common/utility/FileSystem.hpp
   opm/common/utility/MemPacker.hpp
   opm/common/utility/OpmInputError.hpp
+  opm/common/utility/SaltArray.hpp
   opm/common/utility/Serializer.hpp
   opm/common/utility/String.hpp
   opm/common/utility/SymmTensor.hpp
@@ -1314,19 +1316,25 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/material/components/BrineDynamic.hpp
   opm/material/components/C1.hpp
   opm/material/components/C10.hpp
+  opm/material/components/CaIon.hpp
+  opm/material/components/ClIon.hpp
   opm/material/components/CO2.hpp
   opm/material/components/CO2Tables.hpp
   opm/material/components/Component.hpp
   opm/material/components/Dnapl.hpp
   opm/material/components/H2.hpp
   opm/material/components/H2O.hpp
+  opm/material/components/KIon.hpp
   opm/material/components/Lnapl.hpp
   opm/material/components/Mesitylene.hpp
+  opm/material/components/MgIon.hpp
   opm/material/components/N2.hpp
+  opm/material/components/NaIon.hpp
   opm/material/components/NullComponent.hpp
   opm/material/components/SimpleCO2.hpp
   opm/material/components/SimpleH2O.hpp
   opm/material/components/SimpleHuDuanH2O.hpp
+  opm/material/components/SO4Ion.hpp
   opm/material/components/TabulatedComponent.hpp
   opm/material/components/Unit.hpp
   opm/material/components/Xylene.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -572,6 +572,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/test_RPTConfig.cpp
   tests/test_rst.cpp
   tests/test_rst_netbalan.cpp
+  tests/test_SaltArray.cpp
   tests/test_ScheduleGrid.cpp
   tests/test_SegmentMatcher.cpp
   tests/test_makeMSWellFromStandardWell.cpp
@@ -912,6 +913,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/common/utility/FileSystem.hpp
   opm/common/utility/MemPacker.hpp
   opm/common/utility/OpmInputError.hpp
+  opm/common/utility/SaltArray.hpp
   opm/common/utility/Serializer.hpp
   opm/common/utility/String.hpp
   opm/common/utility/SymmTensor.hpp
@@ -1321,19 +1323,25 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/material/components/BrineDynamic.hpp
   opm/material/components/C1.hpp
   opm/material/components/C10.hpp
+  opm/material/components/CaIon.hpp
+  opm/material/components/ClIon.hpp
   opm/material/components/CO2.hpp
   opm/material/components/CO2Tables.hpp
   opm/material/components/Component.hpp
   opm/material/components/Dnapl.hpp
   opm/material/components/H2.hpp
   opm/material/components/H2O.hpp
+  opm/material/components/KIon.hpp
   opm/material/components/Lnapl.hpp
   opm/material/components/Mesitylene.hpp
+  opm/material/components/MgIon.hpp
   opm/material/components/N2.hpp
+  opm/material/components/NaIon.hpp
   opm/material/components/NullComponent.hpp
   opm/material/components/SimpleCO2.hpp
   opm/material/components/SimpleH2O.hpp
   opm/material/components/SimpleHuDuanH2O.hpp
+  opm/material/components/SO4Ion.hpp
   opm/material/components/TabulatedComponent.hpp
   opm/material/components/Unit.hpp
   opm/material/components/Xylene.hpp

--- a/opm/common/utility/SaltArray.hpp
+++ b/opm/common/utility/SaltArray.hpp
@@ -1,0 +1,619 @@
+/*
+  Copyright 2026 NORCE.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef OPM_SALTARRAY_HPP
+#define OPM_SALTARRAY_HPP
+
+#include <opm/input/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/material/components/CaIon.hpp>
+#include <opm/material/components/ClIon.hpp>
+#include <opm/material/components/KIon.hpp>
+#include <opm/material/components/MgIon.hpp>
+#include <opm/material/components/NaIon.hpp>
+#include <opm/material/components/SO4Ion.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <numeric>
+
+namespace Opm
+{
+
+// SaltUnit tags for SaltArray
+struct SaltMolality
+{
+};
+
+struct SaltMassFraction
+{
+};
+
+struct SaltMoleFraction
+{
+};
+
+// Helper conversion struct
+template <class FromSaltUnit, class ToSaltUnit>
+struct SaltUnitConverter;
+
+/// Salt ion indices for SaltArray
+enum class SaltIndex : std::size_t
+{
+    NA, K, CA, MG, CL, SO4,
+    NCOMP // DO NOT CHANGE! Must be the last enum to set size of SaltArray!
+};
+
+/// Enum for classifying cations and anions
+enum class IonType
+{
+    Cation, Anion
+};
+
+/*!
+ * Converts ion string name to index
+ *
+ * @param s Ion name
+ * @return Index of salt ion
+ */
+inline SaltIndex
+saltIndexFromString(const std::string& s)
+{
+    if (s == "NA") {
+        return SaltIndex::NA;
+    }
+    if (s == "K") {
+        return SaltIndex::K;
+    }
+    if (s == "CA") {
+        return SaltIndex::CA;
+    }
+    if (s == "MG") {
+        return SaltIndex::MG;
+    }
+    if (s == "CL") {
+        return SaltIndex::CL;
+    }
+    if (s == "SO4") {
+        return SaltIndex::SO4;
+    }
+    throw std::invalid_argument("SaltIndex not valid!");
+}
+
+/*!
+ * Categorize ion in cation or anion
+ *
+ * @param s Index of salt ion
+ * @return Cation or anion category
+ */
+inline IonType
+categorizeIon(const SaltIndex s)
+{
+    switch (s) {
+    case SaltIndex::CA:
+    case SaltIndex::NA:
+    case SaltIndex::MG:
+    case SaltIndex::K:
+        return IonType::Cation;
+    case SaltIndex::CL:
+    case SaltIndex::SO4:
+        return IonType::Anion;
+    default:
+        throw std::runtime_error("Unknown SaltIndex");
+    }
+}
+
+/*!
+ * Returns the ion strength or salt ion. Positive for cations; negative for anions.
+ *
+ * @param s Index of salt ion
+ * @return Ion strength
+ */
+inline short
+ionStrength(const SaltIndex s)
+{
+    switch (s) {
+    case SaltIndex::CA:
+        return 2;
+    case SaltIndex::NA:
+        return 1;
+    case SaltIndex::MG:
+        return 2;
+    case SaltIndex::K:
+        return 1;
+    case SaltIndex::CL:
+        return -1;
+    case SaltIndex::SO4:
+        return -2;
+    default:
+        throw std::runtime_error("Unknown SaltIndex");
+    }
+}
+
+/*!
+ * Get molar mass of salt ion
+ *
+ * @param ind Index of salt ion
+ * @return Molar mass
+ */
+template <class Scalar>
+Scalar
+saltMolarMass(const SaltIndex ind)
+{
+    switch (ind) {
+    case SaltIndex::NA:
+        return NaIon<Scalar>::molarMass();
+    case SaltIndex::K:
+        return KIon<Scalar>::molarMass();
+    case SaltIndex::CA:
+        return CaIon<Scalar>::molarMass();
+    case SaltIndex::CL:
+        return ClIon<Scalar>::molarMass();
+    case SaltIndex::MG:
+        return MgIon<Scalar>::molarMass();
+    case SaltIndex::SO4:
+        return SO4Ion<Scalar>::molarMass();
+    default:
+        throw std::invalid_argument("SaltIndex not valid!");
+    }
+}
+
+/*!
+ * Wrapper around std::array for salt components with some convenience functions and conversion
+ * to SaltArrays with different units
+ *
+ * @tparam T Value type (typically Scalar or Evaluation)
+ * @tparam SaltUnit Unit of salt array elements
+ */
+template <class T, class SaltUnit>
+class SaltArray
+{
+public:
+    using SaltIndexPair = std::pair<std::vector<SaltIndex>, std::vector<SaltIndex> >;
+
+    static constexpr std::size_t ncomp = static_cast<std::size_t>(SaltIndex::NCOMP);
+
+    /*!
+     * Default constructor
+     */
+    SaltArray() = default;
+
+    /*!
+     * Conversion constructor
+     *
+     * @tparam U Value type different from T
+     * @param other Salt array to convert from
+     */
+    template <class U>
+    explicit SaltArray(const SaltArray<U, SaltUnit>& other)
+    {
+        std::ranges::transform(other,
+                               saltData_.begin(),
+                               [](const U& val) {
+                                   return static_cast<T>(val);
+                               });
+    }
+
+    /*!
+     * Assign array elements from a deck array
+     *
+     * @param record Deck record array
+     */
+    void assignFromDeckRecord(const DeckRecord& record)
+    {
+        assert(record.size() == saltData_.size());
+        for (const auto& item : record) {
+            auto recItem = static_cast<T>(item.get<double>(0));
+            auto index = saltIndexFromString(item.name());
+            (*this)[index] = recItem;
+        }
+    }
+
+    /*!
+     * Return read-only view of array element at a salt ion index
+     *
+     * @param ind Index of salt ion
+     * @return Array element
+     */
+    const T& operator[](const SaltIndex ind) const
+    {
+        return saltData_[static_cast<std::size_t>(ind)];
+    }
+
+    /*!
+     * Return array element at a salt ion index
+     *
+     * @param ind Index of salt ion
+     * @return Array element
+     */
+    T& operator[](const SaltIndex ind)
+    {
+        return saltData_[static_cast<std::size_t>(ind)];
+    }
+
+    /*!
+     * Check for equal SaltArray
+     *
+     * @param other Comparison array
+     * @return True if arrays are equal
+     */
+    bool operator==(const SaltArray& other) const
+    {
+        return saltData_ == other.saltData_;
+    }
+
+    /*!
+     * Default copy assignment
+     *
+     * @param other Array to copy
+     * @return Copy of other array
+     */
+    SaltArray& operator=(const SaltArray& other) = default;
+
+    /*!
+     * Conversion copy assignment for simple assignment to new value type (that supports conversion)
+     *
+     * @tparam U Value type of other array
+     * @param other Array to copy
+     * @return Copy of array
+     */
+    template <class U>
+    SaltArray& operator=(const SaltArray<U, SaltUnit>& other)
+    {
+        std::ranges::transform(other,
+                               saltData_.begin(),
+                               [](const U& val) {
+                                   return static_cast<T>(val);
+                               });
+        return *this;
+    }
+
+    /*!
+     * Array begin iterator
+     *
+     * @return Iterator
+     */
+    auto begin()
+    {
+        return saltData_.begin();
+    }
+
+    /*!
+     * Array end iterator
+     *
+     * @return Iterator
+     */
+    auto end()
+    {
+        return saltData_.end();
+    }
+
+    /*!
+     * Read-only view of array begin iterator
+     *
+     * @return Iterator
+     */
+    [[nodiscard]] auto begin() const
+    {
+        return saltData_.begin();
+    }
+
+    /*!
+     * Read-only view of array end iterator
+     *
+     * @return Iterator
+     */
+    [[nodiscard]] auto end() const
+    {
+        return saltData_.end();
+    }
+
+    /*!
+     * Size of array, which should be equal to number of supported ions in @ref SaltIndex
+     *
+     * @return Size of array
+     */
+    [[nodiscard]] constexpr std::size_t size() const
+    {
+        return saltData_.size();
+    }
+
+    /*!
+     * Sum of array elements.
+     * @note For mass and mole fraction arrays, 1 - sum() is equal to mass/mole fraction of H2O
+     *
+     * @return Sum
+     */
+    T sum() const
+    {
+        return std::accumulate(begin(), end(), T{});
+    }
+
+    /*!
+     * Fill all elements with zero
+     */
+    void clear() noexcept
+    {
+        saltData_.fill(T{});
+    }
+
+    /*!
+     * Check if any elements are non-zero
+     *
+     * @return True if any element non-zero
+     */
+    [[nodiscard]] bool any_nonzero() const noexcept
+    {
+        return std::any_of(begin(),
+                           end(),
+                           [](const T& val) {
+                               return val != T{};
+                           });
+    }
+
+    /*!
+     * Get cations and anions of non-zero ions in descending ion strength
+     *
+     * @return Pair of cation and anion vectors
+     */
+    [[nodiscard]] SaltIndexPair cations_and_anions() const
+    {
+        std::vector<std::pair<short, SaltIndex> > cations;
+        std::vector<std::pair<short, SaltIndex> > anions;
+        cations.reserve(size());
+        anions.reserve(size());
+        for (std::size_t i = 0; i < size(); ++i) {
+            auto ind = static_cast<SaltIndex>(i);
+            auto ionStr = ionStrength(ind);
+            if ((*this)[ind] != T{}) {
+                if (categorizeIon(ind) == IonType::Cation) {
+                    cations.emplace_back(ionStr, ind);
+
+                } else {
+                    anions.emplace_back(ionStr, ind);
+                }
+            }
+        }
+
+        // Sort by ion strength: descending for cations, ascending for anions
+        std::ranges::sort(cations, std::ranges::greater{}, &std::pair<short, SaltIndex>::first);
+        std::ranges::sort(anions, {}, &std::pair<short, SaltIndex>::first);
+
+        // Return only cations and anions SaltIndex
+        std::vector<SaltIndex> cationIndex;
+        std::vector<SaltIndex> anionIndex;
+        cationIndex.reserve(cations.size());
+        anionIndex.reserve(anions.size());
+        std::ranges::transform(cations,
+                               std::back_inserter(cationIndex),
+                               &std::pair<short, SaltIndex>::second);
+        std::ranges::transform(anions,
+                               std::back_inserter(anionIndex),
+                               &std::pair<short, SaltIndex>::second);
+
+        return {cationIndex, anionIndex};
+    }
+
+    /*!
+     * Return an array with elements converted to new unit
+     *
+     * @tparam NewSaltUnit New unit for returning array
+     * @return Converted array
+     */
+    template <class NewSaltUnit>
+    SaltArray<T, NewSaltUnit> convert_to() const
+    {
+        return SaltUnitConverter<SaltUnit, NewSaltUnit>::template convert<T>(*this);
+    }
+
+    template <class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(saltData_);
+    }
+
+private:
+    std::array<T, ncomp> saltData_{}; ///< Array of salt ion values
+}; // class SaltArray
+
+// ------------------------------------------
+// Conversion between different salt units
+// ------------------------------------------
+template <>
+struct SaltUnitConverter<SaltMassFraction, SaltMolality>
+{
+    /*!
+     * Convert mass fraction to molality:
+     * https://en.wikipedia.org/wiki/Molality#Mass_fraction
+     *
+     * @tparam T Value type
+     * @param saltArray Mass fraction array
+     * @return Molality array
+     */
+    template <class T>
+    static SaltArray<T, SaltMolality> convert(const SaltArray<T, SaltMassFraction>& saltArray)
+    {
+        SaltArray<T, SaltMolality> molalityArray;
+        for (std::size_t i = 0; i < saltArray.size(); ++i) {
+            auto sIdx = static_cast<SaltIndex>(i);
+            molalityArray[sIdx] = saltArray[sIdx] / saltMolarMass<T>(sIdx);
+        }
+
+        T s = 1.0 - saltArray.sum();
+        for (auto& elem : molalityArray) {
+            elem /= s;
+        }
+
+        return molalityArray;
+    }
+};
+
+template <>
+struct SaltUnitConverter<SaltMassFraction, SaltMoleFraction>
+{
+    /*!
+     * Convert mass fraction to mole fraction:
+     * https://en.wikipedia.org/wiki/Mass_fraction_(chemistry)#Mole_fraction
+     *
+     * @tparam T Value type
+     * @param saltArray Mass fraction array
+     * @return Mole fraction array
+     */
+    template <class T>
+    static SaltArray<T, SaltMoleFraction> convert(const SaltArray<T, SaltMassFraction>& saltArray)
+    {
+        SaltArray<T, SaltMoleFraction> moleFracArray;
+        T s = 1.0;
+        for (std::size_t i = 0; i < saltArray.size(); ++i) {
+            auto sIdx = static_cast<SaltIndex>(i);
+            moleFracArray[sIdx] = saltArray[sIdx] * 18.01518e-3 / saltMolarMass<T>(sIdx);
+            s += moleFracArray[sIdx] - saltArray[sIdx];
+        }
+
+        for (auto& elem : moleFracArray) {
+            elem /= s;
+        }
+
+        return moleFracArray;
+    }
+};
+
+template <>
+struct SaltUnitConverter<SaltMoleFraction, SaltMassFraction>
+{
+    /*!
+     * Convert mole fraction to mass fraction:
+     * https://en.wikipedia.org/wiki/Mole_fraction#Mass_fraction
+     *
+     * @tparam T Value type
+     * @param saltArray Mole fraction array
+     * @return Mass fraction array
+     */
+    template <class T>
+    static SaltArray<T, SaltMassFraction> convert(const SaltArray<T, SaltMoleFraction>& saltArray)
+    {
+        SaltArray<T, SaltMassFraction> massFracArray;
+        T s = 18.01518e-3;
+        for (std::size_t i = 0; i < saltArray.size(); ++i) {
+            auto sIdx = static_cast<SaltIndex>(i);
+            massFracArray[sIdx] = saltArray[sIdx] * saltMolarMass<T>(sIdx);
+            s += massFracArray[sIdx] - saltArray[sIdx] * 18.01518e-3;
+        }
+
+        for (auto& elem : massFracArray) {
+            elem /= s;
+        }
+
+        return massFracArray;
+    }
+};
+
+template <>
+struct SaltUnitConverter<SaltMoleFraction, SaltMolality>
+{
+    /*!
+     * Convert mole fraction to molality:
+     * https://en.wikipedia.org/wiki/Molality#Mole_fraction
+     *
+     * @tparam T Value type
+     * @param saltArray Mole fraction array
+     * @return Molality array
+     */
+    template <class T>
+    static SaltArray<T, SaltMolality> convert(const SaltArray<T, SaltMoleFraction>& saltArray)
+    {
+        SaltArray<T, SaltMolality> molalityArray;
+        for (std::size_t i = 0; i < saltArray.size(); ++i) {
+            auto sIdx = static_cast<SaltIndex>(i);
+            molalityArray[sIdx] = saltArray[sIdx] / 18.01518e-3;
+        }
+
+        T s = 1.0 - saltArray.sum();
+        for (auto& elem : molalityArray) {
+            elem /= s;
+        }
+
+        return molalityArray;
+    }
+};
+
+template <>
+struct SaltUnitConverter<SaltMolality, SaltMoleFraction>
+{
+    /*!
+     * Convert molality to mole fraction:
+     * https://en.wikipedia.org/wiki/Molality#Mole_fraction
+     *
+     * @tparam T Value type
+     * @param saltArray Molality array
+     * @return Mole fraction array
+     */
+    template <class T>
+    static SaltArray<T, SaltMoleFraction> convert(const SaltArray<T, SaltMolality>& saltArray)
+    {
+        SaltArray<T, SaltMoleFraction> moleFracArray;
+        T s = 1.0;
+        for (std::size_t i = 0; i < saltArray.size(); ++i) {
+            auto sIdx = static_cast<SaltIndex>(i);
+            moleFracArray[sIdx] = saltArray[sIdx] * 18.01518e-3;
+            s += moleFracArray[sIdx];
+        }
+
+        for (auto& elem : moleFracArray) {
+            elem /= s;
+        }
+
+        return moleFracArray;
+    }
+};
+
+template <>
+struct SaltUnitConverter<SaltMolality, SaltMassFraction>
+{
+    /*!
+     * Convert molality to mass fraction:
+     * https://en.wikipedia.org/wiki/Molality#Mass_fraction
+     *
+     * @tparam T Value type
+     * @param saltArray Molality array
+     * @return Mass fraction array
+     */
+    template <class T>
+    static SaltArray<T, SaltMassFraction> convert(const SaltArray<T, SaltMolality>& saltArray)
+    {
+        SaltArray<T, SaltMassFraction> massFracArray;
+        T s = 1.0;
+        for (std::size_t i = 0; i < saltArray.size(); ++i) {
+            auto sIdx = static_cast<SaltIndex>(i);
+            massFracArray[sIdx] = saltArray[sIdx] * saltMolarMass<T>(sIdx);
+            s += massFracArray[sIdx];
+        }
+
+        for (auto& elem : massFracArray) {
+            elem /= s;
+        }
+
+        return massFracArray;
+    }
+};
+
+}
+
+#endif //OPM_SALTARRAY_HPP

--- a/opm/material/components/CaIon.hpp
+++ b/opm/material/components/CaIon.hpp
@@ -1,0 +1,67 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 NORCE.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::CaIon
+ */
+#ifndef OPM_CAION_HPP
+#define OPM_CAION_HPP
+
+#include <opm/material/components/Component.hpp>
+
+namespace Opm
+{
+
+/*!
+ * \ingroup Components
+ *
+ * \brief Properties of Ca2+ (calcium) ion
+ *
+ * \tparam Scalar The type used for scalar values
+ */
+template <class Scalar>
+class CaIon : public Component<Scalar, CaIon<Scalar> >
+{
+public:
+    /*!
+     * \copydoc Component::name
+     */
+    static std::string_view name()
+    {
+        return "Ca2+";
+    }
+
+    /*!
+     * \copydoc Component::molarMass
+     */
+    static Scalar molarMass()
+    {
+        return 40.078e-3;
+    }
+};
+
+}
+
+#endif //OPM_CAION_HPP

--- a/opm/material/components/ClIon.hpp
+++ b/opm/material/components/ClIon.hpp
@@ -1,0 +1,67 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 NORCE.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::ClIon
+ */
+#ifndef OPM_CLION_HPP
+#define OPM_CLION_HPP
+
+#include <opm/material/components/Component.hpp>
+
+namespace Opm
+{
+
+/*!
+ * \ingroup Components
+ *
+ * \brief Properties of Cl- (chloride) ion
+ *
+ * \tparam Scalar The type used for scalar values
+ */
+template <class Scalar>
+class ClIon : public Component<Scalar, ClIon<Scalar> >
+{
+public:
+    /*!
+     * \copydoc Component::name
+     */
+    static std::string_view name()
+    {
+        return "Cl-";
+    }
+
+    /*!
+     * \copydoc Component::molarMass
+     */
+    static Scalar molarMass()
+    {
+        return 35.45e-3;
+    }
+};
+
+}
+
+#endif //OPM_CLION_HPP

--- a/opm/material/components/KIon.hpp
+++ b/opm/material/components/KIon.hpp
@@ -1,0 +1,67 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 NORCE.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::KIon
+ */
+#ifndef OPM_KION_HPP
+#define OPM_KION_HPP
+
+#include <opm/material/components/Component.hpp>
+
+namespace Opm
+{
+
+/*!
+ * \ingroup Components
+ *
+ * \brief Properties of K+ (potassium) ion
+ *
+ * \tparam Scalar The type used for scalar values
+ */
+template <class Scalar>
+class KIon : public Component<Scalar, KIon<Scalar> >
+{
+public:
+    /*!
+     * \copydoc Component::name
+     */
+    static std::string_view name()
+    {
+        return "K+";
+    }
+
+    /*!
+     * \copydoc Component::molarMass
+     */
+    static Scalar molarMass()
+    {
+        return 39.0983e-3;
+    }
+};
+
+}
+
+#endif //OPM_KION_HPP

--- a/opm/material/components/MgIon.hpp
+++ b/opm/material/components/MgIon.hpp
@@ -1,0 +1,67 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 NORCE.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::MgIon
+ */
+#ifndef OPM_MGION_HPP
+#define OPM_MGION_HPP
+
+#include <opm/material/components/Component.hpp>
+
+namespace Opm
+{
+
+/*!
+ * \ingroup Components
+ *
+ * \brief Properties of Mg2+ (magnesium) ion
+ *
+ * \tparam Scalar The type used for scalar values
+ */
+template <class Scalar>
+class MgIon : public Component<Scalar, MgIon<Scalar> >
+{
+public:
+    /*!
+     * \copydoc Component::name
+     */
+    static std::string_view name()
+    {
+        return "Mg2+";
+    }
+
+    /*!
+     * \copydoc Component::molarMass
+     */
+    static Scalar molarMass()
+    {
+        return 24.305e-3;
+    }
+};
+
+}
+
+#endif //OPM_MGION_HPP

--- a/opm/material/components/NaIon.hpp
+++ b/opm/material/components/NaIon.hpp
@@ -1,0 +1,67 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 NORCE.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::NaIon
+ */
+#ifndef OPM_NAION_HPP
+#define OPM_NAION_HPP
+
+#include <opm/material/components/Component.hpp>
+
+namespace Opm
+{
+
+/*!
+ * \ingroup Components
+ *
+ * \brief Properties of Na+ (sodium) ion
+ *
+ * \tparam Scalar The type used for scalar values
+ */
+template <class Scalar>
+class NaIon : public Component<Scalar, NaIon<Scalar> >
+{
+public:
+    /*!
+     * \copydoc Component::name
+     */
+    static std::string_view name()
+    {
+        return "Na+";
+    }
+
+    /*!
+     * \copydoc Component::molarMass
+     */
+    static Scalar molarMass()
+    {
+        return 22.9898e-3;
+    }
+};
+
+}
+
+#endif //OPM_NAION_HPP

--- a/opm/material/components/SO4Ion.hpp
+++ b/opm/material/components/SO4Ion.hpp
@@ -1,0 +1,67 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 NORCE.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::SO4Ion
+ */
+#ifndef OPM_SO4ION_HPP
+#define OPM_SO4ION_HPP
+
+#include <opm/material/components/Component.hpp>
+
+namespace Opm
+{
+
+/*!
+ * \ingroup Components
+ *
+ * \brief Properties of SO4{2-} (sulfate) ion
+ *
+ * \tparam Scalar The type used for scalar values
+ */
+template <class Scalar>
+class SO4Ion : public Component<Scalar, SO4Ion<Scalar> >
+{
+public:
+    /*!
+     * \copydoc Component::name
+     */
+    static std::string_view name()
+    {
+        return "SO42-";
+    }
+
+    /*!
+     * \copydoc Component::molarMass
+     */
+    static Scalar molarMass()
+    {
+        return 96.06e-3;
+    }
+};
+
+}
+
+#endif //OPM_SO4ION_HPP

--- a/tests/test_SaltArray.cpp
+++ b/tests/test_SaltArray.cpp
@@ -1,0 +1,273 @@
+/*
+  Copyright 2026 NORCE.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <config.h>
+
+#include <opm/common/utility/SaltArray.hpp>
+#include <opm/material/densead/Evaluation.hpp>
+
+#define BOOST_TEST_MODULE SaltArrayTests
+#include <boost/mpl/list.hpp>
+#include <boost/test/unit_test.hpp>
+
+using namespace Opm;
+
+using EvalTypes = boost::mpl::list<float,
+                                   double,
+                                   DenseAd::Evaluation<float, 3>,
+                                   DenseAd::Evaluation<double, 3> >;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ConstructorTests, Eval, EvalTypes)
+{
+    // Default constructor
+    SaltArray<Eval, SaltMassFraction> saltMassFrac;
+    BOOST_CHECK(!saltMassFrac.any_nonzero());
+    SaltArray<Eval, SaltMoleFraction> saltMoleFrac;
+    BOOST_CHECK(!saltMoleFrac.any_nonzero());
+    SaltArray<Eval, SaltMolality> saltMolal;
+    BOOST_CHECK(!saltMolal.any_nonzero());
+
+    // Copy constructor
+    for (std::size_t i = 0; i < saltMassFrac.size(); ++i) {
+        auto index = static_cast<SaltIndex>(i);
+        saltMassFrac[index] = static_cast<Eval>(i + 1);
+        saltMoleFrac[index] = static_cast<Eval>(i + 1);
+        saltMolal[index] = static_cast<Eval>(i + 1);
+    }
+    SaltArray<Eval, SaltMassFraction> saltMassFrac2(saltMassFrac);
+    BOOST_CHECK_EQUAL_COLLECTIONS(saltMassFrac.begin(),
+                                  saltMassFrac.end(),
+                                  saltMassFrac2.begin(),
+                                  saltMassFrac2.end());
+    SaltArray<Eval, SaltMoleFraction> saltMoleFrac2(saltMoleFrac);
+    BOOST_CHECK_EQUAL_COLLECTIONS(saltMoleFrac.begin(),
+                                  saltMoleFrac.end(),
+                                  saltMoleFrac2.begin(),
+                                  saltMoleFrac2.end());
+    SaltArray<Eval, SaltMolality> saltMolal2(saltMolal);
+    BOOST_CHECK_EQUAL_COLLECTIONS(saltMolal.begin(),
+                                  saltMolal.end(),
+                                  saltMolal2.begin(),
+                                  saltMolal2.end());
+
+    // Conversion constructor (only double/float to Evaluation<double>/Evaluation<float>)
+    if constexpr (std::is_same_v<Eval, float> || std::is_same_v<Eval, double>) {
+        SaltArray<DenseAd::Evaluation<Eval, 3>, SaltMassFraction> saltMassFracEval(saltMassFrac);
+        BOOST_CHECK(saltMassFracEval.any_nonzero());
+        BOOST_CHECK_EQUAL_COLLECTIONS(saltMassFracEval.begin(),
+                                      saltMassFracEval.end(),
+                                      saltMassFrac.begin(),
+                                      saltMassFrac.end());
+        SaltArray<DenseAd::Evaluation<Eval, 3>, SaltMoleFraction> saltMoleFracEval(saltMoleFrac);
+        BOOST_CHECK(saltMoleFracEval.any_nonzero());
+        BOOST_CHECK_EQUAL_COLLECTIONS(saltMoleFracEval.begin(),
+                                      saltMoleFracEval.end(),
+                                      saltMoleFrac.begin(),
+                                      saltMoleFrac.end());
+        SaltArray<DenseAd::Evaluation<Eval, 3>, SaltMolality> saltMolalEval(saltMolal);
+        BOOST_CHECK(saltMolalEval.any_nonzero());
+        BOOST_CHECK_EQUAL_COLLECTIONS(saltMolalEval.begin(),
+                                      saltMolalEval.end(),
+                                      saltMolal.begin(),
+                                      saltMolal.end());
+    }
+
+    // Test clear (i.e., fill array with zeros)
+    saltMolal.clear();
+    saltMassFrac.clear();
+    saltMoleFrac.clear();
+    BOOST_CHECK(!saltMolal.any_nonzero());
+    BOOST_CHECK(!saltMassFrac.any_nonzero());
+    BOOST_CHECK(!saltMoleFrac.any_nonzero());
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(CopyAssignmentTests, Eval, EvalTypes)
+{
+    // Setup
+    SaltArray<Eval, SaltMassFraction> saltMassFrac;
+    SaltArray<Eval, SaltMoleFraction> saltMoleFrac;
+    SaltArray<Eval, SaltMolality> saltMolal;
+    for (std::size_t i = 0; i < saltMassFrac.size(); ++i) {
+        auto index = static_cast<SaltIndex>(i);
+        saltMassFrac[index] = static_cast<Eval>(i + 1);
+        saltMoleFrac[index] = static_cast<Eval>(i + 1);
+        saltMolal[index] = static_cast<Eval>(i + 1);
+    }
+
+    // Copy assignment, same type
+    SaltArray<Eval, SaltMassFraction> saltMassFrac2 = saltMassFrac;
+    SaltArray<Eval, SaltMoleFraction> saltMoleFrac2 = saltMoleFrac;
+    SaltArray<Eval, SaltMolality> saltMolal2 = saltMolal;
+    BOOST_CHECK_EQUAL_COLLECTIONS(saltMassFrac.begin(),
+                                  saltMassFrac.end(),
+                                  saltMassFrac2.begin(),
+                                  saltMassFrac2.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(saltMoleFrac.begin(),
+                                  saltMoleFrac.end(),
+                                  saltMoleFrac2.begin(),
+                                  saltMoleFrac2.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(saltMolal.begin(),
+                                  saltMolal.end(),
+                                  saltMolal2.begin(),
+                                  saltMolal2.end());
+
+    // Copy assignment, conversion (only double/float to Evaluation<double>/Evaluation<float>)
+    if constexpr (std::is_same_v<Eval, float> || std::is_same_v<Eval, double>) {
+        SaltArray<DenseAd::Evaluation<Eval, 3>, SaltMassFraction> saltMassFracEval;
+        saltMassFracEval = saltMassFrac;
+        BOOST_CHECK(saltMassFracEval.any_nonzero());
+        BOOST_CHECK_EQUAL_COLLECTIONS(saltMassFracEval.begin(),
+                                      saltMassFracEval.end(),
+                                      saltMassFrac.begin(),
+                                      saltMassFrac.end());
+        SaltArray<DenseAd::Evaluation<Eval, 3>, SaltMoleFraction> saltMoleFracEval;
+        saltMoleFracEval = saltMoleFrac;
+        BOOST_CHECK(saltMoleFracEval.any_nonzero());
+        BOOST_CHECK_EQUAL_COLLECTIONS(saltMoleFracEval.begin(),
+                                      saltMoleFracEval.end(),
+                                      saltMoleFrac.begin(),
+                                      saltMoleFrac.end());
+        SaltArray<DenseAd::Evaluation<Eval, 3>, SaltMolality> saltMolalEval;
+        saltMolalEval = saltMolal;
+        BOOST_CHECK(saltMolalEval.any_nonzero());
+        BOOST_CHECK_EQUAL_COLLECTIONS(saltMolalEval.begin(),
+                                      saltMolalEval.end(),
+                                      saltMolal.begin(),
+                                      saltMolal.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(UnitConversionTests, Eval, EvalTypes)
+{
+    // Setup
+    SaltArray<Eval, SaltMolality> expectedSaltMolal;
+    expectedSaltMolal[SaltIndex::NA] = 1.0;
+    expectedSaltMolal[SaltIndex::K] = 2.0;
+    expectedSaltMolal[SaltIndex::CA] = 3.0;
+    expectedSaltMolal[SaltIndex::MG] = 4.0;
+    expectedSaltMolal[SaltIndex::CL] = 5.0;
+    expectedSaltMolal[SaltIndex::SO4] = 6.0;
+
+    SaltArray<Eval, SaltMoleFraction> expectedSaltMoleFrac;
+    expectedSaltMoleFrac[SaltIndex::NA] = 0.0130712;
+    expectedSaltMoleFrac[SaltIndex::K] = 0.0261424;
+    expectedSaltMoleFrac[SaltIndex::CA] = 0.0392136;
+    expectedSaltMoleFrac[SaltIndex::MG] = 0.0522848;
+    expectedSaltMoleFrac[SaltIndex::CL] = 0.0653560;
+    expectedSaltMoleFrac[SaltIndex::SO4] = 0.0784272;
+    Eval expectedH2OMoleFrac = 0.725998;
+
+    SaltArray<Eval, SaltMassFraction> expectedSaltMassFrac;
+    expectedSaltMassFrac[SaltIndex::NA] = 0.0110850;
+    expectedSaltMassFrac[SaltIndex::K] = 0.0377240;
+    expectedSaltMassFrac[SaltIndex::CA] = 0.0580360;
+    expectedSaltMassFrac[SaltIndex::MG] = 0.0469030;
+    expectedSaltMassFrac[SaltIndex::CL] = 0.0855510;
+    expectedSaltMassFrac[SaltIndex::SO4] = 0.278418;
+    Eval expectedH2OMassFrac = 0.482283;
+
+    //
+    // Conversion from molality
+    //
+    SaltArray<Eval, SaltMassFraction> convSaltMassFrac =
+        expectedSaltMolal.template convert_to<SaltMassFraction>();
+    SaltArray<Eval, SaltMoleFraction> convSaltMoleFrac
+        = expectedSaltMolal.template convert_to<SaltMoleFraction>();
+    for (std::size_t i = 0; i < expectedSaltMolal.size(); ++i) {
+        auto index = static_cast<SaltIndex>(i);
+        BOOST_CHECK_CLOSE(convSaltMoleFrac[index], expectedSaltMoleFrac[index], 5.0e-1);
+        BOOST_CHECK_CLOSE(convSaltMassFrac[index], expectedSaltMassFrac[index], 5.0e-1);
+    }
+    BOOST_CHECK_CLOSE(1.0 - convSaltMassFrac.sum(), expectedH2OMassFrac, 5.0e-1);
+    BOOST_CHECK_CLOSE(1.0 - convSaltMoleFrac.sum(), expectedH2OMoleFrac, 5.0e-1);
+
+    //
+    // Conversion from mass fraction
+    //
+    SaltArray<Eval, SaltMolality> convSaltMolal =
+        expectedSaltMassFrac.template convert_to<SaltMolality>();
+    SaltArray<Eval, SaltMoleFraction> convSaltMoleFrac2 =
+        expectedSaltMassFrac.template convert_to<SaltMoleFraction>();
+    for (std::size_t i = 0; i < expectedSaltMassFrac.size(); ++i) {
+        auto index = static_cast<SaltIndex>(i);
+        BOOST_CHECK_CLOSE(convSaltMolal[index], expectedSaltMolal[index], 5.0e-1);
+        BOOST_CHECK_CLOSE(convSaltMoleFrac2[index], expectedSaltMoleFrac[index], 5.0e-1);
+    }
+    BOOST_CHECK_CLOSE(1.0 - convSaltMoleFrac2.sum(), expectedH2OMoleFrac, 5.0e-1);
+
+    //
+    // Conversion from mole fraction
+    //
+    SaltArray<Eval, SaltMolality> convSaltMolal2 =
+        expectedSaltMoleFrac.template convert_to<SaltMolality>();
+    SaltArray<Eval, SaltMassFraction> convSaltMassFrac2 =
+        expectedSaltMoleFrac.template convert_to<SaltMassFraction>();
+    for (std::size_t i = 0; i < expectedSaltMassFrac.size(); ++i) {
+        auto index = static_cast<SaltIndex>(i);
+        BOOST_CHECK_CLOSE(convSaltMolal2[index], expectedSaltMolal[index], 5.0e-1);
+        BOOST_CHECK_CLOSE(convSaltMassFrac2[index], expectedSaltMassFrac[index], 5.0e-1);
+    }
+    BOOST_CHECK_CLOSE(1.0 - convSaltMassFrac2.sum(), expectedH2OMassFrac, 5.0e-1);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(CationAnionTests, Eval, EvalTypes)
+{
+    // Both cations and anions
+    SaltArray<Eval, SaltMolality> saltMolal;
+    saltMolal[SaltIndex::MG] = 1.0;
+    saltMolal[SaltIndex::SO4] = 1.0;
+    saltMolal[SaltIndex::K] = 2.0;
+    saltMolal[SaltIndex::CL] = 2.0;
+    auto [cations, anions] = saltMolal.cations_and_anions();
+    BOOST_CHECK(!cations.empty());
+    BOOST_CHECK(!anions.empty());
+    BOOST_CHECK(cations.size() == 2);
+    BOOST_CHECK(anions.size() == 2);
+
+    // Cations and anions in descending ion strength
+    BOOST_CHECK(cations[0] == SaltIndex::MG);
+    BOOST_CHECK(cations[1] == SaltIndex::K);
+    BOOST_CHECK(anions[0] == SaltIndex::SO4);
+    BOOST_CHECK(anions[1] == SaltIndex::CL);
+
+    // Only cations
+    SaltArray<Eval, SaltMolality> saltMolal2;
+    saltMolal2[SaltIndex::NA] = 1.0;
+    saltMolal2[SaltIndex::CA] = 2.0;
+    auto [cations2, anions2] = saltMolal2.cations_and_anions();
+    BOOST_CHECK(!cations2.empty());
+    BOOST_CHECK(anions2.empty());
+    BOOST_CHECK(cations2.size() == 2);
+
+    // Cations in descending ion strength
+    BOOST_CHECK(cations2[0] == SaltIndex::CA);
+    BOOST_CHECK(cations2[1] == SaltIndex::NA);
+
+    // Only anions
+    SaltArray<Eval, SaltMolality> saltMolal3;
+    saltMolal3[SaltIndex::CL] = 1.0;
+    saltMolal3[SaltIndex::SO4] = 2.0;
+    auto [cations3, anions3] = saltMolal3.cations_and_anions();
+    BOOST_CHECK(cations3.empty());
+    BOOST_CHECK(!anions3.empty());
+    BOOST_CHECK(anions3.size() == 2);
+
+    // Anions in descending ion strength
+    BOOST_CHECK(anions3[0] == SaltIndex::SO4);
+    BOOST_CHECK(anions3[1] == SaltIndex::CL);
+}


### PR DESCRIPTION
This PR implements a container for storing multicomponent salt (ions) in a specific unit. The implementation includes some convenience functions for useful calculations, especially conversion between different units.

This container will be used to implement multicomponent salts in CO2STORE, which will come in other PRs.