### PR TITLE
[WIP] Implement WELSEGS support for well trajectories

### DIFF
--- a/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
@@ -63,7 +63,7 @@ namespace {
                double center_depth_in,
                std::optional<double> thermal_length_in,
                int segment_number_in,
-               std::size_t seqIndex_in);
+               std::optional<std::size_t> seqIndex_in);
 
         int m_i;
         int m_j;
@@ -86,7 +86,10 @@ namespace {
         std::optional<double> m_thermal_length;
 
         int segment_number;
-        std::size_t m_seqIndex;
+        // Position of the COMPSEGS record within its keyword.  Empty for
+        // records derived from a trajectory, which carry no ordering of their
+        // own; the connection keeps the order it was created in instead.
+        std::optional<std::size_t> m_seqIndex;
 
         void calculateCenterDepthWithSegments(const Opm::WellSegments& segment_set);
     };
@@ -99,7 +102,7 @@ namespace {
                    const double center_depth_in,
                    std::optional<double> thermal_length_in,
                    const int segment_number_in,
-                   const std::size_t seqIndex_in)
+                   const std::optional<std::size_t> seqIndex_in)
         : m_i              { i_in }
         , m_j              { j_in }
         , m_k              { k_in }
@@ -447,8 +450,6 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
             const auto thermal_length = std::optional<double>{};
             const auto segment_number = 0;
 
-            const auto seqIndex = compsegs.size();
-
             compsegs.emplace_back(trajectory_point.ijk[0],
                                   trajectory_point.ijk[1],
                                   trajectory_point.ijk[2],
@@ -457,7 +458,7 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
                                   direction,
                                   trajectory_point.centerTVD,
                                   thermal_length,
-                                  segment_number, seqIndex);
+                                  segment_number, std::nullopt);
         }
 
         processCOMPSEGS__(well_name, segments, compsegs);
@@ -542,7 +543,8 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
                 connection.updateSegment(compseg.segment_number,
                                          cdepth,
                                          thermal_length,
-                                         compseg.m_seqIndex,
+                                         compseg.m_seqIndex
+                                             .value_or(connection.sort_value()),
                                          std::make_pair(compseg.m_distance_start,
                                                         compseg.m_distance_end));
             }

--- a/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
@@ -63,7 +63,7 @@ namespace {
                double center_depth_in,
                std::optional<double> thermal_length_in,
                int segment_number_in,
-               std::optional<std::size_t> seqIndex_in);
+               std::optional<std::size_t> sort_value_in);
 
         int m_i;
         int m_j;
@@ -86,10 +86,14 @@ namespace {
         std::optional<double> m_thermal_length;
 
         int segment_number;
-        // Position of the COMPSEGS record within its keyword.  Empty for
-        // records derived from a trajectory, which carry no ordering of their
-        // own; the connection keeps the order it was created in instead.
-        std::optional<std::size_t> m_seqIndex;
+
+        // The Connection::sort_value() this record assigns.  Set from the
+        // COMPSEGS keyword, which lists the connections and thereby orders
+        // them.  Empty for a record derived from a trajectory: those
+        // connections are numbered as COMPTRAJ creates them, across all of the
+        // well's records, and counting records instead would leave two
+        // connections sharing a number whenever two branches share a cell.
+        std::optional<std::size_t> m_sort_value;
 
         void calculateCenterDepthWithSegments(const Opm::WellSegments& segment_set);
     };
@@ -102,7 +106,7 @@ namespace {
                    const double center_depth_in,
                    std::optional<double> thermal_length_in,
                    const int segment_number_in,
-                   const std::optional<std::size_t> seqIndex_in)
+                   const std::optional<std::size_t> sort_value_in)
         : m_i              { i_in }
         , m_j              { j_in }
         , m_k              { k_in }
@@ -113,7 +117,7 @@ namespace {
         , center_depth     { center_depth_in }
         , m_thermal_length { thermal_length_in }
         , segment_number   { segment_number_in }
-        , m_seqIndex       { seqIndex_in }
+        , m_sort_value     { sort_value_in }
     {}
 
     void Record::calculateCenterDepthWithSegments(const Opm::WellSegments& segment_set)
@@ -403,7 +407,7 @@ The use of negative center depth in item 9 is not supported. Well: {})", well_na
                         ? std::optional<double>{ record.getItem<Kw::THERMAL_LENGTH>().getSIDouble(0) }
                         : std::nullopt;
 
-                    const std::size_t seqIndex = compsegs.size();
+                    const std::size_t sort_value = compsegs.size();
                     compsegs.emplace_back(I, J, K,
                                           branch,
                                           distance_start, distance_end,
@@ -411,7 +415,7 @@ The use of negative center depth in item 9 is not supported. Well: {})", well_na
                                           center_depth,
                                           thermal_length,
                                           segment_number,
-                                          seqIndex);
+                                          sort_value);
                 }
             }
             else {
@@ -450,6 +454,10 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
             const auto thermal_length = std::optional<double>{};
             const auto segment_number = 0;
 
+            // COMPTRAJ numbers the connections as it creates them, so this
+            // record has no order of its own to impose.
+            const auto sort_value = std::optional<std::size_t>{};
+
             compsegs.emplace_back(trajectory_point.ijk[0],
                                   trajectory_point.ijk[1],
                                   trajectory_point.ijk[2],
@@ -458,7 +466,7 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
                                   direction,
                                   trajectory_point.centerTVD,
                                   thermal_length,
-                                  segment_number, std::nullopt);
+                                  segment_number, sort_value);
         }
 
         processCOMPSEGS__(well_name, segments, compsegs);
@@ -540,10 +548,12 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
                 const double thermal_length = compseg.m_thermal_length
                     .value_or(penetrationThickness(cell.dimensions, connection.dir()));
 
+                // Only COMPSEGS gives a connection order; a trajectory record
+                // leaves the connection the number COMPTRAJ gave it.
                 connection.updateSegment(compseg.segment_number,
                                          cdepth,
                                          thermal_length,
-                                         compseg.m_seqIndex
+                                         compseg.m_sort_value
                                              .value_or(connection.sort_value()),
                                          std::make_pair(compseg.m_distance_start,
                                                         compseg.m_distance_end));

--- a/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
@@ -430,23 +430,22 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
     }
 
     std::vector<Record>
-    compsegsFromTrajectory(std::string_view                                     well_name,
-                           const std::vector<Opm::Compsegs::TrajectorySegment>& trajectory_segments,
-                           const Opm::WellSegments&                             segments)
+    compsegsFromTrajectory(std::string_view                                        well_name,
+                           const int                                               branch,
+                           const std::vector<Opm::Compsegs::TrajectoryConnection>& trajectory_connections,
+                           const Opm::WellSegments&                                segments)
     {
         auto compsegs = std::vector<Record> {};
 
-        compsegs.reserve(trajectory_segments.size());
+        compsegs.reserve(trajectory_connections.size());
 
-        for (const auto& trajectory_point : trajectory_segments) {
+        for (const auto& trajectory_point : trajectory_connections) {
             // Defaulted values:
             const auto direction = Opm::Connection::Direction::X;
-            const auto center_depth = 0.0;
             // Thermal length (COMPSEGS item 10); left unset here, then filled
             // in process_compsegs_records().
             const auto thermal_length = std::optional<double>{};
             const auto segment_number = 0;
-            const auto branch = 1;
 
             const auto seqIndex = compsegs.size();
 
@@ -456,7 +455,7 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
                                   branch,
                                   trajectory_point.startMD, trajectory_point.endMD,
                                   direction,
-                                  center_depth,
+                                  trajectory_point.centerTVD,
                                   thermal_length,
                                   segment_number, seqIndex);
         }
@@ -607,17 +606,18 @@ namespace Opm::Compsegs {
     }
 
     WellConnections
-    getConnectionsAndSegmentsFromTrajectory(std::string_view                      well_name,
-                                            const std::vector<TrajectorySegment>& trajectory_segments,
-                                            const WellSegments&                   segments,
-                                            const WellConnections&                input_connections,
-                                            const ScheduleGrid&                   grid,
-                                            const KeywordLocation&                location,
-                                            const ParseContext&                   parseContext,
-                                            ErrorGuard&                           errors)
+    getConnectionsToSegmentsFromTrajectory(std::string_view                         well_name,
+                                           const int                                branch,
+                                           const std::vector<TrajectoryConnection>& trajectory_connections,
+                                           const WellSegments&                      segments,
+                                           const WellConnections&                   input_connections,
+                                           const ScheduleGrid&                      grid,
+                                           const KeywordLocation&                   location,
+                                           const ParseContext&                      parseContext,
+                                           ErrorGuard&                              errors)
     {
         const auto compsegs_vector =
-            compsegsFromTrajectory(well_name, trajectory_segments, segments);
+            compsegsFromTrajectory(well_name, branch, trajectory_connections, segments);
 
         return process_compsegs_records(well_name, compsegs_vector, input_connections,
                                         grid, location, parseContext, errors);

--- a/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
@@ -517,12 +517,22 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
             const int k = compseg.m_k;
 
             if (const auto& cell = grid.get_cell(i, j, k); cell.is_active()) {
+                auto& connection = new_connection_set.getFromIJK(i, j, k);
+
+                // A cell reached by several COMPTRAJ branches still holds a
+                // single connection, which can only be attached to one
+                // segment.  Let the owner branch -- the lowest numbered
+                // contributor, i.e. the one closest to the main stem -- claim
+                // it and ignore the records of the other branches.
+                const auto owner = connection.segmentOwnerBranch();
+                if (owner.has_value() && (*owner != compseg.m_branch_number)) {
+                    continue;
+                }
+
                 // Negative values to indicate cell depths should be used
                 const double cdepth = (compseg.center_depth >= 0.0)
                     ? compseg.center_depth
                     : cell.depth;
-
-                auto& connection = new_connection_set.getFromIJK(i, j, k);
 
                 // Fall back to the grid-block thickness when COMPSEGS item 10
                 // was defaulted (see penetrationThickness).

--- a/opm/input/eclipse/Schedule/MSW/Compsegs.hpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.hpp
@@ -85,26 +85,32 @@ namespace Opm::Compsegs {
                     const ParseContext&    parseContext,
                     ErrorGuard&            errors);
 
-    /// Single well segment of a grid-independent well (WELTRAJ/COMPTRAJ
+    /// Single well connection to a segment of a grid-independent well (WELTRAJ/COMPTRAJ
     /// keywords).
-    struct TrajectorySegment
+    struct TrajectoryConnection
     {
-        /// Measured depth along well bore at the start of the segment.
+        /// Measured depth along well bore at the start of the connection to the segment.
         double startMD{};
 
-        /// Measured depth along well bore at the end of the segment.
+        /// Measured depth along well bore at the end of the connection to the segment.
         double endMD{};
+        
+        /// True vertical depth along well bore at the measured center depth of the connection to the segment.
+        double centerTVD{};
 
-        /// Cartesian IJK tuple of the cell intersected by this segment.
+        /// Cartesian IJK tuple of the cell intersected by this connection.
         std::array<int, 3> ijk{};
     };
 
-    /// Allocate well/reservoir connections to well segements.
+    /// Allocate well/reservoir connections to well segments.
     ///
     /// \param[in] well_name Named well for which to allocate connections to
     /// well segments.
     ///
-    /// \param[in] trajectory_segments Cells intersected by the well bore
+    /// \param[in] branch Branch number for which to allocate connections to
+    /// well segments.
+    ///
+    /// \param[in] trajectory_connections Cells intersected by the well bore
     /// trajectory.
     ///
     /// \param[in] segments All well segments defined for well \p well_name,
@@ -127,14 +133,15 @@ namespace Opm::Compsegs {
     /// \return Input connections \p input_connections amended to include
     /// well segment allocation.
     WellConnections
-    getConnectionsAndSegmentsFromTrajectory(std::string_view                      well_name,
-                                            const std::vector<TrajectorySegment>& trajectory_segments,
-                                            const WellSegments&                   segments,
-                                            const WellConnections&                input_connections,
-                                            const ScheduleGrid&                   grid,
-                                            const KeywordLocation&                location,
-                                            const ParseContext&                   parseContext,
-                                            ErrorGuard&                           errors);
+    getConnectionsToSegmentsFromTrajectory(std::string_view                         well_name,
+                                           const int                                branch,
+                                           const std::vector<TrajectoryConnection>& trajectory_connections,
+                                           const WellSegments&                      segments,
+                                           const WellConnections&                   input_connections,
+                                           const ScheduleGrid&                      grid,
+                                           const KeywordLocation&                   location,
+                                           const ParseContext&                      parseContext,
+                                           ErrorGuard&                              errors);
 
     /// Form connection and segment structures for a single well from
     /// restart file information.

--- a/opm/input/eclipse/Schedule/MSW/Compsegs.hpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.hpp
@@ -85,20 +85,21 @@ namespace Opm::Compsegs {
                     const ParseContext&    parseContext,
                     ErrorGuard&            errors);
 
-    /// Single well connection to a segment of a grid-independent well (WELTRAJ/COMPTRAJ
-    /// keywords).
+    /// Single connection of a grid-independent well (WELTRAJ/COMPTRAJ
+    /// keywords) to the cell it perforates.
     struct TrajectoryConnection
     {
-        /// Measured depth along well bore at the start of the connection to the segment.
+        /// Measured depth at which the trajectory enters the cell.
         double startMD{};
 
-        /// Measured depth along well bore at the end of the connection to the segment.
+        /// Measured depth at which the trajectory leaves the cell.
         double endMD{};
 
-        /// True vertical depth along well bore at the measured center depth of the connection to the segment.
+        /// True vertical depth of the trajectory at the measured depth
+        /// midway between startMD and endMD.
         double centerTVD{};
 
-        /// Cartesian IJK tuple of the cell intersected by this connection.
+        /// Cartesian IJK tuple of the cell perforated by this connection.
         std::array<int, 3> ijk{};
     };
 
@@ -117,7 +118,7 @@ namespace Opm::Compsegs {
     /// from the WELSEGS keyword.
     ///
     /// \param[in] input_connections Preliminary well connection objects
-    /// from COMPDAT.
+    /// from COMPTRAJ.
     ///
     /// \param[in] grid Run's active cells.
     ///

--- a/opm/input/eclipse/Schedule/MSW/Compsegs.hpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.hpp
@@ -85,26 +85,32 @@ namespace Opm::Compsegs {
                     const ParseContext&    parseContext,
                     ErrorGuard&            errors);
 
-    /// Single well segment of a grid-independent well (WELTRAJ/COMPTRAJ
+    /// Single well connection to a segment of a grid-independent well (WELTRAJ/COMPTRAJ
     /// keywords).
-    struct TrajectorySegment
+    struct TrajectoryConnection
     {
-        /// Measured depth along well bore at the start of the segment.
+        /// Measured depth along well bore at the start of the connection to the segment.
         double startMD{};
 
-        /// Measured depth along well bore at the end of the segment.
+        /// Measured depth along well bore at the end of the connection to the segment.
         double endMD{};
 
-        /// Cartesian IJK tuple of the cell intersected by this segment.
+        /// True vertical depth along well bore at the measured center depth of the connection to the segment.
+        double centerTVD{};
+
+        /// Cartesian IJK tuple of the cell intersected by this connection.
         std::array<int, 3> ijk{};
     };
 
-    /// Allocate well/reservoir connections to well segements.
+    /// Allocate well/reservoir connections to well segments.
     ///
     /// \param[in] well_name Named well for which to allocate connections to
     /// well segments.
     ///
-    /// \param[in] trajectory_segments Cells intersected by the well bore
+    /// \param[in] branch Branch number for which to allocate connections to
+    /// well segments.
+    ///
+    /// \param[in] trajectory_connections Cells intersected by the well bore
     /// trajectory.
     ///
     /// \param[in] segments All well segments defined for well \p well_name,
@@ -127,14 +133,15 @@ namespace Opm::Compsegs {
     /// \return Input connections \p input_connections amended to include
     /// well segment allocation.
     WellConnections
-    getConnectionsAndSegmentsFromTrajectory(std::string_view                      well_name,
-                                            const std::vector<TrajectorySegment>& trajectory_segments,
-                                            const WellSegments&                   segments,
-                                            const WellConnections&                input_connections,
-                                            const ScheduleGrid&                   grid,
-                                            const KeywordLocation&                location,
-                                            const ParseContext&                   parseContext,
-                                            ErrorGuard&                           errors);
+    getConnectionsToSegmentsFromTrajectory(std::string_view                         well_name,
+                                           const int                                branch,
+                                           const std::vector<TrajectoryConnection>& trajectory_connections,
+                                           const WellSegments&                      segments,
+                                           const WellConnections&                   input_connections,
+                                           const ScheduleGrid&                      grid,
+                                           const KeywordLocation&                   location,
+                                           const ParseContext&                      parseContext,
+                                           ErrorGuard&                              errors);
 
     /// Form connection and segment structures for a single well from
     /// restart file information.

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -26,6 +26,7 @@
 #include <opm/input/eclipse/Schedule/MSW/Segment.hpp>
 #include <opm/input/eclipse/Schedule/MSW/Valve.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
+#include <opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
@@ -231,43 +232,10 @@ namespace Opm {
         this->addSegment(segment);
     }
 
-
-    void WellSegments::addWellSegmentsFromLengthsAndDepths(const std::string &wname,
-                                                           const std::vector<std::pair<double, double>>& lengths_and_depths,
-                                                           double diameter, const UnitSystem& unit_system)
-    {
-        const int branchID = 1;  // Only main branch for now.
-
-        const double roughness = 0.0;  // Defaulted: ROUGHNESS in WELSEGS.
-        const double area = std::numbers::pi * diameter * diameter / 4.0;
-        const double volume = Segment::invalidValue();
-
-        // Add segments:
-        int segmentID = 2;
-        for (auto [length, depth]: lengths_and_depths) {
-            this->addSegment(
-                segmentID, branchID, segmentID - 1, depth, length, diameter,
-                roughness, area, volume, true, 0.0, 0.0
-            );
-            segmentID += 1;
-        }
-
-        // Fix inlets:
-        for (const auto& segment : this->m_segments) {
-            const int outlet_segment = segment.outletSegment();
-            if (outlet_segment <= 0) { // no outlet segment
-                continue;
-            }
-
-            const int outlet_segment_index = segment_number_to_index[outlet_segment];
-            m_segments[outlet_segment_index].addInletSegment(segment.segmentNumber());
-        }
-
-        this->process(wname, unit_system, WellSegments::LengthDepth::ABS, this->depthTopSegment(), this->lengthTopSegment());
-    }
-
-
-    void WellSegments::loadWELSEGS(const DeckKeyword& welsegsKeyword, const UnitSystem& unit_system)
+    void WellSegments::loadWELSEGS(const DeckKeyword& welsegsKeyword,
+                                   const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                                   const std::map<int, std::vector<double>>& mds,
+                                   const UnitSystem& unit_system)
     {
         // For the first record, which provides the information for the top
         // segment and information for the whole segment set.
@@ -285,6 +253,14 @@ namespace Opm {
 
         const auto nodeX_top = record1.getItem("TOP_X").getSIDouble(0);
         const auto nodeY_top = record1.getItem("TOP_Y").getSIDouble(0);
+
+        if (!mds.empty() && length_top < mds.at(1)[0]) {
+            throw std::logic_error {fmt::format(
+                "TOP_LENGTH {} in WELSEGS for well {} is less than the trajectory starting MD {}.",
+                length_top,
+                wname,
+                mds.at(1)[0])};
+        }
 
         // Pipe-wall thermal properties for the whole segment set.  Individual
         // segments may override these in their own records.
@@ -375,6 +351,24 @@ namespace Opm {
             // If the length_depth_type is INC, then the depth is the depth change of the segment from the outlet segment.
             // If the length_depth_type is ABS, then the depth is the absolute depth of last the segment node in the range.
             const double depth = record.getItem("DEPTH").getSIDouble(0);
+            if (mds.empty()) {
+                if (record.getItem("DEPTH").defaultApplied(0)) {
+                    throw std::logic_error {
+                        fmt::format("DEPTH is defaulted for well {}. DEPTH values may only be "
+                                    "defaulted in WELSEGS for grid-independent wells. Please "
+                                    "provide an explicit DEPTH value.",
+                                    wname)};
+                }
+
+            } else {
+                if (depth != 0.0) {
+                    OpmLog::warning(fmt::format(
+                        "DEPTH value {:.3e} in WELSEGS for grid-independent well {} is not "
+                        "defaulted. The value will be ignored.",
+                        depth,
+                        wname));
+                }
+            }
 
             double volume = invalid_value;
             {
@@ -446,7 +440,7 @@ namespace Opm {
             m_segments[outlet_segment_index].addInletSegment(segment.segmentNumber());
         }
 
-        this->process(wname, unit_system, length_depth_type, depth_top, length_top);
+        this->process(wname, coords, mds, unit_system, length_depth_type, depth_top, length_top);
     }
 
     const Segment& WellSegments::getFromSegmentNumber(const int segment_number) const {
@@ -461,16 +455,18 @@ namespace Opm {
     }
 
     void WellSegments::process(const std::string& well_name,
+                               const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                               const std::map<int, std::vector<double>>& mds,
                                const UnitSystem& unit_system,
                                const LengthDepth length_depth,
                                const double      depth_top,
                                const double      length_top)
     {
         if (length_depth == LengthDepth::ABS) {
-            this->processABS();
+            this->processABS(coords, mds);
         }
         else if (length_depth == LengthDepth::INC) {
-            this->processINC(depth_top, length_top);
+            this->processINC(coords, mds, depth_top, length_top);
         }
         else {
             throw std::logic_error {
@@ -482,16 +478,38 @@ namespace Opm {
         this->checkSegmentDepthConsistency(well_name, unit_system);
     }
 
-    void WellSegments::processABS()
+    void
+    WellSegments::processABS(const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                             const std::map<int, std::vector<double>>& mds)
     {
         // Meaningless value to indicate unspecified/uncompleted values
         const double invalid_value = Segment::invalidValue();
 
         orderSegments();
 
+        external::cvf::ref<external::RigWellPath> wellPathGeometry;
+        int current_branch = 0;
+        if (!coords.empty()) {
+            wellPathGeometry = new external::RigWellPath;
+        }
+
         std::size_t current_index = 1;
         while (current_index < size()) {
-            if (m_segments[current_index].dataReady()) {
+            const auto& current_segment = this->m_segments[current_index];
+
+            if (!coords.empty() && current_branch != current_segment.branchNumber()) {
+                current_branch = current_segment.branchNumber();
+                initWellPathGeometry(
+                    wellPathGeometry, coords.at(current_branch), mds.at(current_branch));
+            }
+
+            if (current_segment.dataReady()) {
+                if (!coords.empty()) {
+                    const auto length = current_segment.totalLength();
+                    const auto coord = wellPathGeometry->interpolatedPointAlongWellPath(length);
+                    Segment new_segment(current_segment, coord[2], length, coord[0], coord[1]);
+                    this->addSegment(new_segment);
+                }
                 current_index++;
                 continue;
             }
@@ -557,6 +575,13 @@ namespace Opm {
                     ? volume_segment
                     : old_segment.volume();
 
+                if (!coords.empty()) {
+                    const auto coord = wellPathGeometry->interpolatedPointAlongWellPath(new_length);
+                    new_x = coord[0];
+                    new_y = coord[1];
+                    new_depth = coord[2];
+                }
+
                 this->addSegment(Segment {
                     old_segment, new_depth, new_length,
                     new_volume, new_x, new_y
@@ -584,7 +609,11 @@ namespace Opm {
         }
     }
 
-    void WellSegments::processINC(double depth_top, double length_top)
+    void
+    WellSegments::processINC(const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                             const std::map<int, std::vector<double>>& mds,
+                             double depth_top,
+                             double length_top)
     {
         // Update the information inside the WellSegments to be in ABS way
         Segment new_top_segment(this->m_segments[0], depth_top, length_top);
@@ -592,14 +621,38 @@ namespace Opm {
 
         orderSegments();
 
-        // Begin with the second segment
-        for (std::size_t i_index = 1; i_index < size(); ++i_index) {
-            if (m_segments[i_index].dataReady()) {
+        external::cvf::ref<external::RigWellPath> wellPathGeometry;
+        int current_branch = 0;
+        if (!coords.empty()) {
+            wellPathGeometry = new external::RigWellPath;
+        }
+
+        for (std::size_t i_index = 0; i_index < size(); ++i_index) {
+            const auto& current_segment = this->m_segments[i_index];
+
+            if (!coords.empty() && current_branch != current_segment.branchNumber()) {
+                current_branch = current_segment.branchNumber();
+                initWellPathGeometry(
+                    wellPathGeometry, coords.at(current_branch), mds.at(current_branch));
+            }
+
+            if (current_segment.dataReady()) {
+                if (!coords.empty()) {
+                    const auto length = current_segment.totalLength();
+                    const auto coord = wellPathGeometry->interpolatedPointAlongWellPath(length);
+                    Segment new_segment(current_segment, coord[2], length, coord[0], coord[1]);
+                    this->addSegment(new_segment);
+                }
+                continue;
+            }
+
+            // Begin with the second segment to fix the lenghts and depths.
+            if (i_index == 0) {
                 continue;
             }
 
             // Find its outlet segment
-            const int outlet_segment = m_segments[i_index].outletSegment();
+            const int outlet_segment = current_segment.outletSegment();
             const int outlet_index = segmentNumberToIndex(outlet_segment);
 
             // assert some information of the outlet_segment
@@ -608,14 +661,22 @@ namespace Opm {
 
             const double outlet_depth = m_segments[outlet_index].depth();
             const double outlet_length = m_segments[outlet_index].totalLength();
-            const double temp_depth = outlet_depth + m_segments[i_index].depth();
-            const double temp_length = outlet_length + m_segments[i_index].totalLength();
-            const auto new_x = m_segments[outlet_index].node_X() + m_segments[i_index].node_X();
-            const auto new_y = m_segments[outlet_index].node_Y() + m_segments[i_index].node_Y();
+            double temp_depth = outlet_depth + current_segment.depth();
+            const double temp_length = outlet_length + current_segment.totalLength();
+            double new_x = m_segments[outlet_index].node_X() + current_segment.node_X();
+            double new_y = m_segments[outlet_index].node_Y() + current_segment.node_Y();
+
+            if (!coords.empty()) {
+                // Update the depth from the trajectory.
+                const auto tmp_coord = wellPathGeometry->interpolatedPointAlongWellPath(temp_length);
+                new_x = tmp_coord[0];
+                new_y = tmp_coord[1];
+                temp_depth = tmp_coord[2];
+            }
 
             // Applying the calculated length and depth to the current segment
-            this->addSegment(Segment {
-                this->m_segments[i_index],
+            this->addSegment(Segment { 
+                current_segment,
                 temp_depth, temp_length, new_x, new_y
             });
         }

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -25,6 +25,7 @@
 #include <opm/input/eclipse/Schedule/MSW/SICD.hpp>
 #include <opm/input/eclipse/Schedule/MSW/Segment.hpp>
 #include <opm/input/eclipse/Schedule/MSW/Valve.hpp>
+#include <opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
@@ -263,11 +264,15 @@ namespace Opm {
             m_segments[outlet_segment_index].addInletSegment(segment.segmentNumber());
         }
 
-        this->process(wname, unit_system, WellSegments::LengthDepth::ABS, this->depthTopSegment(), this->lengthTopSegment());
+        this->process(wname, {}, {}, unit_system, WellSegments::LengthDepth::ABS,
+                      this->depthTopSegment(), this->lengthTopSegment());
     }
 
 
-    void WellSegments::loadWELSEGS(const DeckKeyword& welsegsKeyword, const UnitSystem& unit_system)
+    void WellSegments::loadWELSEGS(const DeckKeyword& welsegsKeyword,
+                                   const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                                   const std::map<int, std::vector<double>>& mds,
+                                   const UnitSystem& unit_system)
     {
         // For the first record, which provides the information for the top
         // segment and information for the whole segment set.
@@ -285,6 +290,14 @@ namespace Opm {
 
         const auto nodeX_top = record1.getItem("TOP_X").getSIDouble(0);
         const auto nodeY_top = record1.getItem("TOP_Y").getSIDouble(0);
+
+        if (!mds.empty() && length_top < mds.at(1).front()) {
+            throw std::logic_error {
+                fmt::format("TOP_LENGTH {} in WELSEGS for well {} is less than "
+                            "the trajectory starting MD {}.",
+                            length_top, wname, mds.at(1).front())
+            };
+        }
 
         // Pipe-wall thermal properties for the whole segment set.  Individual
         // segments may override these in their own records.
@@ -375,6 +388,21 @@ namespace Opm {
             // If the length_depth_type is INC, then the depth is the depth change of the segment from the outlet segment.
             // If the length_depth_type is ABS, then the depth is the absolute depth of last the segment node in the range.
             const double depth = record.getItem("DEPTH").getSIDouble(0);
+            if (mds.empty()) {
+                if (record.getItem("DEPTH").defaultApplied(0)) {
+                    throw std::logic_error {
+                        fmt::format("DEPTH is defaulted for well {}. DEPTH values may only be "
+                                    "defaulted in WELSEGS for grid-independent wells. Please "
+                                    "provide an explicit DEPTH value.", wname)
+                    };
+                }
+            }
+            else if (! record.getItem("DEPTH").defaultApplied(0)) {
+                OpmLog::warning(fmt::format(
+                    "DEPTH value {:.3e} in WELSEGS for grid-independent well {} is not "
+                    "defaulted. The value will be ignored and the segment node depth "
+                    "taken from the well trajectory instead.", depth, wname));
+            }
 
             double volume = invalid_value;
             {
@@ -446,7 +474,7 @@ namespace Opm {
             m_segments[outlet_segment_index].addInletSegment(segment.segmentNumber());
         }
 
-        this->process(wname, unit_system, length_depth_type, depth_top, length_top);
+        this->process(wname, coords, mds, unit_system, length_depth_type, depth_top, length_top);
     }
 
     const Segment& WellSegments::getFromSegmentNumber(const int segment_number) const {
@@ -461,16 +489,18 @@ namespace Opm {
     }
 
     void WellSegments::process(const std::string& well_name,
+                               const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                               const std::map<int, std::vector<double>>& mds,
                                const UnitSystem& unit_system,
                                const LengthDepth length_depth,
                                const double      depth_top,
                                const double      length_top)
     {
         if (length_depth == LengthDepth::ABS) {
-            this->processABS();
+            this->processABS(coords, mds);
         }
         else if (length_depth == LengthDepth::INC) {
-            this->processINC(depth_top, length_top);
+            this->processINC(coords, mds, depth_top, length_top);
         }
         else {
             throw std::logic_error {
@@ -482,16 +512,43 @@ namespace Opm {
         this->checkSegmentDepthConsistency(well_name, unit_system);
     }
 
-    void WellSegments::processABS()
+    void
+    WellSegments::processABS(const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                             const std::map<int, std::vector<double>>& mds)
     {
         // Meaningless value to indicate unspecified/uncompleted values
         const double invalid_value = Segment::invalidValue();
 
         orderSegments();
 
+        external::cvf::ref<external::RigWellPath> wellPathGeometry;
+        int current_branch = 0;
+        if (!coords.empty()) {
+            wellPathGeometry = new external::RigWellPath;
+        }
+
         std::size_t current_index = 1;
         while (current_index < size()) {
-            if (m_segments[current_index].dataReady()) {
+            const auto& current_segment = this->m_segments[current_index];
+
+            if (!coords.empty() && (current_branch != current_segment.branchNumber())) {
+                current_branch = current_segment.branchNumber();
+                initWellPathGeometry(wellPathGeometry,
+                                     coords.at(current_branch), mds.at(current_branch));
+            }
+
+            if (current_segment.dataReady()) {
+                if (!coords.empty()) {
+                    // Take the segment node's depth and X/Y position from the
+                    // trajectory rather than from the WELSEGS record.
+                    const auto length = current_segment.totalLength();
+                    const auto coord = wellPathGeometry->interpolatedPointAlongWellPath(length);
+
+                    this->addSegment(Segment {
+                        current_segment, coord[2], length, coord[0], coord[1]
+                    });
+                }
+
                 current_index++;
                 continue;
             }
@@ -557,6 +614,15 @@ namespace Opm {
                     ? volume_segment
                     : old_segment.volume();
 
+                if (!coords.empty()) {
+                    // Interpolated segment nodes take their depth and X/Y
+                    // position from the trajectory too.
+                    const auto coord = wellPathGeometry->interpolatedPointAlongWellPath(new_length);
+                    new_x     = coord[0];
+                    new_y     = coord[1];
+                    new_depth = coord[2];
+                }
+
                 this->addSegment(Segment {
                     old_segment, new_depth, new_length,
                     new_volume, new_x, new_y
@@ -584,7 +650,11 @@ namespace Opm {
         }
     }
 
-    void WellSegments::processINC(double depth_top, double length_top)
+    void
+    WellSegments::processINC(const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                             const std::map<int, std::vector<double>>& mds,
+                             double depth_top,
+                             double length_top)
     {
         // Update the information inside the WellSegments to be in ABS way
         Segment new_top_segment(this->m_segments[0], depth_top, length_top);
@@ -592,14 +662,44 @@ namespace Opm {
 
         orderSegments();
 
-        // Begin with the second segment
-        for (std::size_t i_index = 1; i_index < size(); ++i_index) {
-            if (m_segments[i_index].dataReady()) {
+        external::cvf::ref<external::RigWellPath> wellPathGeometry;
+        int current_branch = 0;
+        if (!coords.empty()) {
+            wellPathGeometry = new external::RigWellPath;
+        }
+
+        for (std::size_t i_index = 0; i_index < size(); ++i_index) {
+            const auto& current_segment = this->m_segments[i_index];
+
+            if (!coords.empty() && (current_branch != current_segment.branchNumber())) {
+                current_branch = current_segment.branchNumber();
+                initWellPathGeometry(wellPathGeometry,
+                                     coords.at(current_branch), mds.at(current_branch));
+            }
+
+            if (current_segment.dataReady()) {
+                if (!coords.empty()) {
+                    // Take the segment node's depth and X/Y position from the
+                    // trajectory rather than from the WELSEGS record.
+                    const auto length = current_segment.totalLength();
+                    const auto coord = wellPathGeometry->interpolatedPointAlongWellPath(length);
+
+                    this->addSegment(Segment {
+                        current_segment, coord[2], length, coord[0], coord[1]
+                    });
+                }
+
+                continue;
+            }
+
+            // Only the top segment's own values are absolute; it is handled
+            // above and never needs an outlet lookup.
+            if (i_index == 0) {
                 continue;
             }
 
             // Find its outlet segment
-            const int outlet_segment = m_segments[i_index].outletSegment();
+            const int outlet_segment = current_segment.outletSegment();
             const int outlet_index = segmentNumberToIndex(outlet_segment);
 
             // assert some information of the outlet_segment
@@ -608,14 +708,23 @@ namespace Opm {
 
             const double outlet_depth = m_segments[outlet_index].depth();
             const double outlet_length = m_segments[outlet_index].totalLength();
-            const double temp_depth = outlet_depth + m_segments[i_index].depth();
-            const double temp_length = outlet_length + m_segments[i_index].totalLength();
-            const auto new_x = m_segments[outlet_index].node_X() + m_segments[i_index].node_X();
-            const auto new_y = m_segments[outlet_index].node_Y() + m_segments[i_index].node_Y();
+            double temp_depth = outlet_depth + current_segment.depth();
+            const double temp_length = outlet_length + current_segment.totalLength();
+            double new_x = m_segments[outlet_index].node_X() + current_segment.node_X();
+            double new_y = m_segments[outlet_index].node_Y() + current_segment.node_Y();
+
+            if (!coords.empty()) {
+                // Take the segment node's depth and X/Y position from the
+                // trajectory rather than accumulating the WELSEGS increments.
+                const auto coord = wellPathGeometry->interpolatedPointAlongWellPath(temp_length);
+                new_x      = coord[0];
+                new_y      = coord[1];
+                temp_depth = coord[2];
+            }
 
             // Applying the calculated length and depth to the current segment
             this->addSegment(Segment {
-                this->m_segments[i_index],
+                current_segment,
                 temp_depth, temp_length, new_x, new_y
             });
         }

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -169,6 +169,56 @@ In {{file}} line {{line}}
         return geometry->interpolatedPointAlongWellPath
             (std::clamp(md, md_range.begin, md_range.end));
     }
+
+    /// The well trajectory, holding one branch at a time.
+    ///
+    /// orderSegments() stores the segments of a branch consecutively, so
+    /// walking the segments in order visits each branch once and the geometry
+    /// is rebuilt once per branch rather than once per segment.
+    class BranchTrajectory
+    {
+    public:
+        BranchTrajectory(const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                         const std::map<int, std::vector<double>>&                mds,
+                         std::string_view                                         well_name)
+            : m_coords   (coords)
+            , m_mds      (mds)
+            , m_well_name(well_name)
+        {
+            if (this->active()) {
+                this->m_geometry = new external::RigWellPath;
+            }
+        }
+
+        /// Whether the well is grid independent.  A grid dependent well has no
+        /// trajectory and keeps the segment node positions given in WELSEGS.
+        bool active() const
+        {
+            return !this->m_coords.empty();
+        }
+
+        /// The point on \p branch's trajectory at measured depth \p md.
+        external::cvf::Vec3d at(const int branch, const double md)
+        {
+            if (branch != this->m_branch) {
+                this->m_md_range = selectBranch(this->m_geometry, this->m_coords,
+                                                this->m_mds, this->m_well_name, branch);
+                this->m_branch = branch;
+            }
+
+            return trajectoryPoint(this->m_geometry, this->m_md_range,
+                                   this->m_well_name, branch, md);
+        }
+
+    private:
+        const std::map<int, std::array<std::vector<double>, 3>>& m_coords;
+        const std::map<int, std::vector<double>>&                m_mds;
+        std::string_view                                         m_well_name;
+
+        external::cvf::ref<external::RigWellPath> m_geometry{};
+        BranchMDRange                             m_md_range{};
+        int                                       m_branch{0};
+    };
 }
 
 namespace Opm {
@@ -391,12 +441,8 @@ namespace Opm {
                     nodeX_top_in, nodeY_top_in, wname));
             }
 
-            auto wellPathGeometry = external::cvf::ref<external::RigWellPath>
-                { new external::RigWellPath };
-
-            const auto md_range = selectBranch(wellPathGeometry, coords, mds, wname, 1);
-            const auto coord = trajectoryPoint(wellPathGeometry, md_range,
-                                               wname, 1, length_top);
+            auto trajectory = BranchTrajectory { coords, mds, wname };
+            const auto coord = trajectory.at(1, length_top);
 
             nodeX_top = coord[0];
             nodeY_top = coord[1];
@@ -625,30 +671,19 @@ namespace Opm {
 
         orderSegments();
 
-        external::cvf::ref<external::RigWellPath> wellPathGeometry;
-        BranchMDRange md_range{};
-        int current_branch = 0;
-        if (!coords.empty()) {
-            wellPathGeometry = new external::RigWellPath;
-        }
+        auto trajectory = BranchTrajectory { coords, mds, well_name };
 
         std::size_t current_index = 1;
         while (current_index < size()) {
             const auto& current_segment = this->m_segments[current_index];
-
-            if (!coords.empty() && (current_branch != current_segment.branchNumber())) {
-                current_branch = current_segment.branchNumber();
-                md_range = selectBranch(wellPathGeometry, coords, mds,
-                                        well_name, current_branch);
-            }
+            const auto  branch          = current_segment.branchNumber();
 
             if (current_segment.dataReady()) {
-                if (!coords.empty()) {
+                if (trajectory.active()) {
                     // Take the segment node's depth and X/Y position from the
                     // trajectory rather than from the WELSEGS record.
                     const auto length = current_segment.totalLength();
-                    const auto coord = trajectoryPoint(wellPathGeometry, md_range,
-                                                       well_name, current_branch, length);
+                    const auto coord = trajectory.at(branch, length);
 
                     this->addSegment(Segment {
                         current_segment, coord[2], length, coord[0], coord[1]
@@ -720,11 +755,10 @@ namespace Opm {
                     ? volume_segment
                     : old_segment.volume();
 
-                if (!coords.empty()) {
+                if (trajectory.active()) {
                     // Interpolated segment nodes take their depth and X/Y
                     // position from the trajectory too.
-                    const auto coord = trajectoryPoint(wellPathGeometry, md_range,
-                                                       well_name, current_branch, new_length);
+                    const auto coord = trajectory.at(branch, new_length);
                     new_x     = coord[0];
                     new_y     = coord[1];
                     new_depth = coord[2];
@@ -770,29 +804,18 @@ namespace Opm {
 
         orderSegments();
 
-        external::cvf::ref<external::RigWellPath> wellPathGeometry;
-        BranchMDRange md_range{};
-        int current_branch = 0;
-        if (!coords.empty()) {
-            wellPathGeometry = new external::RigWellPath;
-        }
+        auto trajectory = BranchTrajectory { coords, mds, well_name };
 
         for (std::size_t i_index = 0; i_index < size(); ++i_index) {
             const auto& current_segment = this->m_segments[i_index];
-
-            if (!coords.empty() && (current_branch != current_segment.branchNumber())) {
-                current_branch = current_segment.branchNumber();
-                md_range = selectBranch(wellPathGeometry, coords, mds,
-                                        well_name, current_branch);
-            }
+            const auto  branch          = current_segment.branchNumber();
 
             if (current_segment.dataReady()) {
-                if (!coords.empty()) {
+                if (trajectory.active()) {
                     // Take the segment node's depth and X/Y position from the
                     // trajectory rather than from the WELSEGS record.
                     const auto length = current_segment.totalLength();
-                    const auto coord = trajectoryPoint(wellPathGeometry, md_range,
-                                                       well_name, current_branch, length);
+                    const auto coord = trajectory.at(branch, length);
 
                     this->addSegment(Segment {
                         current_segment, coord[2], length, coord[0], coord[1]
@@ -823,11 +846,10 @@ namespace Opm {
             double new_x = m_segments[outlet_index].node_X() + current_segment.node_X();
             double new_y = m_segments[outlet_index].node_Y() + current_segment.node_Y();
 
-            if (!coords.empty()) {
+            if (trajectory.active()) {
                 // Take the segment node's depth and X/Y position from the
                 // trajectory rather than accumulating the WELSEGS increments.
-                const auto coord = trajectoryPoint(wellPathGeometry, md_range,
-                                                   well_name, current_branch, temp_length);
+                const auto coord = trajectory.at(branch, temp_length);
                 new_x      = coord[0];
                 new_y      = coord[1];
                 temp_depth = coord[2];

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -103,73 +103,6 @@ In {{file}} line {{line}}
                                  msg, location, errors);
     }
 
-    /// The measured depth range covered by a branch's trajectory.
-    struct BranchMDRange
-    {
-        double begin{};
-        double end{};
-    };
-
-    /// Point \p geometry at the trajectory of \p branch.
-    ///
-    /// Reports a missing branch instead of letting the lookup escape as a
-    /// std::out_of_range.  WELSEGS may name a branch that WELTRAJ never
-    /// defined, either directly or through a segment whose branch number was
-    /// mistyped.
-    BranchMDRange
-    selectBranch(external::cvf::ref<external::RigWellPath>&                    geometry,
-                 const std::map<int, std::array<std::vector<double>, 3>>&      coords,
-                 const std::map<int, std::vector<double>>&                     mds,
-                 std::string_view                                              well_name,
-                 const int                                                     branch)
-    {
-        const auto coordPos = coords.find(branch);
-        const auto mdPos = mds.find(branch);
-
-        if ((coordPos == coords.end()) || (mdPos == mds.end()) || mdPos->second.empty()) {
-            throw std::logic_error {
-                fmt::format("Well {} has segments on branch {}, but no WELTRAJ "
-                            "trajectory for that branch. Every branch used in "
-                            "WELSEGS must first be defined by WELTRAJ.",
-                            well_name, branch)
-            };
-        }
-
-        Opm::initWellPathGeometry(geometry, coordPos->second, mdPos->second);
-
-        return { mdPos->second.front(), mdPos->second.back() };
-    }
-
-    /// Interpolate the trajectory at measured depth \p md.
-    ///
-    /// A segment node outside the branch's trajectory would otherwise be
-    /// placed by extrapolating past its end, silently giving the well a
-    /// geometry the deck never described.
-    external::cvf::Vec3d
-    trajectoryPoint(const external::cvf::ref<external::RigWellPath>& geometry,
-                    const BranchMDRange&                             md_range,
-                    std::string_view                                 well_name,
-                    const int                                        branch,
-                    const double                                     md)
-    {
-        // The trajectory MDs and the segment lengths both come from the deck
-        // in the same unit, so a relative tolerance on the branch length is
-        // enough to absorb the round-off of reading them back.
-        const auto tol = 1.0e-10 * std::max(1.0, md_range.end - md_range.begin);
-
-        if ((md < md_range.begin - tol) || (md > md_range.end + tol)) {
-            throw std::logic_error {
-                fmt::format("Segment node at measured depth {} on branch {} of "
-                            "well {} lies outside the branch's trajectory, "
-                            "which covers measured depths {} to {}.",
-                            md, branch, well_name, md_range.begin, md_range.end)
-            };
-        }
-
-        return geometry->interpolatedPointAlongWellPath
-            (std::clamp(md, md_range.begin, md_range.end));
-    }
-
     /// The well trajectory, holding one branch at a time.
     ///
     /// orderSegments() stores the segments of a branch consecutively, so
@@ -201,22 +134,79 @@ In {{file}} line {{line}}
         external::cvf::Vec3d at(const int branch, const double md)
         {
             if (branch != this->m_branch) {
-                this->m_md_range = selectBranch(this->m_geometry, this->m_coords,
-                                                this->m_mds, this->m_well_name, branch);
-                this->m_branch = branch;
+                this->selectBranch(branch);
             }
 
-            return trajectoryPoint(this->m_geometry, this->m_md_range,
-                                   this->m_well_name, branch, md);
+            return this->interpolate(md);
         }
 
     private:
+        /// Point the geometry at \p branch's trajectory.
+        ///
+        /// Reports a missing branch instead of letting the lookup escape as a
+        /// std::out_of_range.  WELSEGS may name a branch that WELTRAJ never
+        /// defined, either directly or through a segment whose branch number
+        /// was mistyped.
+        void selectBranch(const int branch)
+        {
+            const auto coordPos = this->m_coords.find(branch);
+            const auto mdPos = this->m_mds.find(branch);
+
+            if ((coordPos == this->m_coords.end()) ||
+                (mdPos == this->m_mds.end()) || mdPos->second.empty())
+            {
+                throw std::logic_error {
+                    fmt::format("Well {} has segments on branch {}, but no WELTRAJ "
+                                "trajectory for that branch. Every branch used in "
+                                "WELSEGS must first be defined by WELTRAJ.",
+                                this->m_well_name, branch)
+                };
+            }
+
+            Opm::initWellPathGeometry(this->m_geometry, coordPos->second, mdPos->second);
+
+            this->m_branch_mds = &mdPos->second;
+            this->m_branch = branch;
+        }
+
+        /// Interpolate the selected branch's trajectory at measured depth \p md.
+        ///
+        /// A segment node outside the branch's trajectory would otherwise be
+        /// placed by extrapolating past its end, silently giving the well a
+        /// geometry the deck never described.
+        external::cvf::Vec3d interpolate(const double md) const
+        {
+            // Branch numbers start at 1, so at() always selects a branch first.
+            assert(this->m_branch_mds != nullptr);
+
+            const auto begin = this->m_branch_mds->front();
+            const auto end = this->m_branch_mds->back();
+
+            // The trajectory MDs and the segment lengths both come from the
+            // deck in the same unit, so a relative tolerance on the branch
+            // length is enough to absorb the round-off of reading them back.
+            const auto tol = 1.0e-10 * std::max(1.0, end - begin);
+
+            if ((md < begin - tol) || (md > end + tol)) {
+                throw std::logic_error {
+                    fmt::format("Segment node at measured depth {} on branch {} of "
+                                "well {} lies outside the branch's trajectory, "
+                                "which covers measured depths {} to {}.",
+                                md, this->m_branch, this->m_well_name, begin, end)
+                };
+            }
+
+            // Clamping keeps a node accepted by the tolerance from extrapolating.
+            return this->m_geometry->interpolatedPointAlongWellPath
+                (std::clamp(md, begin, end));
+        }
+
         const std::map<int, std::array<std::vector<double>, 3>>& m_coords;
         const std::map<int, std::vector<double>>&                m_mds;
         std::string_view                                         m_well_name;
 
         external::cvf::ref<external::RigWellPath> m_geometry{};
-        BranchMDRange                             m_md_range{};
+        const std::vector<double>*                m_branch_mds{nullptr};
         int                                       m_branch{0};
     };
 }

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -102,6 +102,73 @@ In {{file}} line {{line}}
         parseContext.handleError(Opm::ParseContext::SCHEDULE_ICD_INCOMPATIBLE_PDROP_MODEL,
                                  msg, location, errors);
     }
+
+    /// The measured depth range covered by a branch's trajectory.
+    struct BranchMDRange
+    {
+        double begin{};
+        double end{};
+    };
+
+    /// Point \p geometry at the trajectory of \p branch.
+    ///
+    /// Reports a missing branch instead of letting the lookup escape as a
+    /// std::out_of_range.  WELSEGS may name a branch that WELTRAJ never
+    /// defined, either directly or through a segment whose branch number was
+    /// mistyped.
+    BranchMDRange
+    selectBranch(external::cvf::ref<external::RigWellPath>&                    geometry,
+                 const std::map<int, std::array<std::vector<double>, 3>>&      coords,
+                 const std::map<int, std::vector<double>>&                     mds,
+                 std::string_view                                              well_name,
+                 const int                                                     branch)
+    {
+        const auto coordPos = coords.find(branch);
+        const auto mdPos = mds.find(branch);
+
+        if ((coordPos == coords.end()) || (mdPos == mds.end()) || mdPos->second.empty()) {
+            throw std::logic_error {
+                fmt::format("Well {} has segments on branch {}, but no WELTRAJ "
+                            "trajectory for that branch. Every branch used in "
+                            "WELSEGS must first be defined by WELTRAJ.",
+                            well_name, branch)
+            };
+        }
+
+        Opm::initWellPathGeometry(geometry, coordPos->second, mdPos->second);
+
+        return { mdPos->second.front(), mdPos->second.back() };
+    }
+
+    /// Interpolate the trajectory at measured depth \p md.
+    ///
+    /// A segment node outside the branch's trajectory would otherwise be
+    /// placed by extrapolating past its end, silently giving the well a
+    /// geometry the deck never described.
+    external::cvf::Vec3d
+    trajectoryPoint(const external::cvf::ref<external::RigWellPath>& geometry,
+                    const BranchMDRange&                             md_range,
+                    std::string_view                                 well_name,
+                    const int                                        branch,
+                    const double                                     md)
+    {
+        // The trajectory MDs and the segment lengths both come from the deck
+        // in the same unit, so a relative tolerance on the branch length is
+        // enough to absorb the round-off of reading them back.
+        const auto tol = 1.0e-10 * std::max(1.0, md_range.end - md_range.begin);
+
+        if ((md < md_range.begin - tol) || (md > md_range.end + tol)) {
+            throw std::logic_error {
+                fmt::format("Segment node at measured depth {} on branch {} of "
+                            "well {} lies outside the branch's trajectory, "
+                            "which covers measured depths {} to {}.",
+                            md, branch, well_name, md_range.begin, md_range.end)
+            };
+        }
+
+        return geometry->interpolatedPointAlongWellPath
+            (std::clamp(md, md_range.begin, md_range.end));
+    }
 }
 
 namespace Opm {
@@ -288,15 +355,51 @@ namespace Opm {
         const LengthDepth length_depth_type = LengthDepthFromString(record1.getItem("INFO_TYPE").getTrimmedString(0));
         m_comp_pressure_drop = CompPressureDropFromString(record1.getItem("PRESSURE_COMPONENTS").getTrimmedString(0));
 
-        const auto nodeX_top = record1.getItem("TOP_X").getSIDouble(0);
-        const auto nodeY_top = record1.getItem("TOP_Y").getSIDouble(0);
+        const auto nodeX_top_in = record1.getItem("TOP_X").getSIDouble(0);
+        const auto nodeY_top_in = record1.getItem("TOP_Y").getSIDouble(0);
 
-        if (!mds.empty() && length_top < mds.at(1).front()) {
-            throw std::logic_error {
-                fmt::format("TOP_LENGTH {} in WELSEGS for well {} is less than "
-                            "the trajectory starting MD {}.",
-                            length_top, wname, mds.at(1).front())
-            };
+        auto nodeX_top = nodeX_top_in;
+        auto nodeY_top = nodeY_top_in;
+
+        if (! mds.empty()) {
+            const auto mainStem = mds.find(1);
+            if ((mainStem == mds.end()) || mainStem->second.empty()) {
+                throw std::logic_error {
+                    fmt::format("Well {} has WELTRAJ trajectory data, but none "
+                                "for the main stem. Branch 1 must be defined "
+                                "before WELSEGS can position its segments.", wname)
+                };
+            }
+
+            if (length_top < mainStem->second.front()) {
+                throw std::logic_error {
+                    fmt::format("TOP_LENGTH {} in WELSEGS for well {} is less than "
+                                "the trajectory starting MD {}.",
+                                length_top, wname, mainStem->second.front())
+                };
+            }
+
+            // The top segment's node sits on the trajectory, just like every
+            // other node, so any position given in the deck is redundant.
+            if (! (record1.getItem("TOP_X").defaultApplied(0) &&
+                   record1.getItem("TOP_Y").defaultApplied(0)))
+            {
+                OpmLog::warning(fmt::format(
+                    "TOP_X/TOP_Y values ({:.3e}, {:.3e}) in WELSEGS for grid-independent "
+                    "well {} are not defaulted. The values will be ignored and the top "
+                    "segment node position taken from the well trajectory instead.",
+                    nodeX_top_in, nodeY_top_in, wname));
+            }
+
+            auto wellPathGeometry = external::cvf::ref<external::RigWellPath>
+                { new external::RigWellPath };
+
+            const auto md_range = selectBranch(wellPathGeometry, coords, mds, wname, 1);
+            const auto coord = trajectoryPoint(wellPathGeometry, md_range,
+                                               wname, 1, length_top);
+
+            nodeX_top = coord[0];
+            nodeY_top = coord[1];
         }
 
         // Pipe-wall thermal properties for the whole segment set.  Individual
@@ -497,10 +600,10 @@ namespace Opm {
                                const double      length_top)
     {
         if (length_depth == LengthDepth::ABS) {
-            this->processABS(coords, mds);
+            this->processABS(well_name, coords, mds);
         }
         else if (length_depth == LengthDepth::INC) {
-            this->processINC(coords, mds, depth_top, length_top);
+            this->processINC(well_name, coords, mds, depth_top, length_top);
         }
         else {
             throw std::logic_error {
@@ -513,7 +616,8 @@ namespace Opm {
     }
 
     void
-    WellSegments::processABS(const std::map<int, std::array<std::vector<double>, 3>>& coords,
+    WellSegments::processABS(const std::string& well_name,
+                             const std::map<int, std::array<std::vector<double>, 3>>& coords,
                              const std::map<int, std::vector<double>>& mds)
     {
         // Meaningless value to indicate unspecified/uncompleted values
@@ -522,6 +626,7 @@ namespace Opm {
         orderSegments();
 
         external::cvf::ref<external::RigWellPath> wellPathGeometry;
+        BranchMDRange md_range{};
         int current_branch = 0;
         if (!coords.empty()) {
             wellPathGeometry = new external::RigWellPath;
@@ -533,8 +638,8 @@ namespace Opm {
 
             if (!coords.empty() && (current_branch != current_segment.branchNumber())) {
                 current_branch = current_segment.branchNumber();
-                initWellPathGeometry(wellPathGeometry,
-                                     coords.at(current_branch), mds.at(current_branch));
+                md_range = selectBranch(wellPathGeometry, coords, mds,
+                                        well_name, current_branch);
             }
 
             if (current_segment.dataReady()) {
@@ -542,7 +647,8 @@ namespace Opm {
                     // Take the segment node's depth and X/Y position from the
                     // trajectory rather than from the WELSEGS record.
                     const auto length = current_segment.totalLength();
-                    const auto coord = wellPathGeometry->interpolatedPointAlongWellPath(length);
+                    const auto coord = trajectoryPoint(wellPathGeometry, md_range,
+                                                       well_name, current_branch, length);
 
                     this->addSegment(Segment {
                         current_segment, coord[2], length, coord[0], coord[1]
@@ -617,7 +723,8 @@ namespace Opm {
                 if (!coords.empty()) {
                     // Interpolated segment nodes take their depth and X/Y
                     // position from the trajectory too.
-                    const auto coord = wellPathGeometry->interpolatedPointAlongWellPath(new_length);
+                    const auto coord = trajectoryPoint(wellPathGeometry, md_range,
+                                                       well_name, current_branch, new_length);
                     new_x     = coord[0];
                     new_y     = coord[1];
                     new_depth = coord[2];
@@ -651,7 +758,8 @@ namespace Opm {
     }
 
     void
-    WellSegments::processINC(const std::map<int, std::array<std::vector<double>, 3>>& coords,
+    WellSegments::processINC(const std::string& well_name,
+                             const std::map<int, std::array<std::vector<double>, 3>>& coords,
                              const std::map<int, std::vector<double>>& mds,
                              double depth_top,
                              double length_top)
@@ -663,6 +771,7 @@ namespace Opm {
         orderSegments();
 
         external::cvf::ref<external::RigWellPath> wellPathGeometry;
+        BranchMDRange md_range{};
         int current_branch = 0;
         if (!coords.empty()) {
             wellPathGeometry = new external::RigWellPath;
@@ -673,8 +782,8 @@ namespace Opm {
 
             if (!coords.empty() && (current_branch != current_segment.branchNumber())) {
                 current_branch = current_segment.branchNumber();
-                initWellPathGeometry(wellPathGeometry,
-                                     coords.at(current_branch), mds.at(current_branch));
+                md_range = selectBranch(wellPathGeometry, coords, mds,
+                                        well_name, current_branch);
             }
 
             if (current_segment.dataReady()) {
@@ -682,7 +791,8 @@ namespace Opm {
                     // Take the segment node's depth and X/Y position from the
                     // trajectory rather than from the WELSEGS record.
                     const auto length = current_segment.totalLength();
-                    const auto coord = wellPathGeometry->interpolatedPointAlongWellPath(length);
+                    const auto coord = trajectoryPoint(wellPathGeometry, md_range,
+                                                       well_name, current_branch, length);
 
                     this->addSegment(Segment {
                         current_segment, coord[2], length, coord[0], coord[1]
@@ -716,7 +826,8 @@ namespace Opm {
             if (!coords.empty()) {
                 // Take the segment node's depth and X/Y position from the
                 // trajectory rather than accumulating the WELSEGS increments.
-                const auto coord = wellPathGeometry->interpolatedPointAlongWellPath(temp_length);
+                const auto coord = trajectoryPoint(wellPathGeometry, md_range,
+                                                   well_name, current_branch, temp_length);
                 new_x      = coord[0];
                 new_y      = coord[1];
                 temp_depth = coord[2];

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -300,9 +300,9 @@ namespace Opm {
     }
 
 
-    void WellSegments::addWellSegmentsFromLengthsAndDepths(const std::string &wname,
-                                                           const std::vector<std::pair<double, double>>& lengths_and_depths,
-                                                           double diameter, const UnitSystem& unit_system)
+    void WellSegments::loadFromLengthsAndDepths(const std::string &wname,
+                                                const std::vector<std::pair<double, double>>& lengths_and_depths,
+                                                double diameter, const UnitSystem& unit_system)
     {
         const int branchID = 1;  // Only main branch for now.
 

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -29,6 +29,8 @@
 #include <string_view>
 #include <utility>
 #include <vector>
+#include <array>
+#include <map>
 
 namespace Opm {
     class AutoICD;
@@ -77,10 +79,10 @@ namespace Opm {
         WellSegments() = default;
         WellSegments(CompPressureDrop compDrop,
                      const std::vector<Segment>& segments);
-        void loadWELSEGS( const DeckKeyword& welsegsKeyword, const UnitSystem& unit_system);
-        void addWellSegmentsFromLengthsAndDepths(const std::string &wname,
-                                                 const std::vector<std::pair<double, double>>& lengths_and_depths,
-                                                 double diameter, const UnitSystem& unit_system);
+        void loadWELSEGS(const DeckKeyword& welsegsKeyword,
+                         const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                         const std::map<int, std::vector<double>>& mds,
+                         const UnitSystem& unit_system);
 
         static WellSegments serializationTestObject();
 
@@ -152,10 +154,19 @@ namespace Opm {
         }
 
     private:
-        void processABS();
-        void processINC(double depth_top, double length_top);
-        void process(const std::string& well_name, const UnitSystem& unit_system,
-                     LengthDepth length_depth, double depth_top, double length_top);
+        void processABS(const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                        const std::map<int, std::vector<double>>& mds);
+        void processINC(const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                        const std::map<int, std::vector<double>>& mds,
+                        double depth_top,
+                        double length_top);
+        void process(const std::string& well_name,
+                     const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                     const std::map<int, std::vector<double>>& mds,
+                     const UnitSystem& unit_system,
+                     LengthDepth length_depth,
+                     double depth_top,
+                     double length_top);
         void addSegment(const Segment& new_segment);
         void addSegment(const int segment_number,
                         const int branch,

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -166,9 +166,11 @@ namespace Opm {
         }
 
     private:
-        void processABS(const std::map<int, std::array<std::vector<double>, 3>>& coords,
+        void processABS(const std::string& well_name,
+                        const std::map<int, std::array<std::vector<double>, 3>>& coords,
                         const std::map<int, std::vector<double>>& mds);
-        void processINC(const std::map<int, std::array<std::vector<double>, 3>>& coords,
+        void processINC(const std::string& well_name,
+                        const std::map<int, std::array<std::vector<double>, 3>>& coords,
                         const std::map<int, std::vector<double>>& mds,
                         double depth_top,
                         double length_top);

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -22,6 +22,7 @@
 
 #include <opm/input/eclipse/Schedule/MSW/Segment.hpp>
 
+#include <array>
 #include <cstddef>
 #include <map>
 #include <set>
@@ -77,7 +78,20 @@ namespace Opm {
         WellSegments() = default;
         WellSegments(CompPressureDrop compDrop,
                      const std::vector<Segment>& segments);
-        void loadWELSEGS( const DeckKeyword& welsegsKeyword, const UnitSystem& unit_system);
+
+        /// Load a WELSEGS keyword.
+        ///
+        /// \param[in] coords Well trajectory X/Y/Z coordinates, keyed by
+        /// branch number.  Empty for grid-dependent wells, in which case
+        /// the segment node depths are taken from the keyword itself.
+        ///
+        /// \param[in] mds Well trajectory measured depths, keyed by branch
+        /// number.  Empty for grid-dependent wells.
+        void loadWELSEGS(const DeckKeyword& welsegsKeyword,
+                         const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                         const std::map<int, std::vector<double>>& mds,
+                         const UnitSystem& unit_system);
+
         void addWellSegmentsFromLengthsAndDepths(const std::string &wname,
                                                  const std::vector<std::pair<double, double>>& lengths_and_depths,
                                                  double diameter, const UnitSystem& unit_system);
@@ -152,10 +166,19 @@ namespace Opm {
         }
 
     private:
-        void processABS();
-        void processINC(double depth_top, double length_top);
-        void process(const std::string& well_name, const UnitSystem& unit_system,
-                     LengthDepth length_depth, double depth_top, double length_top);
+        void processABS(const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                        const std::map<int, std::vector<double>>& mds);
+        void processINC(const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                        const std::map<int, std::vector<double>>& mds,
+                        double depth_top,
+                        double length_top);
+        void process(const std::string& well_name,
+                     const std::map<int, std::array<std::vector<double>, 3>>& coords,
+                     const std::map<int, std::vector<double>>& mds,
+                     const UnitSystem& unit_system,
+                     LengthDepth length_depth,
+                     double depth_top,
+                     double length_top);
         void addSegment(const Segment& new_segment);
         void addSegment(const int segment_number,
                         const int branch,

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -92,9 +92,9 @@ namespace Opm {
                          const std::map<int, std::vector<double>>& mds,
                          const UnitSystem& unit_system);
 
-        void addWellSegmentsFromLengthsAndDepths(const std::string &wname,
-                                                 const std::vector<std::pair<double, double>>& lengths_and_depths,
-                                                 double diameter, const UnitSystem& unit_system);
+        void loadFromLengthsAndDepths(const std::string &wname,
+                                      const std::vector<std::pair<double, double>>& lengths_and_depths,
+                                      double diameter, const UnitSystem& unit_system);
 
         static WellSegments serializationTestObject();
 

--- a/opm/input/eclipse/Schedule/MSW/makeMSWellFromStandardWell.cpp
+++ b/opm/input/eclipse/Schedule/MSW/makeMSWellFromStandardWell.cpp
@@ -89,8 +89,8 @@ Well makeMultiSegmentWellPerConnection(const Well& input_well,
         lengths_and_depths.emplace_back(md, depth);
         prev_depth = depth;
     }
-    segments.addWellSegmentsFromLengthsAndDepths(well.name(), lengths_and_depths,
-                                                 tubing_diameter, unit_system);
+    segments.loadFromLengthsAndDepths(well.name(), lengths_and_depths,
+                                      tubing_diameter, unit_system);
     well.updateSegments(std::make_shared<WellSegments>(std::move(segments)));
 
     // Attach each connection to its own segment (connection c -> segment c+2,

--- a/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -497,6 +497,13 @@ namespace Opm
     void Connection::setComptrajBranches(std::vector<int>           branches,
                                          std::vector<CTFProperties> branch_ctf)
     {
+        assert(std::ranges::is_sorted(branches));
+        assert(std::ranges::adjacent_find(branches) == branches.end());
+
+        // Per-branch CTFs are stored only once a cell has more than one
+        // contributor.
+        assert(branch_ctf.empty() || (branch_ctf.size() == branches.size()));
+
         this->m_branches = std::move(branches);
         this->m_branch_ctf = std::move(branch_ctf);
     }

--- a/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -434,10 +434,121 @@ namespace Opm
         this->ctf_properties_.static_dfac_corr_coeff = c;
     }
 
-    void Connection::resetComptrajBranch(const int branch)
+    namespace {
+
+        /// Combine the CTF properties of all branches perforating one cell.
+        ///
+        /// Mirrors the export-side combination rules ResInsight applies when
+        /// it writes COMPDAT for a multi-lateral well (OPM/ResInsight#7049).
+        Connection::CTFProperties
+        combineBranchCTFs(const std::vector<Connection::CTFProperties>& branch_ctf)
+        {
+            auto combined = Connection::CTFProperties{};
+
+            // Transmissibility, Kh and perforated length are additive.
+            auto cf_total = 0.0;
+            for (const auto& ctf : branch_ctf) {
+                combined.CF += ctf.CF;
+                combined.Kh += ctf.Kh;
+                combined.connection_length += ctf.connection_length;
+
+                cf_total += ctf.CF;
+            }
+
+            // Wellbore radius, skin and D-factor are CF-weighted averages.
+            // Fall back to an unweighted average if the CFs cannot serve as
+            // weights.
+            const auto weighted = cf_total > 0.0;
+            for (const auto& ctf : branch_ctf) {
+                const auto weight = weighted ? ctf.CF : 1.0;
+
+                combined.rw += weight * ctf.rw;
+                combined.skin_factor += weight * ctf.skin_factor;
+                combined.d_factor += weight * ctf.d_factor;
+            }
+
+            const auto num_branches = static_cast<double>(branch_ctf.size());
+            const auto norm = weighted ? cf_total : num_branches;
+
+            combined.rw /= norm;
+            combined.skin_factor /= norm;
+
+            // The D-factor is additionally divided by the number of
+            // contributing branches.
+            combined.d_factor /= norm * num_branches;
+
+            // Effective permeability and the equivalent radii are properties
+            // of the cell, not of the individual perforations, so they are
+            // taken as they are rather than combined.  Every branch
+            // perforating this cell computed them from the same cell
+            // properties and the same (Z) direction.
+            combined.Ke = branch_ctf.front().Ke;
+            combined.r0 = branch_ctf.front().r0;
+            combined.re = branch_ctf.front().re;
+
+            // peaceman_denom and static_dfac_corr_coeff are not set for
+            // trajectory-based connections and are left at zero.
+
+            return combined;
+        }
+
+    } // Anonymous namespace
+
+    void Connection::setComptrajBranches(std::vector<int>           branches,
+                                         std::vector<CTFProperties> branch_ctf)
     {
-        this->m_branches.assign(1, branch);
-        this->m_branch_ctf.clear();
+        this->m_branches = std::move(branches);
+        this->m_branch_ctf = std::move(branch_ctf);
+    }
+
+    void Connection::addComptrajBranch(const int branch, const CTFProperties& ctf)
+    {
+        if (this->m_branches.empty()) {
+            // First contributor to this cell.
+            this->m_branches.assign(1, branch);
+            this->m_branch_ctf.clear();
+            this->ctf_properties_ = ctf;
+            return;
+        }
+
+        if ((this->m_branches.size() == 1) && (this->m_branches.front() == branch)) {
+            // The only contributor re-specifies itself; the later record
+            // wins outright and there is nothing to combine.
+            this->m_branch_ctf.clear();
+            this->ctf_properties_ = ctf;
+            return;
+        }
+
+        if (this->m_branch_ctf.empty()) {
+            // Promoting a single contributor to several.  That contributor's
+            // values are still those of the connection itself.
+            this->m_branch_ctf.assign(1, this->ctf_properties_);
+        }
+
+        const auto pos = std::lower_bound(this->m_branches.begin(),
+                                          this->m_branches.end(), branch);
+        const auto idx = std::distance(this->m_branches.begin(), pos);
+
+        if ((pos == this->m_branches.end()) || (*pos != branch)) {
+            this->m_branches.insert(pos, branch);
+            this->m_branch_ctf.insert(this->m_branch_ctf.begin() + idx, ctf);
+        }
+        else {
+            // Re-specifying one branch replaces only that branch's share.
+            this->m_branch_ctf[idx] = ctf;
+        }
+
+        this->ctf_properties_ = combineBranchCTFs(this->m_branch_ctf);
+    }
+
+    std::optional<int> Connection::segmentOwnerBranch() const
+    {
+        if (this->m_branches.empty()) {
+            return std::nullopt;
+        }
+
+        // m_branches is kept in ascending order.
+        return this->m_branches.front();
     }
 
     bool Connection::fromTrajectory() const

--- a/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -501,6 +501,23 @@ namespace Opm
         this->m_branch_ctf = std::move(branch_ctf);
     }
 
+    void Connection::setBranchCTF(const int branch, const CTFProperties& ctf)
+    {
+        // An empty range means the branch is absent, and its begin() is then
+        // the position at which to insert it.
+        const auto found = std::ranges::equal_range(this->m_branches, branch);
+        const auto offset = found.begin() - this->m_branches.begin();
+
+        if (found.empty()) {
+            this->m_branches.insert(this->m_branches.begin() + offset, branch);
+            this->m_branch_ctf.insert(this->m_branch_ctf.begin() + offset, ctf);
+        }
+        else {
+            // Re-specifying one branch replaces only that branch's share.
+            this->m_branch_ctf[offset] = ctf;
+        }
+    }
+
     void Connection::addComptrajBranch(const int branch, const CTFProperties& ctf)
     {
         if (this->m_branches.empty()) {
@@ -525,18 +542,7 @@ namespace Opm
             this->m_branch_ctf.assign(1, this->ctf_properties_);
         }
 
-        const auto pos = std::lower_bound(this->m_branches.begin(),
-                                          this->m_branches.end(), branch);
-        const auto idx = std::distance(this->m_branches.begin(), pos);
-
-        if ((pos == this->m_branches.end()) || (*pos != branch)) {
-            this->m_branches.insert(pos, branch);
-            this->m_branch_ctf.insert(this->m_branch_ctf.begin() + idx, ctf);
-        }
-        else {
-            // Re-specifying one branch replaces only that branch's share.
-            this->m_branch_ctf[idx] = ctf;
-        }
+        this->setBranchCTF(branch, ctf);
 
         this->ctf_properties_ = combineBranchCTFs(this->m_branch_ctf);
     }

--- a/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -202,6 +202,12 @@ namespace Opm
         result.m_econ_limits = std::make_unique<ConnectionEconLimits>(
             ConnectionEconLimits::serializationTestObject());
 
+        result.m_branches = {1, 2};
+        result.m_branch_ctf = {
+            CTFProperties::serializationTestObject(),
+            CTFProperties::serializationTestObject()
+        };
+
         return result;
     }
 
@@ -428,6 +434,17 @@ namespace Opm
         this->ctf_properties_.static_dfac_corr_coeff = c;
     }
 
+    void Connection::resetComptrajBranch(const int branch)
+    {
+        this->m_branches.assign(1, branch);
+        this->m_branch_ctf.clear();
+    }
+
+    bool Connection::fromTrajectory() const
+    {
+        return !this->m_branches.empty();
+    }
+
     std::string Connection::str() const
     {
         std::stringstream ss;
@@ -484,6 +501,8 @@ namespace Opm
             && (this->ctf_properties_ == that.ctf_properties_)
             && (this->m_filter_cake == that.m_filter_cake)
             && (this->m_econ_limits == that.m_econ_limits)
+            && (this->m_branches == that.m_branches)
+            && (this->m_branch_ctf == that.m_branch_ctf)
             ;
     }
 

--- a/opm/input/eclipse/Schedule/Well/Connection.hpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.hpp
@@ -258,9 +258,48 @@ namespace Opm {
         void setDefaultSatTabId(bool id);
         void setStaticDFacCorrCoeff(const double c);
 
-        /// Record \p branch as this connection's only COMPTRAJ contributor,
-        /// discarding any per-branch CTF values accumulated so far.
-        void resetComptrajBranch(int branch);
+        /// Branch numbers that have contributed a COMPTRAJ perforation to
+        /// this connection, in ascending order.
+        const std::vector<int>& comptrajBranches() const
+        {
+            return this->m_branches;
+        }
+
+        /// Per-branch CTF properties, parallel to comptrajBranches().  Empty
+        /// while fewer than two branches contribute, in which case
+        /// ctfProperties() already holds the single contributor's values.
+        const std::vector<CTFProperties>& comptrajBranchCTFs() const
+        {
+            return this->m_branch_ctf;
+        }
+
+        /// Restore branch bookkeeping onto a connection that was rebuilt in
+        /// place.
+        void setComptrajBranches(std::vector<int>           branches,
+                                 std::vector<CTFProperties> branch_ctf);
+
+        /// Combine a COMPTRAJ perforation from \p branch into this
+        /// connection.
+        ///
+        /// A cell may be intersected by several branches of a multi-lateral
+        /// well, each contributing its own transmissibility.  Re-specifying a
+        /// branch that already contributes replaces that branch's
+        /// contribution; other branches' contributions are retained.
+        ///
+        /// Updates ctfProperties() to the combination of all contributing
+        /// branches.
+        ///
+        /// \param[in] branch Contributing branch number.
+        ///
+        /// \param[in] ctf CTF properties of this branch's perforation.
+        void addComptrajBranch(int branch, const CTFProperties& ctf);
+
+        /// Well segment owner among the contributing branches.
+        ///
+        /// A cell shared by several branches is allocated to the segment of
+        /// the lowest-numbered contributing branch.  Nullopt for connections
+        /// that do not originate from COMPTRAJ.
+        std::optional<int> segmentOwnerBranch() const;
 
         /// Whether this connection originates from COMPTRAJ rather than from
         /// COMPDAT.

--- a/opm/input/eclipse/Schedule/Well/Connection.hpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.hpp
@@ -448,6 +448,10 @@ namespace Opm {
         /// holds that branch's values.
         std::vector<CTFProperties> m_branch_ctf{};
 
+        /// Record \p ctf as the contribution of \p branch, keeping
+        /// m_branches sorted and m_branch_ctf aligned with it.
+        void setBranchCTF(int branch, const CTFProperties& ctf);
+
         static std::string CTFKindToString(const CTFKind);
     };
 

--- a/opm/input/eclipse/Schedule/Well/Connection.hpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.hpp
@@ -257,6 +257,8 @@ namespace Opm {
         void setCF(double CF);
         void setDefaultSatTabId(bool id);
         void setStaticDFacCorrCoeff(const double c);
+        void resetComptrajBranch(int branch);
+        bool fromTrajectory() const;
 
         void scaleWellPi(double wellPi);
         bool prepareWellPIScaling();
@@ -293,6 +295,8 @@ namespace Opm {
             serializer(this->m_subject_to_welpi);
             serializer(this->m_filter_cake);
             serializer(this->m_econ_limits);
+            serializer(this->m_branches);
+            serializer(this->m_branch_ctf);
         }
 
     private:
@@ -387,6 +391,12 @@ namespace Opm {
         std::optional<FilterCake> m_filter_cake{};
 
         Utility::CopyablePtr<ConnectionEconLimits> m_econ_limits{};
+
+        // Branch numbers that have contributed a COMPTRAJ perforation.
+        std::vector<int> m_branches{};
+
+        // Each contributing branch's CTFProperties from COMPTRAJ perforations.
+        std::vector<CTFProperties> m_branch_ctf{};
 
         static std::string CTFKindToString(const CTFKind);
     };

--- a/opm/input/eclipse/Schedule/Well/Connection.hpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.hpp
@@ -258,6 +258,14 @@ namespace Opm {
         void setDefaultSatTabId(bool id);
         void setStaticDFacCorrCoeff(const double c);
 
+        /// Record \p branch as this connection's only COMPTRAJ contributor,
+        /// discarding any per-branch CTF values accumulated so far.
+        void resetComptrajBranch(int branch);
+
+        /// Whether this connection originates from COMPTRAJ rather than from
+        /// COMPDAT.
+        bool fromTrajectory() const;
+
         void scaleWellPi(double wellPi);
         bool prepareWellPIScaling();
         bool applyWellPIScaling(const double scaleFactor);
@@ -293,6 +301,8 @@ namespace Opm {
             serializer(this->m_subject_to_welpi);
             serializer(this->m_filter_cake);
             serializer(this->m_econ_limits);
+            serializer(this->m_branches);
+            serializer(this->m_branch_ctf);
         }
 
     private:
@@ -387,6 +397,17 @@ namespace Opm {
         std::optional<FilterCake> m_filter_cake{};
 
         Utility::CopyablePtr<ConnectionEconLimits> m_econ_limits{};
+
+        /// Branch numbers that have contributed a COMPTRAJ perforation to
+        /// this connection, in ascending order.  Empty for connections that
+        /// do not originate from COMPTRAJ.
+        std::vector<int> m_branches{};
+
+        /// Each contributing branch's CTF properties, parallel to
+        /// m_branches.  Only populated once more than one branch
+        /// contributes; with a single contributor ctf_properties_ already
+        /// holds that branch's values.
+        std::vector<CTFProperties> m_branch_ctf{};
 
         static std::string CTFKindToString(const CTFKind);
     };

--- a/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
@@ -21,6 +21,7 @@
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
+#include <opm/common/utility/numeric/linearInterpolation.hpp>
 
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
@@ -57,70 +58,39 @@ namespace Opm
 namespace
 {
 
-    std::pair<std::vector<Compsegs::TrajectorySegment>, std::vector<std::pair<double, double>>>
-    get_segment_geometries(HandlerContext&                                            handlerContext,
-                           const std::vector<external::WellPathCellIntersectionInfo>& intersections,
-                           const external::cvf::ref<external::RigWellPath>&           wellPathGeometry)
-    {
-        std::vector<Compsegs::TrajectorySegment> trajectory_segments{};
-        std::vector<std::pair<double, double>> cell_md_and_tvd{};
-
-        trajectory_segments.reserve(intersections.size());
-        cell_md_and_tvd.reserve(intersections.size());
-
-        const auto& ecl_grid = handlerContext.grid.get_grid();
-
-        for (const auto& intersection : intersections) {
-            trajectory_segments.push_back({
-                    intersection.startMD,
-                    intersection.endMD,
-                    ecl_grid->getIJK(intersection.globCellIndex)
-                });
-
-            const double cell_md = 0.5 * (intersection.startMD + intersection.endMD);
-            const double cell_tvd = wellPathGeometry->interpolatedPointAlongWellPath(cell_md)[2];
-
-            cell_md_and_tvd.emplace_back(cell_md, cell_tvd);
-        }
-
-        return { std::move(trajectory_segments), std::move(cell_md_and_tvd) };
-    }
-
-
     void
     process_segments(HandlerContext&                                            handlerContext,
                      Well&                                                      well,
+                     const int                                                  branch,
                      const std::vector<external::WellPathCellIntersectionInfo>& intersections,
-                     const external::cvf::ref<external::RigWellPath>&           wellPathGeometry,
-                     const double                                               diameter)
+                     const external::cvf::ref<external::RigWellPath>&           wellPathGeometry)
     {
-        if (! well.isMultiSegment()) {
+        if (!well.isMultiSegment()) {
             return;
         }
 
-        // For now, no segments may be defined via WELSEGS, except for the top:
-        if (well.getSegments().size() > 1) {
-            const auto msg = fmt::format("   {} already defines segments "
-                                         "with the WELSEGS keyword", well.name());
-
-            throw OpmInputError(msg, handlerContext.keyword.location());
+        std::vector<Compsegs::TrajectoryConnection> trajectory_connections {};
+        trajectory_connections.reserve(intersections.size());
+        const auto& ecl_grid = handlerContext.grid.get_grid();
+        for (const auto& intersection : intersections) {
+            const double center_tvd = wellPathGeometry->interpolatedPointAlongWellPath(
+                0.5 * (intersection.startMD + intersection.endMD))[2];
+            trajectory_connections.push_back({intersection.startMD,
+                                              intersection.endMD,
+                                              center_tvd,
+                                              ecl_grid->getIJK(intersection.globCellIndex)});
         }
 
-        const auto& [trajectory_segments, cell_md_and_tvd] =
-            get_segment_geometries(handlerContext, intersections, wellPathGeometry);
-
-        well.addWellSegmentsFromLengthsAndDepths
-            (cell_md_and_tvd, diameter, handlerContext.keyword.location());
-
-        auto new_connections = Compsegs::getConnectionsAndSegmentsFromTrajectory
-            (well.name(),
-             trajectory_segments,
-             well.getSegments(),
-             well.getConnections(),
-             handlerContext.grid,
-             handlerContext.keyword.location(),
-             handlerContext.parseContext,
-             handlerContext.errors);
+        auto new_connections = Compsegs::getConnectionsToSegmentsFromTrajectory
+            (well.name(), 
+            branch,
+            trajectory_connections,
+            well.getSegments(),
+            well.getConnections(),
+            handlerContext.grid,
+            handlerContext.keyword.location(),
+            handlerContext.parseContext,
+            handlerContext.errors);
 
         well.updateConnections
             (std::make_shared<WellConnections>(std::move(new_connections)), false);
@@ -174,9 +144,9 @@ Well {} has no connections to the grid. The well will remain SHUT)", name);
                 }
 
                 process_segments(handlerContext, well,
+                                 record.getItem<Kw::BRANCH_NUMBER>().get<int>(0),
                                  wellTraj.intersections,
-                                 wellTraj.wellPathGeometry,
-                                 record.getItem<Kw::DIAMETER>().getSIDouble(0));
+                                 wellTraj.wellPathGeometry);
 
                 handlerContext.state().wells.update(std::move(well));
 
@@ -203,19 +173,29 @@ Well {} has no connections to the grid. The well will remain SHUT)", name);
             for (const auto& name : wellnames) {
                 auto well = handlerContext.state().wells.get(name);
 
+                if (well.isMultiSegment()) {
+                    const auto msg = fmt::format(
+                        "Well {} is a segmented grid-independent well, but its WELSEGS keyword "
+                        "must be defined after the corresponding WELTRAJ keyword. Please check "
+                        "the order of the keywords in the input file.",
+                        name);
+                    throw OpmInputError(msg, handlerContext.keyword.location());
+                }
+
                 auto connections = std::make_shared<WellConnections>(well.getConnections());
                 connections->loadWELTRAJ(record, name, handlerContext.grid,
                                          handlerContext.keyword.location());
+                for (auto const& [branch, md] : connections->getMD()) {
+                    if (md.size() > 1) {
+                        const bool strictly_increasing = std::adjacent_find
+                            (md.begin(), md.end(), std::greater_equal<>{}) == md.end();
 
-                if (const auto& md = connections->getMD(); md.size() > 1) {
-                    const bool strictly_increasing = std::adjacent_find
-                        (md.begin(), md.end(), std::greater_equal<>{}) == md.end();
+                        if (!strictly_increasing) {
+                            const auto msg = fmt::format("Well {} measured depth column "
+                                                         "is not strictly increasing", name);
 
-                    if (!strictly_increasing) {
-                        const auto msg = fmt::format("Well {} measured depth column "
-                                                     "is not strictly increasing", name);
-
-                        throw OpmInputError(msg, handlerContext.keyword.location());
+                            throw OpmInputError(msg, handlerContext.keyword.location());
+                        }
                     }
                 }
 
@@ -241,6 +221,47 @@ getGridIndependentWellKeywordHandlers()
         {"COMPTRAJ", &handleCOMPTRAJ},
         {"WELTRAJ", &handleWELTRAJ},
     };
+}
+
+void initWellPathGeometry(
+    external::cvf::ref<external::RigWellPath>& wellPathGeometry,         
+    const std::array<std::vector<double>, 3>& coords, const std::vector<double>& mds,
+    std::optional<double> top_opt, std::optional<double> bot_opt
+) {
+    std::vector<external::cvf::Vec3d> points;
+    std::vector<double> measured_depths;
+
+    const double top = top_opt.value_or(mds.front());
+    const double bot = bot_opt.value_or(mds.back());
+
+    // Calulate the x,y,z coordinates of the begin and end of a perforation
+    if (top < mds.front() || bot > mds.back()) {
+        throw std::logic_error(fmt::format("Perforation interval [{}, {}] is outside of the well path range [{}, {}]",
+            top, bot, mds.front(), mds.back()));
+    }
+        
+    external::cvf::Vec3d p_top, p_bot;
+    for (std::size_t i = 0; i < 3 ; ++i) {
+        p_top[i] = linearInterpolation(mds, coords[i], top);
+        p_bot[i] = linearInterpolation(mds, coords[i], bot);
+    }
+    points.push_back(p_top);
+    measured_depths.push_back(top);
+
+    points.reserve(coords[0].size());
+    measured_depths.reserve(coords[0].size());
+    for (std::size_t i = 0; i < coords[0].size(); ++i) {
+        if (mds[i] > top and mds[i] < bot) {
+            points.push_back(external::cvf::Vec3d(coords[0][i], coords[1][i], coords[2][i]));
+            measured_depths.push_back(mds[i]);
+        }
+    }
+
+    points.push_back(p_bot);
+    measured_depths.push_back(bot);
+
+    wellPathGeometry->setWellPathPoints(points);
+    wellPathGeometry->setMeasuredDepths(measured_depths);
 }
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
@@ -29,6 +29,7 @@
 #include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleGrid.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
+#include <opm/input/eclipse/Schedule/ScheduleStatic.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 
@@ -57,6 +58,19 @@ namespace Opm
 
 namespace
 {
+
+    std::string appendRestartHint(std::string msg, const HandlerContext& handlerContext)
+    {
+        const auto restart_step = handlerContext.static_schedule().rst_info.report_step;
+        if (restart_step != 0) {
+            msg += fmt::format(
+                " This may be caused by continuing this well after a restart "
+                "(resumed at report step {}) - restarting is not supported "
+                "for trajectory-based (COMPTRAJ/WELTRAJ) wells.", restart_step);
+        }
+
+        return msg;
+    }
 
     void
     process_segments(HandlerContext&                                            handlerContext,
@@ -112,8 +126,12 @@ namespace
             for (const auto& name : wellnames) {
                 auto well = handlerContext.state().wells.get(name);
 
-                if (!well.getConnections().empty()) {
-                    const auto msg = fmt::format(R"(   {} is already connected)", name);
+                const auto& existing_connections = well.getConnections();
+                if (!existing_connections.empty() && !existing_connections[0].fromTrajectory()) {
+                    const auto msg = appendRestartHint(fmt::format(
+                        "Well {} already has COMPDAT-defined connections and cannot "
+                        "also be defined using COMPTRAJ. A well must use either COMPDAT "
+                        "or COMPTRAJ, never both.", name), handlerContext);
                     throw OpmInputError(msg, handlerContext.keyword.location());
                 }
 
@@ -172,6 +190,15 @@ Well {} has no connections to the grid. The well will remain SHUT)", name);
 
             for (const auto& name : wellnames) {
                 auto well = handlerContext.state().wells.get(name);
+
+                const auto& existing_connections = well.getConnections();
+                if (!existing_connections.empty() && !existing_connections[0].fromTrajectory()) {
+                    const auto msg = appendRestartHint(fmt::format(
+                        "Well {} already has COMPDAT-defined connections and cannot "
+                        "also be defined using WELTRAJ/COMPTRAJ. A well must use either "
+                        "COMPDAT or COMPTRAJ, never both.", name), handlerContext);
+                    throw OpmInputError(msg, handlerContext.keyword.location());
+                }
 
                 if (well.isMultiSegment()) {
                     const auto msg = fmt::format(

--- a/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
@@ -46,6 +46,7 @@
 #include <algorithm>
 #include <functional>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -278,6 +279,17 @@ void initWellPathGeometry(external::cvf::ref<external::RigWellPath>& wellPathGeo
 {
     const double top = top_opt.value_or(mds.front());
     const double bot = bot_opt.value_or(mds.back());
+
+    if ((top < mds.front()) || (bot > mds.back()) || (bot < top)) {
+        // linearInterpolation() clamps to the end points, so an interval
+        // reaching past the trajectory would be silently truncated and one
+        // that runs backwards would collapse to a point.
+        throw std::logic_error {
+            fmt::format("Perforation interval {} to {} is not contained in the "
+                        "branch's trajectory, which covers measured depths "
+                        "{} to {}.", top, bot, mds.front(), mds.back())
+        };
+    }
 
     std::vector<external::cvf::Vec3d> points;
     std::vector<double> measured_depths;

--- a/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
@@ -21,6 +21,7 @@
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
+#include <opm/common/utility/numeric/linearInterpolation.hpp>
 
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
@@ -246,6 +247,45 @@ getGridIndependentWellKeywordHandlers()
         {"COMPTRAJ", &handleCOMPTRAJ},
         {"WELTRAJ", &handleWELTRAJ},
     };
+}
+
+void initWellPathGeometry(external::cvf::ref<external::RigWellPath>& wellPathGeometry,
+                          const std::array<std::vector<double>, 3>&  coords,
+                          const std::vector<double>&                 mds,
+                          std::optional<double>                      top_opt,
+                          std::optional<double>                      bot_opt)
+{
+    const double top = top_opt.value_or(mds.front());
+    const double bot = bot_opt.value_or(mds.back());
+
+    std::vector<external::cvf::Vec3d> points;
+    std::vector<double> measured_depths;
+
+    points.reserve(coords[0].size() + 2);
+    measured_depths.reserve(coords[0].size() + 2);
+
+    // Calulate the x,y,z coordinates of the begin and end of the interval
+    external::cvf::Vec3d p_top, p_bot;
+    for (std::size_t i = 0; i < 3; ++i) {
+        p_top[i] = linearInterpolation(mds, coords[i], top);
+        p_bot[i] = linearInterpolation(mds, coords[i], bot);
+    }
+
+    points.push_back(p_top);
+    measured_depths.push_back(top);
+
+    for (std::size_t i = 0; i < coords[0].size(); ++i) {
+        if ((mds[i] > top) && (mds[i] < bot)) {
+            points.push_back(external::cvf::Vec3d(coords[0][i], coords[1][i], coords[2][i]));
+            measured_depths.push_back(mds[i]);
+        }
+    }
+
+    points.push_back(p_bot);
+    measured_depths.push_back(bot);
+
+    wellPathGeometry->setWellPathPoints(points);
+    wellPathGeometry->setMeasuredDepths(measured_depths);
 }
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
@@ -207,13 +207,18 @@ Well {} has no connections to the grid. The well will remain SHUT)", name);
                 connections->loadWELTRAJ(record, name, handlerContext.grid,
                                          handlerContext.keyword.location());
 
-                if (const auto& md = connections->getMD(); md.size() > 1) {
+                for (const auto& [branch, md] : connections->getMD()) {
+                    if (md.size() < 2) {
+                        continue;
+                    }
+
                     const bool strictly_increasing = std::adjacent_find
                         (md.begin(), md.end(), std::greater_equal<>{}) == md.end();
 
                     if (!strictly_increasing) {
                         const auto msg = fmt::format("Well {} measured depth column "
-                                                     "is not strictly increasing", name);
+                                                     "for branch {} is not strictly increasing",
+                                                     name, branch);
 
                         throw OpmInputError(msg, handlerContext.keyword.location());
                     }

--- a/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
@@ -91,6 +91,20 @@ namespace
             return;
         }
 
+        if (well.getSegments().size() <= 1) {
+            // Grid-independent segmented wells used to have their segments
+            // generated from the trajectory, one per perforated cell, and
+            // WELSEGS was only allowed to give the top segment.  The segment
+            // structure now comes from WELSEGS, so such a deck would quietly
+            // put the whole well on the top segment.
+            const auto msg = fmt::format(
+                "Well {} is a segmented grid-independent well, but its WELSEGS keyword "
+                "only defines the top segment. The segment structure of a COMPTRAJ well "
+                "is taken from WELSEGS and must be given explicitly.", well.name());
+
+            throw OpmInputError(msg, handlerContext.keyword.location());
+        }
+
         std::vector<Compsegs::TrajectoryConnection> trajectory_connections{};
         trajectory_connections.reserve(intersections.size());
 

--- a/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
@@ -29,6 +29,7 @@
 #include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleGrid.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
+#include <opm/input/eclipse/Schedule/ScheduleStatic.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 
@@ -57,6 +58,26 @@ namespace Opm
 
 namespace
 {
+
+    /// Amend \p msg with a hint about restart support when the run was
+    /// resumed from a restart file.
+    ///
+    /// A restart-restored connection carries no branch information, so it is
+    /// indistinguishable from a COMPDAT connection and continuing the well
+    /// with COMPTRAJ/WELTRAJ trips the mixing guard. Say so, rather than
+    /// leaving the user with a rule they appear not to have broken.
+    std::string appendRestartHint(std::string msg, const HandlerContext& handlerContext)
+    {
+        const auto restart_step = handlerContext.static_schedule().rst_info.report_step;
+
+        if (restart_step != 0) {
+            msg += fmt::format(" This may be caused by continuing this well after a restart "
+                               "(resumed at report step {}) - restarting is not supported "
+                               "for trajectory-based (COMPTRAJ/WELTRAJ) wells.", restart_step);
+        }
+
+        return msg;
+    }
 
     void
     process_segments(HandlerContext&                                            handlerContext,
@@ -117,8 +138,14 @@ namespace
             for (const auto& name : wellnames) {
                 auto well = handlerContext.state().wells.get(name);
 
-                if (!well.getConnections().empty()) {
-                    const auto msg = fmt::format(R"(   {} is already connected)", name);
+                const auto& existing_connections = well.getConnections();
+                if (!existing_connections.empty() && !existing_connections[0].fromTrajectory()) {
+                    const auto msg = appendRestartHint(
+                        fmt::format("Well {} already has COMPDAT-defined connections and cannot "
+                                    "also be defined using COMPTRAJ. A well must use either "
+                                    "COMPDAT or COMPTRAJ, never both.", name),
+                        handlerContext);
+
                     throw OpmInputError(msg, handlerContext.keyword.location());
                 }
 
@@ -177,6 +204,17 @@ Well {} has no connections to the grid. The well will remain SHUT)", name);
 
             for (const auto& name : wellnames) {
                 auto well = handlerContext.state().wells.get(name);
+
+                const auto& existing_connections = well.getConnections();
+                if (!existing_connections.empty() && !existing_connections[0].fromTrajectory()) {
+                    const auto msg = appendRestartHint(
+                        fmt::format("Well {} already has COMPDAT-defined connections and cannot "
+                                    "also be defined using WELTRAJ/COMPTRAJ. A well must use "
+                                    "either COMPDAT or COMPTRAJ, never both.", name),
+                        handlerContext);
+
+                    throw OpmInputError(msg, handlerContext.keyword.location());
+                }
 
                 if (well.isMultiSegment()) {
                     const auto msg = fmt::format(

--- a/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.cpp
@@ -58,64 +58,38 @@ namespace Opm
 namespace
 {
 
-    std::pair<std::vector<Compsegs::TrajectorySegment>, std::vector<std::pair<double, double>>>
-    get_segment_geometries(HandlerContext&                                            handlerContext,
-                           const std::vector<external::WellPathCellIntersectionInfo>& intersections,
-                           const external::cvf::ref<external::RigWellPath>&           wellPathGeometry)
-    {
-        std::vector<Compsegs::TrajectorySegment> trajectory_segments{};
-        std::vector<std::pair<double, double>> cell_md_and_tvd{};
-
-        trajectory_segments.reserve(intersections.size());
-        cell_md_and_tvd.reserve(intersections.size());
-
-        const auto& ecl_grid = handlerContext.grid.get_grid();
-
-        for (const auto& intersection : intersections) {
-            trajectory_segments.push_back({
-                    intersection.startMD,
-                    intersection.endMD,
-                    ecl_grid->getIJK(intersection.globCellIndex)
-                });
-
-            const double cell_md = 0.5 * (intersection.startMD + intersection.endMD);
-            const double cell_tvd = wellPathGeometry->interpolatedPointAlongWellPath(cell_md)[2];
-
-            cell_md_and_tvd.emplace_back(cell_md, cell_tvd);
-        }
-
-        return { std::move(trajectory_segments), std::move(cell_md_and_tvd) };
-    }
-
-
     void
     process_segments(HandlerContext&                                            handlerContext,
                      Well&                                                      well,
+                     const int                                                  branch,
                      const std::vector<external::WellPathCellIntersectionInfo>& intersections,
-                     const external::cvf::ref<external::RigWellPath>&           wellPathGeometry,
-                     const double                                               diameter)
+                     const external::cvf::ref<external::RigWellPath>&           wellPathGeometry)
     {
         if (! well.isMultiSegment()) {
             return;
         }
 
-        // For now, no segments may be defined via WELSEGS, except for the top:
-        if (well.getSegments().size() > 1) {
-            const auto msg = fmt::format("   {} already defines segments "
-                                         "with the WELSEGS keyword", well.name());
+        std::vector<Compsegs::TrajectoryConnection> trajectory_connections{};
+        trajectory_connections.reserve(intersections.size());
 
-            throw OpmInputError(msg, handlerContext.keyword.location());
+        const auto& ecl_grid = handlerContext.grid.get_grid();
+
+        for (const auto& intersection : intersections) {
+            const double center_md = 0.5 * (intersection.startMD + intersection.endMD);
+            const double center_tvd = wellPathGeometry->interpolatedPointAlongWellPath(center_md)[2];
+
+            trajectory_connections.push_back({
+                    intersection.startMD,
+                    intersection.endMD,
+                    center_tvd,
+                    ecl_grid->getIJK(intersection.globCellIndex)
+                });
         }
 
-        const auto& [trajectory_segments, cell_md_and_tvd] =
-            get_segment_geometries(handlerContext, intersections, wellPathGeometry);
-
-        well.addWellSegmentsFromLengthsAndDepths
-            (cell_md_and_tvd, diameter, handlerContext.keyword.location());
-
-        auto new_connections = Compsegs::getConnectionsAndSegmentsFromTrajectory
+        auto new_connections = Compsegs::getConnectionsToSegmentsFromTrajectory
             (well.name(),
-             trajectory_segments,
+             branch,
+             trajectory_connections,
              well.getSegments(),
              well.getConnections(),
              handlerContext.grid,
@@ -175,9 +149,9 @@ Well {} has no connections to the grid. The well will remain SHUT)", name);
                 }
 
                 process_segments(handlerContext, well,
+                                 record.getItem<Kw::BRANCH_NUMBER>().get<int>(0),
                                  wellTraj.intersections,
-                                 wellTraj.wellPathGeometry,
-                                 record.getItem<Kw::DIAMETER>().getSIDouble(0));
+                                 wellTraj.wellPathGeometry);
 
                 handlerContext.state().wells.update(std::move(well));
 
@@ -203,6 +177,15 @@ Well {} has no connections to the grid. The well will remain SHUT)", name);
 
             for (const auto& name : wellnames) {
                 auto well = handlerContext.state().wells.get(name);
+
+                if (well.isMultiSegment()) {
+                    const auto msg = fmt::format(
+                        "Well {} is a segmented grid-independent well, but its WELSEGS keyword "
+                        "must be defined after the corresponding WELTRAJ keyword. Please check "
+                        "the order of the keywords in the input file.", name);
+
+                    throw OpmInputError(msg, handlerContext.keyword.location());
+                }
 
                 auto connections = std::make_shared<WellConnections>(well.getConnections());
                 connections->loadWELTRAJ(record, name, handlerContext.grid,

--- a/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.hpp
+++ b/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.hpp
@@ -24,11 +24,21 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <array>
+#include <optional>
+
+#include <external/resinsight/ReservoirDataModel/RigWellPath.h>
 
 namespace Opm {
 
 //! \brief Obtain a list of grid independent well keyword handlers.
 std::vector<std::pair<std::string,KeywordHandlers::handler_function>> getGridIndependentWellKeywordHandlers();
+
+void initWellPathGeometry(
+    external::cvf::ref<external::RigWellPath>& wellPathGeometry,         
+    const std::array<std::vector<double>, 3>& coords, const std::vector<double>& mds,
+    std::optional<double> top_opt = std::nullopt, std::optional<double> bot_opt = std::nullopt
+);
 
 }
 

--- a/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.hpp
+++ b/opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.hpp
@@ -24,11 +24,35 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <array>
+#include <optional>
+
+#include <external/resinsight/ReservoirDataModel/RigWellPath.h>
 
 namespace Opm {
 
 //! \brief Obtain a list of grid independent well keyword handlers.
 std::vector<std::pair<std::string,KeywordHandlers::handler_function>> getGridIndependentWellKeywordHandlers();
+
+/// Populate a well path geometry from a branch trajectory.
+///
+/// \param[in,out] wellPathGeometry Geometry object to fill with the
+/// trajectory points and measured depths of the requested interval.
+///
+/// \param[in] coords Trajectory X/Y/Z coordinate columns of a single branch.
+///
+/// \param[in] mds Trajectory measured depths of a single branch.
+///
+/// \param[in] top_opt Measured depth at which the interval starts.
+/// Defaults to the start of the branch trajectory.
+///
+/// \param[in] bot_opt Measured depth at which the interval ends.  Defaults
+/// to the end of the branch trajectory.
+void initWellPathGeometry(external::cvf::ref<external::RigWellPath>& wellPathGeometry,
+                          const std::array<std::vector<double>, 3>&  coords,
+                          const std::vector<double>&                 mds,
+                          std::optional<double>                      top_opt = std::nullopt,
+                          std::optional<double>                      bot_opt = std::nullopt);
 
 }
 

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1970,11 +1970,11 @@ void Well::updateSegments(std::shared_ptr<WellSegments> segments_arg)
 
 bool Well::handleWELSEGS(const DeckKeyword& keyword)
 {
-    const auto& connections = this->getConnections();
-    const auto& coords = connections.getCoord();
-    const auto& mds = connections.getMD();
+    const auto& well_connections = this->getConnections();
+    const auto& coords = well_connections.getCoord();
+    const auto& mds = well_connections.getMD();
 
-    if (!connections.empty() && !coords.empty()) {
+    if (!well_connections.empty() && !coords.empty()) {
         throw OpmInputError {
             fmt::format("The WELSEGS keyword for well {} must be defined before "
                         "the corresponding COMPTRAJ keyword.", this->name()),

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1920,35 +1920,31 @@ void Well::updateSegments(std::shared_ptr<WellSegments> segments_arg)
 
 bool Well::handleWELSEGS(const DeckKeyword& keyword)
 {
+    const auto& cons = this->getConnections();
+    const auto& coords = cons.getCoord();
+    const auto& md = cons.getMD();
+
+    if (!cons.empty() and !coords.empty()) {
+        throw OpmInputError {fmt::format("The WELSEGS keyword for well {} must be defined before "
+                                         "the corresponding COMPTRAJ keyword.",
+                                         this->name()),
+                             keyword.location()};
+    }
+
     if (this->segments != nullptr) {
         auto new_segments = std::make_shared<WellSegments>(*this->segments);
-        new_segments->loadWELSEGS(keyword, *unit_system);
+        new_segments->loadWELSEGS(keyword, coords, md, *unit_system);
 
         this->updateSegments(std::move(new_segments));
     }
     else {
         auto well_segments = std::make_shared<WellSegments>();
-        well_segments->loadWELSEGS(keyword, *unit_system);
+        well_segments->loadWELSEGS(keyword, coords, md, *unit_system);
 
         this->updateSegments(std::move(well_segments));
     }
 
     return true;
-}
-
-void Well::addWellSegmentsFromLengthsAndDepths(const std::vector<std::pair<double, double>>& lengths_and_depths, double diameter, const KeywordLocation& location)
-{
-    if (this->segments == nullptr || this->segments->empty()) {
-        throw OpmInputError{
-            fmt::format("The WELSEGS keyword must be specified for well {} "
-                        "before creating segments through the COMPTRAJ keyword.", this->name()),
-            location
-        };
-    }
-    auto new_segments = std::make_shared<WellSegments>(*this->segments);
-    new_segments->addWellSegmentsFromLengthsAndDepths(this->name(), lengths_and_depths, diameter, *unit_system);
-
-    this->updateSegments(std::move(new_segments));
 }
 
 bool Well::updatePVTTable(std::optional<int> pvt_table_)

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1970,15 +1970,19 @@ void Well::updateSegments(std::shared_ptr<WellSegments> segments_arg)
 
 bool Well::handleWELSEGS(const DeckKeyword& keyword)
 {
+    const auto& connections = this->getConnections();
+    const auto& coords = connections.getCoord();
+    const auto& mds = connections.getMD();
+
     if (this->segments != nullptr) {
         auto new_segments = std::make_shared<WellSegments>(*this->segments);
-        new_segments->loadWELSEGS(keyword, *unit_system);
+        new_segments->loadWELSEGS(keyword, coords, mds, *unit_system);
 
         this->updateSegments(std::move(new_segments));
     }
     else {
         auto well_segments = std::make_shared<WellSegments>();
-        well_segments->loadWELSEGS(keyword, *unit_system);
+        well_segments->loadWELSEGS(keyword, coords, mds, *unit_system);
 
         this->updateSegments(std::move(well_segments));
     }

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1974,6 +1974,14 @@ bool Well::handleWELSEGS(const DeckKeyword& keyword)
     const auto& coords = connections.getCoord();
     const auto& mds = connections.getMD();
 
+    if (!connections.empty() && !coords.empty()) {
+        throw OpmInputError {
+            fmt::format("The WELSEGS keyword for well {} must be defined before "
+                        "the corresponding COMPTRAJ keyword.", this->name()),
+            keyword.location()
+        };
+    }
+
     if (this->segments != nullptr) {
         auto new_segments = std::make_shared<WellSegments>(*this->segments);
         new_segments->loadWELSEGS(keyword, coords, mds, *unit_system);
@@ -1988,21 +1996,6 @@ bool Well::handleWELSEGS(const DeckKeyword& keyword)
     }
 
     return true;
-}
-
-void Well::addWellSegmentsFromLengthsAndDepths(const std::vector<std::pair<double, double>>& lengths_and_depths, double diameter, const KeywordLocation& location)
-{
-    if (this->segments == nullptr || this->segments->empty()) {
-        throw OpmInputError{
-            fmt::format("The WELSEGS keyword must be specified for well {} "
-                        "before creating segments through the COMPTRAJ keyword.", this->name()),
-            location
-        };
-    }
-    auto new_segments = std::make_shared<WellSegments>(*this->segments);
-    new_segments->addWellSegmentsFromLengthsAndDepths(this->name(), lengths_and_depths, diameter, *unit_system);
-
-    this->updateSegments(std::move(new_segments));
 }
 
 bool Well::updatePVTTable(std::optional<int> pvt_table_)

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -612,7 +612,6 @@ public:
     void setFilterConc(const UDAValue& conc);
     double evalFilterConc(const SummaryState& summary_sate) const;
     bool applyGlobalWPIMULT(double scale_factor);
-    void addWellSegmentsFromLengthsAndDepths(const std::vector<std::pair<double, double>>& lengths_and_depths, double diameter, const KeywordLocation& location);
 
     ProductionControls productionControls(const SummaryState& st) const;
     InjectionControls injectionControls(const SummaryState& st) const;

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -615,7 +615,6 @@ public:
     void setFilterConc(const UDAValue& conc);
     double evalFilterConc(const SummaryState& summary_sate) const;
     bool applyGlobalWPIMULT(double scale_factor);
-    void addWellSegmentsFromLengthsAndDepths(const std::vector<std::pair<double, double>>& lengths_and_depths, double diameter, const KeywordLocation& location);
 
     ProductionControls productionControls(const SummaryState& st) const;
     InjectionControls injectionControls(const SummaryState& st) const;

--- a/opm/input/eclipse/Schedule/Well/WellCompletionKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellCompletionKeywordHandlers.cpp
@@ -20,8 +20,10 @@
 #include "WellCompletionKeywordHandlers.hpp"
 
 #include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
+#include <opm/input/eclipse/Schedule/ScheduleStatic.hpp>
 #include <opm/input/eclipse/Schedule/Well/WDFAC.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
@@ -44,6 +46,27 @@ namespace {
 
 using namespace Opm;
 
+/// Amend \p msg with a hint about restart support when the run was resumed
+/// from a restart file.
+///
+/// A restart-restored connection carries no branch information, so a well
+/// that originally used COMPTRAJ looks like a COMPDAT well after a restart.
+/// The reverse mixing guard therefore cannot fire in that case; when it does
+/// fire the deck really does mix the two, but say so anyway for symmetry with
+/// the COMPTRAJ/WELTRAJ side.
+std::string appendRestartHint(std::string msg, const HandlerContext& handlerContext)
+{
+    const auto restart_step = handlerContext.static_schedule().rst_info.report_step;
+
+    if (restart_step != 0) {
+        msg += fmt::format(" This may be caused by continuing this well after a restart "
+                           "(resumed at report step {}) - restarting is not supported "
+                           "for trajectory-based (COMPTRAJ/WELTRAJ) wells.", restart_step);
+    }
+
+    return msg;
+}
+
 template <typename CompdatKwHandler>
 void handleCOMPDATX(HandlerContext&    handlerContext,
                     CompdatKwHandler&& compdatKwHandler)
@@ -64,6 +87,16 @@ void handleCOMPDATX(HandlerContext&    handlerContext,
             if (newConnsInserted) {
                 connPos->second = std::make_shared<WellConnections>
                     (well.getConnections());
+
+                if (!connPos->second->empty() && (*connPos->second)[0].fromTrajectory()) {
+                    const auto msg = appendRestartHint(
+                        fmt::format("Well {} already has COMPTRAJ-defined connections and "
+                                    "cannot also be defined using COMPDAT. A well must use "
+                                    "either COMPDAT or COMPTRAJ, never both.", wname),
+                        handlerContext);
+
+                    throw OpmInputError(msg, handlerContext.keyword.location());
+                }
             }
 
             // Connections opened/shut by this record; used to raise/clear

--- a/opm/input/eclipse/Schedule/Well/WellCompletionKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellCompletionKeywordHandlers.cpp
@@ -20,8 +20,10 @@
 #include "WellCompletionKeywordHandlers.hpp"
 
 #include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
+#include <opm/input/eclipse/Schedule/ScheduleStatic.hpp>
 #include <opm/input/eclipse/Schedule/Well/WDFAC.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
@@ -44,6 +46,19 @@ namespace {
 
 using namespace Opm;
 
+std::string appendRestartHint(std::string msg, const HandlerContext& handlerContext)
+{
+    const auto restart_step = handlerContext.static_schedule().rst_info.report_step;
+    if (restart_step != 0) {
+        msg += fmt::format(
+            " This may be caused by continuing this well after a restart "
+            "(resumed at report step {}) - restarting is not supported "
+            "for trajectory-based (COMPTRAJ/WELTRAJ) wells.", restart_step);
+    }
+
+    return msg;
+}
+
 template <typename CompdatKwHandler>
 void handleCOMPDATX(HandlerContext&    handlerContext,
                     CompdatKwHandler&& compdatKwHandler)
@@ -64,6 +79,14 @@ void handleCOMPDATX(HandlerContext&    handlerContext,
             if (newConnsInserted) {
                 connPos->second = std::make_shared<WellConnections>
                     (well.getConnections());
+
+                if (!connPos->second->empty() && (*connPos->second)[0].fromTrajectory()) {
+                    const auto msg = appendRestartHint(fmt::format(
+                        "Well {} already has COMPTRAJ-defined connections and cannot "
+                        "also be defined using COMPDAT. A well must use either COMPDAT "
+                        "or COMPTRAJ, never both.", wname), handlerContext);
+                    throw OpmInputError(msg, handlerContext.keyword.location());
+                }
             }
 
             // Connections opened/shut by this record; used to raise/clear

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -23,6 +23,7 @@
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/common/utility/ActiveGridCells.hpp>
 
@@ -61,6 +62,7 @@
 #include <cstddef>
 #include <numbers>
 #include <optional>
+#include <ranges>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -718,6 +720,24 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
         using Kw = ParserKeywords::COMPTRAJ;
 
         const auto branch = record.getItem<Kw::BRANCH_NUMBER>().get<int>(0);
+
+        if (branch <= 0) {
+            throw OpmInputError {
+                fmt::format("Branch number {} for well {} must be a positive "
+                            "integer. Branch 1 is the main stem.", branch, wname),
+                location
+            };
+        }
+
+        if (! this->coord.contains(branch)) {
+            throw OpmInputError {
+                fmt::format("Well {} has no WELTRAJ trajectory for branch {}. "
+                            "Every branch referenced by COMPTRAJ must first be "
+                            "defined by WELTRAJ.", wname, branch),
+                location
+            };
+        }
+
         const auto& perf_top = record.getItem<Kw::PERF_TOP>();
         const auto& perf_bot = record.getItem<Kw::PERF_BOT>();
 
@@ -860,6 +880,23 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                 throw std::logic_error(msg);
             }
 
+            if (! (std::isfinite(ctf_props.CF) && std::isfinite(ctf_props.Kh) &&
+                   (ctf_props.CF >= 0.0) && (ctf_props.Kh >= 0.0)))
+            {
+                // Degenerate cell geometry, e.g. a zero thickness cell.  A
+                // single such contribution would poison the combined CTF of
+                // every branch reaching this cell, so leave it out entirely.
+                OpmLog::warning(fmt::format(R"(Problem with COMPTRAJ keyword
+In {} line {}
+Branch {} of well {} yields a non-representable connection transmissibility factor ({}) or Kh ({}) in cell ({},{},{}). The connection will be ignored)",
+                                            location.filename, location.lineno,
+                                            branch, wname,
+                                            ctf_props.CF, ctf_props.Kh,
+                                            ijk[0] + 1, ijk[1] + 1, ijk[2] + 1));
+
+                continue;
+            }
+
             // Todo: check what needs to be done for polymerMW module, see
             // loadCOMPDAT used by the PolymerMW module
 
@@ -903,6 +940,20 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                 auto branch_ctf = prev->comptrajBranchCTFs();
                 const auto prev_ctf = prev->ctfProperties();
 
+                if ((state == Connection::State::SHUT) &&
+                    std::ranges::any_of(branches, [branch](const int b)
+                                        { return b != branch; }))
+                {
+                    // There is only one state per connection, so shutting a
+                    // cell through one branch also shuts off the others.
+                    OpmLog::warning(fmt::format(R"(Problem with COMPTRAJ keyword
+In {} line {}
+Branch {} of well {} shuts cell ({},{},{}), which is also perforated by other branches of the same well. The cell will be shut for all of them)",
+                                                location.filename, location.lineno,
+                                                branch, wname,
+                                                ijk[0] + 1, ijk[1] + 1, ijk[2] + 1));
+                }
+
                 *prev = Connection {
                     ijk[0], ijk[1], ijk[2],
                     cell.global_index, compl_num,
@@ -926,6 +977,15 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                                       [[maybe_unused]] const KeywordLocation& location)
     {
         int branch = record.getItem("BRANCH_NUMBER").get<int>(0);
+
+        if (branch <= 0) {
+            throw OpmInputError {
+                fmt::format("Branch number {} for well {} must be a positive "
+                            "integer. Branch 1 is the main stem.", branch, wname),
+                location
+            };
+        }
+
         double x = record.getItem("X").getSIDouble(0);
         double y = record.getItem("Y").getSIDouble(0);
 

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -886,7 +886,7 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                                     noConn, 0,
                                     defaultSatTable);
 
-                this->m_connections.back().resetComptrajBranch(branch);
+                this->m_connections.back().addComptrajBranch(branch, ctf_props);
             }
             else {
                 const auto compl_num = prev->complnum();
@@ -895,17 +895,27 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                 const auto perf_range = prev->perf_range();
                 const auto thermal_length = prev->thermalLength();
 
+                // The connection is rebuilt so that this record's state and
+                // saturation table win; its branch bookkeeping has to survive
+                // that, since the branches perforating this cell are
+                // cumulative.
+                auto branches = prev->comptrajBranches();
+                auto branch_ctf = prev->comptrajBranchCTFs();
+                const auto prev_ctf = prev->ctfProperties();
+
                 *prev = Connection {
                     ijk[0], ijk[1], ijk[2],
                     cell.global_index, compl_num,
                     state, direction, ctf_kind, satTableId,
-                    cell.depth, ctf_props,
+                    cell.depth, prev_ctf,
                     css_ind, defaultSatTable
                 };
 
                 prev->updateSegment(conSegNo, cell.depth, thermal_length,
                                     css_ind, perf_range);
-                prev->resetComptrajBranch(branch);
+
+                prev->setComptrajBranches(std::move(branches), std::move(branch_ctf));
+                prev->addComptrajBranch(branch, ctf_props);
             }
         }
     }

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -887,6 +887,7 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                                     direction, ctf_kind,
                                     noConn, 0,
                                     defaultSatTable);
+                this->m_connections.back().resetComptrajBranch(branch);
             }
             else {
                 const auto compl_num = prev->complnum();
@@ -905,6 +906,7 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
 
                 prev->updateSegment(conSegNo, cell.depth, thermal_length,
                                     css_ind, *perf_range);
+                prev->resetComptrajBranch(branch);
             }
         }
     }

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -904,7 +904,7 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                 };
 
                 prev->updateSegment(conSegNo, cell.depth, thermal_length,
-                                    css_ind, *perf_range);
+                                    css_ind, perf_range);
                 prev->resetComptrajBranch(branch);
             }
         }

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -25,7 +25,6 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <opm/common/utility/ActiveGridCells.hpp>
-#include <opm/common/utility/numeric/linearInterpolation.hpp>
 
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
@@ -46,11 +45,12 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 
+#include <opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.hpp>
+
 #include <external/resinsight/LibCore/cvfVector3.h>
 #include <external/resinsight/ReservoirDataModel/RigHexIntersectionTools.h>
 #include <external/resinsight/ReservoirDataModel/RigWellLogExtractionTools.h>
 #include <external/resinsight/ReservoirDataModel/RigWellLogExtractor.h>
-#include <external/resinsight/ReservoirDataModel/RigWellPath.h>
 
 #include "../WellTraj/RigEclipseWellLogExtractor.hpp"
 #include "WellTrajInfo.hpp"
@@ -750,39 +750,10 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
         // Get the grid
         const auto& ecl_grid = grid.get_grid();
 
-        std::vector<external::cvf::Vec3d> points;
-        std::vector<double> measured_depths;
-
-        const auto& branch_coord = this->coord.at(branch);
-        const auto& branch_md = this->md.at(branch);
-
         // Calulate the x,y,z coordinates of the begin and end of a perforation
-        const auto m_top = perf_top.getSIDouble(0);
-        const auto m_bot = perf_bot.getSIDouble(0);
-        external::cvf::Vec3d p_top, p_bot;
-        for (std::size_t i = 0; i < 3 ; ++i) {
-            p_top[i] = linearInterpolation(branch_md, branch_coord[i], m_top);
-            p_bot[i] = linearInterpolation(branch_md, branch_coord[i], m_bot);
-        }
-        points.push_back(p_top);
-        measured_depths.push_back(m_top);
-
-        points.reserve(branch_coord[0].size());
-        measured_depths.reserve(branch_coord[0].size());
-        for (std::size_t i = 0; i < branch_coord[0].size(); ++i) {
-            if (branch_md[i] > m_top and branch_md[i] < m_bot) {
-                points.push_back(external::cvf::Vec3d(branch_coord[0][i],
-                                                      branch_coord[1][i],
-                                                      branch_coord[2][i]));
-                measured_depths.push_back(branch_md[i]);
-            }
-        }
-
-        points.push_back(p_bot);
-        measured_depths.push_back(m_bot);
-
-        wellTraj.wellPathGeometry->setWellPathPoints(points);
-        wellTraj.wellPathGeometry->setMeasuredDepths(measured_depths);
+        initWellPathGeometry(wellTraj.wellPathGeometry,
+                             this->coord.at(branch), this->md.at(branch),
+                             perf_top.getSIDouble(0), perf_bot.getSIDouble(0));
 
         external::cvf::ref<external::RigEclipseWellLogExtractor> e {
             new external::RigEclipseWellLogExtractor {

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -885,6 +885,8 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                                     direction, ctf_kind,
                                     noConn, 0,
                                     defaultSatTable);
+
+                this->m_connections.back().resetComptrajBranch(branch);
             }
             else {
                 const auto compl_num = prev->complnum();
@@ -903,6 +905,7 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
 
                 prev->updateSegment(conSegNo, cell.depth, thermal_length,
                                     css_ind, *perf_range);
+                prev->resetComptrajBranch(branch);
             }
         }
     }

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -789,6 +789,12 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
         // exit cell face point and connection length.
         wellTraj.intersections = e->cellIntersectionInfosAlongWellPath();
 
+        // Intersections that do not become a connection.  The caller derives
+        // this record's COMPSEGS records from the intersections, and every one
+        // of those has to find its connection, so the two lists are kept in
+        // step.
+        auto skipped = std::vector<std::size_t>{};
+
         for (std::size_t is = 0; is < wellTraj.intersections.size(); ++is) {
             const auto ijk = ecl_grid->getIJK(wellTraj.intersections[is].globCellIndex);
 
@@ -816,6 +822,7 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
                                              ijk[2] + 1, wname);
                 OpmLog::warning(msg);
 
+                skipped.push_back(is);
                 continue;
             }
 
@@ -894,6 +901,7 @@ Branch {} of well {} yields a non-representable connection transmissibility fact
                                             ctf_props.CF, ctf_props.Kh,
                                             ijk[0] + 1, ijk[1] + 1, ijk[2] + 1));
 
+                skipped.push_back(is);
                 continue;
             }
 
@@ -968,6 +976,10 @@ Branch {} of well {} shuts cell ({},{},{}), which is also perforated by other br
                 prev->setComptrajBranches(std::move(branches), std::move(branch_ctf));
                 prev->addComptrajBranch(branch, ctf_props);
             }
+        }
+
+        for (const auto is : std::views::reverse(skipped)) {
+            wellTraj.intersections.erase(wellTraj.intersections.begin() + is);
         }
     }
 

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -787,16 +787,16 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
 
         // This gives the intersected grid cells IJK, cell face entrance &
         // exit cell face point and connection length.
-        wellTraj.intersections = e->cellIntersectionInfosAlongWellPath();
+        const auto intersections = e->cellIntersectionInfosAlongWellPath();
 
-        // Intersections that do not become a connection.  The caller derives
-        // this record's COMPSEGS records from the intersections, and every one
-        // of those has to find its connection, so the two lists are kept in
-        // step.
-        auto skipped = std::vector<std::size_t>{};
+        // The caller derives this record's COMPSEGS records from the
+        // intersections and every one of those has to find its connection, so
+        // only the intersections that become one are kept.
+        wellTraj.intersections.clear();
+        wellTraj.intersections.reserve(intersections.size());
 
-        for (std::size_t is = 0; is < wellTraj.intersections.size(); ++is) {
-            const auto ijk = ecl_grid->getIJK(wellTraj.intersections[is].globCellIndex);
+        for (std::size_t is = 0; is < intersections.size(); ++is) {
+            const auto ijk = ecl_grid->getIJK(intersections[is].globCellIndex);
 
             // When using WELTRAJ & COMPTRAJ one may use default settings in
             // WELSPECS for headI/J and let the headI/J be calculated by the
@@ -822,7 +822,6 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
                                              ijk[2] + 1, wname);
                 OpmLog::warning(msg);
 
-                skipped.push_back(is);
                 continue;
             }
 
@@ -859,7 +858,7 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
                 ctf_kind = ::Opm::Connection::CTFKind::Defaulted;
 
                 const auto& connection_vector =
-                    wellTraj.intersections[is].intersectionLengthsInCellCS;
+                    intersections[is].intersectionLengthsInCellCS;
 
                 const auto perm_thickness =
                     permThickness(connection_vector, cell_perm, props->ntg);
@@ -901,7 +900,6 @@ Branch {} of well {} yields a non-representable connection transmissibility fact
                                             ctf_props.CF, ctf_props.Kh,
                                             ijk[0] + 1, ijk[1] + 1, ijk[2] + 1));
 
-                skipped.push_back(is);
                 continue;
             }
 
@@ -976,10 +974,8 @@ Branch {} of well {} shuts cell ({},{},{}), which is also perforated by other br
                 prev->setComptrajBranches(std::move(branches), std::move(branch_ctf));
                 prev->addComptrajBranch(branch, ctf_props);
             }
-        }
 
-        for (const auto is : std::views::reverse(skipped)) {
-            wellTraj.intersections.erase(wellTraj.intersections.begin() + is);
+            wellTraj.intersections.push_back(intersections[is]);
         }
     }
 

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -715,18 +715,19 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
                                   const KeywordLocation& location,
                                   WellTrajInfo&          wellTraj)
     {
-        if (this->coord[0].size() == 0) return;  // No path.
+        using Kw = ParserKeywords::COMPTRAJ;
 
-        const auto& perf_top = record.getItem("PERF_TOP");
-        const auto& perf_bot = record.getItem("PERF_BOT");
+        const auto branch = record.getItem<Kw::BRANCH_NUMBER>().get<int>(0);
+        const auto& perf_top = record.getItem<Kw::PERF_TOP>();
+        const auto& perf_bot = record.getItem<Kw::PERF_BOT>();
 
-        const auto& CFItem = record.getItem("CONNECTION_TRANSMISSIBILITY_FACTOR");
-        const auto& diameterItem = record.getItem("DIAMETER");
-        const auto& KhItem = record.getItem("Kh");
-        const auto skin_factor = record.getItem("SKIN").getSIDouble(0);
-        const auto d_factor = record.getItem("D_FACTOR").getSIDouble(0);
-        const auto& satTableIdItem = record.getItem("SAT_TABLE");
-        const auto state = Connection::StateFromString(record.getItem("STATE").getTrimmedString(0));
+        const auto& CFItem = record.getItem<Kw::CONNECTION_TRANSMISSIBILITY_FACTOR>();
+        const auto& diameterItem = record.getItem<Kw::DIAMETER>();
+        const auto& KhItem = record.getItem<Kw::Kh>();
+        const auto skin_factor = record.getItem<Kw::SKIN>().getSIDouble(0);
+        const auto d_factor = record.getItem<Kw::D_FACTOR>().getSIDouble(0);
+        const auto& satTableIdItem = record.getItem<Kw::SAT_TABLE>();
+        const auto state = Connection::StateFromString(record.getItem<Kw::STATE>().getTrimmedString(0));
 
         int satTableId = -1;
         bool defaultSatTable = true;
@@ -752,23 +753,28 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
         std::vector<external::cvf::Vec3d> points;
         std::vector<double> measured_depths;
 
+        const auto& branch_coord = this->coord.at(branch);
+        const auto& branch_md = this->md.at(branch);
+
         // Calulate the x,y,z coordinates of the begin and end of a perforation
         const auto m_top = perf_top.getSIDouble(0);
         const auto m_bot = perf_bot.getSIDouble(0);
         external::cvf::Vec3d p_top, p_bot;
         for (std::size_t i = 0; i < 3 ; ++i) {
-            p_top[i] = linearInterpolation(this->md, this->coord[i], m_top);
-            p_bot[i] = linearInterpolation(this->md, this->coord[i], m_bot);
+            p_top[i] = linearInterpolation(branch_md, branch_coord[i], m_top);
+            p_bot[i] = linearInterpolation(branch_md, branch_coord[i], m_bot);
         }
         points.push_back(p_top);
         measured_depths.push_back(m_top);
 
-        points.reserve(this->coord[0].size());
-        measured_depths.reserve(this->coord[0].size());
-        for (std::size_t i = 0; i < coord[0].size(); ++i) {
-            if (this->md[i] > m_top and this->md[i] < m_bot) {
-                points.push_back(external::cvf::Vec3d(coord[0][i], coord[1][i], coord[2][i]));
-                measured_depths.push_back(this->md[i]);
+        points.reserve(branch_coord[0].size());
+        measured_depths.reserve(branch_coord[0].size());
+        for (std::size_t i = 0; i < branch_coord[0].size(); ++i) {
+            if (branch_md[i] > m_top and branch_md[i] < m_bot) {
+                points.push_back(external::cvf::Vec3d(branch_coord[0][i],
+                                                      branch_coord[1][i],
+                                                      branch_coord[2][i]));
+                measured_depths.push_back(branch_md[i]);
             }
         }
 
@@ -800,8 +806,8 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
             // trajectory data.
             //
             // If these defaults are used the headI/J are set to the first
-            // intersection.
-            if (is == 0) {
+            // intersection of the main branch.
+            if (branch == 1 && is == 0) {
                 if (this->headI < 0) { this->headI = ijk[0]; }
                 if (this->headJ < 0) { this->headJ = ijk[1]; }
             }
@@ -935,6 +941,7 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                                       [[maybe_unused]] const ScheduleGrid&    grid,
                                       [[maybe_unused]] const KeywordLocation& location)
     {
+        int branch = record.getItem("BRANCH_NUMBER").get<int>(0);
         double x = record.getItem("X").getSIDouble(0);
         double y = record.getItem("Y").getSIDouble(0);
 
@@ -944,11 +951,11 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
             mapaxes->inv_transform(x, y);
         }
 
-        this->coord[0].push_back(x);
-        this->coord[1].push_back(y);
-        this->coord[2].push_back(record.getItem("TVD").getSIDouble(0));
+        this->coord[branch][0].push_back(x);
+        this->coord[branch][1].push_back(y);
+        this->coord[branch][2].push_back(record.getItem("TVD").getSIDouble(0));
 
-        this->md.push_back(record.getItem("MD").getSIDouble(0));
+        this->md[branch].push_back(record.getItem("MD").getSIDouble(0));
     }
 
     void WellConnections::applyDFactorCorrelation(const ScheduleGrid& grid,
@@ -1162,9 +1169,14 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
         return this->headJ;
     }
 
-    const std::vector<double>& WellConnections::getMD() const
+    const std::map<int, std::vector<double>>& WellConnections::getMD() const
     {
         return this->md;
+    }
+
+    const std::map<int, std::array<std::vector<double>, 3>>& WellConnections::getCoord() const
+    {
+        return this->coord;
     }
 
     std::optional<int>

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -25,7 +25,6 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <opm/common/utility/ActiveGridCells.hpp>
-#include <opm/common/utility/numeric/linearInterpolation.hpp>
 
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
@@ -46,11 +45,12 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 
+#include <opm/input/eclipse/Schedule/Well/GridIndependentWellKeywordHandlers.hpp>
+
 #include <external/resinsight/LibCore/cvfVector3.h>
 #include <external/resinsight/ReservoirDataModel/RigHexIntersectionTools.h>
 #include <external/resinsight/ReservoirDataModel/RigWellLogExtractionTools.h>
 #include <external/resinsight/ReservoirDataModel/RigWellLogExtractor.h>
-#include <external/resinsight/ReservoirDataModel/RigWellPath.h>
 
 #include "../WellTraj/RigEclipseWellLogExtractor.hpp"
 #include "WellTrajInfo.hpp"
@@ -292,6 +292,7 @@ Connection ({},{},{}) (direction '{}') for well {} ignored because
 
         return connection_factor;
     }
+
 
 } // anonymous namespace
 
@@ -716,17 +717,20 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
                                   WellTrajInfo&          wellTraj)
     {
         if (this->coord[0].size() == 0) return;  // No path.
+        
+        using Kw = ParserKeywords::COMPTRAJ;
 
-        const auto& perf_top = record.getItem("PERF_TOP");
-        const auto& perf_bot = record.getItem("PERF_BOT");
+        const auto& branch = record.getItem<Kw::BRANCH_NUMBER>().get<int>(0);
+        const auto& perf_top = record.getItem<Kw::PERF_TOP>();
+        const auto& perf_bot = record.getItem<Kw::PERF_BOT>();
 
-        const auto& CFItem = record.getItem("CONNECTION_TRANSMISSIBILITY_FACTOR");
-        const auto& diameterItem = record.getItem("DIAMETER");
-        const auto& KhItem = record.getItem("Kh");
-        const auto skin_factor = record.getItem("SKIN").getSIDouble(0);
-        const auto d_factor = record.getItem("D_FACTOR").getSIDouble(0);
-        const auto& satTableIdItem = record.getItem("SAT_TABLE");
-        const auto state = Connection::StateFromString(record.getItem("STATE").getTrimmedString(0));
+        const auto& CFItem = record.getItem<Kw::CONNECTION_TRANSMISSIBILITY_FACTOR>();
+        const auto& diameterItem = record.getItem<Kw::DIAMETER>();
+        const auto& KhItem = record.getItem<Kw::Kh>();
+        const auto skin_factor = record.getItem<Kw::SKIN>().getSIDouble(0);
+        const auto d_factor = record.getItem<Kw::D_FACTOR>().getSIDouble(0);
+        const auto& satTableIdItem = record.getItem<Kw::SAT_TABLE>();
+        const auto state = Connection::StateFromString(record.getItem<Kw::STATE>().getTrimmedString(0));
 
         int satTableId = -1;
         bool defaultSatTable = true;
@@ -749,34 +753,9 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
         // Get the grid
         const auto& ecl_grid = grid.get_grid();
 
-        std::vector<external::cvf::Vec3d> points;
-        std::vector<double> measured_depths;
-
         // Calulate the x,y,z coordinates of the begin and end of a perforation
-        const auto m_top = perf_top.getSIDouble(0);
-        const auto m_bot = perf_bot.getSIDouble(0);
-        external::cvf::Vec3d p_top, p_bot;
-        for (std::size_t i = 0; i < 3 ; ++i) {
-            p_top[i] = linearInterpolation(this->md, this->coord[i], m_top);
-            p_bot[i] = linearInterpolation(this->md, this->coord[i], m_bot);
-        }
-        points.push_back(p_top);
-        measured_depths.push_back(m_top);
-
-        points.reserve(this->coord[0].size());
-        measured_depths.reserve(this->coord[0].size());
-        for (std::size_t i = 0; i < coord[0].size(); ++i) {
-            if (this->md[i] > m_top and this->md[i] < m_bot) {
-                points.push_back(external::cvf::Vec3d(coord[0][i], coord[1][i], coord[2][i]));
-                measured_depths.push_back(this->md[i]);
-            }
-        }
-
-        points.push_back(p_bot);
-        measured_depths.push_back(m_bot);
-
-        wellTraj.wellPathGeometry->setWellPathPoints(points);
-        wellTraj.wellPathGeometry->setMeasuredDepths(measured_depths);
+        initWellPathGeometry(wellTraj.wellPathGeometry, this->coord.at(branch), this->md.at(branch), 
+                             perf_top.getSIDouble(0), perf_bot.getSIDouble(0));
 
         external::cvf::ref<external::RigEclipseWellLogExtractor> e {
             new external::RigEclipseWellLogExtractor {
@@ -800,8 +779,8 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
             // trajectory data.
             //
             // If these defaults are used the headI/J are set to the first
-            // intersection.
-            if (is == 0) {
+            // intersection of the main branch.
+            if (branch == 1 && is == 0) {
                 if (this->headI < 0) { this->headI = ijk[0]; }
                 if (this->headJ < 0) { this->headJ = ijk[1]; }
             }
@@ -935,6 +914,7 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                                       [[maybe_unused]] const ScheduleGrid&    grid,
                                       [[maybe_unused]] const KeywordLocation& location)
     {
+        int branch = record.getItem("BRANCH_NUMBER").get<int>(0);
         double x = record.getItem("X").getSIDouble(0);
         double y = record.getItem("Y").getSIDouble(0);
 
@@ -944,11 +924,11 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
             mapaxes->inv_transform(x, y);
         }
 
-        this->coord[0].push_back(x);
-        this->coord[1].push_back(y);
-        this->coord[2].push_back(record.getItem("TVD").getSIDouble(0));
+        this->coord[branch][0].push_back(x);
+        this->coord[branch][1].push_back(y);
+        this->coord[branch][2].push_back(record.getItem("TVD").getSIDouble(0));
 
-        this->md.push_back(record.getItem("MD").getSIDouble(0));
+        this->md[branch].push_back(record.getItem("MD").getSIDouble(0));
     }
 
     void WellConnections::applyDFactorCorrelation(const ScheduleGrid& grid,
@@ -1162,9 +1142,14 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
         return this->headJ;
     }
 
-    const std::vector<double>& WellConnections::getMD() const
+    const std::map<int, std::vector<double>>& WellConnections::getMD() const
     {
         return this->md;
+    }
+
+    const std::map<int, std::array<std::vector<double>, 3>>& WellConnections::getCoord() const
+    {
+        return this->coord;
     }
 
     std::optional<int>

--- a/opm/input/eclipse/Schedule/Well/WellConnections.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.hpp
@@ -21,12 +21,15 @@
 #define CONNECTIONSET_HPP_
 
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+#include <external/resinsight/ReservoirDataModel/RigWellPath.h>
+
 
 #include <array>
 #include <cstddef>
 #include <optional>
 #include <string>
 #include <vector>
+#include <map>
 
 namespace Opm {
     class ActiveGridCells;
@@ -128,7 +131,8 @@ namespace Opm {
 
         int getHeadI() const;
         int getHeadJ() const;
-        const std::vector<double>& getMD() const;
+        const std::map<int, std::vector<double>>& getMD() const;
+        const std::map<int, std::array<std::vector<double>, 3>>& getCoord() const;
         std::size_t size() const;
         bool empty() const;
         std::size_t num_open() const;
@@ -209,8 +213,8 @@ namespace Opm {
         int headJ{0};
         std::vector<Connection> m_connections{};
 
-        std::array<std::vector<double>, 3> coord{};
-        std::vector<double> md{};
+        std::map<int, std::array<std::vector<double>, 3>> coord{};
+        std::map<int, std::vector<double>> md{};
 
         void addConnection(const int i, const int j, const int k,
                            const std::size_t global_index,

--- a/opm/input/eclipse/Schedule/Well/WellConnections.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.hpp
@@ -24,6 +24,7 @@
 
 #include <array>
 #include <cstddef>
+#include <map>
 #include <optional>
 #include <string>
 #include <vector>
@@ -128,7 +129,12 @@ namespace Opm {
 
         int getHeadI() const;
         int getHeadJ() const;
-        const std::vector<double>& getMD() const;
+
+        /// Well trajectory measured depths, keyed by branch number.
+        const std::map<int, std::vector<double>>& getMD() const;
+
+        /// Well trajectory X/Y/Z coordinates, keyed by branch number.
+        const std::map<int, std::array<std::vector<double>, 3>>& getCoord() const;
         std::size_t size() const;
         bool empty() const;
         std::size_t num_open() const;
@@ -209,8 +215,8 @@ namespace Opm {
         int headJ{0};
         std::vector<Connection> m_connections{};
 
-        std::array<std::vector<double>, 3> coord{};
-        std::vector<double> md{};
+        std::map<int, std::array<std::vector<double>, 3>> coord{};
+        std::map<int, std::vector<double>> md{};
 
         void addConnection(const int i, const int j, const int k,
                            const std::size_t global_index,

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/W/WELSEGS
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/W/WELSEGS
@@ -96,7 +96,8 @@
       {
         "name": "DEPTH",
         "value_type": "DOUBLE",
-        "dimension": "Length"
+        "dimension": "Length",
+        "default": 0
       },
       {
         "name": "DIAMETER",

--- a/opm/input/eclipse/share/keywords/900_OPM/C/COMPTRAJ
+++ b/opm/input/eclipse/share/keywords/900_OPM/C/COMPTRAJ
@@ -15,7 +15,7 @@
       "name": "BRANCH_NUMBER",
       "value_type": "INT",
       "default": 1,
-      "comment": "Not used"
+      "comment": "Trajectory branch the perforation interval belongs to. Branch 1 is the main stem"
     },
     {
       "item": 3,
@@ -85,8 +85,7 @@
       "item": 13,
       "name": "D_FACTOR",
       "value_type": "DOUBLE",
-      "dimension": "1",
-      "comment": "Not used"
+      "dimension": "1"
     }
   ]
 }

--- a/opm/input/eclipse/share/keywords/900_OPM/W/WELTRAJ
+++ b/opm/input/eclipse/share/keywords/900_OPM/W/WELTRAJ
@@ -14,7 +14,7 @@
       "name": "BRANCH_NUMBER",
       "value_type": "INT",
       "default": 1,
-      "comment": "Not used"
+      "comment": "Branch this trajectory point belongs to. Branch 1 is the main stem"
     },
     {
       "item": 3,

--- a/tests/SPE1CASE1_WELTRAJ_MSW.DATA
+++ b/tests/SPE1CASE1_WELTRAJ_MSW.DATA
@@ -1,156 +1,56 @@
--- This reservoir simulation deck is made available under the Open Database
--- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
--- individual contents of the database are licensed under the Database Contents
--- License: http://opendatacommons.org/licenses/dbcl/1.0/
-
--- Copyright (C) 2023 Equinor
-
--- This simulation is based on the data given in
--- 'Comparison of Solutions to a Three-Dimensional
--- Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
--- Journal of Petroleum Technology, January 1981
-
--- Note: This is a modified version of SPE1CASE1
--- This model specifies the well trajectories independent of grid indexes
--- This model use keywords WELTRAJ and COMPTRAJ instead of COMPDAT
--- This model generates multi-segment wells from WELSEGS without segment structure
-
-
----------------------------------------------------------------------------
------------------------- SPE1 - CASE 1 ------------------------------------
----------------------------------------------------------------------------
-
 RUNSPEC
--- -------------------------------------------------------------------------
-
 TITLE
-   SPE1 - CASE 1
-
+  SPE1 - CASE 1
 DIMENS
-   10 10 3 /
-
--- The number of equilibration regions is inferred from the EQLDIMS
--- keyword.
+  10 10 3 /
 EQLDIMS
 /
-
--- The number of PVTW tables is inferred from the TABDIMS keyword;
--- when no data is included in the keyword the default values are used.
 TABDIMS
 /
-
+WSEGDIMS
+  2 10 1 1 /
 OIL
 GAS
 WATER
 DISGAS
--- As seen from figure 4 in Odeh, GOR is increasing with time,
--- which means that dissolved gas is present
-
 FIELD
-
 START
-   1 'JAN' 2015 /
-
+  1 'JAN' 2015 /
 WELLDIMS
--- Item 1: maximum number of wells in the model
--- 	   - there are two wells in the problem; injector and producer
--- Item 2: maximum number of grid blocks connected to any one well
--- 	   - must be one as the wells are located at specific grid blocks
--- Item 3: maximum number of groups in the model
--- 	   - we are dealing with only one 'group'
--- Item 4: maximum number of wells in any one group
--- 	   - there must be two wells in a group as there are two wells in total
-   2 9 1 2 /
-
+  2 9 1 2 /
 UNIFIN
 UNIFOUT
-
 GRID
-
--- The INIT keyword is used to request an .INIT file. The .INIT file
--- is written before the simulation actually starts, and contains grid
--- properties and saturation tables as inferred from the input
--- deck. There are no other keywords which can be used to configure
--- exactly what is written to the .INIT file.
 INIT
-
--- -------------------------------------------------------------------------
 MAPUNITS
 'FEET' /
-
-MAPAXES
-2000.0 3100.0
+MAPAXES 
+2000.0 3100.0 
 2000.0 3000.0
-2100.0 3000 0  /
-
-DX
--- There are in total 300 cells with length 1000ft in x-direction
-   	300*1000 /
+2100.0 3000 0  / 
+DX 
+  	300*1000 /
 DY
--- There are in total 300 cells with length 1000ft in y-direction
 	300*1000 /
 DZ
--- The layers are 20, 30 and 50 ft thick, in each layer there are 100 cells
 	100*20 100*30 100*50 /
-
 TOPS
--- The depth of the top of each grid block
 	100*8325 /
-
 PORO
--- Constant porosity of 0.3 throughout all 300 grid cells
-   	300*0.3 /
-
+  	300*0.3 /
 PERMX
--- The layers have perm. 500mD, 50mD and 200mD, respectively.
 	100*500 100*50 100*200 /
-
 PERMY
--- Equal to PERMX
 	100*500 100*50 100*200 /
-
 PERMZ
--- Cannot find perm. in z-direction in Odeh's paper
--- For the time being, we will assume PERMZ equal to PERMX and PERMY:
 	100*500 100*50 100*200 /
-
-
 PROPS
--- -------------------------------------------------------------------------
-
 PVTW
--- Item 1: pressure reference (psia)
--- Item 2: water FVF (rb per bbl or rb per stb)
--- Item 3: water compressibility (psi^{-1})
--- Item 4: water viscosity (cp)
--- Item 5: water 'viscosibility' (psi^{-1})
-
--- Using values from Norne:
--- In METRIC units:
--- 	277.0 1.038 4.67E-5 0.318 0.0 /
--- In FIELD units:
-    	4017.55 1.038 3.22E-6 0.318 0.0 /
-
+  	4017.55 1.038 3.22E-6 0.318 0.0 /
 ROCK
--- Item 1: reference pressure (psia)
--- Item 2: rock compressibility (psi^{-1})
-
--- Using values from table 1 in Odeh:
 	14.7 3E-6 /
-
 SWOF
--- Column 1: water saturation
---   	     - this has been set to (almost) equally spaced values from 0.12 to 1
--- Column 2: water relative permeability
---   	     - generated from the Corey-type approx. formula
---	       the coeffisient is set to 10e-5, S_{orw}=0 and S_{wi}=0.12
--- Column 3: oil relative permeability when only oil and water are present
---	     - we will use the same values as in column 3 in SGOF.
--- 	       This is not really correct, but since only the first
---	       two values are of importance, this does not really matter
--- Column 4: water-oil capillary pressure (psi)
-
-0.12	0    		 	1	0
+0.12	0  		 	1	0
 0.18	4.64876033057851E-008	1	0
 0.24	0.000000186		0.997	0
 0.3	4.18388429752066E-007	0.98	0
@@ -165,16 +65,7 @@ SWOF
 0.84	6.69421487603306E-006	0	0
 0.91	8.05914256198347E-006	0	0
 1	0.00001			0	0 /
-
-
 SGOF
--- Column 1: gas saturation
--- Column 2: gas relative permeability
--- Column 3: oil relative permeability when oil, gas and connate water are present
--- Column 4: oil-gas capillary pressure (psi)
--- 	     - stated to be zero in Odeh's paper
-
--- Values in column 1-3 are taken from table 3 in Odeh's paper:
 0	0	1	0
 0.001	0	1	0
 0.02	0	0.997	0
@@ -188,35 +79,11 @@ SGOF
 0.5	0.72	0.001	0
 0.6	0.87	0.0001	0
 0.7	0.94	0.000	0
-0.85	0.98	0.000	0
+0.85	0.98	0.000	0 
 0.88	0.984	0.000	0 /
---1.00	1.0	0.000	0 /
--- Warning from Eclipse: first sat. value in SWOF + last sat. value in SGOF
--- 	   		 must not be greater than 1, but Eclipse still runs
--- Flow needs the sum to be excactly 1 so I added a row with gas sat. =  0.88
--- The corresponding krg value was estimated by assuming linear rel. between
--- gas sat. and krw. between gas sat. 0.85 and 1.00 (the last two values given)
-
 DENSITY
--- Density (lb per ft³) at surface cond. of
--- oil, water and gas, respectively (in that order)
-
--- Using values from Norne:
--- In METRIC units:
---      859.5 1033.0 0.854 /
--- In FIELD units:
-      	53.66 64.49 0.0533 /
-
+   	53.66 64.49 0.0533 /
 PVDG
--- Column 1: gas phase pressure (psia)
--- Column 2: gas formation volume factor (rb per Mscf)
--- 	     - in Odeh's paper the units are said to be given in rb per bbl,
--- 	       but this is assumed to be a mistake: FVF-values in Odeh's paper
---	       are given in rb per scf, not rb per bbl. This will be in
---	       agreement with conventions
--- Column 3: gas viscosity (cP)
-
--- Using values from lower right table in Odeh's table 2:
 14.700	166.666	0.008000
 264.70	12.0930	0.009600
 514.70	6.27400	0.011200
@@ -227,14 +94,7 @@ PVDG
 4014.7	0.81100	0.026800
 5014.7	0.64900	0.030900
 9014.7	0.38600	0.047000 /
-
 PVTO
--- Column 1: dissolved gas-oil ratio (Mscf per stb)
--- Column 2: bubble point pressure (psia)
--- Column 3: oil FVF for saturated oil (rb per stb)
--- Column 4: oil viscosity for saturated oil (cP)
-
--- Use values from top left table in Odeh's table 2:
 0.0010	14.7	1.0620	1.0400 /
 0.0905	264.7	1.1500	0.9750 /
 0.1800	514.7	1.2070	0.9100 /
@@ -242,75 +102,27 @@ PVTO
 0.6360	2014.7	1.4350	0.6950 /
 0.7750	2514.7	1.5000	0.6410 /
 0.9300	3014.7	1.5650	0.5940 /
-1.2700	4014.7	1.6950	0.5100
+1.2700	4014.7	1.6950	0.5100 
 	9014.7	1.5790	0.7400 /
-1.6180	5014.7	1.8270	0.4490
-	9014.7	1.7370	0.6310 /
--- It is required to enter data for undersaturated oil for the highest GOR
--- (i.e. the last row) in the PVTO table.
--- In order to fulfill this requirement, values for oil FVF and viscosity
--- at 9014.7psia and GOR=1.618 for undersaturated oil have been approximated:
--- It has been assumed that there is a linear relation between the GOR
--- and the FVF when keeping the pressure constant at 9014.7psia.
--- From Odeh we know that (at 9014.7psia) the FVF is 2.357 at GOR=2.984
--- for saturated oil and that the FVF is 1.579 at GOR=1.27 for undersaturated oil,
--- so it is possible to use the assumption described above.
--- An equivalent approximation for the viscosity has been used.
+1.6180	5014.7	1.8270	0.4490 
+	9014.7	1.7370	0.6310 /	
 /
-
 SOLUTION
--- -------------------------------------------------------------------------
-
 EQUIL
--- Item 1: datum depth (ft)
--- Item 2: pressure at datum depth (psia)
--- 	   - Odeh's table 1 says that initial reservoir pressure is
--- 	     4800 psi at 8400ft, which explains choice of item 1 and 2
--- Item 3: depth of water-oil contact (ft)
--- 	   - chosen to be directly under the reservoir
--- Item 4: oil-water capillary pressure at the water oil contact (psi)
--- 	   - given to be 0 in Odeh's paper
--- Item 5: depth of gas-oil contact (ft)
--- 	   - chosen to be directly above the reservoir
--- Item 6: gas-oil capillary pressure at gas-oil contact (psi)
--- 	   - given to be 0 in Odeh's paper
--- Item 7: RSVD-table
--- Item 8: RVVD-table
--- Item 9: Set to 0 as this is the only value supported by OPM
-
--- Item #: 1 2    3    4 5    6 7 8 9
 	8400 4800 8450 0 8300 0 1 0 0 /
-
 RSVD
--- Dissolved GOR is initially constant with depth through the reservoir.
--- The reason is that the initial reservoir pressure given is higher
----than the bubble point presssure of 4014.7psia, meaning that there is no
--- free gas initially present.
 8300 1.270
 8450 1.270 /
-
 SUMMARY
--- -------------------------------------------------------------------------
-
--- 1a) Oil rate vs time
 FOPR
--- Field Oil Production Rate
-
--- 1b) GOR vs time
 WGOR
--- Well Gas-Oil Ratio
-   'PROD'
+  'PROD'
 /
--- Using FGOR instead of WGOR:PROD results in the same graph
 FGOR
-
--- 2a) Pressures of the cell where the injector and producer are located
 BPR
 1  1  1 /
 10 10 3 /
 /
-
--- 2b) Gas saturation at grid points given in Odeh's paper
 BGSAT
 1  1  1 /
 1  1  2 /
@@ -322,8 +134,6 @@ BGSAT
 10 10 2 /
 10 10 3 /
 /
-
--- In order to compare Eclipse with Flow:
 WBHP
   'INJ'
   'PROD'
@@ -377,71 +187,63 @@ WWPT
   'PROD'
 /
 SCHEDULE
--- -------------------------------------------------------------------------
 RPTSCHED
-	'PRES' 'SGAS' 'RS' WELSPECS /
-
+	'WELSPECS' /
 RPTRST
 	'BASIC=1' /
-
-
--- If no resolution (i.e. case 1), the two following lines must be added:
 DRSDT
  0 /
--- if DRSDT is set to 0, GOR cannot rise and free gas does not
--- dissolve in undersaturated oil -> constant bubble point pressure
 
 WELSPECS
--- Item #: 1	 2	3	4	5	 6
-	'INJ'	  'G1'  9	9	1*	'GAS' /
-	'PROD'	'G1'  2	2	1*	'OIL' /
-/
-
-WELSEGS
-   INJ      8325.00000     8325.00000     1*        ABS         'HF-'    /
-/
-WELSEGS
-   PROD     8325.00000     8325.00000     1*        ABS         'HF-'    /
+   INJ   'G1'     9  9  1*     'GAS'    /
+   PROD  'G1'     2  2  1*     'OIL'    /
 /
 
 WELTRAJ
--- WELL	BRANCH_NO	X		Y	     TVD 	  	MD
-'INJ'   1*  10400	      11600       8325.0      8325.0    /
-'INJ'   1*  10400	      11600       8425.0      8425.0    /
-'PROD'  1*  3400.00     4500.00     8325.00     8325.00  /
-'PROD'  1*  3858.19     4688.67     8374.60     8825.00  /
-'PROD'  1*  5326.76     6005.95     8403.97     10825.00 /
-'PROD'  1*  6500.00     7300.00     8410.00     12571.74 /
+-- WELNAME  IBRANCH  XCORD     YCORD     TVD       MD
+'INJ'  1*  10400	     11600	     8325.0      8325.0  /
+'INJ'  1*  10400	     11600       8425.0      8425.0  /
+'PROD' 1*  3400.00     4500.00     8325.00     8325.00 /
+'PROD' 1*  3858.19     4688.67     8374.60     8822.99 /
+'PROD' 1*  5326.76     6005.95     8403.97     10796.0 /
+'PROD' 1*  6500.00     7300.00     8410.00     12542.7 /
 /
 
---PERF REF is MD or TVD, now assumed MD
-COMPTRAJ
--- WELL	 BRANCH  PERF	    PERF    PERF COMPL STATE SAT    CONN DIAM	KH	SKIN D_FACT
--- NAME  NO      TOP      BOT     REF  NO    --    TABLE  FACT --   --  --   --
-  'INJ'	 1*  8325.0   8425.0    1*  1*	 1*  1*  1*  0.5  1*  0.1  1*  /
-  'PROD' 1*  8325.00  12571.74  1*  1*	 1*  1*  1*  0.5  1*  0.1  1*  /
+WELSEGS
+-- Well     Dep 1          Tlen 1         Vol 1     Len&Dep     PresDrop
+   INJ      8325.00000     8325.00000     1*        ABS         'HF-'    /
+-- First Seg     Last Seg     Branch No     Outlet Seg     Length         Depth Change     Diam        Rough    
+   2             2            1             1              8335.00000     1*       0.50000     0.0000000 /
+   3             3            1             2              8360.00000     1*       0.50000     0.0000000 /
+   4             4            1             3              8400.00000     1*       0.50000     0.0000000 /
+/
+WELSEGS
+-- Well     Dep 1          Tlen 1         Vol 1     Len&Dep     PresDrop
+   PROD     8325.00000     8325.00000     1*        ABS         'HF-'    /
+-- First Seg     Last Seg     Branch No     Outlet Seg     Length          Depth Change     Diam        Rough    
+   2             2            1             1              8425.40132      1*       0.50000     0.0000000 /
+   3             3            1             2              8687.83219      1*       0.50000     0.0000000 /
+   4             4            1             3              8931.68657      1*       0.50000     0.0000000 /
+   5             5            1             4              9151.40517      1*       0.50000     0.0000000 /
+   6             6            1             5              9823.15208      1*       0.50000     0.0000000 /
+   7             7            1             6              10572.04932     1*       0.50000     0.0000000 /
+   8             8            1             7              11292.71446     1*       0.50000     0.0000000 /
+   9             9            1             8              11968.06602     1*       0.50000     0.0000000 /
+   10            10           1             9              12340.26993     1*       0.50000     0.0000000 /
 /
 
-WCONINJE
--- Item #:1	 2	 3	 4	5      6  7
-	'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 9014 /
+COMPTRAJ 
+-- WELNAME IBRANCH  TOP	     BOT       REF  ICOMP  STATUS  SATNUM  CONFACT  DW	 KH	 SKIN  D_FACT
+  'INJ'	   1*       8325.0   8425.0    1*   1*	   1*      1*      1*       0.5  1*  0.1   1*    /
+  'PROD'   1*       8325.00  12542.7   1*   1*	   1*      1*      1*       0.5  1*  0.1   1*    /
 /
--- Stated in Odeh that gas inj. rate (item 5) is 100MMscf per day
--- BHP upper limit (item 7) should not be exceeding the highest
--- pressure in the PVT table=9014.7psia (default is 100 000psia)
 
 WCONPROD
--- Item #:1	2      3     4	   5  9
 	'PROD' 'OPEN' 'ORAT' 20000 4* 1000 /
 /
--- It is stated in Odeh's paper that the maximum oil prod. rate
--- is 20 000stb per day which explains the choice of value in item 4.
--- The items > 4 are defaulted with the exception of item  9,
--- the BHP lower limit, which is given to be 1000psia in Odeh's paper
-
+WCONINJE
+	'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 9014 /
+/
 TSTEP
---Advance the simulater once a month for one year:
 31 /
-
-
 END

--- a/tests/SPE1CASE1_WELTRAJ_MSW.DATA
+++ b/tests/SPE1CASE1_WELTRAJ_MSW.DATA
@@ -13,7 +13,8 @@
 -- Note: This is a modified version of SPE1CASE1
 -- This model specifies the well trajectories independent of grid indexes
 -- This model use keywords WELTRAJ and COMPTRAJ instead of COMPDAT
--- This model generates multi-segment wells from WELSEGS without segment structure
+-- This model generates multi-segment wells whose segment structure is given
+-- by WELSEGS and whose segment node depths are taken from the trajectory
 
 
 ---------------------------------------------------------------------------
@@ -38,6 +39,11 @@ EQLDIMS
 -- when no data is included in the keyword the default values are used.
 TABDIMS
 /
+
+-- Maximum number of multi-segment wells, and of segments and branches
+-- in any one of them.
+WSEGDIMS
+   2 10 1 1 /
 
 OIL
 GAS
@@ -397,21 +403,40 @@ WELSPECS
 	'PROD'	'G1'  2	2	1*	'OIL' /
 /
 
-WELSEGS
-   INJ      8325.00000     8325.00000     1*        ABS         'HF-'    /
-/
-WELSEGS
-   PROD     8325.00000     8325.00000     1*        ABS         'HF-'    /
-/
-
 WELTRAJ
 -- WELL	BRANCH_NO	X		Y	     TVD 	  	MD
 'INJ'   1*  10400	      11600       8325.0      8325.0    /
 'INJ'   1*  10400	      11600       8425.0      8425.0    /
 'PROD'  1*  3400.00     4500.00     8325.00     8325.00  /
-'PROD'  1*  3858.19     4688.67     8374.60     8825.00  /
-'PROD'  1*  5326.76     6005.95     8403.97     10825.00 /
-'PROD'  1*  6500.00     7300.00     8410.00     12571.74 /
+'PROD'  1*  3858.19     4688.67     8374.60     8822.99  /
+'PROD'  1*  5326.76     6005.95     8403.97     10796.0  /
+'PROD'  1*  6500.00     7300.00     8410.00     12542.7  /
+/
+
+-- The segment structure is given explicitly. Segment node depths are
+-- defaulted; they are interpolated from the WELTRAJ trajectory above at
+-- each segment's measured depth, so WELSEGS must follow WELTRAJ.
+WELSEGS
+-- Well     Dep 1          Tlen 1         Vol 1     Len&Dep     PresDrop
+   INJ      8325.00000     8325.00000     1*        ABS         'HF-'    /
+-- First Seg  Last Seg  Branch No  Outlet Seg  Length         Depth Change  Diam       Rough
+   2          2         1          1           8335.00000     1*            0.50000    0.0000000 /
+   3          3         1          2           8360.00000     1*            0.50000    0.0000000 /
+   4          4         1          3           8400.00000     1*            0.50000    0.0000000 /
+/
+WELSEGS
+-- Well     Dep 1          Tlen 1         Vol 1     Len&Dep     PresDrop
+   PROD     8325.00000     8325.00000     1*        ABS         'HF-'    /
+-- First Seg  Last Seg  Branch No  Outlet Seg  Length         Depth Change  Diam       Rough
+   2          2         1          1           8425.40132     1*            0.50000    0.0000000 /
+   3          3         1          2           8687.83219     1*            0.50000    0.0000000 /
+   4          4         1          3           8931.68657     1*            0.50000    0.0000000 /
+   5          5         1          4           9151.40517     1*            0.50000    0.0000000 /
+   6          6         1          5           9823.15208     1*            0.50000    0.0000000 /
+   7          7         1          6           10572.04932    1*            0.50000    0.0000000 /
+   8          8         1          7           11292.71446    1*            0.50000    0.0000000 /
+   9          9         1          8           11968.06602    1*            0.50000    0.0000000 /
+   10         10        1          9           12340.26993    1*            0.50000    0.0000000 /
 /
 
 --PERF REF is MD or TVD, now assumed MD
@@ -419,7 +444,7 @@ COMPTRAJ
 -- WELL	 BRANCH  PERF	    PERF    PERF COMPL STATE SAT    CONN DIAM	KH	SKIN D_FACT
 -- NAME  NO      TOP      BOT     REF  NO    --    TABLE  FACT --   --  --   --
   'INJ'	 1*  8325.0   8425.0    1*  1*	 1*  1*  1*  0.5  1*  0.1  1*  /
-  'PROD' 1*  8325.00  12571.74  1*  1*	 1*  1*  1*  0.5  1*  0.1  1*  /
+  'PROD' 1*  8325.00  12542.7   1*  1*	 1*  1*  1*  0.5  1*  0.1  1*  /
 /
 
 WCONINJE

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -1746,3 +1746,48 @@ BOOST_AUTO_TEST_CASE(Comptraj_Perforation_Interval_Must_Lie_On_The_Branch)
         BOOST_CHECK_THROW(comptrajSchedule(deck), Opm::OpmInputError);
     }
 }
+
+BOOST_AUTO_TEST_CASE(Comptraj_Three_Branches_Sharing_A_Cell)
+{
+    // A main stem with two laterals kicking off inside the same cell, so
+    // that cell (3,3,2) has three contributors.
+    const auto deck = comptrajDeck(R"(WELSPECS
+  'W1' 'G' 3 3 2000.0 OIL /
+/
+WELTRAJ
+  'W1'    1     250    250    2000    2000 /
+  'W1'    1     250    250    2030    2030 /
+  'W1'    2     250    250    2015    2015 /
+  'W1'    2     450    250    2015    2215 /
+  'W1'    3     250    250    2015    2015 /
+  'W1'    3     250    450    2015    2215 /
+/
+COMPTRAJ
+-- WELL BRANCH  TOP    BOT   REF NO STATE SAT   CF   DIAM   KH  SKIN
+  'W1'    1    2010   2020   2*     1*    1*   10.0  0.20  100  1.0 /
+  'W1'    2    2015   2115   2*     1*    1*   30.0  0.40  300  5.0 /
+  'W1'    3    2015   2115   2*     1*    1*   60.0  0.60  600  9.0 /
+/
+)");
+
+    const auto sched = comptrajSchedule(deck);
+    const auto& connections = sched.getWell("W1", 0).getConnections();
+
+    const auto& shared = connectionAt(connections, 2, 2, 1);
+
+    BOOST_REQUIRE_EQUAL(shared.comptrajBranches().size(), std::size_t{3});
+    BOOST_CHECK_EQUAL(shared.comptrajBranches()[0], 1);
+    BOOST_CHECK_EQUAL(shared.comptrajBranches()[1], 2);
+    BOOST_CHECK_EQUAL(shared.comptrajBranches()[2], 3);
+
+    BOOST_CHECK_CLOSE(shared.CF(), siCF(deck, 10.0 + 30.0 + 60.0), 1.0e-8);
+    BOOST_CHECK_CLOSE(shared.Kh(), siKh(deck, 100.0 + 300.0 + 600.0), 1.0e-8);
+
+    BOOST_CHECK_CLOSE(shared.rw(),
+                      (10.0*0.10 + 30.0*0.20 + 60.0*0.30) / 100.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(shared.skinFactor(),
+                      (10.0*1.0 + 30.0*5.0 + 60.0*9.0) / 100.0, 1.0e-8);
+
+    // The main stem still owns the cell.
+    BOOST_CHECK_EQUAL(shared.segmentOwnerBranch().value(), 1);
+}

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -1653,3 +1653,63 @@ COMPTRAJ
 
     BOOST_CHECK_NO_THROW(comptrajSchedule(deck));
 }
+
+BOOST_AUTO_TEST_CASE(Comptraj_Branch_Number_Must_Be_Positive)
+{
+    // WELTRAJ.
+    {
+        const auto deck = comptrajDeck(R"(WELSPECS
+  'W1' 'G' 3 3 2000.0 OIL /
+/
+WELTRAJ
+  'W1'    0     250    250    2000    2000 /
+  'W1'    0     250    250    2030    2030 /
+/
+)");
+
+        BOOST_CHECK_THROW(comptrajSchedule(deck), Opm::OpmInputError);
+    }
+
+    // COMPTRAJ.
+    {
+        const auto deck = comptrajDeck(weltraj_two_branches + R"(COMPTRAJ
+  'W1'   -1    2000   2010   2*     1*    1*   10.0  0.25  100  0 /
+/
+)");
+
+        BOOST_CHECK_THROW(comptrajSchedule(deck), Opm::OpmInputError);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Comptraj_Unknown_Branch_Is_An_Input_Error)
+{
+    // Branch 3 is never given a trajectory.  This used to escape as a raw
+    // std::out_of_range from the trajectory lookup.
+    const auto deck = comptrajDeck(weltraj_two_branches + R"(COMPTRAJ
+  'W1'    3    2000   2010   2*     1*    1*   10.0  0.25  100  0 /
+/
+)");
+
+    BOOST_CHECK_THROW(comptrajSchedule(deck), Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(Comptraj_Shutting_A_Shared_Cell_Shuts_It_For_All_Branches)
+{
+    const auto deck = comptrajDeck(weltraj_two_branches + R"(COMPTRAJ
+  'W1'    1    2000   2020   2*     OPEN  1*   10.0  0.20  100  1.0 /
+  'W1'    2    2015   2115   2*     SHUT  1*   30.0  0.40  300  5.0 /
+/
+)");
+
+    const auto sched = comptrajSchedule(deck);
+    const auto& connections = sched.getWell("W1", 0).getConnections();
+
+    const auto& shared = connectionAt(connections, 2, 2, 1);
+
+    // The state of the last record to touch the cell wins, for every branch.
+    BOOST_CHECK_EQUAL(shared.comptrajBranches().size(), std::size_t{2});
+    BOOST_CHECK(shared.state() == Opm::Connection::State::SHUT);
+
+    // Cells that only branch 1 reaches stay open.
+    BOOST_CHECK(connectionAt(connections, 2, 2, 0).state() == Opm::Connection::State::OPEN);
+}

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -61,6 +61,8 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
+
 namespace {
     double cp_rm3_per_db()
     {
@@ -1325,4 +1327,329 @@ Problem with keyword COMPDAT
 In <memory string> line 44
 Connection (2,1,2) (direction 'Y') for well P ignored because
    PERMZ=0.000e+00 mD and PERMX=0.000e+00 mD.)");
+}
+
+// ---------------------------------------------------------------------------
+// Multiple COMPTRAJ records and branches per well
+// ---------------------------------------------------------------------------
+
+namespace {
+
+    /// Build a deck around \p schedule with a 5x5x3 grid of 100x100x10 m
+    /// cells whose top layer starts at 2000 m.
+    Opm::Deck comptrajDeck(const std::string& schedule)
+    {
+        return Opm::Parser{}.parseString(R"(RUNSPEC
+START
+  18 MAR 2026 /
+OIL
+WATER
+DIMENS
+  5 5 3 /
+TABDIMS
+/
+EQLDIMS
+/
+WELLDIMS
+  2 20 1 2 /
+WSEGDIMS
+  2 20 3 /
+GRID
+DXV
+  5*100 /
+DYV
+  5*100 /
+DZV
+  3*10 /
+DEPTHZ
+  36*2000 /
+EQUALS
+  PERMX 100 /
+  PERMY 100 /
+  PERMZ  10 /
+  PORO    0.3 /
+/
+PROPS
+DENSITY
+  800 1000 1 /
+SOLUTION
+EQUIL
+  2010 200 2010 1.23 1995 0.0 1* 1* -5 /
+SCHEDULE
+)" + schedule + R"(
+TSTEP
+  5*10 /
+END
+)");
+    }
+
+    /// Convert a connection transmissibility factor from the deck's units.
+    double siCF(const Opm::Deck& deck, const double cf)
+    {
+        return deck.getActiveUnitSystem()
+            .to_si(Opm::UnitSystem::measure::transmissibility, cf);
+    }
+
+    /// Convert a Kh product from the deck's units.
+    double siKh(const Opm::Deck& deck, const double kh)
+    {
+        return deck.getActiveUnitSystem()
+            .to_si(Opm::UnitSystem::measure::effective_Kh, kh);
+    }
+
+    Opm::Schedule comptrajSchedule(const Opm::Deck& deck)
+    {
+        const auto es = Opm::EclipseState { deck };
+
+        return Opm::Schedule {
+            deck, es, Opm::ParseContext{}, *std::make_unique<Opm::ErrorGuard>(),
+            std::make_shared<Opm::Python>()
+        };
+    }
+
+    const Opm::Connection&
+    connectionAt(const Opm::WellConnections& connections, const int i, const int j, const int k)
+    {
+        for (const auto& conn : connections) {
+            if (conn.sameCoordinate(i, j, k)) {
+                return conn;
+            }
+        }
+
+        BOOST_FAIL(fmt::format("No connection at ({},{},{})", i, j, k));
+        return connections[0];
+    }
+
+    // A vertical main branch through column (3,3) and a lateral running in
+    // the X direction through the middle layer, so that cell (3,3,2) is
+    // perforated by both.  Measured depths are chosen so that MD == TVD along
+    // the vertical part.
+    const std::string weltraj_two_branches = R"(WELSPECS
+  'W1' 'G' 3 3 2000.0 OIL /
+/
+WELTRAJ
+-- WELL BRANCH   X      Y      TVD     MD
+  'W1'    1     250    250    2000    2000 /
+  'W1'    1     250    250    2030    2030 /
+  'W1'    2     250    250    2015    2015 /
+  'W1'    2     450    250    2015    2215 /
+/
+)";
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(Comptraj_Same_Branch_Disjoint_Intervals)
+{
+    // Two COMPTRAJ records for the same branch, covering the top and the
+    // bottom layer but not the middle one.
+    const auto deck = comptrajDeck(weltraj_two_branches + R"(COMPTRAJ
+-- WELL BRANCH  TOP    BOT   REF NO STATE SAT   CF   DIAM   KH  SKIN
+  'W1'    1    2000   2010   2*     1*    1*   10.0  0.25  100  0 /
+/
+COMPTRAJ
+  'W1'    1    2020   2030   2*     1*    1*   30.0  0.25  300  0 /
+/
+)");
+
+    const auto sched = comptrajSchedule(deck);
+    const auto& connections = sched.getWell("W1", 0).getConnections();
+
+    BOOST_REQUIRE_EQUAL(connections.size(), std::size_t{2});
+
+    const auto& top = connectionAt(connections, 2, 2, 0);
+    const auto& bottom = connectionAt(connections, 2, 2, 2);
+
+    BOOST_CHECK(top.fromTrajectory());
+    BOOST_CHECK(bottom.fromTrajectory());
+
+    // Each cell has a single contributor, so its CTF is that record's.
+    BOOST_CHECK_EQUAL(top.comptrajBranches().size(), std::size_t{1});
+    BOOST_CHECK_EQUAL(bottom.comptrajBranches().size(), std::size_t{1});
+    BOOST_CHECK(top.comptrajBranchCTFs().empty());
+    BOOST_CHECK(bottom.comptrajBranchCTFs().empty());
+}
+
+BOOST_AUTO_TEST_CASE(Comptraj_Same_Branch_Overlapping_Interval_Last_Wins)
+{
+    const auto deck = comptrajDeck(weltraj_two_branches + R"(COMPTRAJ
+  'W1'    1    2000   2010   2*     1*    1*   10.0  0.25  100  0 /
+/
+COMPTRAJ
+  'W1'    1    2000   2010   2*     1*    1*   30.0  0.25  300  0 /
+/
+)");
+
+    const auto sched = comptrajSchedule(deck);
+    const auto& connections = sched.getWell("W1", 0).getConnections();
+
+    BOOST_REQUIRE_EQUAL(connections.size(), std::size_t{1});
+
+    const auto& conn = connectionAt(connections, 2, 2, 0);
+
+    // Re-specifying the only contributing branch replaces its contribution
+    // outright rather than adding to it.
+    BOOST_REQUIRE_EQUAL(conn.comptrajBranches().size(), std::size_t{1});
+    BOOST_CHECK(conn.comptrajBranchCTFs().empty());
+    BOOST_CHECK_CLOSE(conn.CF(), siCF(deck, 30.0), 1.0e-8);
+    BOOST_CHECK_CLOSE(conn.Kh(), siKh(deck, 300.0), 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Comptraj_Two_Branches_Without_Shared_Cell)
+{
+    // Branch 1 perforates the top layer only, branch 2 the two cells the
+    // lateral reaches beyond the shared column.
+    const auto deck = comptrajDeck(weltraj_two_branches + R"(COMPTRAJ
+  'W1'    1    2000   2010   2*     1*    1*   10.0  0.25  100  0 /
+  'W1'    2    2115   2215   2*     1*    1*   30.0  0.25  300  0 /
+/
+)");
+
+    const auto sched = comptrajSchedule(deck);
+    const auto& connections = sched.getWell("W1", 0).getConnections();
+
+    BOOST_REQUIRE_EQUAL(connections.size(), std::size_t{3});
+
+    for (const auto& conn : connections) {
+        BOOST_CHECK_EQUAL(conn.comptrajBranches().size(), std::size_t{1});
+        BOOST_CHECK(conn.comptrajBranchCTFs().empty());
+    }
+
+    BOOST_CHECK_EQUAL(connectionAt(connections, 2, 2, 0).comptrajBranches().front(), 1);
+    BOOST_CHECK_EQUAL(connectionAt(connections, 3, 2, 1).comptrajBranches().front(), 2);
+    BOOST_CHECK_EQUAL(connectionAt(connections, 4, 2, 1).comptrajBranches().front(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(Comptraj_Two_Branches_Sharing_A_Cell)
+{
+    // Both branches perforate cell (3,3,2); their transmissibilities combine.
+    const auto deck = comptrajDeck(weltraj_two_branches + R"(COMPTRAJ
+  'W1'    1    2010   2020   2*     1*    1*   10.0  0.20  100  1.0 /
+  'W1'    2    2015   2115   2*     1*    1*   30.0  0.40  300  5.0 /
+/
+)");
+
+    const auto sched = comptrajSchedule(deck);
+    const auto& connections = sched.getWell("W1", 0).getConnections();
+
+    const auto& shared = connectionAt(connections, 2, 2, 1);
+
+    BOOST_REQUIRE_EQUAL(shared.comptrajBranches().size(), std::size_t{2});
+    BOOST_CHECK_EQUAL(shared.comptrajBranches()[0], 1);
+    BOOST_CHECK_EQUAL(shared.comptrajBranches()[1], 2);
+    BOOST_REQUIRE_EQUAL(shared.comptrajBranchCTFs().size(), std::size_t{2});
+
+    // CF and Kh are additive.
+    BOOST_CHECK_CLOSE(shared.CF(), siCF(deck, 10.0 + 30.0), 1.0e-8);
+    BOOST_CHECK_CLOSE(shared.Kh(), siKh(deck, 100.0 + 300.0), 1.0e-8);
+
+    // Wellbore radius and skin are CF-weighted averages.
+    BOOST_CHECK_CLOSE(shared.rw(), (10.0*0.10 + 30.0*0.20) / 40.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(shared.skinFactor(), (10.0*1.0 + 30.0*5.0) / 40.0, 1.0e-8);
+
+    // The cell that only branch 2 reaches keeps that branch's own values.
+    const auto& lateral_only = connectionAt(connections, 3, 2, 1);
+    BOOST_REQUIRE_EQUAL(lateral_only.comptrajBranches().size(), std::size_t{1});
+    BOOST_CHECK_CLOSE(lateral_only.CF(), siCF(deck, 30.0), 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Comptraj_Respecifying_One_Branch_Of_A_Shared_Cell)
+{
+    // The third record re-specifies branch 1 on the shared cell; branch 2's
+    // contribution must survive unchanged.
+    const auto deck = comptrajDeck(weltraj_two_branches + R"(COMPTRAJ
+  'W1'    1    2010   2020   2*     1*    1*   10.0  0.20  100  1.0 /
+  'W1'    2    2015   2115   2*     1*    1*   30.0  0.40  300  5.0 /
+/
+COMPTRAJ
+  'W1'    1    2010   2020   2*     1*    1*   50.0  0.20  700  1.0 /
+/
+)");
+
+    const auto sched = comptrajSchedule(deck);
+    const auto& connections = sched.getWell("W1", 0).getConnections();
+
+    const auto& shared = connectionAt(connections, 2, 2, 1);
+
+    BOOST_REQUIRE_EQUAL(shared.comptrajBranches().size(), std::size_t{2});
+    BOOST_CHECK_CLOSE(shared.CF(), siCF(deck, 50.0 + 30.0), 1.0e-8);
+    BOOST_CHECK_CLOSE(shared.Kh(), siKh(deck, 700.0 + 300.0), 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Comptraj_Branch_Order_Does_Not_Matter)
+{
+    const auto branch_first = R"(COMPTRAJ
+  'W1'    1    2010   2020   2*     1*    1*   10.0  0.20  100  1.0 /
+  'W1'    2    2015   2115   2*     1*    1*   30.0  0.40  300  5.0 /
+/
+)";
+
+    const auto lateral_first = R"(COMPTRAJ
+  'W1'    2    2015   2115   2*     1*    1*   30.0  0.40  300  5.0 /
+  'W1'    1    2010   2020   2*     1*    1*   10.0  0.20  100  1.0 /
+/
+)";
+
+    const auto deck_a = comptrajDeck(weltraj_two_branches + branch_first);
+    const auto deck_b = comptrajDeck(weltraj_two_branches + lateral_first);
+
+    const auto sched_a = comptrajSchedule(deck_a);
+    const auto sched_b = comptrajSchedule(deck_b);
+
+    const auto& a = connectionAt(sched_a.getWell("W1", 0).getConnections(), 2, 2, 1);
+    const auto& b = connectionAt(sched_b.getWell("W1", 0).getConnections(), 2, 2, 1);
+
+    BOOST_CHECK(a.comptrajBranches() == b.comptrajBranches());
+    BOOST_CHECK_CLOSE(a.CF(), b.CF(), 1.0e-8);
+    BOOST_CHECK_CLOSE(a.Kh(), b.Kh(), 1.0e-8);
+    BOOST_CHECK_CLOSE(a.rw(), b.rw(), 1.0e-8);
+    BOOST_CHECK_CLOSE(a.skinFactor(), b.skinFactor(), 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Comptraj_Compdat_Mixing_Is_Rejected)
+{
+    // COMPDAT after COMPTRAJ.
+    {
+        const auto deck = comptrajDeck(weltraj_two_branches + R"(COMPTRAJ
+  'W1'    1    2000   2010   2*     1*    1*   10.0  0.25  100  0 /
+/
+COMPDAT
+  'W1'  3  3  1  1  OPEN  1  1*  0.25 /
+/
+)");
+
+        BOOST_CHECK_THROW(comptrajSchedule(deck), Opm::OpmInputError);
+    }
+
+    // COMPTRAJ after COMPDAT.
+    {
+        const auto deck = comptrajDeck(R"(WELSPECS
+  'W1' 'G' 3 3 2000.0 OIL /
+/
+COMPDAT
+  'W1'  3  3  1  1  OPEN  1  1*  0.25 /
+/
+WELTRAJ
+  'W1'    1     250    250    2000    2000 /
+  'W1'    1     250    250    2030    2030 /
+/
+)");
+
+        BOOST_CHECK_THROW(comptrajSchedule(deck), Opm::OpmInputError);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Comptraj_Repeated_Records_Are_Accepted)
+{
+    const auto deck = comptrajDeck(weltraj_two_branches + R"(COMPTRAJ
+  'W1'    1    2000   2010   2*     1*    1*   10.0  0.25  100  0 /
+/
+COMPTRAJ
+  'W1'    1    2020   2030   2*     1*    1*   30.0  0.25  300  0 /
+/
+COMPTRAJ
+  'W1'    2    2115   2215   2*     1*    1*   30.0  0.25  300  0 /
+/
+)");
+
+    BOOST_CHECK_NO_THROW(comptrajSchedule(deck));
 }

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -1713,3 +1713,36 @@ BOOST_AUTO_TEST_CASE(Comptraj_Shutting_A_Shared_Cell_Shuts_It_For_All_Branches)
     // Cells that only branch 1 reaches stay open.
     BOOST_CHECK(connectionAt(connections, 2, 2, 0).state() == Opm::Connection::State::OPEN);
 }
+
+BOOST_AUTO_TEST_CASE(Comptraj_Perforation_Interval_Must_Lie_On_The_Branch)
+{
+    // Past the end of the branch's trajectory.
+    {
+        const auto deck = comptrajDeck(weltraj_two_branches + R"(COMPTRAJ
+  'W1'    1    2000   2100   2*     1*    1*   10.0  0.25  100  0 /
+/
+)");
+
+        BOOST_CHECK_THROW(comptrajSchedule(deck), Opm::OpmInputError);
+    }
+
+    // Before its start.
+    {
+        const auto deck = comptrajDeck(weltraj_two_branches + R"(COMPTRAJ
+  'W1'    2    2000   2100   2*     1*    1*   10.0  0.25  100  0 /
+/
+)");
+
+        BOOST_CHECK_THROW(comptrajSchedule(deck), Opm::OpmInputError);
+    }
+
+    // Reversed.
+    {
+        const auto deck = comptrajDeck(weltraj_two_branches + R"(COMPTRAJ
+  'W1'    1    2020   2010   2*     1*    1*   10.0  0.25  100  0 /
+/
+)");
+
+        BOOST_CHECK_THROW(comptrajSchedule(deck), Opm::OpmInputError);
+    }
+}

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -2482,6 +2482,27 @@ WELSEGS
     BOOST_CHECK_THROW(mswTrajectorySchedule(schedule), Opm::OpmInputError);
 }
 
+BOOST_AUTO_TEST_CASE(Comptraj_MSW_Connection_Sort_Values_Are_Unique)
+{
+    // The connections of an MSW well are sorted on their sort value, so two
+    // connections sharing one leaves their relative order up to the sorting
+    // algorithm.  Each COMPTRAJ record used to number its own connections
+    // from zero.
+    for (const auto& schedule : {msw_two_branch_prelude + comptraj_main_stem + comptraj_lateral,
+                                 msw_two_branch_prelude + comptraj_lateral + comptraj_main_stem})
+    {
+        const auto sched = mswTrajectorySchedule(schedule);
+        const auto& connections = sched.getWell("W1", 0).getConnections();
+
+        auto sort_values = std::set<std::size_t>{};
+        for (const auto& conn : connections) {
+            sort_values.insert(conn.sort_value());
+        }
+
+        BOOST_CHECK_EQUAL(sort_values.size(), connections.size());
+    }
+}
+
 BOOST_AUTO_TEST_CASE(Comptraj_MSW_Skipped_Cells_Do_Not_Break_Segment_Assignment)
 {
     // A cell with no lateral permeability has no representable connection

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -2151,29 +2151,39 @@ BOOST_AUTO_TEST_CASE(loadCOMPTRAJTESTSPE1_MSW) {
         WELLNAME: 'PROD'
         # X   Y    TVDMSL   MDMSL
         3400.00     4500.00     8325.00     8325.00
-        3858.19     4688.67     8374.60     8825.00
-        5326.76     6005.95     8403.97     10825.00
-        6500.00     7300.00     8410.00     12571.74
+        3858.19     4688.67     8374.60     8822.99
+        5326.76     6005.95     8403.97     10796.0
+        6500.00     7300.00     8410.00     12542.7
         -999
-     and adjusting the completion data in agreement with the COMPTRAJ data in the input file
+     and adjusting the completion data in agreement with the COMPTRAJ data in the input file.
+
+     Both connection depths and segment node depths are obtained by interpolating into the
+     trajectory. The trajectory is piece-wise linear, so these should reproduce the reference
+     values from ResInsight.
    */
-  const std::array<double, 9> connection_factor{
+  const std::array<double, 9> connection_factors{
     110.5461, 17.75799, 36.04859, 60.75019, 235.1933, 94.73938, 222.7472, 74.7769, 89.2022
+  };
+  const std::array<double, 9> connection_depths{
+    8335.0, 8361.1, 8376.2, 8379.4, 8389.4, 8400.6, 8405.6, 8408.0, 8409.3
   };
   const std::array<int, 9> global_index{11, 111, 211, 212, 222, 223, 233, 234, 244};
   BOOST_CHECK_EQUAL(connections.size(), 9);
   for (std::size_t i = 0 ; i < connections.size();  ++i ) {
-       BOOST_CHECK_CLOSE(connections[i].CF(), units.to_si(Opm::UnitSystem::measure::transmissibility, connection_factor[i]), 2e-2);
+       BOOST_CHECK_CLOSE(connections[i].CF(), units.to_si(Opm::UnitSystem::measure::transmissibility, connection_factors[i]), 2e-2);
        BOOST_CHECK_EQUAL(connections[i].global_index(), global_index[i]);
+       BOOST_CHECK_CLOSE(connections[i].depth(), units.to_si(Opm::UnitSystem::measure::length, connection_depths[i]), 2e-2);
   }
 
-  const std::array<double, 10> lengths{
-    8325.0, 8425.8, 8689.4, 8935.1, 9157.9, 9838.8, 10597.0, 11321.0, 11997.0, 12369.0
+  // Segment node depths are interpolated from the trajectory at the segment's
+  // measured depth, rather than taken from the (defaulted) WELSEGS DEPTH item.
+  const std::array<double, 10> depths{
+    8325.0, 8335.0, 8361.1, 8376.2, 8379.4, 8389.4, 8400.6, 8405.6, 8408.0, 8409.3
   };
   BOOST_CHECK_EQUAL(segments.size(), 10);
   for (std::size_t i = 0; i < segments.size(); ++i) {
     BOOST_CHECK_EQUAL(segments[i].segmentNumber(), i + 1);
     BOOST_CHECK_EQUAL(segments[i].outletSegment(), i);
-    BOOST_CHECK_CLOSE(segments[i].totalLength(), units.to_si(Opm::UnitSystem::measure::length, lengths[i]), 2e-2);
+    BOOST_CHECK_CLOSE(segments[i].depth(), units.to_si(Opm::UnitSystem::measure::length, depths[i]), 2e-2);
   }
 }

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -137,7 +137,7 @@ WSEGAICD
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set{};
     const Opm::UnitSystem unit_system {}; // Metric by default
-    segment_set.loadWELSEGS(welsegs, unit_system);
+    segment_set.loadWELSEGS(welsegs, {}, {}, unit_system);
 
     BOOST_CHECK_EQUAL(7U, segment_set.size());
 
@@ -315,7 +315,7 @@ WSEGSICD
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set{};
     const Opm::UnitSystem unit_system {}; // Metric by default
-    segment_set.loadWELSEGS(welsegs, unit_system);
+    segment_set.loadWELSEGS(welsegs, {}, {}, unit_system);
 
     BOOST_CHECK_EQUAL(7U, segment_set.size());
 
@@ -903,7 +903,7 @@ BOOST_AUTO_TEST_CASE(WrongDistanceCOMPSEGS)
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set{};
     const Opm::UnitSystem unit_system {}; // Metric by default
-    segment_set.loadWELSEGS(welsegs, unit_system);
+    segment_set.loadWELSEGS(welsegs, {}, {}, unit_system);
 
     BOOST_CHECK_EQUAL(6U, segment_set.size());
 
@@ -987,7 +987,7 @@ BOOST_AUTO_TEST_CASE(NegativeDepthCOMPSEGS)
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set{};
     const Opm::UnitSystem unit_system {}; // Metric by default
-    segment_set.loadWELSEGS(welsegs, unit_system);
+    segment_set.loadWELSEGS(welsegs, {}, {}, unit_system);
 
     BOOST_CHECK_EQUAL(6U, segment_set.size());
 
@@ -1076,7 +1076,7 @@ BOOST_AUTO_TEST_CASE(testwsegvalv)
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set{};
     const Opm::UnitSystem unit_system {}; // Metric by default
-    segment_set.loadWELSEGS(welsegs, unit_system);
+    segment_set.loadWELSEGS(welsegs, {}, {}, unit_system);
 
     BOOST_CHECK_EQUAL(8U, segment_set.size());
 

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -137,7 +137,7 @@ WSEGAICD
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set{};
     const Opm::UnitSystem unit_system {}; // Metric by default
-    segment_set.loadWELSEGS(welsegs, unit_system);
+    segment_set.loadWELSEGS(welsegs, {}, {}, unit_system);
 
     BOOST_CHECK_EQUAL(7U, segment_set.size());
 
@@ -315,7 +315,7 @@ WSEGSICD
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set{};
     const Opm::UnitSystem unit_system {}; // Metric by default
-    segment_set.loadWELSEGS(welsegs, unit_system);
+    segment_set.loadWELSEGS(welsegs, {}, {}, unit_system);
 
     BOOST_CHECK_EQUAL(7U, segment_set.size());
 
@@ -903,7 +903,7 @@ BOOST_AUTO_TEST_CASE(WrongDistanceCOMPSEGS)
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set{};
     const Opm::UnitSystem unit_system {}; // Metric by default
-    segment_set.loadWELSEGS(welsegs, unit_system);
+    segment_set.loadWELSEGS(welsegs, {}, {}, unit_system);
 
     BOOST_CHECK_EQUAL(6U, segment_set.size());
 
@@ -987,7 +987,7 @@ BOOST_AUTO_TEST_CASE(NegativeDepthCOMPSEGS)
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set{};
     const Opm::UnitSystem unit_system {}; // Metric by default
-    segment_set.loadWELSEGS(welsegs, unit_system);
+    segment_set.loadWELSEGS(welsegs, {}, {}, unit_system);
 
     BOOST_CHECK_EQUAL(6U, segment_set.size());
 
@@ -1076,7 +1076,7 @@ BOOST_AUTO_TEST_CASE(testwsegvalv)
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set{};
     const Opm::UnitSystem unit_system {}; // Metric by default
-    segment_set.loadWELSEGS(welsegs, unit_system);
+    segment_set.loadWELSEGS(welsegs, {}, {}, unit_system);
 
     BOOST_CHECK_EQUAL(8U, segment_set.size());
 
@@ -2151,29 +2151,37 @@ BOOST_AUTO_TEST_CASE(loadCOMPTRAJTESTSPE1_MSW) {
         WELLNAME: 'PROD'
         # X   Y    TVDMSL   MDMSL
         3400.00     4500.00     8325.00     8325.00
-        3858.19     4688.67     8374.60     8825.00
-        5326.76     6005.95     8403.97     10825.00
-        6500.00     7300.00     8410.00     12571.74
+        3858.19     4688.67     8374.60     8822.99
+        5326.76     6005.95     8403.97     10796.0
+        6500.00     7300.00     8410.00     12542.7
         -999
-     and adjusting the completion data in agreement with the COMPTRAJ data in the input file
+    and adjusting the completion data in agreement with the COMPTRAJ data in the input file
+
+    Both connection depths and segment depths are calculated by interpolating into the trajectory. Because
+    the trajectory is piece-wise linear, in this case the results should be the same as the reference
+    values obtained by using ResInsight.     
    */
-  const std::array<double, 9> connection_factor{
+  const std::array<double, 9> connection_factors{
     110.5461, 17.75799, 36.04859, 60.75019, 235.1933, 94.73938, 222.7472, 74.7769, 89.2022
+  };
+  const std::array<double, 9> connection_depths{
+    8335.0, 8361.1, 8376.2, 8379.4, 8389.4, 8400.6, 8405.6, 8408.0, 8409.3
   };
   const std::array<int, 9> global_index{11, 111, 211, 212, 222, 223, 233, 234, 244};
   BOOST_CHECK_EQUAL(connections.size(), 9);
   for (std::size_t i = 0 ; i < connections.size();  ++i ) {
-       BOOST_CHECK_CLOSE(connections[i].CF(), units.to_si(Opm::UnitSystem::measure::transmissibility, connection_factor[i]), 2e-2);
+       BOOST_CHECK_CLOSE(connections[i].CF(), units.to_si(Opm::UnitSystem::measure::transmissibility, connection_factors[i]), 2e-2);
        BOOST_CHECK_EQUAL(connections[i].global_index(), global_index[i]);
+       BOOST_CHECK_CLOSE(connections[i].depth(), units.to_si(Opm::UnitSystem::measure::length, connection_depths[i]), 2e-2);
   }
 
-  const std::array<double, 10> lengths{
-    8325.0, 8425.8, 8689.4, 8935.1, 9157.9, 9838.8, 10597.0, 11321.0, 11997.0, 12369.0
-  };
+  const std::array<double, 10> depths{
+    8325.0, 8335.0, 8361.1, 8376.2, 8379.4, 8389.4, 8400.6, 8405.6, 8408.0, 8409.3
+};
   BOOST_CHECK_EQUAL(segments.size(), 10);
   for (std::size_t i = 0; i < segments.size(); ++i) {
     BOOST_CHECK_EQUAL(segments[i].segmentNumber(), i + 1);
     BOOST_CHECK_EQUAL(segments[i].outletSegment(), i);
-    BOOST_CHECK_CLOSE(segments[i].totalLength(), units.to_si(Opm::UnitSystem::measure::length, lengths[i]), 2e-2);
+    BOOST_CHECK_CLOSE(segments[i].depth(), units.to_si(Opm::UnitSystem::measure::length, depths[i]), 2e-2);
   }
 }

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -2482,6 +2482,30 @@ WELSEGS
     BOOST_CHECK_THROW(mswTrajectorySchedule(schedule), Opm::OpmInputError);
 }
 
+BOOST_AUTO_TEST_CASE(Welsegs_Top_Segment_Only_Is_Rejected_For_A_Trajectory_Well)
+{
+    // The segment structure of a grid-independent well comes from WELSEGS.
+    // A WELSEGS with only its header record leaves nothing for the
+    // connections to attach to except the top segment, which would put the
+    // whole well on segment 1 without saying so.
+    const auto schedule = R"(WELSPECS
+  'W1' 'G' 3 3 2000.0 OIL /
+/
+WELTRAJ
+  'W1'    1     250    250    2000    2000 /
+  'W1'    1     250    250    2030    2030 /
+/
+WELSEGS
+  'W1'    2000      2000      1*   ABS  'HF-' /
+/
+COMPTRAJ
+  'W1'    1    2000   2030   2*     1*    1*   10.0  0.15  100  0 /
+/
+)";
+
+    BOOST_CHECK_THROW(mswTrajectorySchedule(schedule), Opm::OpmInputError);
+}
+
 BOOST_AUTO_TEST_CASE(Comptraj_MSW_Connection_Sort_Values_Are_Unique)
 {
     // The connections of an MSW well are sorted on their sort value, so two

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -58,6 +58,9 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <vector>
+
+#include <fmt/format.h>
 
 BOOST_AUTO_TEST_CASE(AICDWellTest)
 {
@@ -2186,4 +2189,185 @@ BOOST_AUTO_TEST_CASE(loadCOMPTRAJTESTSPE1_MSW) {
     BOOST_CHECK_EQUAL(segments[i].outletSegment(), i);
     BOOST_CHECK_CLOSE(segments[i].depth(), units.to_si(Opm::UnitSystem::measure::length, depths[i]), 2e-2);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Segment ownership of cells reached by several COMPTRAJ branches
+// ---------------------------------------------------------------------------
+
+namespace {
+
+    // A vertical main stem through column (3,3) and a lateral running in the
+    // X direction through the middle layer.  Cell (3,3,2) is perforated by
+    // both branches, cells (4,3,2) and (5,3,2) by the lateral only.
+    //
+    // The trajectories are chosen so that MD == TVD along the main stem and
+    // the lateral is horizontal, which makes the cell/segment measured depths
+    // easy to follow:
+    //
+    //   branch 1 : MD 2000 -> 2030, cells (3,3,1), (3,3,2), (3,3,3)
+    //   branch 2 : MD 2015 -> 2215, cells (3,3,2), (4,3,2), (5,3,2)
+    //
+    // Segment nodes sit at the cell centres, so segments 2, 3 and 4 cover the
+    // main stem cells and segments 5, 6 and 7 the lateral ones.  The shared
+    // cell is therefore claimed by segment 3 when branch 1 owns it and by
+    // segment 5 when branch 2 does.
+    const std::string msw_two_branch_prelude = R"(WELSPECS
+  'W1' 'G' 3 3 2000.0 OIL /
+/
+WELTRAJ
+-- WELL BRANCH   X      Y      TVD     MD
+  'W1'    1     250    250    2000    2000 /
+  'W1'    1     250    250    2030    2030 /
+  'W1'    2     250    250    2015    2015 /
+  'W1'    2     450    250    2015    2215 /
+/
+WELSEGS
+-- WELL  TOP_DEPTH TOP_LENGTH VOL  TYPE PRESSURE
+  'W1'    2000      2000      1*   ABS  'HF-' /
+-- SEG1 SEG2 BRANCH OUTLET LENGTH DEPTH DIAM  ROUGH
+    2    2     1      1     2005   2005  0.15 1.0e-5 /
+    3    3     1      2     2015   2015  0.15 1.0e-5 /
+    4    4     1      3     2025   2025  0.15 1.0e-5 /
+    5    5     2      2     2040   2015  0.10 1.0e-5 /
+    6    6     2      5     2115   2015  0.10 1.0e-5 /
+    7    7     2      6     2190   2015  0.10 1.0e-5 /
+/
+)";
+
+    const std::string comptraj_main_stem = R"(COMPTRAJ
+-- WELL BRANCH  TOP    BOT   REF NO STATE SAT   CF   DIAM   KH  SKIN
+  'W1'    1    2000   2030   2*     1*    1*   10.0  0.15  100  0 /
+/
+)";
+
+    const std::string comptraj_lateral = R"(COMPTRAJ
+  'W1'    2    2015   2215   2*     1*    1*   30.0  0.10  300  0 /
+/
+)";
+
+    Opm::Schedule mswTrajectorySchedule(const std::string& schedule)
+    {
+        const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+START
+  18 MAR 2026 /
+OIL
+WATER
+DIMENS
+  5 5 3 /
+TABDIMS
+/
+EQLDIMS
+/
+WELLDIMS
+  2 20 1 2 /
+WSEGDIMS
+  2 20 3 /
+GRID
+DXV
+  5*100 /
+DYV
+  5*100 /
+DZV
+  3*10 /
+DEPTHZ
+  36*2000 /
+EQUALS
+  PERMX 100 /
+  PERMY 100 /
+  PERMZ  10 /
+  PORO    0.3 /
+/
+PROPS
+DENSITY
+  800 1000 1 /
+SOLUTION
+EQUIL
+  2010 200 2010 1.23 1995 0.0 1* 1* -5 /
+SCHEDULE
+)" + schedule + R"(
+TSTEP
+  5*10 /
+END
+)");
+
+        const auto es = Opm::EclipseState { deck };
+
+        return Opm::Schedule {
+            deck, es, Opm::ParseContext{}, *std::make_unique<Opm::ErrorGuard>(),
+            std::make_shared<Opm::Python>()
+        };
+    }
+
+    int segmentOfCell(const Opm::WellConnections& connections,
+                      const int i, const int j, const int k)
+    {
+        for (const auto& conn : connections) {
+            if (conn.sameCoordinate(i, j, k)) {
+                return conn.segment();
+            }
+        }
+
+        BOOST_FAIL(fmt::format("No connection at ({},{},{})", i, j, k));
+        return -1;
+    }
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(Comptraj_MSW_Shared_Cell_Belongs_To_Owner_Branch)
+{
+    const auto sched =
+        mswTrajectorySchedule(msw_two_branch_prelude +
+                              comptraj_main_stem + comptraj_lateral);
+
+    const auto& well = sched.getWell("W1", 0);
+    BOOST_REQUIRE(well.isMultiSegment());
+
+    const auto& connections = well.getConnections();
+    BOOST_REQUIRE_EQUAL(connections.size(), std::size_t{5});
+
+    // The shared cell is claimed by branch 1, the lowest numbered
+    // contributor, and hence attached to a main stem segment.
+    BOOST_CHECK_EQUAL(segmentOfCell(connections, 2, 2, 1), 3);
+
+    // Main stem cells above and below the lateral.
+    BOOST_CHECK_EQUAL(segmentOfCell(connections, 2, 2, 0), 2);
+    BOOST_CHECK_EQUAL(segmentOfCell(connections, 2, 2, 2), 4);
+
+    // Cells only the lateral reaches keep their lateral segments.
+    BOOST_CHECK_EQUAL(segmentOfCell(connections, 3, 2, 1), 6);
+    BOOST_CHECK_EQUAL(segmentOfCell(connections, 4, 2, 1), 7);
+}
+
+BOOST_AUTO_TEST_CASE(Comptraj_MSW_Segment_Ownership_Is_Order_Independent)
+{
+    // The lateral is completed before the main stem here, so branch 2
+    // temporarily owns the shared cell.  Once branch 1 arrives it takes over,
+    // giving the same result as the opposite order.
+    const auto sched =
+        mswTrajectorySchedule(msw_two_branch_prelude +
+                              comptraj_lateral + comptraj_main_stem);
+
+    const auto& connections = sched.getWell("W1", 0).getConnections();
+    BOOST_REQUIRE_EQUAL(connections.size(), std::size_t{5});
+
+    BOOST_CHECK_EQUAL(segmentOfCell(connections, 2, 2, 1), 3);
+    BOOST_CHECK_EQUAL(segmentOfCell(connections, 2, 2, 0), 2);
+    BOOST_CHECK_EQUAL(segmentOfCell(connections, 2, 2, 2), 4);
+    BOOST_CHECK_EQUAL(segmentOfCell(connections, 3, 2, 1), 6);
+    BOOST_CHECK_EQUAL(segmentOfCell(connections, 4, 2, 1), 7);
+}
+
+BOOST_AUTO_TEST_CASE(Comptraj_MSW_Every_Connection_Is_Attached_To_A_Segment)
+{
+    for (const auto& schedule : {msw_two_branch_prelude + comptraj_main_stem + comptraj_lateral,
+                                 msw_two_branch_prelude + comptraj_lateral + comptraj_main_stem})
+    {
+        const auto sched = mswTrajectorySchedule(schedule);
+        const auto& connections = sched.getWell("W1", 0).getConnections();
+
+        for (const auto& conn : connections) {
+            BOOST_CHECK_GT(conn.segment(), 0);
+        }
+    }
 }

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -2371,3 +2371,111 @@ BOOST_AUTO_TEST_CASE(Comptraj_MSW_Every_Connection_Is_Attached_To_A_Segment)
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(Welsegs_Branch_Without_Trajectory_Is_Rejected)
+{
+    // Segment 5 is put on branch 3, for which WELTRAJ has no trajectory.
+    const auto schedule = R"(WELSPECS
+  'W1' 'G' 3 3 2000.0 OIL /
+/
+WELTRAJ
+  'W1'    1     250    250    2000    2000 /
+  'W1'    1     250    250    2030    2030 /
+  'W1'    2     250    250    2015    2015 /
+  'W1'    2     450    250    2015    2215 /
+/
+WELSEGS
+  'W1'    2000      2000      1*   ABS  'HF-' /
+    2    2     1      1     2005   2005  0.15 1.0e-5 /
+    3    3     1      2     2015   2015  0.15 1.0e-5 /
+    4    4     1      3     2025   2025  0.15 1.0e-5 /
+    5    5     3      2     2040   2015  0.10 1.0e-5 /
+/
+)";
+
+    BOOST_CHECK_THROW(mswTrajectorySchedule(schedule), Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(Welsegs_Segment_Node_Beyond_Trajectory_Is_Rejected)
+{
+    // Segment 7 sits at MD 2300, past the end of branch 2's trajectory
+    // (MD 2215).  Extrapolating there would invent well geometry.
+    const auto schedule = R"(WELSPECS
+  'W1' 'G' 3 3 2000.0 OIL /
+/
+WELTRAJ
+  'W1'    1     250    250    2000    2000 /
+  'W1'    1     250    250    2030    2030 /
+  'W1'    2     250    250    2015    2015 /
+  'W1'    2     450    250    2015    2215 /
+/
+WELSEGS
+  'W1'    2000      2000      1*   ABS  'HF-' /
+    2    2     1      1     2005   2005  0.15 1.0e-5 /
+    3    3     1      2     2015   2015  0.15 1.0e-5 /
+    4    4     1      3     2025   2025  0.15 1.0e-5 /
+    5    5     2      2     2040   2015  0.10 1.0e-5 /
+    6    6     2      5     2115   2015  0.10 1.0e-5 /
+    7    7     2      6     2300   2015  0.10 1.0e-5 /
+/
+)";
+
+    BOOST_CHECK_THROW(mswTrajectorySchedule(schedule), Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(Welsegs_Top_Node_Is_Taken_From_The_Trajectory)
+{
+    // TOP_X/TOP_Y are given, but the trajectory decides where the top node
+    // is; the deck values are only reported and then discarded.
+    const auto schedule = R"(WELSPECS
+  'W1' 'G' 3 3 2000.0 OIL /
+/
+WELTRAJ
+  'W1'    1     250    250    2000    2000 /
+  'W1'    1     250    250    2030    2030 /
+  'W1'    2     250    250    2015    2015 /
+  'W1'    2     450    250    2015    2215 /
+/
+WELSEGS
+-- WELL TOP_DEPTH TOP_LENGTH VOL TYPE PRESSURE TOP_X TOP_Y
+  'W1'    2000      2000     1*  ABS  'HF-'    777   888 /
+    2    2     1      1     2005   2005  0.15 1.0e-5 /
+    3    3     1      2     2015   2015  0.15 1.0e-5 /
+    4    4     1      3     2025   2025  0.15 1.0e-5 /
+    5    5     2      2     2040   2015  0.10 1.0e-5 /
+    6    6     2      5     2115   2015  0.10 1.0e-5 /
+    7    7     2      6     2190   2015  0.10 1.0e-5 /
+/
+)" + comptraj_main_stem + comptraj_lateral;
+
+    const auto sched = mswTrajectorySchedule(schedule);
+    const auto& segments = sched.getWell("W1", 0).getSegments();
+
+    BOOST_CHECK_CLOSE(segments[0].node_X(), 250.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(segments[0].node_Y(), 250.0, 1.0e-8);
+
+    // The lateral runs in the X direction at constant Y, so its nodes track
+    // the trajectory rather than the main stem's position.
+    const auto& seg6 = segments[sched.getWell("W1", 0).getSegments().segmentNumberToIndex(6)];
+    BOOST_CHECK_CLOSE(seg6.node_X(), 350.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(seg6.node_Y(), 250.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(seg6.depth(), 2015.0, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Welsegs_Top_Length_Before_Trajectory_Start_Is_Rejected)
+{
+    const auto schedule = R"(WELSPECS
+  'W1' 'G' 3 3 2000.0 OIL /
+/
+WELTRAJ
+  'W1'    1     250    250    2000    2000 /
+  'W1'    1     250    250    2030    2030 /
+/
+WELSEGS
+  'W1'    2000      1990      1*   ABS  'HF-' /
+    2    2     1      1     2005   2005  0.15 1.0e-5 /
+/
+)";
+
+    BOOST_CHECK_THROW(mswTrajectorySchedule(schedule), Opm::OpmInputError);
+}

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -2246,7 +2246,8 @@ WELSEGS
 /
 )";
 
-    Opm::Schedule mswTrajectorySchedule(const std::string& schedule)
+    Opm::Schedule mswTrajectorySchedule(const std::string& schedule,
+                                        const std::string& extra_grid = {})
     {
         const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
 START
@@ -2278,6 +2279,7 @@ EQUALS
   PERMZ  10 /
   PORO    0.3 /
 /
+)" + extra_grid + R"(
 PROPS
 DENSITY
   800 1000 1 /
@@ -2478,4 +2480,42 @@ WELSEGS
 )";
 
     BOOST_CHECK_THROW(mswTrajectorySchedule(schedule), Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(Comptraj_MSW_Skipped_Cells_Do_Not_Break_Segment_Assignment)
+{
+    // A cell with no lateral permeability has no representable connection
+    // factor and is left out of the well, exactly as COMPDAT leaves it out.
+    // The COMPSEGS records derived from the trajectory must not keep looking
+    // for the connection that was never made.
+    const auto schedule = R"(WELSPECS
+  'W1' 'G' 3 3 2000.0 OIL /
+/
+WELTRAJ
+  'W1'    1     250    250    2000    2000 /
+  'W1'    1     250    250    2030    2030 /
+/
+WELSEGS
+  'W1'    2000      2000      1*   ABS  'HF-' /
+    2    2     1      1     2005   2005  0.15 1.0e-5 /
+    3    3     1      2     2015   2015  0.15 1.0e-5 /
+    4    4     1      3     2025   2025  0.15 1.0e-5 /
+/
+COMPTRAJ
+-- CF and Kh defaulted, so they are calculated from the cell properties.
+  'W1'    1    2000   2030   2*     1*    1*   1*    0.15  1*   0 /
+/
+)";
+
+    const auto sched = mswTrajectorySchedule(schedule, R"(EQUALS
+  PERMX 0 3 3 3 3 2 2 /
+  PERMY 0 3 3 3 3 2 2 /
+/
+)");
+
+    const auto& connections = sched.getWell("W1", 0).getConnections();
+
+    BOOST_REQUIRE_EQUAL(connections.size(), std::size_t{2});
+    BOOST_CHECK_EQUAL(segmentOfCell(connections, 2, 2, 0), 2);
+    BOOST_CHECK_EQUAL(segmentOfCell(connections, 2, 2, 2), 4);
 }

--- a/tests/parser/ScheduleRestartTests.cpp
+++ b/tests/parser/ScheduleRestartTests.cpp
@@ -25,6 +25,7 @@
 #include <opm/io/eclipse/ERst.hpp>
 #include <opm/io/eclipse/RestartFileView.hpp>
 
+#include <opm/common/utility/OpmInputError.hpp>
 #include <opm/common/utility/TimeService.hpp>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
@@ -57,10 +58,12 @@
 #include <algorithm>
 #include <cstddef>
 #include <filesystem>
+#include <fstream>
 #include <iterator>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -435,4 +438,80 @@ BOOST_AUTO_TEST_CASE(RestartTest)
     //         return date == tp;
     //     }
     // };
+}
+
+namespace {
+
+    /// The restart deck with \p extra_schedule inserted at the top of its
+    /// SCHEDULE section.
+    Deck restartDeckWithSchedule(const Parser& parser, const std::string& extra_schedule)
+    {
+        auto input = std::string {};
+        {
+            auto is = std::ifstream { "SPE1CASE2_RESTART.DATA" };
+            input.assign(std::istreambuf_iterator<char> { is },
+                         std::istreambuf_iterator<char> {});
+        }
+
+        const auto schedule_pos = input.find("\nSCHEDULE\n");
+        BOOST_REQUIRE(schedule_pos != std::string::npos);
+
+        input.insert(schedule_pos + std::string { "\nSCHEDULE\n" }.size(),
+                     extra_schedule);
+
+        return parser.parseString(input);
+    }
+
+    Schedule restartedSchedule(const std::string& extra_schedule)
+    {
+        Parser parser;
+
+        auto base_deck = parser.parseFile("SPE1CASE2.DATA");
+        const auto base_state = EclipseState { base_deck };
+
+        auto rst_file = std::make_shared<EclIO::ERst>("SPE1CASE2.X0060");
+        auto rst_view = std::make_shared<EclIO::RestartFileView>(std::move(rst_file), 60);
+        auto rst_state = RestartIO::RstState::load(std::move(rst_view),
+                                                   base_state.runspec(), parser);
+
+        const auto deck = restartDeckWithSchedule(parser, extra_schedule);
+        const auto ecl_state = EclipseState { deck };
+
+        return Schedule {
+            deck, ecl_state, std::make_shared<Python>(),
+            false, /*slave_mode=*/false, true, {}, &rst_state
+        };
+    }
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(Restarted_Well_Cannot_Continue_With_A_Trajectory)
+{
+    // Connections restored from a restart file are COMPDAT-like: the restart
+    // file has no trajectory section, so the branch structure of a
+    // COMPTRAJ well cannot be recovered.  Continuing such a well with
+    // WELTRAJ/COMPTRAJ has to be refused rather than silently mixing the two
+    // completion styles.
+    // The diagnostic points at the restart, which is the actual cause here.
+    const auto mentions_restart = [](const OpmInputError& e)
+    {
+        return std::string_view { e.what() }.find("restart") != std::string_view::npos;
+    };
+
+    BOOST_CHECK_EXCEPTION(restartedSchedule(R"(WELTRAJ
+  'PROD'  1  2500  2500  8325  8325 /
+  'PROD'  1  2500  2500  8350  8350 /
+/
+)"), OpmInputError, mentions_restart);
+
+    BOOST_CHECK_EXCEPTION(restartedSchedule(R"(COMPTRAJ
+  'PROD'  1  8325  8350  2*  1*  1*  10.0  0.25  100  0 /
+/
+)"), OpmInputError, mentions_restart);
+
+    // Continuing with COMPDAT, on the other hand, is what restarts are for.
+    BOOST_CHECK_NO_THROW(restartedSchedule(R"(COMPDAT
+  'PROD'  10  10  3  3  OPEN  1*  1*  0.5 /
+/
+)"));
 }


### PR DESCRIPTION
This PR adds support for using the WELSEGS keyword in combination with the WELTRAJ and COMPTRAJ keywords. It allows defining the multi-segment structure with WELSEGS as you normally would. If the well is defined with WELTRAJ and COMPTRAJ, then there is no need to specify the COMPDAT and COMPSEGS keyword, the necessary information will be generated from the WELTRAJ, COMPTRAJ and WELSEGS keywords.

This PR does the following things:

- It removes the previously implemented feature to auto-generate segments from WELTRAJ/COMPTRAJ keywords. I consider this functionality too limited and not fitting well with the normal usage of WELSEGS. Instead the well structure should be specified using existing WELSEGS functionality.
- Normally segments are defined by their length and depth (MD and TVD). When using WELTRAJ these should be compatible with the trajectory. For this reason, the depths defined in WELSEGS will be ignored (with a warning) and instead be interpolated from the WELTRAJ data. When using WELTRAJ/WELSEGS the depth values can now be defaulted, since they are not used anyway.
- Segment ranges also work with trajectories. In normal case this is implemented by dividing both the total length and the total depth of the range in equal pieces. When using a trajectory, the length is still equally divided, but the depths are derived by interpolating in the trajectory. In case the range is over a linear part of the well this is equivalent, but if the segment range is on a non-linear part of the trajectory this potentially much more accurate. 
- COMPSEGS data is generated from WELTRAJ/COMPTRAJ/WELSEGS. If COMPSEGS is used, the center depth of each connection would be derived by linear interpolation into a segment. When trajectories are used, the center depths are derived by interpolation in the trajectory instead, which is equivalent for linear wells, but potentially more accurate in non-linear trajectories.
- Multiple branches are now supported so multi-lateral wells can be modeled using WELTRAJ/COMPTRAJ. This still needs to be tested, and tests/examples will be added.

**Note**: Existing behavior of WELSEGS/COMPSEGS is not changed when trajectories are not used. The only visible changes to WELSEGS is that it now possible to default depth values. However, when trajectories are not used, defaulting depths will raise an error.