### PR TITLE
[LGR Summary] LC* connection-summary evaluators

### DIFF
--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -685,6 +685,16 @@ struct fn_args
     const Opm::Inplace& inplace;
     const Opm::UnitSystem& unit_system;
     const Opm::data::ReservoirCouplingGroupRates* rc_rates{nullptr};
+
+    // When set, restrict per-connection lookups (e.g. crate<>) to the
+    // connection identified by (lgr_grid_filter, lgr_cell_filter) instead
+    // of the (num-1)-derived global Cartesian.  Used by the LC* dispatch
+    // path to address LGR-local connections via the (lgr_grid id,
+    // grid-local linearised Cartesian cell index) pair carried on
+    // data::Connection (lgr_grid / index).  Absent for plain C* and
+    // every non-connection keyword -- existing dispatch is unchanged.
+    const std::optional<int>          lgr_grid_filter{};
+    const std::optional<std::size_t>  lgr_cell_filter{};
 };
 
 /* Since there are several enums in opm scattered about more-or-less
@@ -1450,6 +1460,12 @@ inline quantity crate( const fn_args& args ) {
     // NUMS array in the eclipse SMSPEC file; the values in this array
     // are offset 1 - whereas we need to use this index here to look
     // up a connection with offset 0.
+    //
+    // When args.lgr_grid_filter is set (LC* dispatch path) we match on
+    // the (lgr_grid, grid-local linearised Cartesian) cell-identity pair
+    // carried on data::Connection (lgr_grid / index) instead of on
+    // args.num.  For plain C* keywords both filters are empty and
+    // behaviour is unchanged.
     const size_t global_index = args.num - 1;
     if (args.schedule_wells.empty())
         return zero;
@@ -1464,10 +1480,19 @@ inline quantity crate( const fn_args& args ) {
     }
 
     const auto& well_data = xwPos->second;
-    const auto& completion =
-        std::ranges::find_if(well_data.connections,
-                             [global_index](const Opm::data::Connection& c)
-                             { return c.index == global_index; });
+    // The two LC* filters are engaged together or not at all; the lambda
+    // below dereferences lgr_cell_filter whenever lgr_grid_filter is set.
+    assert(args.lgr_grid_filter.has_value() == args.lgr_cell_filter.has_value());
+    const auto completion = args.lgr_grid_filter.has_value()
+        ? std::ranges::find_if(well_data.connections,
+                               [lgr_grid_match = *args.lgr_grid_filter,
+                                lgr_cell_match = *args.lgr_cell_filter]
+                               (const Opm::data::Connection& c)
+                               { return (c.lgr_grid == lgr_grid_match)
+                                     && (c.index    == lgr_cell_match); })
+        : std::ranges::find_if(well_data.connections,
+                               [global_index](const Opm::data::Connection& c)
+                               { return c.index == global_index; });
 
     if (completion == well_data.connections.end())
         return zero;
@@ -4205,6 +4230,104 @@ namespace Evaluator {
         }
     };
 
+    // LC* connection-summary evaluator.
+    //
+    // LC* nodes carry the deck-side LGR name plus 0-based ijk on
+    // SummaryNode::lgr ({name, ijk}).  At dispatch time we resolve those
+    // once into the cell-identity pair that data::Connection carries
+    // (data::Connection::lgr_grid and data::Connection::index):
+    //
+    //   lgr_grid id  = grid.get_lgr_cell_index(name) + 1
+    //                  (0 = GLOBAL, 1..N matches Connection::get_lgr_level())
+    //   cell index   = grid.getLGRCell(name).getGlobalIndex(i, j, k)
+    //                  (grid-local linearised Cartesian cell index, 0-based)
+    //
+    // The pair is stuffed into fn_args::{lgr_grid_filter, lgr_cell_filter}
+    // before dispatch; the existing crate<> template picks up those
+    // filters and matches the right connection.  The leading 'L' of the
+    // keyword is stripped to look up the underlying C* evaluator
+    // (LCOFR -> COFR, LCWPR -> CWPR, ...).
+    class LgrConnectionValue : public Base
+    {
+    public:
+        explicit LgrConnectionValue(Opm::EclIO::SummaryNode node, ofun fcn)
+            : node_(std::move(node))
+            , fcn_ (std::move(fcn))
+        {}
+
+        void update(const std::size_t       sim_step,
+                    const double            stepSize,
+                    const InputData&        input,
+                    const SimulatorResults& simRes,
+                    Opm::SummaryState&      st) const override
+        {
+            assert(this->node_.lgr.has_value() &&
+                   "LgrConnectionValue dispatched on a node without lgr info");
+
+            const auto wells = find_wells(input.sched, this->node_,
+                                          static_cast<int>(sim_step), input.reg);
+
+            // The well-vs-LGR ownership check already happened in
+            // find_single_well via node.lgr; if no well remains the node
+            // is silently absent from UNSMRY.
+            if (wells.empty()) {
+                return;
+            }
+
+            // Wildcard LC records (no I/J/K) leave node.number ==
+            // default_number.  This decision depends only on node.number, so
+            // resolve it before computing the LGR id -- a wildcard node never
+            // needs it.  (Unfiltered lgr-only dispatch is deferred for now;
+            // the underlying ofun would resolve all matching LGR connections.)
+            if (this->node_.number == Opm::EclIO::SummaryNode::default_number) {
+                return;
+            }
+
+            const auto& lgr_name = this->node_.lgr->name;
+
+            // LGR id matching data::Connection::lgr_grid.  get_lgr_cell_index
+            // returns the 0-based position in the GLOBAL-stripped label list;
+            // +1 recovers the on-disk id.
+            const int lgr_id = static_cast<int>(
+                input.grid.get_lgr_cell_index(lgr_name)) + 1;
+
+            // SummaryConfig::keywordLC already resolved (LGR, I, J, K) to
+            // NUMS = grid-local linearised Cartesian cell index + 1 and stored
+            // it on the node.  Recover the 0-based cell index here and pair it
+            // with lgr_id as the connection's cell identity.
+            const auto gridLocalCellIndex =
+                static_cast<std::size_t>(this->node_.number - 1);
+
+            EfficiencyFactor eFac{};
+            eFac.setFactors(this->node_, input.sched, wells, sim_step,
+                            simRes.wellSol);
+
+            const fn_args args {
+                wells, "", this->node_.keyword,
+                stepSize, static_cast<int>(sim_step),
+                /*num=*/0, /*extra_data=*/std::nullopt,
+                st,
+                simRes.wellSol, simRes.wbp, simRes.grpNwrkSol,
+                input.reg, input.grid, input.sched,
+                std::move(eFac.factors),
+                input.initial_inplace, simRes.inplace,
+                input.sched.getUnits(),
+                simRes.rc_rates,
+                /*lgr_grid_filter=*/lgr_id,
+                /*lgr_cell_filter=*/gridLocalCellIndex,
+            };
+
+            const auto& usys = input.es.getUnits();
+            const auto  prm  = this->fcn_(args);
+
+            updateValue(this->node_, usys.from_si(prm.unit, prm.value), st);
+        }
+
+    private:
+        Opm::EclIO::SummaryNode node_;
+        ofun                    fcn_;
+    };
+
     class BlockValue : public Base
     {
     public:
@@ -4713,12 +4836,15 @@ namespace Evaluator {
         Descriptor userDefinedValue();
         Descriptor unknownParameter();
 
+        Descriptor lgrConnectionValue();
+
         bool isBlockValue();
         bool isAquiferValue();
         bool isRegionValue();
         bool isInterRegionValue();
         bool isGlobalProcessValue();
         bool isLgrWellValue();
+        bool isLgrConnectionValue();
         bool isFunctionRelation();
         bool isUserDefined();
 
@@ -4749,6 +4875,9 @@ namespace Evaluator {
         if (this->isGlobalProcessValue())
             return this->globalProcessValue();
 
+        if (this->isLgrConnectionValue())
+            return this->lgrConnectionValue();
+
         if (this->isLgrWellValue() || this->isFunctionRelation())
             return this->functionRelation();
 
@@ -4761,6 +4890,18 @@ namespace Evaluator {
 
         desc.unit = this->functionUnitString();
         desc.evaluator.reset(new FunctionRelation {
+            *this->node_, std::move(this->paramFunction_)
+        });
+
+        return desc;
+    }
+
+    Factory::Descriptor Factory::lgrConnectionValue()
+    {
+        auto desc = this->unknownParameter();
+
+        desc.unit = this->functionUnitString();
+        desc.evaluator.reset(new LgrConnectionValue {
             *this->node_, std::move(this->paramFunction_)
         });
 
@@ -4938,6 +5079,32 @@ namespace Evaluator {
         // well-vs-LGR ownership check happens downstream in find_single_well().
         if ((this->node_->category != Opm::EclIO::SummaryNode::Category::Well) ||
             !this->node_->keyword.starts_with("LW") ||
+            !this->node_->lgr.has_value())
+        {
+            return false;
+        }
+
+        auto fpos = funs.find(this->node_->keyword.substr(1));
+        if (fpos == funs.end()) {
+            return false;
+        }
+
+        this->paramFunction_ = fpos->second;
+        return true;
+    }
+
+    bool Factory::isLgrConnectionValue()
+    {
+        // LGR connection summary vectors (LC*) dispatch through a thin
+        // LgrConnectionValue evaluator that resolves the (lgr_grid id,
+        // grid-local linearised Cartesian cell index) pair from
+        // node.lgr->{name, ijk} and stuffs it into fn_args before
+        // calling the underlying C* ofun.  The keyword's leading 'L' is
+        // stripped to look up the global connection keyword in the funs
+        // map (LCOFR -> COFR, ...).  The well-vs-LGR ownership check
+        // happens downstream in find_single_well().
+        if ((this->node_->category != Opm::EclIO::SummaryNode::Category::Connection) ||
+            !this->node_->keyword.starts_with("LC") ||
             !this->node_->lgr.has_value())
         {
             return false;

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -51,6 +51,8 @@
 #include <opm/input/eclipse/Deck/Deck.hpp>
 
 #include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
 
 #include <tests/WorkArea.hpp>
 
@@ -3666,7 +3668,7 @@ BOOST_AUTO_TEST_CASE(Test_SummaryState)
 }
 
 // -------------------------------------------------------------------------
-// LGR well evaluator tests (PR-003)
+// LGR well evaluator tests
 // -------------------------------------------------------------------------
 
 namespace {
@@ -3933,6 +3935,172 @@ TSTEP
     if (st.has_well_var("PROD", "LWOPR")) {
         BOOST_CHECK_EQUAL(st.get_well_var("PROD", "LWOPR"), 0.0);
     }
+}
+
+BOOST_AUTO_TEST_CASE(LGR_connection_factory_dispatch)
+{
+    // Verify that the Factory routes LC* nodes to LgrConnectionValue
+    // (not unknownParameter / not generic FunctionRelation).  We confirm
+    // this indirectly: after eval(), the LC* key must be present in
+    // SummaryState with the rate that we attached to the matching LGR
+    // connection via data::Connection::{lgr_grid,index}.
+    const std::string lgr_conn_deck = R"(
+RUNSPEC
+TITLE
+   LGR_SUMMARY_PR4C_TEST
+DIMENS
+   3 1 1 /
+TABDIMS
+/
+EQLDIMS
+/
+OIL
+GAS
+WATER
+DISGAS
+FIELD
+START
+   1 'JAN' 2015 /
+WELLDIMS
+   2 1 1 2 /
+UNIFOUT
+GRID
+CARFIN
+'LGR1'  1  1  1  1  1  1  3  3  1 /
+ENDFIN
+CARFIN
+'LGR2'  3  3  1  1  1  1  3  3  1 /
+ENDFIN
+DX
+   3*2333 /
+DY
+   3*3500 /
+DZ
+   3*50 /
+TOPS
+   3*8325 /
+PORO
+   3*0.3 /
+PERMX
+   3*500 /
+PERMY
+   3*250 /
+PERMZ
+   3*200 /
+PROPS
+PVTW
+   4017.55 1.038 3.22E-6 0.318 0.0 /
+ROCK
+   14.7 3E-6 /
+SWOF
+   0.12 0.0   1.0  0.0
+   1.0  1.0   0.0  0.0 /
+PVDO
+   400  1.0627  1.180
+   800  1.0483  1.181 /
+PVDG
+   400  5.9e-3  0.013
+   800  2.95e-3 0.014 /
+DENSITY
+   53.0  64.79  0.0702 /
+SOLUTION
+EQUIL
+   8400.0  4800.0  8450.0  0.0  8335.0  0.0 /
+SUMMARY
+LCOPR
+   'LGR2'  'PROD'  3 3 1 /
+/
+SCHEDULE
+WELSPECL
+   'PROD'  'G1'  'LGR2'  3  3  8400  'OIL' /
+/
+COMPDATL
+   'PROD'  'LGR2'  3  3  1  1  'OPEN'  1*  1*  0.5 /
+/
+WCONPROD
+   'PROD'  'OPEN'  'ORAT'  20000  4*  1000 /
+/
+TSTEP
+   1 /
+)";
+
+    WorkArea ta { "lgr_summary_pr4c" };
+
+    const auto deck    = Parser{}.parseString(lgr_conn_deck);
+    const auto es      = EclipseState{ deck };
+    const auto& grid   = es.getInputGrid();
+    const auto  sched  = Schedule{ deck, es, std::make_shared<Python>() };
+
+    // SummaryConfig's default constructor uses a global-only CellIndexMapper
+    // — that leaves LCOPR's node.number == default_number.  Provide an
+    // LGR-aware mapper so the (LGR, I, J, K) record resolves to a real
+    // (grid-local linearised Cartesian + 1) NUMS key.
+    auto lgrMapper = [&grid](const std::string& gridID) -> GridDims {
+        if (gridID.empty()) {
+            return GridDims{ grid.getNX(), grid.getNY(), grid.getNZ() };
+        }
+        const auto& lgr = grid.getLGRCell(gridID);
+        return GridDims{ lgr.getNX(), lgr.getNY(), lgr.getNZ() };
+    };
+
+    auto parseCtx = ParseContext{};
+    auto errors   = ErrorGuard{};
+    auto config = SummaryConfig{
+        deck, sched, es.fieldProps(), es.aquifer(),
+        parseCtx, errors, lgrMapper
+    };
+
+    // LGR id: declaration order + 1 (0 reserved for GLOBAL).
+    const int lgr_id = static_cast<int>(grid.get_lgr_cell_index("LGR2")) + 1;
+
+    // Grid-local linearised Cartesian cell index, 0-based.
+    // LGR2 is 3x3x1 and the connection is at (3,3,1) → (i,j,k) = (2,2,0).
+    const std::size_t gridLocalCellIndex = grid.getLGRCell("LGR2").getGlobalIndex(2, 2, 0);
+
+    // Build connection-level result for PROD's single LGR connection.
+    const double conn_oil_rate = 100.0 * unit::stb / unit::day;
+
+    auto wells = data::Wells{};
+    {
+        auto& prod = wells["PROD"];
+        prod.rates.set(rt::oil, conn_oil_rate);
+        prod.rates.set(rt::gas, 0.0);
+        prod.rates.set(rt::wat, 0.0);
+        prod.bhp = 5000.0 * unit::psia;
+        prod.thp = 0.0;
+
+        auto conn = data::Connection{};
+        conn.index    = gridLocalCellIndex;
+        conn.lgr_grid = lgr_id;
+        conn.rates.set(rt::oil, conn_oil_rate);
+        conn.rates.set(rt::gas, 0.0);
+        conn.rates.set(rt::wat, 0.0);
+        conn.pressure = 5000.0 * unit::psia;
+        prod.connections.push_back(std::move(conn));
+    }
+
+    auto wbp      = data::WellBlockAveragePressures{};
+    auto grp_nwrk = data::GroupAndNetworkValues{};
+
+    auto writer = out::Summary { config, es, grid, sched, "LGR_PR4C_CASE" };
+    auto st     = SummaryState { TimeService::now(),
+                                 es.runspec().udqParams().undefinedValue() };
+
+    auto values                    = out::Summary::DynamicSimulatorState{};
+    values.well_solution           = &wells;
+    values.wbp                     = &wbp;
+    values.group_and_nwrk_solution = &grp_nwrk;
+
+    writer.eval(1, 1.0 * day, values, st);
+
+    // LC* key must be populated — non-zero means LgrConnectionValue ran
+    // (and matched on (lgr_grid, index) instead of falling through to 0).
+    // Producer convention: rate is stored as negative; unit system is FIELD,
+    // so the rate is reported in STB/day (= 100).
+    const std::size_t conn_number = gridLocalCellIndex + 1; // node.number is 1-based
+    BOOST_CHECK(st.has_conn_var("PROD", "LCOPR", conn_number));
+    BOOST_CHECK_CLOSE(st.get_conn_var("PROD", "LCOPR", conn_number),
+                      -100.0, 1e-5);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Summary


### PR DESCRIPTION
# [LGR Summary] LC* connection-summary evaluators

## Summary

LC* keywords (`LCOFR`, `LCWPR`, `LCGPR`, ...) name a single perforation
inside a local grid refinement:

```
LCOFR
  'LGR2'  'PROD'  3 3 1 /
/
```

`SummaryConfig` already parses and validates them. This PR plugs in the
runtime evaluator so the values actually land in the summary state / UNSMRY.

The dispatch matches connections on the
`(data::Connection::lgr_grid, data::Connection::index)` pair — the same
pair populated in production `flow` runs by
[opm-simulators#7056](https://github.com/OPM/opm-simulators/pull/7056)
(merged 2026-05-22).

## Approach

LC* dispatch reuses the existing `C*` rate/pressure functions (`crate<>`,
connection BHP, …) — same physics, same units. Only the **connection
selector** differs: instead of matching on the global Cartesian derived
from `NUMS - 1`, we match on the LGR-local identity carried by
`data::Connection`.

```
SummaryNode { keyword="LCOFR", lgr->{name="LGR2", ijk=(2,2,0)},
              number = NUMS = cellIndex + 1 }      (populated by SummaryConfig::keywordLC)
              │
              ▼
LgrConnectionValue::update()
  lgr_id    = grid.get_lgr_cell_index("LGR2") + 1  (1..N; 0 reserved for GLOBAL)
  cellIndex = node.number - 1                      (grid-local linearised Cartesian, 0-based)
              │
              ▼
fn_args { lgr_grid_filter = lgr_id,
          lgr_cell_filter = cellIndex, ... }       (NEW: two trailing optionals)
              │
              ▼
crate<phase, injection>(args)
  if (args.lgr_grid_filter)                         (NEW branch)
      match on (c.lgr_grid == *lgr_grid_filter
             && c.index    == *lgr_cell_filter)
  else                                              (unchanged)
      match on  c.index    == args.num - 1
```

The leading `L` is stripped to look up the underlying C* `ofun`
(`LCOFR` → `COFR`, `LCWPR` → `CWPR`, …) — mirrors the LW* evaluator
design. Units and signs follow the C* keyword.

Plain C* keywords leave both filters empty; the C* code path is
**byte-identical** to pre-PR behaviour.

## Cell-index sourcing — from `node.number`, not from `lgr->ijk`

`SummaryConfig::keywordLC` already resolves `(LGR, I, J, K)` to the
grid-local linearised Cartesian cell index and stores
`NUMS = cellIndex + 1` on the node (the on-disk SMSPEC convention). The
evaluator therefore recovers `cellIndex = node.number - 1` directly.
`node.lgr->ijk` is left for keyword-parsing diagnostics; no
`getGlobalIndex` round-trip is needed at evaluator time.

Wildcard LC records (`LCOFR 'LGR2' 'PROD' /` — no I/J/K) leave
`node.number == default_number`; those are silently skipped here and
left for a follow-up (out of scope for the per-cell dispatch).

## Files touched

| File | Change |
|---|---|
| `opm/output/eclipse/Summary.cpp` | `fn_args::{lgr_grid_filter, lgr_cell_filter}`; conditional match in `crate<>`; new `LgrConnectionValue` evaluator + `Factory::isLgrConnectionValue()` predicate + `Factory::lgrConnectionValue()` builder, routed in `Factory::create()` before `isLgrWellValue` |
| `tests/test_Summary.cpp` | new `Summary/LGR_connection_factory_dispatch` test |

Single commit.

## Testing

The new unit test builds a 3×1×1 deck with two CARFIN LGRs (LGR1, LGR2),
`WELSPECL PROD G1 LGR2`, `COMPDATL` perforations, and
`LCOPR 'LGR2' 'PROD' 3 3 1 /` in the summary section. It populates
`data::Connection` with `lgr_grid = 2` and `index =` the grid-local
linearised Cartesian cell index of (LGR2, 2,2,0) directly (no
opm-simulators dependency), then asserts
`st.get_conn_var("PROD", "LCOPR", cellIndex + 1) == -100.0`
(FIELD units, producer sign convention).

## Notes for reviewers

- **Runtime activator is live.** `data::Connection::lgr_grid` and
  `data::Connection::index` are populated in production `flow` runs by
  opm-simulators#7056 (merged 2026-05-22). No companion opm-simulators
  PR is needed.
- **Build/test/review independence.** opm-common cannot link
  opm-simulators, so the unit test builds `data::Connection` literals
  by hand (following the existing pattern in `tests/test_Summary.cpp`).
  The PR is fully developable, testable, reviewable, and mergeable in
  opm-common alone.
- **Two cell-identifier spaces coexist by design**, bridged once at
  dispatch time:

  | Carrier | Space | Producer |
  |--|--|--|
  | `SummaryConfigNode::number` → SMSPEC `NUMS` | grid-local Cartesian + 1 | `SummaryConfig::keywordLC` |
  | `data::Connection::index` (LGR conn) | grid-local linearised Cartesian, 0-based | opm-simulators#7056 |

  The on-disk SMSPEC NUMS encoding is preserved — external readers
  expect it. The evaluator subtracts 1 to obtain the 0-based index for
  the in-memory match.

- **`crate<>` branch is conditional, not refactored.** When both
  filters are empty (every plain `C*` keyword, every non-connection
  keyword), the existing `c.index == global_index` path is used
  verbatim. Reviewers can diff `crate<>` and confirm the unchanged arm
  is unchanged.

- **Public `SummaryConfig` ctor caveat (follow-up).** The 4-arg
  convenience ctor `SummaryConfig{deck, sched, fp, aquifer}` builds a
  global-only `CellIndexMapper` via `GridDims(deck)`, which returns
  `NX=0` for any non-empty `gridID`. `keywordLC` therefore leaves
  `node.number == default_number` for every LC* node and the evaluator
  short-circuits at the wildcard guard. Real `flow` runs need
  `SummaryConfig`'s public ctor (or its EclipseState caller) to pass
  an LGR-aware mapper built from `EclipseGrid::getLGRCell`. This is
  out of scope here — the inline test exercises the explicit-mapper
  ctor and proves the dispatch path itself is correct.