### PR TITLE
Fix Sign Error in TimerLog

### DIFF
--- a/opm/common/OpmLog/TimerLog.cpp
+++ b/opm/common/OpmLog/TimerLog.cpp
@@ -21,46 +21,53 @@
 
 #include <opm/common/OpmLog/TimerLog.hpp>
 
-#include <opm/common/OpmLog/LogUtil.hpp>
-#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/StreamLog.hpp>
 
-#include <cassert>
+#include <chrono>
 #include <cstdint>
-#include <ios>
-#include <sstream>
+#include <ostream>
+#include <string>
+
+#include <fmt/format.h>
 
 namespace Opm {
 
 TimerLog::TimerLog(const std::string& logFile)
-    : StreamLog( logFile , StopTimer | StartTimer )
-    , m_start(0)
-{
-}
+    : StreamLog { logFile, StopTimer | StartTimer }
+{}
 
 TimerLog::TimerLog(std::ostream& os)
-    : StreamLog( os , StopTimer | StartTimer )
-    , m_start(0)
+    : StreamLog { os, StopTimer | StartTimer }
+{}
+
+void TimerLog::clear()
 {
+    m_start = std::chrono::steady_clock::now();
+    m_started = false;
 }
 
-
-
-void TimerLog::addMessageUnconditionally(std::int64_t messageType, const std::string& msg ) {
+void TimerLog::addMessageUnconditionally(const std::int64_t messageType,
+                                         const std::string& msg)
+{
     if (messageType == StopTimer) {
-        clock_t stop = clock();
-        double secondsElapsed = 1.0 * (m_start - stop) / CLOCKS_PER_SEC ;
+        if (!m_started) {
+            StreamLog::addMessageUnconditionally
+                (messageType, fmt::format("Timer not started when receiving user "
+                                          "message '{}'. Elapsed time is zero.", msg));
+            return;
+        }
 
-        std::ostringstream work;
-        work.precision(8);
-        work << std::fixed << msg << ": " << secondsElapsed << " seconds ";
-        StreamLog::addMessageUnconditionally( messageType, work.str());
-    } else {
-        if (messageType == StartTimer)
-            m_start = clock();
+        const auto stop = std::chrono::steady_clock::now();
+        const auto elapsed = std::chrono::duration<double>(stop - m_start);
+
+        const auto logMessage = fmt::format("{}: {:.8f} seconds", msg, elapsed.count());
+        StreamLog::addMessageUnconditionally(messageType, logMessage);
+        m_started = false;
+    }
+    else if (messageType == StartTimer) {
+        m_start = std::chrono::steady_clock::now();
+        m_started = true;
     }
 }
-
-
 
 } // namespace Opm

--- a/opm/common/OpmLog/TimerLog.hpp
+++ b/opm/common/OpmLog/TimerLog.hpp
@@ -21,12 +21,10 @@
 
 #include <opm/common/OpmLog/StreamLog.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <iosfwd>
-#include <memory>
 #include <string>
-
-#include <time.h>
 
 /*
   This class is a simple demonstration of how the logging framework
@@ -35,10 +33,11 @@
 
 namespace Opm {
 
-class TimerLog : public StreamLog {
+class TimerLog : public StreamLog
+{
 public:
-    static const std::int64_t StartTimer = 4096;
-    static const std::int64_t StopTimer  = 8192;
+    static const std::int64_t StartTimer = INT64_C(1) << 12;
+    static const std::int64_t StopTimer  = INT64_C(1) << 13;
 
     explicit TimerLog(const std::string& logFile);
     explicit TimerLog(std::ostream& os);
@@ -48,12 +47,12 @@ public:
 protected:
     void addMessageUnconditionally(std::int64_t messageFlag,
                                    const std::string& message) override;
+
 private:
-    clock_t m_start;
+    std::chrono::steady_clock::time_point m_start{};
+    bool m_started{false};
 };
 
-typedef std::shared_ptr<TimerLog> TimerLogPtr;
-typedef std::shared_ptr<const TimerLog> TimerLogConstPtr;
 } // namespace Opm
 
 #endif

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -21,20 +21,19 @@
 
 #define BOOST_TEST_MODULE LogTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
-#include <opm/common/OpmLog/OpmLog.hpp>
-#include <opm/common/OpmLog/LogBackend.hpp>
 #include <opm/common/OpmLog/CounterLog.hpp>
-#include <opm/common/OpmLog/TimerLog.hpp>
-#include <opm/common/OpmLog/StreamLog.hpp>
-#include <opm/common/OpmLog/LogUtil.hpp>
 #include <opm/common/OpmLog/KeywordLocation.hpp>
+#include <opm/common/OpmLog/LogBackend.hpp>
+#include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
+#include <opm/common/OpmLog/TimerLog.hpp>
 
 #include <cstdint>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 
@@ -186,9 +185,38 @@ BOOST_AUTO_TEST_CASE(TestTimerLog) {
     logger.addMessageType( TimerLog::StartTimer , "Start");
     logger.addMessageType( TimerLog::StopTimer , "Stop");
 
+    timer->clear();
+
+    logger.addMessage( TimerLog::StopTimer , "Stop without start");
     logger.addMessage( TimerLog::StartTimer , "");
     logger.addMessage( TimerLog::StopTimer , "This was fast");
-    std::cout << sstream.str() << std::endl;
+
+    const std::string logText = sstream.str();
+
+    // Note: Would prefer basic_string<>::contains(), but that requires C++23.
+    BOOST_CHECK_MESSAGE(logText.find("Timer not started when receiving user message") != std::string::npos,
+                        "Log message should indicate that timer was not started when "
+                        "receiving StopTimer message without a preceding StartTimer "
+                        "message. Log text was:\n" << logText);
+
+    const auto lastNonNewline = logText.find_last_not_of('\n');
+    BOOST_REQUIRE(lastNonNewline != std::string::npos);
+
+    const auto lastLineStart = logText.find_last_of('\n', lastNonNewline);
+    const auto timingLine = logText.substr(lastLineStart == std::string::npos ? 0 : lastLineStart + 1,
+                                           lastNonNewline - (lastLineStart == std::string::npos ? 0 : lastLineStart + 1) + 1);
+
+    std::istringstream logged(timingLine);
+    std::string prefix;
+    double elapsed = -1.0;
+    std::string unit;
+
+    std::getline(logged, prefix, ':');
+    logged >> elapsed >> unit;
+
+    BOOST_CHECK_EQUAL(prefix, "This was fast");
+    BOOST_CHECK(elapsed >= 0.0);
+    BOOST_CHECK_EQUAL(unit, "seconds");
 }
 
 /*****************************************************************/


### PR DESCRIPTION
The original implementation used `(start - stop)` which is negative when the stop time is later than the start time.  Even if this facility is not heavily used, it should still be correct and not show negative elapsed times.

While here, also switch to using `<chrono>` instead of the C library's `clock()`/`clock_t`/`CLOCKS_PER_SEC` interface and remove two unused type aliases.