### PR TITLE
set HAVE_QUAD as compile definition on QuadMath::QuadMath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,11 +129,6 @@ macro(opm-common_sources_hook)
 
   if(QuadMath_FOUND)
     get_target_property(qm_defs QuadMath::QuadMath INTERFACE_COMPILE_DEFINITIONS)
-    if(qm_defs)
-      list(APPEND qm_defs HAVE_QUAD=1)
-    else()
-      set(qm_defs HAVE_QUAD=1)
-    endif()
     get_target_property(qm_options QuadMath::QuadMath INTERFACE_COMPILE_OPTIONS)
     set_source_files_properties(opm/material/components/CO2.cpp
                                 opm/material/densead/Evaluation.cpp

--- a/cmake/Modules/FindQuadMath.cmake
+++ b/cmake/Modules/FindQuadMath.cmake
@@ -39,6 +39,7 @@ if(QuadMath_FOUND AND NOT TARGET QuadMath::QuadMath)
   # Compiler supports QuadMath: Add appropriate linker flag
   add_library(QuadMath::QuadMath INTERFACE IMPORTED)
   target_link_libraries(QuadMath::QuadMath INTERFACE quadmath)
+  target_compile_definitions(QuadMath::QuadMath INTERFACE HAVE_QUAD=1)
 
   # Somehow needed for DUNE 2.9/g++-12
   target_compile_options(QuadMath::QuadMath INTERFACE

--- a/cmake/Modules/Finddune-fem.cmake
+++ b/cmake/Modules/Finddune-fem.cmake
@@ -22,6 +22,7 @@ endif()
 if(dune-fem_FOUND)
   find_package(GMP)
   find_package(SuperLU)
+
   # make version number available in config.h
   include (UseDuneVer)
   find_dune_version ("dune" "fem")
@@ -31,5 +32,14 @@ if(dune-fem_FOUND)
       DUNE_FEM_VERSION_MAJOR=${DUNE_FEM_VERSION_MAJOR}
       DUNE_FEM_VERSION_MINOR=${DUNE_FEM_VERSION_MINOR}
       DUNE_FEM_VERSION_REVISION=${DUNE_FEM_VERSION_REVISION}
+  )
+
+  # Remove QuadMath dependency
+  get_target_property(DUNE_FEM_LIBRARIES Dune::Fem INTERFACE_LINK_LIBRARIES)
+  list(FILTER DUNE_FEM_LIBRARIES EXCLUDE REGEX "QuadMath::QuadMath")
+  set_target_properties(Dune::Fem
+    PROPERTIES
+    INTERFACE_LINK_LIBRARIES
+      ${DUNE_FEM_LIBRARIES}
   )
 endif()


### PR DESCRIPTION
No reason for manual fiddling when target can be used.