### PR TITLE
adding the support for keyword PRCORR

### DIFF
--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -146,6 +146,7 @@ namespace {
             std::pair {"SSHIFT"sv, section.hasKeyword<Opm::ParserKeywords::SSHIFT>() },
             std::pair {"ACF"sv,    section.hasKeyword<Opm::ParserKeywords::ACF>() },
             std::pair {"BIC"sv,    section.hasKeyword<Opm::ParserKeywords::BIC>() },
+            std::pair {"PRCORR"sv, section.hasKeyword<Opm::ParserKeywords::PRCORR>() },
         };
 
         bool any_comp_prop_kw = false;
@@ -262,6 +263,28 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
                 const auto& item = kw.getRecord(i).getItem<KWEOS::EQUATION>();
                 const auto& equ_str = item.getTrimmedString(0);
                 eos_types[i] = eosTypeFromString(equ_str);
+            }
+        }
+    }
+
+    // PRCORR keyword: modifies the Peng-Robinson EOS. For each EOS region using
+    // PR, switch to PRCORR. For regions using a different EOS, log a message
+    // that PRCORR has no effect there.
+    if (props_section.hasKeyword<ParserKeywords::PRCORR>()) {
+        const auto& keywords = props_section.get<ParserKeywords::PRCORR>();
+        if (keywords.size() > 1) {
+            throw OpmInputError("there are multiple PRCORR keyword specifications",
+                                keywords.begin()->location());
+        }
+        for (std::size_t i = 0; i < eos_types.size(); ++i) {
+            if (eos_types[i] == EOSType::PR) {
+                eos_types[i] = EOSType::PRCORR;
+            } else {
+                const auto msg = fmt::format(
+                    "PRCORR has no effect for EOS region {} because its EOS is "
+                    "{}, which is different from PR.",
+                    i + 1, eosTypeToString(eos_types[i]));
+                OpmLog::info(msg);
             }
         }
     }

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -24,6 +24,7 @@
 
 #include <opm/common/utility/OpmInputError.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/LogUtil.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
@@ -276,16 +277,26 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
             throw OpmInputError("there are multiple PRCORR keyword specifications",
                                 keywords.begin()->location());
         }
+
+        std::string unaffected_regions;
         for (std::size_t i = 0; i < eos_types.size(); ++i) {
             if (eos_types[i] == EOSType::PR) {
                 eos_types[i] = EOSType::PRCORR;
             } else {
-                const auto msg = fmt::format(
-                    "PRCORR has no effect for EOS region {} because its EOS is "
-                    "{}, which is different from PR.",
-                    i + 1, eosTypeToString(eos_types[i]));
-                OpmLog::info(msg);
+                if (!unaffected_regions.empty()) {
+                    unaffected_regions += ", ";
+                }
+                fmt::format_to(std::back_inserter(unaffected_regions),
+                               "{} ({})", i + 1, eosTypeToString(eos_types[i]));
             }
+        }
+
+        if (!unaffected_regions.empty()) {
+            const auto& location = keywords.back().location();
+            const auto msg = fmt::format(
+                "PRCORR is ignored for EOS region(s) {} because their EOS is not PR.",
+                unaffected_regions);
+            OpmLog::info(Opm::Log::fileMessage(location, msg));
         }
     }
 

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/P/PRCORR
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/P/PRCORR
@@ -1,0 +1,6 @@
+{
+  "name": "PRCORR",
+  "sections": [
+    "PROPS"
+  ]
+}

--- a/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1087,6 +1087,7 @@ set( keywords
      001_Eclipse300/O/OILVTIM
      001_Eclipse300/O/OPTIONS3
      001_Eclipse300/P/PCRIT
+     001_Eclipse300/P/PRCORR
      001_Eclipse300/P/PREF
      001_Eclipse300/P/PREFS
      001_Eclipse300/R/REGION2REGION_PROBE_E300

--- a/tests/parser/CompositionalTests.cpp
+++ b/tests/parser/CompositionalTests.cpp
@@ -719,4 +719,70 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTestZMF) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(PRCORRKeywordTest) {
+    // Minimal compositional deck used to verify the handling of the PRCORR
+    // keyword. There are two EOS regions: the first uses PR (and must be
+    // promoted to PRCORR by PRCORR), the second uses SRK (and must be left
+    // unchanged by PRCORR).
+    const std::string deck_string = R"(
+RUNSPEC
+
+METRIC
+
+TABDIMS
+ 8* 2 3 /
+
+OIL
+GAS
+
+DIMENS
+ 1 1 1 /
+
+COMPS
+ 2 /
+
+GRID
+
+DX
+ 1*10 /
+DY
+ 1*10 /
+DZ
+ 1*10 /
+TOPS
+ 1*0 /
+PERMX
+ 1*100 /
+PERMY
+ 1*100 /
+PERMZ
+ 1*100 /
+PORO
+ 1*0.1 /
+
+PROPS
+
+CNAMES
+ C1
+ C10
+/
+
+EOS
+ PR /
+ SRK /
+
+PRCORR
+
+END
+)";
+
+    const Deck deck = Parser{}.parseString(deck_string);
+    const Runspec runspec{deck};
+    const CompositionalConfig comp_config{deck, runspec};
+
+    BOOST_CHECK(CompositionalConfig::EOSType::PRCORR == comp_config.eosType(0));
+    // PRCORR should have no effect on the second region since it is SRK.
+    BOOST_CHECK(CompositionalConfig::EOSType::SRK == comp_config.eosType(1));
+}
+
 }


### PR DESCRIPTION
PRCORR is a keyword without any item. It changes the equation of states to be PRCORR if the equations of states were set to be PR. 