### PR TITLE
Using fmt instead of string concatenation in PhaseUsageInfo

### DIFF
--- a/opm/material/fluidsystems/PhaseUsageInfo.cpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.cpp
@@ -48,6 +48,14 @@ PhaseUsageInfo<IndexTraits>::PhaseUsageInfo()
 }
 
 template <typename IndexTraits>
+short PhaseUsageInfo<IndexTraits>::canonicalToActivePhaseIdx(unsigned phaseIdx) const {
+    if (!phaseIsActive(phaseIdx)) {
+        OPM_THROW(std::logic_error, fmt::format("Canonical phase {} is not active.", phaseIdx));
+    }
+    return canonicalToActivePhaseIdx_[phaseIdx];
+}
+
+template <typename IndexTraits>
 void PhaseUsageInfo<IndexTraits>::updateIndexMapping_() {
     int activePhaseIdx = 0;
     for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {

--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -29,10 +29,6 @@
 
 #include <array>
 #include <cassert>
-#include <stdexcept>
-#include <string>
-
-#include <fmt/format.h>
 
 #include <opm/common/utility/gpuDecorators.hpp>
 
@@ -65,12 +61,7 @@ public:
         return phaseIsActive_[phaseIdx];
     }
 
-    [[nodiscard]] OPM_HOST_DEVICE short canonicalToActivePhaseIdx(unsigned phaseIdx) const {
-        if (!phaseIsActive(phaseIdx)) {
-            OPM_THROW(std::logic_error, fmt::format("Canonical phase {} is not active.", phaseIdx));
-        }
-        return canonicalToActivePhaseIdx_[phaseIdx];
-    }
+    [[nodiscard]] OPM_HOST_DEVICE short canonicalToActivePhaseIdx(unsigned phaseIdx) const;
 
     [[nodiscard]] OPM_HOST_DEVICE short activeToCanonicalPhaseIdx(unsigned activePhaseIdx) const {
         assert(activePhaseIdx< numActivePhases_);

--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -32,6 +32,8 @@
 #include <stdexcept>
 #include <string>
 
+#include <fmt/format.h>
+
 #include <opm/common/utility/gpuDecorators.hpp>
 
 namespace Opm
@@ -65,7 +67,7 @@ public:
 
     [[nodiscard]] OPM_HOST_DEVICE short canonicalToActivePhaseIdx(unsigned phaseIdx) const {
         if (!phaseIsActive(phaseIdx)) {
-            OPM_THROW(std::logic_error, "Canonical phase " + std::to_string(phaseIdx) + " is not active.");
+            OPM_THROW(std::logic_error, fmt::format("Canonical phase {} is not active.", phaseIdx));
         }
         return canonicalToActivePhaseIdx_[phaseIdx];
     }


### PR DESCRIPTION
to remove a -Wstringop-overflow warning

accidently saw it in the jenkins build log, not sure whether it matters. 

```
/build/deps/opm-simulators/opm/simulators/wells/MultisegmentWell_impl.hpp:397:70:
/usr/include/c++/14/bits/char_traits.h:427:56: warning: '__builtin_memcpy' writing 78 bytes into a region of size 16 overflows the destination [-Wstringop-overflow=]
427 | return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
| ^
/build/default/install/include/opm/material/fluidsystems/PhaseUsageInfo.hpp: In member function 'computeWellRatesWithBhp':
/build/default/install/include/opm/material/fluidsystems/PhaseUsageInfo.hpp:68:13: note: at offset 16 into destination object '<anonymous>' of size 32
68 | OPM_THROW(std::logic_error, "Canonical phase " + std::to_string(phaseIdx) + " is not active.");
```