### PR TITLE
Create Schedule Representation for GNETINJE

### DIFF
--- a/opm/input/eclipse/Parser/ParseContext.cpp
+++ b/opm/input/eclipse/Parser/ParseContext.cpp
@@ -133,6 +133,8 @@ namespace Opm {
         this->addKey(SCHEDULE_ICD_INCOMPATIBLE_PDROP_MODEL, InputErrorAction::THROW_EXCEPTION);
 
         addKey(SCHEDULE_INVALID_NAME, InputErrorAction::THROW_EXCEPTION);
+        this->addKey(SCHEDULE_INVALID_INJPHASE, InputErrorAction::WARN);
+        this->addKey(SCHEDULE_INVALID_VFPTABLE, InputErrorAction::THROW_EXCEPTION);
     }
 
     void ParseContext::initEnv()
@@ -385,6 +387,8 @@ namespace Opm {
     const std::string ParseContext::RPT_UNKNOWN_MNEMONIC = "RPT_UNKNOWN_MNEMONIC";
 
     const std::string ParseContext::SCHEDULE_INVALID_NAME = "SCHEDULE_INVALID_NAME";
+    const std::string ParseContext::SCHEDULE_INVALID_INJPHASE = "SCHEDULE_INVALID_INJPHASE";
+    const std::string ParseContext::SCHEDULE_INVALID_VFPTABLE = "SCHEDULE_INVALID_VFPTABLE";
     const std::string ParseContext::ACTIONX_ILLEGAL_KEYWORD = "ACTIONX_ILLEGAL_KEYWORD";
     const std::string ParseContext::PYACTION_ILLEGAL_KEYWORD = "PYACTION_ILLEGAL_KEYWORD";
     const std::string ParseContext::ACTIONX_CONDITION_ERROR = "ACTIONX_CONDITION_ERROR";

--- a/opm/input/eclipse/Parser/ParseContext.hpp
+++ b/opm/input/eclipse/Parser/ParseContext.hpp
@@ -486,6 +486,12 @@ namespace Opm {
         /// through WELSPECS/COMPDAT/GRUPTREE.
         const static std::string SCHEDULE_INVALID_NAME;
 
+        /// A well or group injects an unsupported phase
+        const static std::string SCHEDULE_INVALID_INJPHASE;
+
+        /// A network branch references an invalid flow line.
+        const static std::string SCHEDULE_INVALID_VFPTABLE;
+
         // Only explicitly supported keywords can be included in an ACTIONX
         // or PYACTION block.  These categories control what should happen
         // when encountering an illegal keyword in such blocks.

--- a/opm/input/eclipse/Schedule/Network/NetworkKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Network/NetworkKeywordHandlers.cpp
@@ -24,17 +24,597 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
 
+#include <opm/input/eclipse/Schedule/Group/Group.hpp>
+#include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
+#include <opm/input/eclipse/Schedule/Network/Balance.hpp>
+#include <opm/input/eclipse/Schedule/Network/Branch.hpp>
+#include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
+#include <opm/input/eclipse/Schedule/Network/Node.hpp>
+#include <opm/input/eclipse/Schedule/ScheduleState.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
+
+#include <opm/input/eclipse/Deck/DeckItem.hpp>
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/input/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+
 #include <opm/input/eclipse/Parser/ParserKeywords/B.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/N.hpp>
 
-#include <opm/input/eclipse/Schedule/Network/Balance.hpp>
-#include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
-#include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
-#include <opm/input/eclipse/Schedule/ScheduleState.hpp>
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <concepts>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 #include <fmt/format.h>
+
+namespace {
+    // =======================================================================
+    // Utilities for GNETINJE processing
+    // =======================================================================
+
+    /// Report unsupported injection phase in GNETINJE.
+    ///
+    /// Records a SCHEDULE_INVALID_INJPHASE condition through the normal
+    /// reporting protocol.
+    ///
+    /// \param[in] record GNETINJE record with an unsupported injection
+    /// phase.
+    ///
+    /// \param[in,out] handlerContext Context for the current report step's
+    /// parsing operation.
+    void rejectInvalidGNetInjePhase(const Opm::DeckRecord& record,
+                                    Opm::HandlerContext&   handlerContext)
+    {
+        using Kw = Opm::ParserKeywords::GNETINJE;
+
+        const auto& phaseItem = record.getItem<Kw::PHASE>();
+
+        const auto phase = phaseItem.defaultApplied(0)
+            ? std::string { "<defaulted>" }
+            : phaseItem.getTrimmedString(0);
+
+        const auto msg_fmt = fmt::format(R"(Problem with {{keyword}}
+In {{file}} line {{line}}
+Injection phase '{}' is not permitted.)", phase);
+
+        handlerContext.parseContext
+            .handleError(Opm::ParseContext::SCHEDULE_INVALID_INJPHASE,
+                         msg_fmt, handlerContext.keyword.location(),
+                         handlerContext.errors);
+    }
+
+    /// Extract SI unit terminal pressure from GNETINJE's terminal pressure item.
+    ///
+    /// \param[in] termPress Terminal pressure item from GNETINJE record.
+    ///
+    /// \return Terminal pressure converted to SI units (Pascal) if
+    /// available, nullopt otherwise--e.g., when the terminal pressure is
+    /// defaulted or has a negative value.
+    std::optional<double>
+    parseGNetInjeTerminalPressure(const Opm::DeckItem& termPress)
+    {
+        if (termPress.defaultApplied(0) || (termPress.get<double>(0) < 0.0)) {
+            // Defaulted or negative terminal pressure => not a terminal pressure node.
+            return {};
+        }
+
+        return { termPress.getSIDouble(0) };
+    }
+
+    /// Expanded and internalised but mostly unprocessed GNETINJE data
+    ///
+    /// Terminal pressures in SI units and parent nodes inferred from group
+    /// tree.
+    class GNetInjeRaw
+    {
+    public:
+        /// Raw data for a single node in an injection network.
+        ///
+        /// Node name used as primary lookup key and therefore store
+        /// separately.
+        struct Node
+        {
+            /// Node's parent--i.e., parent group.
+            ///
+            /// Nullopt for fixed-pressure terminal nodes.
+            std::optional<std::string> parent{};
+
+            /// Node's fixed terminal pressure (SI units).
+            ///
+            /// Nullopt if this node is *not* a fixed-pressure terminal
+            /// node.
+            std::optional<double> termPress{};
+
+            /// VFP table (keyword VFPINJ) associated with flow line between
+            /// this node and its \c parent.
+            ///
+            /// Nullopt for fixed-pressure terminal nodes.  Special value
+            /// 9999 to signify a flow line with no pressure loss.
+            /// Otherwise, a positive integer identifying an existing VFP
+            /// table.
+            std::optional<int> vfpTable{};
+        };
+
+        /// Access representation of named injection network node.
+        ///
+        /// Creates node on first access.  Otherwise, returns existing node.
+        ///
+        /// \param[in] name Injection network node name (a group name).
+        ///
+        /// \return Mutable injection network node object.
+        Node& node(const std::string& name)
+        {
+            return this->nodes_.try_emplace(name).first->second;
+        }
+
+        /// Beginning of range of injection network nodes.
+        ///
+        /// Mostly to support range-for and other range-based algorithms.
+        ///
+        /// \return Beginning of injection network node range.
+        auto begin() const { return this->nodes_.begin(); }
+
+        /// End of range of injection network nodes.
+        ///
+        /// Mostly to support range-for and other range-based algorithms.
+        ///
+        /// \return One past the end of the injection network node range.
+        auto end() const { return this->nodes_.end(); }
+
+        /// Query for an empty collection.
+        ///
+        /// \return Whether or not the current collection is empty.
+        auto empty() const { return this->nodes_.empty(); }
+
+    private:
+        /// Collection of injection network nodes.
+        std::map<std::string, Node> nodes_{};
+    };
+
+    /// Facility for internalising all records of a single GNETINJE keyword.
+    ///
+    /// We create sequences of raw keyword nodes, split by the injecting
+    /// phase and expanded so that there is one node for each group that
+    /// matches one of the records.
+    class CollectGNetInje
+    {
+    public:
+        /// \param[in,out] handlerContext Context for the current report
+        /// step's parsing operation.  Mutated in the case of parse failure,
+        /// but is otherwise unchanged by this class.
+        explicit CollectGNetInje(Opm::HandlerContext& handlerContext)
+            : handlerContext_ { handlerContext }
+        {}
+
+        /// Parse GNETINJE keyword into sequence of injection network nodes
+        /// split by injecting phase.
+        ///
+        /// \return Sequence of pairs for which \code .first \endcode is the
+        /// injecting phase and \code .second \endcode is the corresponding
+        /// raw injection network nodes.
+        auto operator()()
+        {
+            auto nodes = std::array {
+                std::pair { Opm::Phase::GAS  , GNetInjeRaw{} },
+                std::pair { Opm::Phase::WATER, GNetInjeRaw{} },
+            };
+
+            // The unsupported phase must be outside the set of valid keys
+            // in 'nodes'.
+            this->unsupportedPhase_ = Opm::Phase::OIL;
+
+            this->phaseIndexMap_.clear();
+            std::ranges::for_each(nodes, [ix = std::size_t{0}, this]
+                                  (const auto& node) mutable
+            {
+                this->phaseIndexMap_.insert_or_assign(node.first, ix++);
+            });
+
+            std::ranges::for_each(this->handlerContext_.keyword,
+                                  [&nodes, this](const auto& record)
+            {
+                this->parseRecord(record);
+
+                if (this->vfpTable_.has_value() &&
+                    this->phaseIx_.has_value() &&
+                    !this->gnames_.empty())
+                {
+                    // Valid record; meaning the injection phase is
+                    // supported (gas or water), we have a consistent VFP
+                    // table/terminal pressure setting, and the record
+                    // matches at least one existing group name.
+                    //
+                    // Create raw nodes for each of the matching groups.
+                    this->createNodes(nodes[*this->phaseIx_].second);
+                }
+            });
+
+            return nodes;
+        }
+
+    private:
+        /// Context for the current report step's parsing operation.
+        ///
+        /// Mutated in the case of parse failure, but is otherwise unchanged
+        /// by this class.
+        Opm::HandlerContext& handlerContext_;
+
+        /// Sequence index for the current record's injecting phase.
+        ///
+        /// Nullopt in case of unsupported injecting phase--anything other
+        /// than gas or water.
+        std::optional<std::size_t> phaseIx_{};
+
+        /// Terminal pressure (SI units) for current record.
+        ///
+        /// Nullopt if the current record does not represent a
+        /// fixed-pressure terminal node.
+        std::optional<double> termPress_{};
+
+        /// Index of current record's injection flow line table (VFP table).
+        ///
+        /// Nullopt in the case of parse failure, zero if the current record
+        /// represents a fixed-pressure terminal node.
+        std::optional<int> vfpTable_{};
+
+        /// Group names matching the current record's name root.
+        ///
+        /// Empty if there are no matching groups.  In that case, the record
+        /// is ignored.
+        std::vector<std::string> gnames_{};
+
+        /// Bookkeeping structure for translating phases to sequence
+        /// indices.
+        std::map<Opm::Phase, std::size_t> phaseIndexMap_{};
+
+        /// Sentinel value for phase parsing failure.
+        ///
+        /// Must be something other than the supported 'GAS' and 'WAT'
+        /// phases.
+        Opm::Phase unsupportedPhase_ { Opm::Phase::SOLVENT };
+
+        /// Internalise items of a single GNETINJE keyword record.
+        ///
+        /// Populates the matching group names (\code gnames_ \endcode), the
+        /// injecting phase (\code phaseIx_ \endcode), the terminal pressure
+        /// value if applicable (\code termPress_ \endcode), and the flow
+        /// line VFP table if applicable (\code vfpTable_ \endcode).
+        ///
+        /// \param[in] record Single record from a GNETINJE keyword.
+        void parseRecord(const Opm::DeckRecord& record);
+
+        /// Internalise injecting phase and matching groups.
+        ///
+        /// Populates the matching group names (\code gnames_ \endcode) and
+        /// the injecting phase (\code phaseIx_ \endcode).
+        ///
+        /// \param[in] record Single record from a GNETINJE keyword.
+        void inferPhaseAndGroups(const Opm::DeckRecord& record);
+
+        /// Internalise items of a single GNETINJE keyword record.
+        ///
+        /// Populates the terminal pressure value (\code termPress_
+        /// \endcode) and the flow line VFP table, if applicable (\code
+        /// vfpTable_ \endcode).
+        ///
+        /// \param[in] record Single record from a GNETINJE keyword.
+        void inferTermPressAndVFP(const Opm::DeckRecord& record);
+
+        /// Create raw injection network nodes corresponding to currently
+        /// active GNETINJE record.
+        ///
+        /// \param[in,out] nodes Current injection network nodes for active
+        /// record's injecting phase.  On return, holds nodes for all the
+        /// current record's matching group names.
+        void createNodes(GNetInjeRaw& nodes);
+    };
+
+    void CollectGNetInje::parseRecord(const Opm::DeckRecord& record)
+    {
+        // Keyword structure:
+        //
+        // GNETINJE
+        //    GroupName  Phase   TermPress   VFPTable /
+        //    GroupName  Phase   TermPress   VFPTable /
+        //    ...                                     /
+        //    GroupName  Phase   TermPress   VFPTable /
+        // /
+        //
+        // The GroupName may be a root like "INJ-*", in which case the
+        // record applies to all groups whose name matches that name root.
+        // The Phase must be 'GAS' or 'WAT'.  The terminal pressure
+        // (TermPress) is non-negative for fixed-pressure injection network
+        // "terminal" nodes, and negative or defaulted otherwise.  The VFP
+        // table (item 4) can be set to the special value 9999 to indicate
+        // no pressure loss between the node and its parent.  If the VFP
+        // table is defaulted or explicitly set to zero, then there is no
+        // flow line connecting this node to its parent node.  That will
+        // typically be the case for a terminal node.
+
+        // Note: The conditional in operator()() depends on these data
+        // members being empty or nullopt if the parsing process fails, so
+        // ensure that they start in that known state.
+        this->phaseIx_.reset();
+        this->vfpTable_.reset();
+        this->gnames_.clear();
+
+        this->inferPhaseAndGroups(record);
+
+        if (!this->phaseIx_.has_value() || this->gnames_.empty()) {
+            // Invalid phase or no matching groups.  Ignore record.
+            return;
+        }
+
+        this->inferTermPressAndVFP(record);
+    }
+
+    void CollectGNetInje::inferPhaseAndGroups(const Opm::DeckRecord& record)
+    {
+        using Kw = Opm::ParserKeywords::GNETINJE;
+
+        const auto ph = [&phaseItem = record.getItem<Kw::PHASE>(),
+                         unsuppPhase = this->unsupportedPhase_]()
+        {
+            try {
+                return phaseItem.defaultApplied(0)
+                    ? unsuppPhase // Default => phase match failure.
+                    : Opm::get_phase(phaseItem.getTrimmedString(0));
+            }
+            catch (const std::invalid_argument&) {
+                // The phaseItem contains something that's not recognised by
+                // get_phase().  Return an unsupported phase enumerator to
+                // indicate phase matching failure.
+                return unsuppPhase;
+            }
+        }();
+
+        auto phaseIxPos = this->phaseIndexMap_.find(ph);
+        if (phaseIxPos == this->phaseIndexMap_.end()) {
+            rejectInvalidGNetInjePhase(record, this->handlerContext_);
+            return;
+        }
+
+        this->phaseIx_.emplace(phaseIxPos->second);
+
+        this->gnames_ = this->handlerContext_.groupNames
+            (record.getItem<Kw::GROUP>().getTrimmedString(0));
+
+        if (this->gnames_.empty()) {
+            this->handlerContext_.invalidNamePattern
+                (record.getItem<Kw::GROUP>().getTrimmedString(0));
+        }
+    }
+
+    void CollectGNetInje::inferTermPressAndVFP(const Opm::DeckRecord& record)
+    {
+        using Kw = Opm::ParserKeywords::GNETINJE;
+
+        this->termPress_ = parseGNetInjeTerminalPressure
+            (record.getItem<Kw::PRESSURE>());
+
+        const auto vfpTable = record.getItem<Kw::VFP_TABLE>().get<int>(0);
+
+        if (vfpTable < 0) {
+            // Negative VFP table ID.  This is an error.
+            const auto msg_fmt = fmt::format(R"(Problem with keyword {{keyword}}
+In {{file}} line {{line}}
+Negative VFP table number {} is not permitted.)", vfpTable);
+
+            this->handlerContext_.parseContext
+                .handleError(Opm::ParseContext::SCHEDULE_INVALID_VFPTABLE,
+                             msg_fmt,
+                             this->handlerContext_.keyword.location(),
+                             this->handlerContext_.errors);
+
+            // HandleError() will *typically* throw an exception here, but
+            // we return--and ignore the record--if user has downgraded this
+            // condition to a warning instead.
+            return;
+        }
+
+        if ((vfpTable > 0) && this->termPress_.has_value()) {
+            // We have a VFP table for a terminal node/group.
+            //
+            // This is an error condition.
+            const auto msg_fmt = fmt::format(R"(Problem with keyword {{keyword}}
+In {{file}} line {{line}}
+Explicit VFP table {} cannot be assigned to terminal group{} '{}'
+with terminal pressure {}.)",
+                                             vfpTable,
+                                             (this->gnames_.size() != 1) ? "s" : "",
+                                             record.getItem<Kw::GROUP>().getTrimmedString(0),
+                                             record.getItem<Kw::PRESSURE>().get<double>(0));
+
+            this->handlerContext_.parseContext
+                .handleError(Opm::ParseContext::SCHEDULE_INVALID_VFPTABLE,
+                             msg_fmt,
+                             this->handlerContext_.keyword.location(),
+                             this->handlerContext_.errors);
+
+            // HandleError() will *typically* throw an exception here, but
+            // we return--and ignore the record--if user has downgraded this
+            // condition to a warning instead.
+            return;
+        }
+
+        // If we get here, the terminal pressure and VFP tables are
+        // internally consistent.  Record the VFP table to allow process to
+        // proceed to creating network nodes.
+        //
+        // Note that we intentionally do not verify that the VFP table
+        // identified in this record actually exists at this point.  A query
+        // of the form
+        //
+        //     handlerContext_.state().vfpinj.has(vfpTable)
+        //
+        // checks existence, but if we enforce the requirement that the VFP
+        // table exists then all unit tests must meet that criterion as
+        // well.  That is too much of a burden so we instead defer VFP table
+        // existence checking until the point of use.
+        this->vfpTable_.emplace(vfpTable);
+    }
+
+    void CollectGNetInje::createNodes(GNetInjeRaw& nodes)
+    {
+        assert (this->vfpTable_.has_value());
+
+        if ((*this->vfpTable_ == 0) && !this->termPress_.has_value()) {
+            // VFP table is defaulted for a non-terminal node/group.
+            //
+            // That node/group is not part of the network.  In update mode,
+            // the previous network is copied first, so clear any existing
+            // node/branch state for the affected groups before returning.
+            std::ranges::for_each(this->gnames_,
+                                  [&nodes, &groups = this->handlerContext_.state().groups]
+                                  (const auto& gname)
+            {
+                auto& node = nodes.node(gname);
+
+                node.parent = groups(gname).flow_group();
+
+                node.vfpTable.reset();
+                node.termPress.reset();
+            });
+
+            return;
+        }
+
+        if (this->termPress_.has_value()) {
+            // Define a set of fixed-pressure terminal nodes.
+            //
+            // Clear any stale non-terminal state first in case the same
+            // group was previously seen as a branch node in this keyword
+            // expansion or inherited from an earlier update.
+            std::ranges::for_each(this->gnames_,
+                                  [tpress = *this->termPress_, &nodes]
+                                  (const auto& gname)
+            {
+                 auto& node = nodes.node(gname);
+
+                 node.parent.reset();
+                 node.vfpTable.reset();
+                 node.termPress.emplace(tpress);
+            });
+
+            return;
+        }
+
+        // If we get here, the nodes in 'gnames_' are not terminal and
+        // therefore define branches in the injection network.
+        std::ranges::for_each(this->gnames_,
+                              [&nodes, vfpTable = *this->vfpTable_,
+                               &groups = this->handlerContext_.state().groups]
+                              (const auto& gname)
+        {
+            const auto parent = groups(gname).flow_group();
+
+            if (! parent.has_value()) {
+                return;
+            }
+
+            // 'Gname' has a parent group in the group tree.  Form a branch
+            // to that parent group and associate the flow line with the
+            // current VFP table.
+            auto& node = nodes.node(gname);
+
+            node.parent.emplace(*parent);
+            node.vfpTable.emplace(vfpTable);
+            node.termPress.reset();
+        });
+    }
+
+    // -----------------------------------------------------------------------
+
+    /// Form or update injection network from sequence of raw GNETINJE nodes.
+    ///
+    /// \param[in] rawInjNetworkNodes Internalised and expanded injection
+    /// network nodes from all records in a single GNETINJE keyword that
+    /// pertain to a particular injecting phase.
+    ///
+    /// \param[in,out] injectionNetwork New or existing injection network
+    /// structure.  On exit, updated to hold the nodes and branches implied
+    /// by \c rawInjNetworkNodes.
+    void constructInjectionNetwork(const GNetInjeRaw&        rawInjNetworkNodes,
+                                   Opm::Network::ExtNetwork& injectionNetwork)
+    {
+        auto deferredNodes = std::vector<Opm::Network::Node>{};
+
+        for (const auto& [nodeName, rawNode] : rawInjNetworkNodes) {
+            if (! rawNode.vfpTable.has_value() &&
+                ! rawNode.termPress.has_value())
+            {
+                // VFP table defaulted for non-terminal node.  Node is not
+                // part of network.
+
+                if (rawNode.parent.has_value()) {
+                    // 'NodeName' is down-tree node of a dropped branch.
+                    // Confer dropped branch onto network.
+                    injectionNetwork.drop_branch(*rawNode.parent, nodeName);
+                }
+
+                continue;
+            }
+            else if (! rawNode.parent.has_value()) {
+                // Typically a fixed-pressure terminal node.  Defer
+                // registration until after the raw nodes have been
+                // processed so branch updates and stale branch cleanup are
+                // handled first.
+
+                if (auto& deferredNode = deferredNodes.emplace_back(nodeName);
+                    rawNode.termPress.has_value())
+                {
+                    deferredNode.terminal_pressure(*rawNode.termPress);
+                }
+
+                if (injectionNetwork.has_node(nodeName)) {
+                    if (const auto up = injectionNetwork.uptree_branch(nodeName);
+                        up.has_value())
+                    {
+                        // 'NodeName' used to be non-terminal, but its role
+                        // has changed.  Drop existing up-tree branch to
+                        // avoid stale network topology.
+                        injectionNetwork.drop_branch(up->uptree_node(), nodeName);
+                    }
+                }
+
+                continue;
+            }
+
+            // If we get here, the 'nodeName' refers to a non-terminal node
+            // in the injection network.  Create a branch to its
+            // parent/up-tree node and ensure that there is a network node
+            // object for 'nodeName'.  We *assume* that the parent will
+            // itself be a node in the network and therefore handled
+            // elsewhere.
+            //
+            // Note: There is no artificial lift in injection networks, so
+            // we always assign an ALQ of zero to these branches.
+            const auto alq = 0.0;
+
+            injectionNetwork.add_or_replace_branch(Opm::Network::Branch {
+                nodeName, *rawNode.parent, *rawNode.vfpTable, alq
+            });
+
+            injectionNetwork.update_node(Opm::Network::Node { nodeName });
+        }
+
+        for (auto&& deferredNode : deferredNodes) {
+            injectionNetwork.update_node(std::move(deferredNode));
+        }
+    }
+}
 
 namespace Opm {
 
@@ -68,6 +648,31 @@ void handleBRANPROP(HandlerContext& handlerContext)
     }
 
     handlerContext.state().network.update( std::move( ext_network ));
+}
+
+void handleGNETINJE(HandlerContext& handlerContext)
+{
+    std::ranges::for_each(CollectGNetInje { handlerContext }(),
+                          [&input = handlerContext.state().injectionNetwork]
+                          (const auto& phaseInjectionNetwork)
+    {
+        const auto& [phase, rawInjNetworkNodes] = phaseInjectionNetwork;
+
+        if (rawInjNetworkNodes.empty()) {
+            // No injection network defined for this 'phase'.
+            return;
+        }
+
+        auto networkUpdate = input.has(phase)
+            ? std::make_shared<Network::ExtNetwork>(input.get(phase))
+            : std::make_shared<Network::ExtNetwork>();
+
+        networkUpdate->set_standard_network(true);
+
+        constructInjectionNetwork(rawInjNetworkNodes, *networkUpdate);
+
+        input.update(phase, std::move(networkUpdate));
+    });
 }
 
 void handleGRUPNET(HandlerContext& handlerContext)
@@ -268,8 +873,9 @@ getNetworkHandlers()
 {
     return {
         { "BRANPROP", &handleBRANPROP },
+        { "GNETINJE", &handleGNETINJE },
         { "GRUPNET",  &handleGRUPNET  },
-        { "NEFAC",    &handleNEFAC   },
+        { "NEFAC",    &handleNEFAC    },
         { "NETBALAN", &handleNETBALAN },
         { "NODEPROP", &handleNODEPROP },
     };

--- a/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -394,6 +394,7 @@ bool ScheduleState::operator==(const ScheduleState& other) const {
         && this->wlist_tracker() == other.wlist_tracker()
         && this->wells == other.wells
         && this->satelliteInjection == other.satelliteInjection
+        && this->injectionNetwork == other.injectionNetwork
         && this->inj_streams == other.inj_streams
         && this->groups == other.groups
         && this->vfpprod == other.vfpprod

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -24,6 +24,7 @@
 #include <opm/common/utility/TimeService.hpp>
 
 #include <opm/input/eclipse/EclipseState/Aquifer/AquiferFlux.hpp>
+#include <opm/input/eclipse/EclipseState/Phase.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 
 #include <opm/input/eclipse/Schedule/BCProp.hpp>
@@ -622,6 +623,19 @@ namespace Opm {
         /// Group level satellite injection rates.
         map_member<std::string, GroupSatelliteInjection> satelliteInjection;
 
+        /// Injection networks defined by GNETINJE.
+        ///
+        /// At most one network for each injecting phase--GAS and/or WATER.
+        ///
+        /// We represent injection networks with the \code ExtNetwork
+        /// \endcode type, but nodes and branches in that network do not
+        /// necessarily have a fully consistent set of extended network
+        /// properties.  Client code accessing the network objects should be
+        /// restricted to flow line (\code Branch::vfp_table() \endcode) and
+        /// terminal pressure (\code Node::terminal_pressure() \endcode)
+        /// properties only.
+        map_member<Phase, Network::ExtNetwork> injectionNetwork;
+
         /// Well fracturing seed points and associate fracture plane normal
         /// vectors.
         map_member<std::string, WellFractureSeeds> wseed;
@@ -668,6 +682,7 @@ namespace Opm {
             serializer(groups);
             serializer(wells);
             serializer(this->satelliteInjection);
+            serializer(this->injectionNetwork);
             serializer(wseed);
             serializer(aqufluxs);
             serializer(bcprop);

--- a/tests/parser/NetworkTests.cpp
+++ b/tests/parser/NetworkTests.cpp
@@ -24,8 +24,11 @@
 #include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/input/eclipse/EclipseState/Phase.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 
 #include <opm/input/eclipse/Python/Python.hpp>
@@ -35,11 +38,23 @@
 #include <opm/input/eclipse/Schedule/Network/Node.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 
+#include <opm/input/eclipse/Units/Units.hpp>
+
 #include <opm/input/eclipse/Deck/Deck.hpp>
 
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
 #include <algorithm>
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <ranges>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
 
 using namespace Opm;
 
@@ -580,3 +595,1829 @@ NODEPROP
 BOOST_AUTO_TEST_SUITE_END()     // Extended_Network
 
 BOOST_AUTO_TEST_SUITE_END()     // Keyword_Consistency
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Injection_Networks)
+
+namespace {
+    struct Case
+    {
+        explicit Case(const std::string& input)
+            : Case { Parser{}.parseString(input) }
+        {}
+
+        explicit Case(const Deck& deck)
+            : es    { deck }
+            , sched { deck, es }
+        {}
+
+        EclipseState es{};
+        Schedule sched{};
+    };
+
+    Case twoD_5x1x2(std::string_view gnetInje)
+    {
+        // Group tree structure from opm-tests/network/GNETINJE_GAS-01.DATA
+        //
+        //                                 FIELD
+        //                                   |
+        //                                 PLAT-A
+        //                                   |
+        //                   +---------------+
+        //                   |
+        //                  M5S -------------------------- M5N
+        //                   |                              |
+        //         +---------+---------+                    +------------+
+        //         |                   |                    |            |
+        //        B1                  G1                   C1           F1
+        //         |                   |                    |            |
+        //    +----+-----+         +---+--+             +---+--+      +--+---+
+        //    |    |     |         |      |             |      |      |      |
+        //  B-1H  B-2H  B-3H     G-3H    G-4H         C-1H   C-2H    F-1H   F-2H
+
+        return Case { fmt::format(R"(RUNSPEC
+DIMENS
+  5 1 2 /
+START
+  22 MAY 2026 /
+OIL
+GAS
+WATER
+METRIC
+TABDIMS
+/
+GRID
+DXV
+  5*100 /
+DYV
+  100 /
+DZV
+  2*10 /
+DEPTHZ
+  12*2000 /
+EQUALS
+  PERMX 100 /
+  PERMY 100 /
+  PERMZ  10 /
+  PORO    0.3 /
+/
+PROPS
+DENSITY
+  850  1023  0.1 /
+SCHEDULE
+GRUPTREE
+ 'PLAT-A' 'FIELD' /
+
+ 'M5S'    'PLAT-A'  /
+ 'M5N'    'M5S'  /
+
+ 'C1'     'M5N'  /
+ 'F1'     'M5N'  /
+ 'B1'     'M5S'  /
+ 'G1'     'M5S'  /
+ /
+{}
+DATES
+  1 JUN 2026 /
+  1 JUL 2026 /
+/
+END
+)", gnetInje) };
+    }
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Gas)
+
+BOOST_AUTO_TEST_SUITE(Single_Network_Definition)
+
+namespace {
+    auto wellDefined()
+    {
+        return twoD_5x1x2(R"(GNETINJE
+ 'PLAT-A' 'GAS'  340.0  /
+ 'M5S'    'GAS'   1*   3   /
+ 'G1'     'GAS'   1*  9999 /
+ 'M5N'    'GAS'   1*   2   /
+ 'F1'     'GAS'   1*  9999 /
+/
+)");
+    }
+
+    auto fieldTerminal()
+    {
+        return twoD_5x1x2(R"(GNETINJE
+ 'FIELD'  'GAS'  340.0  /
+ 'PLAT-A' 'GAS'   1*  9999 /
+ 'M5S'    'GAS'   1*   3   /
+ 'G1'     'GAS'   1*  9999 /
+ 'M5N'    'GAS'   1*   2   /
+ 'F1'     'GAS'   1*  9999 /
+/
+)");
+    }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(Existence)
+{
+    const auto cse = wellDefined();
+
+    BOOST_REQUIRE_EQUAL(cse.sched.size(), std::size_t{3});
+
+    BOOST_CHECK_MESSAGE(cse.sched[0].injectionNetwork.has(Phase::GAS),
+                        R"(There must be an injection network for the "GAS" phase at time zero.)");
+
+    BOOST_CHECK_MESSAGE(cse.sched.back().injectionNetwork.has(Phase::GAS),
+                        R"(There must be an injection network for the "GAS" phase.)");
+
+    BOOST_CHECK_MESSAGE(! cse.sched.back().injectionNetwork.has(Phase::WATER),
+                        R"(There must NOT be an injection network for the "WATER" phase.)");
+}
+
+BOOST_AUTO_TEST_CASE(Topology)
+{
+    using namespace std::string_literals;
+
+    const auto injNetwork = wellDefined().sched.back().injectionNetwork.get(Phase::GAS);
+
+    BOOST_REQUIRE_MESSAGE(std::ranges::is_permutation
+                          (injNetwork.node_names(), std::array {
+                              "PLAT-A"s, "M5S"s, "G1"s, "M5N"s, "F1"s,
+                          }),
+                          R"(Injection network does not have the expected nodes.)");
+
+    // F1 and G1 are leaf nodes
+    BOOST_CHECK_MESSAGE(injNetwork.downtree_branches("F1"s).empty(),
+                        R"(Injection network node "F1" must be a leaf node.)");
+
+    BOOST_CHECK_MESSAGE(injNetwork.downtree_branches("G1"s).empty(),
+                        R"(Injection network node "G1" must be a leaf node.)");
+
+    {
+        const auto f1UpBranch = injNetwork.uptree_branch("F1"s);
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch.has_value(),
+                              R"(Injection network node "F1" must be connected to a branch)");
+
+        BOOST_CHECK_EQUAL(f1UpBranch->downtree_node(), "F1"s);
+        BOOST_CHECK_EQUAL(f1UpBranch->uptree_node(), "M5N"s);
+    }
+
+    {
+        const auto g1UpBranch = injNetwork.uptree_branch("G1"s);
+
+        BOOST_REQUIRE_MESSAGE(g1UpBranch.has_value(),
+                              R"(Injection network node "G1" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(g1UpBranch->downtree_node(), "G1"s);
+        BOOST_CHECK_EQUAL(g1UpBranch->uptree_node(), "M5S"s);
+    }
+
+    {
+        const auto m5nUpBranch = injNetwork.uptree_branch("M5N"s);
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch.has_value(),
+                              R"(Injection network node "M5N" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(m5nUpBranch->downtree_node(), "M5N"s);
+        BOOST_CHECK_EQUAL(m5nUpBranch->uptree_node(), "M5S"s);
+    }
+
+    {
+        const auto m5sUpBranch = injNetwork.uptree_branch("M5S"s);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch.has_value(),
+                              R"(Injection network node "M5S" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch->downtree_node(), "M5S"s);
+        BOOST_CHECK_EQUAL(m5sUpBranch->uptree_node(), "PLAT-A"s);
+    }
+
+    {
+        const auto plat_aUpBranch = injNetwork.uptree_branch("PLAT-A"s);
+
+        BOOST_REQUIRE_MESSAGE(! plat_aUpBranch.has_value(),
+                              R"(Injection network node "PLAT-A" must NOT have an upstream branch)");
+    }
+
+    {
+        const auto f1DownBranch = injNetwork.downtree_branches("F1"s);
+        BOOST_CHECK_MESSAGE(f1DownBranch.empty(),
+                            R"(Injection network node "F1" must NOT have downstream branches)");
+    }
+
+    {
+        const auto g1DownBranch = injNetwork.downtree_branches("G1"s);
+        BOOST_CHECK_MESSAGE(g1DownBranch.empty(),
+                            R"(Injection network node "G1" must NOT have downstream branches)");
+    }
+
+    {
+        const auto m5nDownBranch = injNetwork.downtree_branches("M5N"s);
+
+        BOOST_REQUIRE_EQUAL(m5nDownBranch.size(), std::size_t{1});
+
+        BOOST_CHECK_EQUAL(m5nDownBranch.front().uptree_node(), "M5N"s);
+        BOOST_CHECK_EQUAL(m5nDownBranch.front().downtree_node(), "F1"s);
+    }
+
+    {
+        const auto m5sDownBranch = injNetwork.downtree_branches("M5S"s);
+
+        BOOST_REQUIRE_EQUAL(m5sDownBranch.size(), std::size_t{2});
+
+        BOOST_CHECK_MESSAGE(std::ranges::equal(m5sDownBranch, std::array { "M5S"s, "M5S"s },
+                                               std::ranges::equal_to{},
+                                               &Network::Branch::uptree_node),
+                            R"(Upstream node must be "M5S")");
+
+        BOOST_CHECK_MESSAGE(std::ranges::is_permutation(m5sDownBranch, std::array { "M5N"s, "G1"s },
+                                                        std::ranges::equal_to{},
+                                                        &Network::Branch::downtree_node),
+                            R"(Downstream nodes must be "M5N" and "G1")");
+    }
+
+    {
+        const auto plat_aDownBranch = injNetwork.downtree_branches("PLAT-A"s);
+
+        BOOST_REQUIRE_EQUAL(plat_aDownBranch.size(), std::size_t{1});
+
+        BOOST_CHECK_EQUAL(plat_aDownBranch.front().uptree_node(), "PLAT-A"s);
+        BOOST_CHECK_EQUAL(plat_aDownBranch.front().downtree_node(), "M5S"s);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Properties)
+{
+    using namespace std::string_literals;
+
+    const auto injNetwork = wellDefined().sched.back().injectionNetwork.get(Phase::GAS);
+
+    // =======================================================================
+    // Node properties
+    // =======================================================================
+
+    {
+        const auto f1 = injNetwork.node("F1"s);
+
+        BOOST_CHECK_EQUAL(f1.name(), "F1"s);
+        BOOST_CHECK_MESSAGE(! f1.terminal_pressure().has_value(),
+                            R"(Injection network node "F1" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto g1 = injNetwork.node("G1"s);
+
+        BOOST_CHECK_EQUAL(g1.name(), "G1"s);
+        BOOST_CHECK_MESSAGE(! g1.terminal_pressure().has_value(),
+                            R"(Injection network node "G1" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto m5n = injNetwork.node("M5N"s);
+
+        BOOST_CHECK_EQUAL(m5n.name(), "M5N"s);
+        BOOST_CHECK_MESSAGE(! m5n.terminal_pressure().has_value(),
+                            R"(Injection network node "M5N" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto m5s = injNetwork.node("M5S"s);
+
+        BOOST_CHECK_EQUAL(m5s.name(), "M5S"s);
+        BOOST_CHECK_MESSAGE(! m5s.terminal_pressure().has_value(),
+                            R"(Injection network node "M5S" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto plat_a = injNetwork.node("PLAT-A"s);
+
+        BOOST_CHECK_EQUAL(plat_a.name(), "PLAT-A"s);
+
+        BOOST_CHECK_MESSAGE(plat_a.terminal_pressure().has_value(),
+                            R"(Injection network node "PLAT-A" must have a terminal pressure)");
+
+        BOOST_CHECK_CLOSE(plat_a.terminal_pressure().value(),
+                          340.0*unit::barsa, 1.0e-6);
+    }
+
+    // =======================================================================
+    // Branch properties
+    // =======================================================================
+
+    {
+        const auto f1UpBranch = injNetwork.uptree_branch("F1"s);
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "F1")");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! f1UpBranch->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "F1"'s upstream branch.)");
+    }
+
+    {
+        const auto g1UpBranch = injNetwork.uptree_branch("G1"s);
+
+        BOOST_REQUIRE_MESSAGE(g1UpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "G1")");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! g1UpBranch->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "G1"'s upstream branch.)");
+    }
+
+    {
+        const auto m5nUpBranch = injNetwork.uptree_branch("M5N"s);
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5N")");
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5N"'s upstream branch.)");
+
+        BOOST_CHECK_EQUAL(m5nUpBranch->vfp_table().value(), 2);
+    }
+
+    {
+        const auto m5sUpBranch = injNetwork.uptree_branch("M5S"s);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5S")");
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5S"'s upstream branch.)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch->vfp_table().value(), 3);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Existence_Field_Terminal)
+{
+    const auto cse = fieldTerminal();
+
+    BOOST_REQUIRE_EQUAL(cse.sched.size(), std::size_t{3});
+
+    BOOST_CHECK_MESSAGE(cse.sched[0].injectionNetwork.has(Phase::GAS),
+                        R"(There must be an injection network for the "GAS" phase at time zero.)");
+
+    BOOST_CHECK_MESSAGE(cse.sched.back().injectionNetwork.has(Phase::GAS),
+                        R"(There must be an injection network for the "GAS" phase.)");
+
+    BOOST_CHECK_MESSAGE(! cse.sched.back().injectionNetwork.has(Phase::WATER),
+                        R"(There must NOT be an injection network for the "WATER" phase.)");
+}
+
+BOOST_AUTO_TEST_CASE(Topology_Field_Terminal)
+{
+    using namespace std::string_literals;
+
+    const auto injNetwork = fieldTerminal().sched.back().injectionNetwork.get(Phase::GAS);
+
+    BOOST_REQUIRE_MESSAGE(std::ranges::is_permutation
+                          (injNetwork.node_names(), std::array {
+                              "FIELD"s, "PLAT-A"s, "M5S"s, "G1"s, "M5N"s, "F1"s,
+                          }),
+                          R"(Injection network does not have the expected nodes when FIELD is terminal.)");
+
+    // F1 and G1 are leaf nodes
+    BOOST_CHECK_MESSAGE(injNetwork.downtree_branches("F1"s).empty(),
+                        R"(Injection network node "F1" must be a leaf node.)");
+
+    BOOST_CHECK_MESSAGE(injNetwork.downtree_branches("G1"s).empty(),
+                        R"(Injection network node "G1" must be a leaf node.)");
+
+    {
+        const auto f1UpBranch = injNetwork.uptree_branch("F1"s);
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch.has_value(),
+                              R"(Injection network node "F1" must be connected to a branch)");
+
+        BOOST_CHECK_EQUAL(f1UpBranch->downtree_node(), "F1"s);
+        BOOST_CHECK_EQUAL(f1UpBranch->uptree_node(), "M5N"s);
+    }
+
+    {
+        const auto g1UpBranch = injNetwork.uptree_branch("G1"s);
+
+        BOOST_REQUIRE_MESSAGE(g1UpBranch.has_value(),
+                              R"(Injection network node "G1" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(g1UpBranch->downtree_node(), "G1"s);
+        BOOST_CHECK_EQUAL(g1UpBranch->uptree_node(), "M5S"s);
+    }
+
+    {
+        const auto m5nUpBranch = injNetwork.uptree_branch("M5N"s);
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch.has_value(),
+                              R"(Injection network node "M5N" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(m5nUpBranch->downtree_node(), "M5N"s);
+        BOOST_CHECK_EQUAL(m5nUpBranch->uptree_node(), "M5S"s);
+    }
+
+    {
+        const auto m5sUpBranch = injNetwork.uptree_branch("M5S"s);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch.has_value(),
+                              R"(Injection network node "M5S" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch->downtree_node(), "M5S"s);
+        BOOST_CHECK_EQUAL(m5sUpBranch->uptree_node(), "PLAT-A"s);
+    }
+
+    {
+        const auto plat_aUpBranch = injNetwork.uptree_branch("PLAT-A"s);
+
+        BOOST_REQUIRE_MESSAGE(plat_aUpBranch.has_value(),
+                              R"(Injection network node "PLAT-A" must have an upstream branch when FIELD is terminal)");
+
+        BOOST_CHECK_EQUAL(plat_aUpBranch->downtree_node(), "PLAT-A"s);
+        BOOST_CHECK_EQUAL(plat_aUpBranch->uptree_node(), "FIELD"s);
+    }
+
+    {
+        const auto f1DownBranch = injNetwork.downtree_branches("F1"s);
+        BOOST_CHECK_MESSAGE(f1DownBranch.empty(),
+                            R"(Injection network node "F1" must NOT have downstream branches)");
+    }
+
+    {
+        const auto g1DownBranch = injNetwork.downtree_branches("G1"s);
+        BOOST_CHECK_MESSAGE(g1DownBranch.empty(),
+                            R"(Injection network node "G1" must NOT have downstream branches)");
+    }
+
+    {
+        const auto m5nDownBranch = injNetwork.downtree_branches("M5N"s);
+
+        BOOST_REQUIRE_EQUAL(m5nDownBranch.size(), std::size_t{1});
+
+        BOOST_CHECK_EQUAL(m5nDownBranch.front().uptree_node(), "M5N"s);
+        BOOST_CHECK_EQUAL(m5nDownBranch.front().downtree_node(), "F1"s);
+    }
+
+    {
+        const auto m5sDownBranch = injNetwork.downtree_branches("M5S"s);
+
+        BOOST_REQUIRE_EQUAL(m5sDownBranch.size(), std::size_t{2});
+
+        BOOST_CHECK_MESSAGE(std::ranges::equal(m5sDownBranch, std::array { "M5S"s, "M5S"s },
+                                               std::ranges::equal_to{},
+                                               &Network::Branch::uptree_node),
+                            R"(Upstream node must be "M5S")");
+
+        BOOST_CHECK_MESSAGE(std::ranges::is_permutation(m5sDownBranch, std::array { "M5N"s, "G1"s },
+                                                        std::ranges::equal_to{},
+                                                        &Network::Branch::downtree_node),
+                            R"(Downstream nodes must be "M5N" and "G1")");
+    }
+
+    {
+        const auto plat_aDownBranch = injNetwork.downtree_branches("PLAT-A"s);
+
+        BOOST_REQUIRE_EQUAL(plat_aDownBranch.size(), std::size_t{1});
+
+        BOOST_CHECK_EQUAL(plat_aDownBranch.front().uptree_node(), "PLAT-A"s);
+        BOOST_CHECK_EQUAL(plat_aDownBranch.front().downtree_node(), "M5S"s);
+    }
+
+    {
+        const auto fieldDownBranch = injNetwork.downtree_branches("FIELD"s);
+
+        BOOST_REQUIRE_EQUAL(fieldDownBranch.size(), std::size_t{1});
+
+        BOOST_CHECK_EQUAL(fieldDownBranch.front().uptree_node(), "FIELD"s);
+        BOOST_CHECK_EQUAL(fieldDownBranch.front().downtree_node(), "PLAT-A"s);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Properties_Field_Terminal)
+{
+    using namespace std::string_literals;
+
+    const auto injNetwork = fieldTerminal().sched.back().injectionNetwork.get(Phase::GAS);
+
+    // =======================================================================
+    // Node properties
+    // =======================================================================
+
+    {
+        const auto f1 = injNetwork.node("F1"s);
+
+        BOOST_CHECK_EQUAL(f1.name(), "F1"s);
+        BOOST_CHECK_MESSAGE(! f1.terminal_pressure().has_value(),
+                            R"(Injection network node "F1" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto g1 = injNetwork.node("G1"s);
+
+        BOOST_CHECK_EQUAL(g1.name(), "G1"s);
+        BOOST_CHECK_MESSAGE(! g1.terminal_pressure().has_value(),
+                            R"(Injection network node "G1" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto m5n = injNetwork.node("M5N"s);
+
+        BOOST_CHECK_EQUAL(m5n.name(), "M5N"s);
+        BOOST_CHECK_MESSAGE(! m5n.terminal_pressure().has_value(),
+                            R"(Injection network node "M5N" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto m5s = injNetwork.node("M5S"s);
+
+        BOOST_CHECK_EQUAL(m5s.name(), "M5S"s);
+        BOOST_CHECK_MESSAGE(! m5s.terminal_pressure().has_value(),
+                            R"(Injection network node "M5S" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto plat_a = injNetwork.node("PLAT-A"s);
+
+        BOOST_CHECK_EQUAL(plat_a.name(), "PLAT-A"s);
+
+        BOOST_CHECK_MESSAGE(! plat_a.terminal_pressure().has_value(),
+                            R"(Injection network node "PLAT-A" must NOT have a terminal pressure when FIELD is terminal)");
+    }
+
+    {
+        const auto field = injNetwork.node("FIELD"s);
+
+        BOOST_CHECK_EQUAL(field.name(), "FIELD"s);
+
+        BOOST_CHECK_MESSAGE(field.terminal_pressure().has_value(),
+                            R"(Injection network node "FIELD" must have a terminal pressure when FIELD is terminal)");
+
+        BOOST_CHECK_CLOSE(field.terminal_pressure().value(),
+                          340.0*unit::barsa, 1.0e-6);
+    }
+
+    // =======================================================================
+    // Branch properties
+    // =======================================================================
+
+    {
+        const auto f1UpBranch = injNetwork.uptree_branch("F1"s);
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "F1")");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! f1UpBranch->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "F1"'s upstream branch.)");
+    }
+
+    {
+        const auto g1UpBranch = injNetwork.uptree_branch("G1"s);
+
+        BOOST_REQUIRE_MESSAGE(g1UpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "G1")");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! g1UpBranch->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "G1"'s upstream branch.)");
+    }
+
+    {
+        const auto m5nUpBranch = injNetwork.uptree_branch("M5N"s);
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5N")");
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5N"'s upstream branch.)");
+
+        BOOST_CHECK_EQUAL(m5nUpBranch->vfp_table().value(), 2);
+    }
+
+    {
+        const auto m5sUpBranch = injNetwork.uptree_branch("M5S"s);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5S")");
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5S"'s upstream branch.)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch->vfp_table().value(), 3);
+    }
+
+    {
+        const auto plat_aUpBranch = injNetwork.uptree_branch("PLAT-A"s);
+
+        BOOST_REQUIRE_MESSAGE(plat_aUpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "PLAT-A")");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! plat_aUpBranch->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "PLAT-A"'s upstream branch.)");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Reject_InvalidPhase_SOLVENT)
+{
+    const auto cse = twoD_5x1x2(R"(GNETINJE
+ 'PLAT-A' 'SOLVENT'  340.0  /
+/)");
+
+    BOOST_CHECK(! cse.sched.back().injectionNetwork.has(Phase::GAS));
+}
+
+BOOST_AUTO_TEST_CASE(Reject_InvalidPhase_Defaulted)
+{
+    const auto cse = twoD_5x1x2(R"(GNETINJE
+ 'PLAT-A'   1*   340.0  /
+/)");
+
+    BOOST_CHECK(! cse.sched.back().injectionNetwork.has(Phase::GAS));
+}
+
+BOOST_AUTO_TEST_CASE(Reject_InvalidPhase_Typo)
+{
+    const auto cse = twoD_5x1x2(R"(GNETINJE
+ 'PLAT-A' 'GAZ'  340.0  /
+/)");
+
+    BOOST_CHECK(! cse.sched.back().injectionNetwork.has(Phase::GAS));
+}
+
+BOOST_AUTO_TEST_CASE(Reject_NegativeVFPTable)
+{
+    BOOST_CHECK_THROW(twoD_5x1x2(R"(GNETINJE
+ 'M5S'  'GAS'  1*  -1  /
+/)"), OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(Reject_TerminalPressureWithPositiveVFP)
+{
+    BOOST_CHECK_THROW(twoD_5x1x2(R"(GNETINJE
+ 'PLAT-A'  'GAS'  340.0  3  /
+/)"), OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(Reject_MalformedRecord_WrongType)
+{
+    BOOST_CHECK_THROW(twoD_5x1x2(R"(GNETINJE
+ 'M5S'  'GAS'  'NOT-A-NUMBER'  3 /
+/)"), std::exception);
+}
+
+BOOST_AUTO_TEST_CASE(Reject_MalformedRecord_MissingItem)
+{
+    BOOST_CHECK_THROW(twoD_5x1x2(R"(GNETINJE
+ 'M5S  'GAS'  1*  3 /
+/)"), std::exception);
+}
+
+BOOST_AUTO_TEST_CASE(Reject_UnmatchedGroupPattern)
+{
+    BOOST_CHECK_THROW(twoD_5x1x2(R"(GNETINJE
+ 'NO-SUCH*' 'GAS'  340.0  /
+/)"), OpmInputError);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Network_Definition
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Network_With_Updates)
+
+namespace {
+
+    auto networkUpdateChangeFlowLines()
+    {
+        return twoD_5x1x2(R"(GNETINJE
+ 'PLAT-A' 'GAS'  340.0  /
+ 'M5S'    'GAS'   1*   3   /
+ 'G1'     'GAS'   1*  9999 /
+ 'M5N'    'GAS'   1*   2   /
+ 'F1'     'GAS'   1*  9999 /
+/
+TSTEP
+  2*2 /
+GNETINJE
+ 'PLAT-A' 'GAS'  314.159 /
+ 'M5N'    'GAS'   1*  17 /
+ 'F1'     'GAS'   1*  29 /
+/
+)");
+    }
+
+    auto networkUpdateDropBranches()
+    {
+        return twoD_5x1x2(R"(GNETINJE
+ 'PLAT-A' 'GAS'  340.0  /
+ 'M5S'    'GAS'   1*   3   /
+ 'G1'     'GAS'   1*  9999 /
+ 'M5N'    'GAS'   1*   2   /
+ 'F1'     'GAS'   1*  9999 /
+/
+TSTEP
+  2*2 /
+GNETINJE
+ 'M5N'    'GAS'  123.4 / -- Drop link to M5S => M5N is new root
+ 'G1'     'GAS'  /       -- Remove G1 from network
+/
+)");
+    }
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(Topology_Updated_Flow_Lines)
+{
+    using namespace std::string_literals;
+
+    const auto injNetwork = networkUpdateChangeFlowLines().sched.back()
+        .injectionNetwork.get(Phase::GAS);
+
+    BOOST_REQUIRE_MESSAGE(std::ranges::is_permutation
+                          (injNetwork.node_names(), std::array {
+                              "PLAT-A"s, "M5S"s, "G1"s, "M5N"s, "F1"s,
+                          }),
+                          R"(Injection network does not have the expected nodes.)");
+
+    // F1 and G1 are leaf nodes
+    BOOST_CHECK_MESSAGE(injNetwork.downtree_branches("F1"s).empty(),
+                        R"(Injection network node "F1" must be a leaf node.)");
+
+    BOOST_CHECK_MESSAGE(injNetwork.downtree_branches("G1"s).empty(),
+                        R"(Injection network node "G1" must be a leaf node.)");
+
+    {
+        const auto f1UpBranch = injNetwork.uptree_branch("F1"s);
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch.has_value(),
+                              R"(Injection network node "F1" must be connected to a branch)");
+
+        BOOST_CHECK_EQUAL(f1UpBranch->downtree_node(), "F1"s);
+        BOOST_CHECK_EQUAL(f1UpBranch->uptree_node(), "M5N"s);
+    }
+
+    {
+        const auto g1UpBranch = injNetwork.uptree_branch("G1"s);
+
+        BOOST_REQUIRE_MESSAGE(g1UpBranch.has_value(),
+                              R"(Injection network node "G1" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(g1UpBranch->downtree_node(), "G1"s);
+        BOOST_CHECK_EQUAL(g1UpBranch->uptree_node(), "M5S"s);
+    }
+
+    {
+        const auto m5nUpBranch = injNetwork.uptree_branch("M5N"s);
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch.has_value(),
+                              R"(Injection network node "M5N" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(m5nUpBranch->downtree_node(), "M5N"s);
+        BOOST_CHECK_EQUAL(m5nUpBranch->uptree_node(), "M5S"s);
+    }
+
+    {
+        const auto m5sUpBranch = injNetwork.uptree_branch("M5S"s);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch.has_value(),
+                              R"(Injection network node "M5S" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch->downtree_node(), "M5S"s);
+        BOOST_CHECK_EQUAL(m5sUpBranch->uptree_node(), "PLAT-A"s);
+    }
+
+    {
+        const auto plat_aUpBranch = injNetwork.uptree_branch("PLAT-A"s);
+
+        BOOST_REQUIRE_MESSAGE(! plat_aUpBranch.has_value(),
+                              R"(Injection network node "PLAT-A" must NOT have an upstream branch)");
+    }
+
+    {
+        const auto f1DownBranch = injNetwork.downtree_branches("F1"s);
+        BOOST_CHECK_MESSAGE(f1DownBranch.empty(),
+                            R"(Injection network node "F1" must NOT have downstream branches)");
+    }
+
+    {
+        const auto g1DownBranch = injNetwork.downtree_branches("G1"s);
+        BOOST_CHECK_MESSAGE(g1DownBranch.empty(),
+                            R"(Injection network node "G1" must NOT have downstream branches)");
+    }
+
+    {
+        const auto m5nDownBranch = injNetwork.downtree_branches("M5N"s);
+
+        BOOST_REQUIRE_EQUAL(m5nDownBranch.size(), std::size_t{1});
+
+        BOOST_CHECK_EQUAL(m5nDownBranch.front().uptree_node(), "M5N"s);
+        BOOST_CHECK_EQUAL(m5nDownBranch.front().downtree_node(), "F1"s);
+    }
+
+    {
+        const auto m5sDownBranch = injNetwork.downtree_branches("M5S"s);
+
+        BOOST_REQUIRE_EQUAL(m5sDownBranch.size(), std::size_t{2});
+
+        BOOST_CHECK_MESSAGE(std::ranges::equal(m5sDownBranch, std::array { "M5S"s, "M5S"s },
+                                               std::ranges::equal_to{},
+                                               &Network::Branch::uptree_node),
+                            R"(Upstream node must be "M5S")");
+
+        BOOST_CHECK_MESSAGE(std::ranges::is_permutation(m5sDownBranch, std::array { "M5N"s, "G1"s },
+                                                        std::ranges::equal_to{},
+                                                        &Network::Branch::downtree_node),
+                            R"(Downstream nodes must be "M5N" and "G1")");
+    }
+
+    {
+        const auto plat_aDownBranch = injNetwork.downtree_branches("PLAT-A"s);
+
+        BOOST_REQUIRE_EQUAL(plat_aDownBranch.size(), std::size_t{1});
+
+        BOOST_CHECK_EQUAL(plat_aDownBranch.front().uptree_node(), "PLAT-A"s);
+        BOOST_CHECK_EQUAL(plat_aDownBranch.front().downtree_node(), "M5S"s);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Properties_Updated_Flow_Lines)
+{
+    using namespace std::string_literals;
+
+    const auto injNetwork_1 = networkUpdateChangeFlowLines().sched[0].injectionNetwork.get(Phase::GAS);
+    const auto injNetwork_2 = networkUpdateChangeFlowLines().sched.back().injectionNetwork.get(Phase::GAS);
+
+    // =======================================================================
+    // Node properties
+    // =======================================================================
+
+    {
+        const auto f1_1 = injNetwork_1.node("F1"s);
+        const auto f1_2 = injNetwork_2.node("F1"s);
+
+        BOOST_CHECK_EQUAL(f1_1.name(), "F1"s);
+        BOOST_CHECK_MESSAGE(! f1_1.terminal_pressure().has_value(),
+                            R"(Injection network node "F1" must NOT have a terminal pressure at start)");
+
+        BOOST_CHECK_EQUAL(f1_2.name(), "F1"s);
+        BOOST_CHECK_MESSAGE(! f1_2.terminal_pressure().has_value(),
+                            R"(Injection network node "F1" must NOT have a terminal pressure at end)");
+    }
+
+    {
+        const auto g1_1 = injNetwork_1.node("G1"s);
+        const auto g1_2 = injNetwork_2.node("G1"s);
+
+        BOOST_CHECK_EQUAL(g1_1.name(), "G1"s);
+        BOOST_CHECK_MESSAGE(! g1_1.terminal_pressure().has_value(),
+                            R"(Injection network node "G1" must NOT have a terminal pressure at start)");
+
+        BOOST_CHECK_EQUAL(g1_2.name(), "G1"s);
+        BOOST_CHECK_MESSAGE(! g1_2.terminal_pressure().has_value(),
+                            R"(Injection network node "G1" must NOT have a terminal pressure at end)");
+    }
+
+    {
+        const auto m5n_1 = injNetwork_1.node("M5N"s);
+        const auto m5n_2 = injNetwork_2.node("M5N"s);
+
+        BOOST_CHECK_EQUAL(m5n_1.name(), "M5N"s);
+        BOOST_CHECK_MESSAGE(! m5n_1.terminal_pressure().has_value(),
+                            R"(Injection network node "M5N" must NOT have a terminal pressure at start)");
+
+        BOOST_CHECK_EQUAL(m5n_2.name(), "M5N"s);
+        BOOST_CHECK_MESSAGE(! m5n_2.terminal_pressure().has_value(),
+                            R"(Injection network node "M5N" must NOT have a terminal pressure at end)");
+    }
+
+    {
+        const auto m5s_1 = injNetwork_1.node("M5S"s);
+        const auto m5s_2 = injNetwork_2.node("M5S"s);
+
+        BOOST_CHECK_EQUAL(m5s_1.name(), "M5S"s);
+        BOOST_CHECK_MESSAGE(! m5s_1.terminal_pressure().has_value(),
+                            R"(Injection network node "M5S" must NOT have a terminal pressure at start)");
+
+        BOOST_CHECK_EQUAL(m5s_2.name(), "M5S"s);
+        BOOST_CHECK_MESSAGE(! m5s_2.terminal_pressure().has_value(),
+                            R"(Injection network node "M5S" must NOT have a terminal pressure at end)");
+    }
+
+    {
+        const auto plat_a_1 = injNetwork_1.node("PLAT-A"s);
+        const auto plat_a_2 = injNetwork_2.node("PLAT-A"s);
+
+        BOOST_CHECK_EQUAL(plat_a_1.name(), "PLAT-A"s);
+
+        BOOST_CHECK_MESSAGE(plat_a_1.terminal_pressure().has_value(),
+                            R"(Injection network node "PLAT-A" must have a terminal pressure at start)");
+
+        BOOST_CHECK_CLOSE(plat_a_1.terminal_pressure().value(),
+                          340.0*unit::barsa, 1.0e-6);
+
+        BOOST_CHECK_EQUAL(plat_a_2.name(), "PLAT-A"s);
+
+        BOOST_CHECK_MESSAGE(plat_a_2.terminal_pressure().has_value(),
+                            R"(Injection network node "PLAT-A" must have a terminal pressure at end)");
+
+        BOOST_CHECK_CLOSE(plat_a_2.terminal_pressure().value(),
+                          314.159*unit::barsa, 1.0e-6);
+    }
+
+    // =======================================================================
+    // Branch properties
+    // =======================================================================
+
+    {
+        const auto f1UpBranch_1 = injNetwork_1.uptree_branch("F1"s);
+        const auto f1UpBranch_2 = injNetwork_2.uptree_branch("F1"s);
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch_1.has_value(),
+                              R"(There must be an upstream branch attached to injection node "F1" at start)");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! f1UpBranch_1->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "F1"'s upstream branch at start.)");
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch_2.has_value(),
+                              R"(There must be an upstream branch attached to injection node "F1" at end)");
+
+        // VFP table 29 => must have flow line.
+        BOOST_REQUIRE_MESSAGE(f1UpBranch_2->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "F1"'s upstream branch at end.)");
+
+        BOOST_REQUIRE_EQUAL(*f1UpBranch_2->vfp_table(), 29);
+    }
+
+    {
+        const auto g1UpBranch_1 = injNetwork_1.uptree_branch("G1"s);
+        const auto g1UpBranch_2 = injNetwork_2.uptree_branch("G1"s);
+
+        BOOST_REQUIRE_MESSAGE(g1UpBranch_1.has_value(),
+                              R"(There must be an upstream branch attached to injection node "G1" at start)");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! g1UpBranch_1->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "G1"'s upstream branch at start.)");
+
+        BOOST_REQUIRE_MESSAGE(g1UpBranch_2.has_value(),
+                              R"(There must be an upstream branch attached to injection node "G1" at end)");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! g1UpBranch_2->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "G1"'s upstream branch at end.)");
+    }
+
+    {
+        const auto m5nUpBranch_1 = injNetwork_1.uptree_branch("M5N"s);
+        const auto m5nUpBranch_2 = injNetwork_2.uptree_branch("M5N"s);
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch_1.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5N" at start)");
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch_1->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5N"'s upstream branch at start.)");
+
+        BOOST_CHECK_EQUAL(m5nUpBranch_1->vfp_table().value(), 2);
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch_2.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5N" at end)");
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch_2->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5N"'s upstream branch at end.)");
+
+        BOOST_CHECK_EQUAL(m5nUpBranch_2->vfp_table().value(), 17);
+    }
+
+    {
+        const auto m5sUpBranch_1 = injNetwork_1.uptree_branch("M5S"s);
+        const auto m5sUpBranch_2 = injNetwork_2.uptree_branch("M5S"s);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch_1.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5S" at start)");
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch_1->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5S"'s upstream branch at start.)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch_1->vfp_table().value(), 3);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch_2.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5S" at end)");
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch_2->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5S"'s upstream branch at end.)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch_2->vfp_table().value(), 3);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Topology_Dropped_Branches)
+{
+    using namespace std::string_literals;
+
+    const auto injNetwork = networkUpdateDropBranches().sched.back()
+        .injectionNetwork.get(Phase::GAS);
+
+    // Note: Even when we remove branches, the original nodes remain in the
+    // network object.  This is arguably a semantic pitfall and we might
+    // consider adding a way to prune nodes that cannot be reached.
+    BOOST_REQUIRE_MESSAGE(std::ranges::is_permutation
+                          (injNetwork.node_names(), std::array {
+                              "PLAT-A"s, "M5S"s, "G1"s, "M5N"s, "F1"s,
+                          }),
+                          R"(Injection network does not have the expected nodes.)");
+
+    // F1 and G1 must both exist, but G1 must *not* have any branches.
+    BOOST_CHECK_MESSAGE(injNetwork.downtree_branches("F1"s).empty(),
+                        R"(Injection network node "F1" must be a leaf node.)");
+
+    BOOST_CHECK_MESSAGE(injNetwork.downtree_branches("G1"s).empty(),
+                        R"(Injection network node "G1" must NOT have any downstream branches at end.)");
+
+    BOOST_CHECK_MESSAGE(! injNetwork.uptree_branch("G1"s).has_value(),
+                        R"(Injection network node "G1" must NOT have an upstream branch at end.)");
+
+    {
+        const auto roots = injNetwork.roots();
+
+        BOOST_REQUIRE_EQUAL(roots.size(), std::size_t{2});
+
+        BOOST_CHECK_MESSAGE(std::ranges::is_permutation
+                            (roots, std::array { "PLAT-A"s, "M5N"s },
+                             std::ranges::equal_to{},
+                             [](const auto& node) { return node.get().name(); }),
+                            R"(Injection network must have root nodes "PLAT-A" and "M5N" at end.)");
+    }
+
+    {
+        const auto f1UpBranch = injNetwork.uptree_branch("F1"s);
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch.has_value(),
+                              R"(Injection network node "F1" must be connected to a branch)");
+
+        BOOST_CHECK_EQUAL(f1UpBranch->downtree_node(), "F1"s);
+        BOOST_CHECK_EQUAL(f1UpBranch->uptree_node(), "M5N"s);
+    }
+
+    BOOST_REQUIRE_MESSAGE(! injNetwork.uptree_branch("M5N"s).has_value(),
+                          R"(Injection network node "M5N" must NOT have an upstream branch at end.)");
+
+    {
+        const auto m5sUpBranch = injNetwork.uptree_branch("M5S"s);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch.has_value(),
+                              R"(Injection network node "M5S" must have an upstream branch at end.)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch->downtree_node(), "M5S"s);
+        BOOST_CHECK_EQUAL(m5sUpBranch->uptree_node(), "PLAT-A"s);
+    }
+
+    BOOST_REQUIRE_MESSAGE(! injNetwork.uptree_branch("PLAT-A"s).has_value(),
+                          R"(Injection network node "PLAT-A" must NOT have an upstream branch)");
+
+    {
+        const auto m5nDownBranch = injNetwork.downtree_branches("M5N"s);
+
+        BOOST_REQUIRE_EQUAL(m5nDownBranch.size(), std::size_t{1});
+
+        BOOST_CHECK_EQUAL(m5nDownBranch.front().uptree_node(), "M5N"s);
+        BOOST_CHECK_EQUAL(m5nDownBranch.front().downtree_node(), "F1"s);
+    }
+
+    BOOST_REQUIRE_MESSAGE(injNetwork.downtree_branches("M5S"s).empty(),
+                          R"(Injection network node "M5S" must NOT have any downstream branches at end.)");
+
+    {
+        const auto plat_aDownBranch = injNetwork.downtree_branches("PLAT-A"s);
+
+        BOOST_REQUIRE_EQUAL(plat_aDownBranch.size(), std::size_t{1});
+
+        BOOST_CHECK_EQUAL(plat_aDownBranch.front().uptree_node(), "PLAT-A"s);
+        BOOST_CHECK_EQUAL(plat_aDownBranch.front().downtree_node(), "M5S"s);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Properties_Dropped_Branches)
+{
+    using namespace std::string_literals;
+
+    const auto injNetwork_1 = networkUpdateDropBranches().sched[0].injectionNetwork.get(Phase::GAS);
+    const auto injNetwork_2 = networkUpdateDropBranches().sched.back().injectionNetwork.get(Phase::GAS);
+
+    // =======================================================================
+    // Node properties
+    // =======================================================================
+
+    {
+        const auto f1_1 = injNetwork_1.node("F1"s);
+        const auto f1_2 = injNetwork_2.node("F1"s);
+
+        BOOST_CHECK_EQUAL(f1_1.name(), "F1"s);
+        BOOST_CHECK_MESSAGE(! f1_1.terminal_pressure().has_value(),
+                            R"(Injection network node "F1" must NOT have a terminal pressure at start)");
+
+        BOOST_CHECK_EQUAL(f1_2.name(), "F1"s);
+        BOOST_CHECK_MESSAGE(! f1_2.terminal_pressure().has_value(),
+                            R"(Injection network node "F1" must NOT have a terminal pressure at end)");
+    }
+
+    {
+        const auto g1_1 = injNetwork_1.node("G1"s);
+        const auto g1_2 = injNetwork_2.node("G1"s);
+
+        BOOST_CHECK_EQUAL(g1_1.name(), "G1"s);
+        BOOST_CHECK_MESSAGE(! g1_1.terminal_pressure().has_value(),
+                            R"(Injection network node "G1" must NOT have a terminal pressure at start)");
+
+        BOOST_CHECK_EQUAL(g1_2.name(), "G1"s);
+        BOOST_CHECK_MESSAGE(! g1_2.terminal_pressure().has_value(),
+                            R"(Injection network node "G1" must NOT have a terminal pressure at end)");
+    }
+
+    {
+        const auto m5n_1 = injNetwork_1.node("M5N"s);
+        const auto m5n_2 = injNetwork_2.node("M5N"s);
+
+        BOOST_CHECK_EQUAL(m5n_1.name(), "M5N"s);
+        BOOST_CHECK_MESSAGE(! m5n_1.terminal_pressure().has_value(),
+                            R"(Injection network node "M5N" must NOT have a terminal pressure at start)");
+
+        BOOST_CHECK_EQUAL(m5n_2.name(), "M5N"s);
+        BOOST_CHECK_MESSAGE(m5n_2.terminal_pressure().has_value(),
+                            R"(Injection network node "M5N" must have a terminal pressure at end)");
+
+        BOOST_CHECK_CLOSE(*m5n_2.terminal_pressure(),
+                          123.4*unit::barsa, 1.0e-6);
+    }
+
+    {
+        const auto m5s_1 = injNetwork_1.node("M5S"s);
+        const auto m5s_2 = injNetwork_2.node("M5S"s);
+
+        BOOST_CHECK_EQUAL(m5s_1.name(), "M5S"s);
+        BOOST_CHECK_MESSAGE(! m5s_1.terminal_pressure().has_value(),
+                            R"(Injection network node "M5S" must NOT have a terminal pressure at start)");
+
+        BOOST_CHECK_EQUAL(m5s_2.name(), "M5S"s);
+        BOOST_CHECK_MESSAGE(! m5s_2.terminal_pressure().has_value(),
+                            R"(Injection network node "M5S" must NOT have a terminal pressure at end)");
+    }
+
+    {
+        const auto plat_a_1 = injNetwork_1.node("PLAT-A"s);
+        const auto plat_a_2 = injNetwork_2.node("PLAT-A"s);
+
+        BOOST_CHECK_EQUAL(plat_a_1.name(), "PLAT-A"s);
+
+        BOOST_CHECK_MESSAGE(plat_a_1.terminal_pressure().has_value(),
+                            R"(Injection network node "PLAT-A" must have a terminal pressure at start)");
+
+        BOOST_CHECK_CLOSE(plat_a_1.terminal_pressure().value(),
+                          340.0*unit::barsa, 1.0e-6);
+
+        BOOST_CHECK_EQUAL(plat_a_2.name(), "PLAT-A"s);
+
+        BOOST_CHECK_MESSAGE(plat_a_2.terminal_pressure().has_value(),
+                            R"(Injection network node "PLAT-A" must have a terminal pressure at end)");
+
+        BOOST_CHECK_CLOSE(plat_a_2.terminal_pressure().value(),
+                          340.0*unit::barsa, 1.0e-6);
+    }
+
+    // =======================================================================
+    // Branch properties
+    // =======================================================================
+
+    {
+        const auto f1UpBranch_1 = injNetwork_1.uptree_branch("F1"s);
+        const auto f1UpBranch_2 = injNetwork_2.uptree_branch("F1"s);
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch_1.has_value(),
+                              R"(There must be an upstream branch attached to injection node "F1" at start)");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! f1UpBranch_1->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "F1"'s upstream branch at start.)");
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch_2.has_value(),
+                              R"(There must be an upstream branch attached to injection node "F1" at end)");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! f1UpBranch_2->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "F1"'s upstream branch at end.)");
+    }
+
+    {
+        const auto g1UpBranch_1 = injNetwork_1.uptree_branch("G1"s);
+        const auto g1UpBranch_2 = injNetwork_2.uptree_branch("G1"s);
+
+        BOOST_REQUIRE_MESSAGE(g1UpBranch_1.has_value(),
+                              R"(There must be an upstream branch attached to injection node "G1" at start)");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! g1UpBranch_1->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "G1"'s upstream branch at start.)");
+
+        BOOST_REQUIRE_MESSAGE(! g1UpBranch_2.has_value(),
+                              R"(There must NOT be an upstream branch attached to injection node "G1" at end)");
+    }
+
+    {
+        const auto m5nUpBranch_1 = injNetwork_1.uptree_branch("M5N"s);
+        const auto m5nUpBranch_2 = injNetwork_2.uptree_branch("M5N"s);
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch_1.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5N" at start)");
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch_1->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5N"'s upstream branch at start.)");
+
+        BOOST_CHECK_EQUAL(m5nUpBranch_1->vfp_table().value(), 2);
+
+        BOOST_REQUIRE_MESSAGE(! m5nUpBranch_2.has_value(),
+                              R"(There must NOT be an upstream branch attached to injection node "M5N" at end)");
+    }
+
+    {
+        const auto m5sUpBranch_1 = injNetwork_1.uptree_branch("M5S"s);
+        const auto m5sUpBranch_2 = injNetwork_2.uptree_branch("M5S"s);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch_1.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5S" at start)");
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch_1->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5S"'s upstream branch at start.)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch_1->vfp_table().value(), 3);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch_2.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5S" at end)");
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch_2->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5S"'s upstream branch at end.)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch_2->vfp_table().value(), 3);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Network_With_Updates
+
+BOOST_AUTO_TEST_SUITE_END()     // Gas
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Water)
+
+namespace {
+    auto wellDefined()
+    {
+        return twoD_5x1x2(R"(GNETINJE
+ 'PLAT-A' 'WAT'  160.0  /
+ 'M5S'    'WAT'   1*   3   /
+ 'G1'     'WAT'   1*  9999 /
+ 'M5N'    'WAT'   1*   4   /
+ 'F1'     'WAT'   1*  9999 /
+/
+)");
+    }
+
+    auto recordMatchMultipleGroups()
+    {
+        return twoD_5x1x2(R"(GNETINJE
+ 'PLAT-A' 'WAT'  160.0  /
+ 'M5*'    'WAT'   1*  1729 /
+ 'G1'     'WAT'   1*  9999 /
+ 'F1'     'WAT'   1*  9999 /
+/
+)");
+    }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(Existence)
+{
+    const auto cse = wellDefined();
+
+    BOOST_REQUIRE_EQUAL(cse.sched.size(), std::size_t{3});
+
+    BOOST_CHECK_MESSAGE(cse.sched[0].injectionNetwork.has(Phase::WATER),
+                        R"(There must be an injection network for the "WATER" phase at time zero.)");
+
+    BOOST_CHECK_MESSAGE(cse.sched.back().injectionNetwork.has(Phase::WATER),
+                        R"(There must be an injection network for the "WATER" phase.)");
+
+    BOOST_CHECK_MESSAGE(! cse.sched.back().injectionNetwork.has(Phase::GAS),
+                        R"(There must NOT be an injection network for the "GAS" phase.)");
+}
+
+BOOST_AUTO_TEST_CASE(Topology)
+{
+    using namespace std::string_literals;
+
+    const auto injNetwork = wellDefined().sched.back().injectionNetwork.get(Phase::WATER);
+
+    BOOST_REQUIRE_MESSAGE(std::ranges::is_permutation
+                          (injNetwork.node_names(), std::array {
+                              "PLAT-A"s, "M5S"s, "G1"s, "M5N"s, "F1"s,
+                          }),
+                          R"(Injection network does not have the expected nodes.)");
+
+    // F1 and G1 are leaf nodes
+    BOOST_CHECK_MESSAGE(injNetwork.downtree_branches("F1"s).empty(),
+                        R"(Injection network node "F1" must be a leaf node.)");
+
+    BOOST_CHECK_MESSAGE(injNetwork.downtree_branches("G1"s).empty(),
+                        R"(Injection network node "G1" must be a leaf node.)");
+
+    {
+        const auto f1UpBranch = injNetwork.uptree_branch("F1"s);
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch.has_value(),
+                              R"(Injection network node "F1" must be connected to a branch)");
+
+        BOOST_CHECK_EQUAL(f1UpBranch->downtree_node(), "F1"s);
+        BOOST_CHECK_EQUAL(f1UpBranch->uptree_node(), "M5N"s);
+    }
+
+    {
+        const auto g1UpBranch = injNetwork.uptree_branch("G1"s);
+
+        BOOST_REQUIRE_MESSAGE(g1UpBranch.has_value(),
+                              R"(Injection network node "G1" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(g1UpBranch->downtree_node(), "G1"s);
+        BOOST_CHECK_EQUAL(g1UpBranch->uptree_node(), "M5S"s);
+    }
+
+    {
+        const auto m5nUpBranch = injNetwork.uptree_branch("M5N"s);
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch.has_value(),
+                              R"(Injection network node "M5N" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(m5nUpBranch->downtree_node(), "M5N"s);
+        BOOST_CHECK_EQUAL(m5nUpBranch->uptree_node(), "M5S"s);
+    }
+
+    {
+        const auto m5sUpBranch = injNetwork.uptree_branch("M5S"s);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch.has_value(),
+                              R"(Injection network node "M5S" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch->downtree_node(), "M5S"s);
+        BOOST_CHECK_EQUAL(m5sUpBranch->uptree_node(), "PLAT-A"s);
+    }
+
+    {
+        const auto plat_aUpBranch = injNetwork.uptree_branch("PLAT-A"s);
+
+        BOOST_REQUIRE_MESSAGE(! plat_aUpBranch.has_value(),
+                              R"(Injection network node "PLAT-A" must NOT have an upstream branch)");
+    }
+
+    {
+        const auto f1DownBranch = injNetwork.downtree_branches("F1"s);
+        BOOST_CHECK_MESSAGE(f1DownBranch.empty(),
+                            R"(Injection network node "F1" must NOT have downstream branches)");
+    }
+
+    {
+        const auto g1DownBranch = injNetwork.downtree_branches("G1"s);
+        BOOST_CHECK_MESSAGE(g1DownBranch.empty(),
+                            R"(Injection network node "G1" must NOT have downstream branches)");
+    }
+
+    {
+        const auto m5nDownBranch = injNetwork.downtree_branches("M5N"s);
+
+        BOOST_REQUIRE_EQUAL(m5nDownBranch.size(), std::size_t{1});
+
+        BOOST_CHECK_EQUAL(m5nDownBranch.front().uptree_node(), "M5N"s);
+        BOOST_CHECK_EQUAL(m5nDownBranch.front().downtree_node(), "F1"s);
+    }
+
+    {
+        const auto m5sDownBranch = injNetwork.downtree_branches("M5S"s);
+
+        BOOST_REQUIRE_EQUAL(m5sDownBranch.size(), std::size_t{2});
+
+        BOOST_CHECK_MESSAGE(std::ranges::equal(m5sDownBranch, std::array { "M5S"s, "M5S"s },
+                                               std::ranges::equal_to{},
+                                               &Network::Branch::uptree_node),
+                            R"(Upstream node must be "M5S")");
+
+        BOOST_CHECK_MESSAGE(std::ranges::is_permutation(m5sDownBranch, std::array { "M5N"s, "G1"s },
+                                                        std::ranges::equal_to{},
+                                                        &Network::Branch::downtree_node),
+                            R"(Downstream nodes must be "M5N" and "G1")");
+    }
+
+    {
+        const auto plat_aDownBranch = injNetwork.downtree_branches("PLAT-A"s);
+
+        BOOST_REQUIRE_EQUAL(plat_aDownBranch.size(), std::size_t{1});
+
+        BOOST_CHECK_EQUAL(plat_aDownBranch.front().uptree_node(), "PLAT-A"s);
+        BOOST_CHECK_EQUAL(plat_aDownBranch.front().downtree_node(), "M5S"s);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Properties)
+{
+    using namespace std::string_literals;
+
+    const auto injNetwork = wellDefined().sched.back().injectionNetwork.get(Phase::WATER);
+
+    // =======================================================================
+    // Node properties
+    // =======================================================================
+
+    {
+        const auto f1 = injNetwork.node("F1"s);
+
+        BOOST_CHECK_EQUAL(f1.name(), "F1"s);
+        BOOST_CHECK_MESSAGE(! f1.terminal_pressure().has_value(),
+                            R"(Injection network node "F1" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto g1 = injNetwork.node("G1"s);
+
+        BOOST_CHECK_EQUAL(g1.name(), "G1"s);
+        BOOST_CHECK_MESSAGE(! g1.terminal_pressure().has_value(),
+                            R"(Injection network node "G1" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto m5n = injNetwork.node("M5N"s);
+
+        BOOST_CHECK_EQUAL(m5n.name(), "M5N"s);
+        BOOST_CHECK_MESSAGE(! m5n.terminal_pressure().has_value(),
+                            R"(Injection network node "M5N" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto m5s = injNetwork.node("M5S"s);
+
+        BOOST_CHECK_EQUAL(m5s.name(), "M5S"s);
+        BOOST_CHECK_MESSAGE(! m5s.terminal_pressure().has_value(),
+                            R"(Injection network node "M5S" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto plat_a = injNetwork.node("PLAT-A"s);
+
+        BOOST_CHECK_EQUAL(plat_a.name(), "PLAT-A"s);
+
+        BOOST_CHECK_MESSAGE(plat_a.terminal_pressure().has_value(),
+                            R"(Injection network node "PLAT-A" must have a terminal pressure)");
+
+        BOOST_CHECK_CLOSE(plat_a.terminal_pressure().value(),
+                          160.0*unit::barsa, 1.0e-6);
+    }
+
+    // =======================================================================
+    // Branch properties
+    // =======================================================================
+
+    {
+        const auto f1UpBranch = injNetwork.uptree_branch("F1"s);
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "F1")");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! f1UpBranch->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "F1"'s upstream branch.)");
+    }
+
+    {
+        const auto g1UpBranch = injNetwork.uptree_branch("G1"s);
+
+        BOOST_REQUIRE_MESSAGE(g1UpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "G1")");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! g1UpBranch->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "G1"'s upstream branch.)");
+    }
+
+    {
+        const auto m5nUpBranch = injNetwork.uptree_branch("M5N"s);
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5N")");
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5N"'s upstream branch.)");
+
+        BOOST_CHECK_EQUAL(m5nUpBranch->vfp_table().value(), 4);
+    }
+
+    {
+        const auto m5sUpBranch = injNetwork.uptree_branch("M5S"s);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5S")");
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5S"'s upstream branch.)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch->vfp_table().value(), 3);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Existence_Match_Multi)
+{
+    const auto cse = recordMatchMultipleGroups();
+
+    BOOST_REQUIRE_EQUAL(cse.sched.size(), std::size_t{3});
+
+    BOOST_CHECK_MESSAGE(cse.sched[0].injectionNetwork.has(Phase::WATER),
+                        R"(There must be an injection network for the "WATER" phase at time zero.)");
+
+    BOOST_CHECK_MESSAGE(cse.sched.back().injectionNetwork.has(Phase::WATER),
+                        R"(There must be an injection network for the "WATER" phase.)");
+
+    BOOST_CHECK_MESSAGE(! cse.sched.back().injectionNetwork.has(Phase::GAS),
+                        R"(There must NOT be an injection network for the "GAS" phase.)");
+}
+
+BOOST_AUTO_TEST_CASE(Topology_Match_Multi)
+{
+    using namespace std::string_literals;
+
+    const auto injNetwork = recordMatchMultipleGroups().sched.back().injectionNetwork.get(Phase::WATER);
+
+    BOOST_REQUIRE_MESSAGE(std::ranges::is_permutation
+                          (injNetwork.node_names(), std::array {
+                              "PLAT-A"s, "M5S"s, "G1"s, "M5N"s, "F1"s,
+                          }),
+                          R"(Injection network does not have the expected nodes.)");
+
+    // F1 and G1 are leaf nodes
+    BOOST_CHECK_MESSAGE(injNetwork.downtree_branches("F1"s).empty(),
+                        R"(Injection network node "F1" must be a leaf node.)");
+
+    BOOST_CHECK_MESSAGE(injNetwork.downtree_branches("G1"s).empty(),
+                        R"(Injection network node "G1" must be a leaf node.)");
+
+    {
+        const auto f1UpBranch = injNetwork.uptree_branch("F1"s);
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch.has_value(),
+                              R"(Injection network node "F1" must be connected to a branch)");
+
+        BOOST_CHECK_EQUAL(f1UpBranch->downtree_node(), "F1"s);
+        BOOST_CHECK_EQUAL(f1UpBranch->uptree_node(), "M5N"s);
+    }
+
+    {
+        const auto g1UpBranch = injNetwork.uptree_branch("G1"s);
+
+        BOOST_REQUIRE_MESSAGE(g1UpBranch.has_value(),
+                              R"(Injection network node "G1" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(g1UpBranch->downtree_node(), "G1"s);
+        BOOST_CHECK_EQUAL(g1UpBranch->uptree_node(), "M5S"s);
+    }
+
+    {
+        const auto m5nUpBranch = injNetwork.uptree_branch("M5N"s);
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch.has_value(),
+                              R"(Injection network node "M5N" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(m5nUpBranch->downtree_node(), "M5N"s);
+        BOOST_CHECK_EQUAL(m5nUpBranch->uptree_node(), "M5S"s);
+    }
+
+    {
+        const auto m5sUpBranch = injNetwork.uptree_branch("M5S"s);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch.has_value(),
+                              R"(Injection network node "M5S" must have an upstream branch)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch->downtree_node(), "M5S"s);
+        BOOST_CHECK_EQUAL(m5sUpBranch->uptree_node(), "PLAT-A"s);
+    }
+
+    {
+        const auto plat_aUpBranch = injNetwork.uptree_branch("PLAT-A"s);
+
+        BOOST_REQUIRE_MESSAGE(! plat_aUpBranch.has_value(),
+                              R"(Injection network node "PLAT-A" must NOT have an upstream branch)");
+    }
+
+    {
+        const auto f1DownBranch = injNetwork.downtree_branches("F1"s);
+        BOOST_CHECK_MESSAGE(f1DownBranch.empty(),
+                            R"(Injection network node "F1" must NOT have downstream branches)");
+    }
+
+    {
+        const auto g1DownBranch = injNetwork.downtree_branches("G1"s);
+        BOOST_CHECK_MESSAGE(g1DownBranch.empty(),
+                            R"(Injection network node "G1" must NOT have downstream branches)");
+    }
+
+    {
+        const auto m5nDownBranch = injNetwork.downtree_branches("M5N"s);
+
+        BOOST_REQUIRE_EQUAL(m5nDownBranch.size(), std::size_t{1});
+
+        BOOST_CHECK_EQUAL(m5nDownBranch.front().uptree_node(), "M5N"s);
+        BOOST_CHECK_EQUAL(m5nDownBranch.front().downtree_node(), "F1"s);
+    }
+
+    {
+        const auto m5sDownBranch = injNetwork.downtree_branches("M5S"s);
+
+        BOOST_REQUIRE_EQUAL(m5sDownBranch.size(), std::size_t{2});
+
+        BOOST_CHECK_MESSAGE(std::ranges::equal(m5sDownBranch, std::array { "M5S"s, "M5S"s },
+                                               std::ranges::equal_to{},
+                                               &Network::Branch::uptree_node),
+                            R"(Upstream node must be "M5S")");
+
+        BOOST_CHECK_MESSAGE(std::ranges::is_permutation(m5sDownBranch, std::array { "M5N"s, "G1"s },
+                                                        std::ranges::equal_to{},
+                                                        &Network::Branch::downtree_node),
+                            R"(Downstream nodes must be "M5N" and "G1")");
+    }
+
+    {
+        const auto plat_aDownBranch = injNetwork.downtree_branches("PLAT-A"s);
+
+        BOOST_REQUIRE_EQUAL(plat_aDownBranch.size(), std::size_t{1});
+
+        BOOST_CHECK_EQUAL(plat_aDownBranch.front().uptree_node(), "PLAT-A"s);
+        BOOST_CHECK_EQUAL(plat_aDownBranch.front().downtree_node(), "M5S"s);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Properties_Match_Multi)
+{
+    using namespace std::string_literals;
+
+    const auto injNetwork = recordMatchMultipleGroups().sched.back().injectionNetwork.get(Phase::WATER);
+
+    // =======================================================================
+    // Node properties
+    // =======================================================================
+
+    {
+        const auto f1 = injNetwork.node("F1"s);
+
+        BOOST_CHECK_EQUAL(f1.name(), "F1"s);
+        BOOST_CHECK_MESSAGE(! f1.terminal_pressure().has_value(),
+                            R"(Injection network node "F1" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto g1 = injNetwork.node("G1"s);
+
+        BOOST_CHECK_EQUAL(g1.name(), "G1"s);
+        BOOST_CHECK_MESSAGE(! g1.terminal_pressure().has_value(),
+                            R"(Injection network node "G1" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto m5n = injNetwork.node("M5N"s);
+
+        BOOST_CHECK_EQUAL(m5n.name(), "M5N"s);
+        BOOST_CHECK_MESSAGE(! m5n.terminal_pressure().has_value(),
+                            R"(Injection network node "M5N" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto m5s = injNetwork.node("M5S"s);
+
+        BOOST_CHECK_EQUAL(m5s.name(), "M5S"s);
+        BOOST_CHECK_MESSAGE(! m5s.terminal_pressure().has_value(),
+                            R"(Injection network node "M5S" must NOT have a terminal pressure)");
+    }
+
+    {
+        const auto plat_a = injNetwork.node("PLAT-A"s);
+
+        BOOST_CHECK_EQUAL(plat_a.name(), "PLAT-A"s);
+
+        BOOST_CHECK_MESSAGE(plat_a.terminal_pressure().has_value(),
+                            R"(Injection network node "PLAT-A" must have a terminal pressure)");
+
+        BOOST_CHECK_CLOSE(plat_a.terminal_pressure().value(),
+                          160.0*unit::barsa, 1.0e-6);
+    }
+
+    // =======================================================================
+    // Branch properties
+    // =======================================================================
+
+    {
+        const auto f1UpBranch = injNetwork.uptree_branch("F1"s);
+
+        BOOST_REQUIRE_MESSAGE(f1UpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "F1")");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! f1UpBranch->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "F1"'s upstream branch.)");
+    }
+
+    {
+        const auto g1UpBranch = injNetwork.uptree_branch("G1"s);
+
+        BOOST_REQUIRE_MESSAGE(g1UpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "G1")");
+
+        // VFP table 9999 => no flow line.
+        BOOST_REQUIRE_MESSAGE(! g1UpBranch->vfp_table().has_value(),
+                              R"(There must NOT be a flow line (VFP table) attached to "G1"'s upstream branch.)");
+    }
+
+    {
+        const auto m5nUpBranch = injNetwork.uptree_branch("M5N"s);
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5N")");
+
+        BOOST_REQUIRE_MESSAGE(m5nUpBranch->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5N"'s upstream branch.)");
+
+        BOOST_CHECK_EQUAL(m5nUpBranch->vfp_table().value(), 1729);
+    }
+
+    {
+        const auto m5sUpBranch = injNetwork.uptree_branch("M5S"s);
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch.has_value(),
+                              R"(There must be an upstream branch attached to injection node "M5S")");
+
+        BOOST_REQUIRE_MESSAGE(m5sUpBranch->vfp_table().has_value(),
+                              R"(There must be a flow line (VFP table) attached to "M5S"'s upstream branch.)");
+
+        BOOST_CHECK_EQUAL(m5sUpBranch->vfp_table().value(), 1729);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Reject_InvalidPhase_SOLVENT)
+{
+    const auto cse = twoD_5x1x2(R"(GNETINJE
+ 'PLAT-A' 'SOLVENT'  160.0  /
+/)");
+
+    BOOST_CHECK(! cse.sched.back().injectionNetwork.has(Phase::WATER));
+}
+
+BOOST_AUTO_TEST_CASE(Reject_InvalidPhase_Defaulted)
+{
+    const auto cse = twoD_5x1x2(R"(GNETINJE
+ 'PLAT-A'   1*   160.0  /
+/)");
+
+    BOOST_CHECK(! cse.sched.back().injectionNetwork.has(Phase::WATER));
+}
+
+BOOST_AUTO_TEST_CASE(Reject_InvalidPhase_Typo)
+{
+    const auto cse = twoD_5x1x2(R"(GNETINJE
+ 'PLAT-A' 'WATRR'  160.0  /
+/)");
+
+    BOOST_CHECK(! cse.sched.back().injectionNetwork.has(Phase::WATER));
+}
+
+BOOST_AUTO_TEST_CASE(Reject_NegativeVFPTable)
+{
+    BOOST_CHECK_THROW(twoD_5x1x2(R"(GNETINJE
+ 'M5S'  'WAT'  1*  -1  /
+/)"), OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(Reject_TerminalPressureWithPositiveVFP)
+{
+    BOOST_CHECK_THROW(twoD_5x1x2(R"(GNETINJE
+ 'PLAT-A'  'WAT'  160.0  3  /
+/)"), OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(Reject_MalformedRecord_WrongType)
+{
+    BOOST_CHECK_THROW(twoD_5x1x2(R"(GNETINJE
+ 'M5S'  'WAT'  'NOT-A-NUMBER'  3 /
+/)"), std::exception);
+}
+
+BOOST_AUTO_TEST_CASE(Reject_MalformedRecord_MissingItem)
+{
+    BOOST_CHECK_THROW(twoD_5x1x2(R"(GNETINJE
+ 'M5S  'WAT'  1*  3 /
+/)"), std::exception);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Water
+
+BOOST_AUTO_TEST_SUITE_END()     // Injection_Networks


### PR DESCRIPTION
The GNETINJE keyword defines injection networks similarly to the GRUPNET standard network model for production networks.  There is at most one injection network for each of the injection phases "GAS" and "WATER", and each record in GNETINJE pertains to a particular phase.

This PR constructs an in-memory representation of injection networks defined by GNETINJE.  We leverage the existing network classes `Network::ExtNetwork`, `Network::Node`, and `Network::Branch` for the individual entities and network as a whole, but the nodes and branches do not necessarily have self-consistent sets of properties in this case.  Client code should only query the terminal pressure property for the nodes and the flow line/VFP table property for the branches when processing injection network information.

Note: This initial implementation treats subsequent GNETINJE keywords as **updates** to an original network.  If we need replacement behaviour instead, then that will require changes to the logic.

From a technical perspective, this implementation is split into two stages.  The first stage, defined by helper classes `CollectGNetInje` and `GNetInjeRaw` in `NetworkKeywordHandlers.cpp`, reads all records from a single GNETINJE keyword, determines the pertinent phase, converts pressure units, and expands group name roots.  The second phase, implemented in the body of `handleGNETINJE()`, consumes the first stage and converts it into a proper network representation.

We also introduce two new `ParseContext` diagnostic keys to produce appropriate diagnostic messages for faulty GNETINJE specifications

  * SCHEDULE_INVALID_INJPHASE denotes an invalid/unsupported injection phase.  Its default action is to issue a warning. In the GNETINJE context, this by default means producing a diagnostic message about an unuspported phase if the injection phase specified in item 2 is anything other than 'GAS' or 'WAT'.

  * SCHEDULE_INVALID_VFPTABLE denotes an invalid VFP table.  Its default action is to throw an exception.  In the GNETINJE case, this will currently happen if the input requests a negative VFP table index or if the input defines a VFP table for a fixed-pressure terminal node.