### PR TITLE
Fixes FindTBB for old versions (like on RedHat 8) with DUNE 2.11

### DIFF
--- a/cmake/Modules/FindTBB.cmake
+++ b/cmake/Modules/FindTBB.cmake
@@ -26,6 +26,8 @@ if(NOT TBB_FOUND)
       if(NOT TARGET TBB::tbb)
 	message(STATUS "Found TBB library using pkg config")
 	add_library(TBB::tbb ALIAS PkgConfig::PkgConfigTBB)
+	# Needed for DUNE 2.11
+	set(TBB_FOUND ON)
       endif()
     endif()
   endif(PKG_CONFIG_FOUND)


### PR DESCRIPTION
Whenver we fallback to pkgconfig we still need to make sure that we properly mark TBB as found using TBB_FOUND. Otherwise dune-common will claim that it was not found and CMake will fail.