### PR TITLE
Include Standard Network Flag in Equality Predicate

### DIFF
--- a/opm/input/eclipse/Schedule/Network/ExtNetwork.cpp
+++ b/opm/input/eclipse/Schedule/Network/ExtNetwork.cpp
@@ -42,7 +42,7 @@ ExtNetwork ExtNetwork::serializationTestObject()
     object.m_branches = {Branch::serializationTestObject()};
     object.insert_indexed_node_names = {"test1", "test2"};
     object.m_nodes = {{"test3", Node::serializationTestObject()}};
-    object.m_is_standard_network = false;
+    object.m_is_standard_network = true;
     return object;
 }
 
@@ -63,9 +63,11 @@ void ExtNetwork::set_standard_network(bool is_standard_network)
 
 bool ExtNetwork::operator==(const ExtNetwork& rhs) const
 {
-    return this->m_branches == rhs.m_branches
-        && this->insert_indexed_node_names == rhs.insert_indexed_node_names
-        && this->m_nodes == rhs.m_nodes;
+    return (this->m_branches == rhs.m_branches)
+        && (this->insert_indexed_node_names == rhs.insert_indexed_node_names)
+        && (this->m_nodes == rhs.m_nodes)
+        && (this->m_is_standard_network == rhs.m_is_standard_network)
+        ;
 }
 
 bool ExtNetwork::has_node(const std::string& name) const

--- a/opm/input/eclipse/Schedule/Network/ExtNetwork.hpp
+++ b/opm/input/eclipse/Schedule/Network/ExtNetwork.hpp
@@ -71,6 +71,10 @@ public:
     }
 
 private:
+    // Note to maintainers: If you make changes to this list of data
+    // members, then please update serializeOp(), operator==(), and
+    // serializationTestObject() accordingly.
+
     std::vector<Branch> m_branches;
     std::vector<std::string> insert_indexed_node_names;
     std::map<std::string, Node> m_nodes;


### PR DESCRIPTION
The `ExtNetwork::operator==()` equality predicate did not include the standard network flag (`ExtNetwork::m_is_standard_network`).  This would allow `ExtNetwork` objects with equal structure, but different standard network flags to compare equal and potentially hide serialisation problems.