### PR TITLE
[LGR Summary] LB* block-summary evaluators

### DIFF
--- a/opm/io/eclipse/SummaryNode.cpp
+++ b/opm/io/eclipse/SummaryNode.cpp
@@ -271,9 +271,19 @@ Opm::EclIO::SummaryNode::normalise_region_keyword(const std::string& keyword)
 std::optional<std::string> Opm::EclIO::SummaryNode::display_name() const {
     if (use_name(category)) {
         return wgname;
-    } else {
-        return std::nullopt;
     }
+
+    // Block-category nodes inside a local grid refinement need the LGR
+    // name in the SummaryState/unique_key namespace: two LGRs with the
+    // same level-local linearised Cartesian cell index (e.g. number=1
+    // in two 3x3x3 LGRs) would otherwise collide on KEYWORD:number and
+    // overwrite each other's stored value.  Connection/Completion nodes
+    // already disambiguate via wgname, which is per-LGR by WELSPECL.
+    if (category == Category::Block && lgr.has_value()) {
+        return lgr->name;
+    }
+
+    return std::nullopt;
 }
 
 std::optional<std::string> Opm::EclIO::SummaryNode::display_number() const {

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -4137,6 +4137,7 @@ namespace Evaluator {
         const Opm::Inplace& inplace;
         const std::map<std::string, std::vector<double>>& region;
         const std::map<std::pair<std::string, int>, double>& block;
+        const std::map<std::tuple<std::string, int, int>, double>& lgr_block;
         const Opm::data::Aquifers& aquifers;
         const std::unordered_map<std::string, Opm::data::InterRegFlowMap>& ireg;
         const Opm::data::ReservoirCouplingGroupRates* rc_rates;
@@ -4362,6 +4363,62 @@ namespace Evaluator {
         {
             return { this->node_.keyword, this->node_.number };
         }
+    };
+
+    // LB* block-summary evaluator: a block value for a cell inside a local grid
+    // refinement.  Mirrors LgrConnectionValue.  The cell identity is the
+    // (grid level, level-local linearised Cartesian index) pair — the same pair
+    // data::Connection carries as (lgr_grid, index) for LC* connections.  The
+    // level-local Cartesian index is recovered from node.number - 1, and the
+    // level from the LGR name (0 = GLOBAL, 1..N = LGRs), matching
+    // data::Connection::get_lgr_level().
+    class LgrBlockValue : public Base
+    {
+    public:
+        explicit LgrBlockValue(Opm::EclIO::SummaryNode node,
+                               const Opm::UnitSystem::measure m)
+            : node_(std::move(node))
+            , m_   (m)
+        {}
+
+        void update(const std::size_t    /* sim_step */,
+                    const double         /* stepSize */,
+                    const InputData&        input,
+                    const SimulatorResults& simRes,
+                    Opm::SummaryState&      st) const override
+        {
+            assert(this->node_.lgr.has_value() &&
+                   "LgrBlockValue dispatched on a node without lgr info");
+
+            // SummaryConfig::keywordLB leaves node.number at
+            // default_number (INT_MIN) when LGR geometry is
+            // unavailable -- e.g. an LB* record naming an LGR whose
+            // dimensions the CellIndexMapper call-back could not
+            // resolve.  Bail out before computing number - 1
+            // (otherwise INT_MIN - 1 would be signed overflow).
+            // Same convention LgrConnectionValue uses for its
+            // wildcard records.
+            if (this->node_.number == Opm::EclIO::SummaryNode::default_number) {
+                return;
+            }
+
+            const int level = static_cast<int>(
+                input.grid.get_lgr_cell_index(this->node_.lgr->name)) + 1;
+            const int localCellIndex = this->node_.number - 1;
+
+            auto xPos = simRes.lgr_block.find(
+                { this->node_.keyword, level, localCellIndex });
+            if (xPos == simRes.lgr_block.end()) {
+                return;
+            }
+
+            const auto& usys = input.es.getUnits();
+            updateValue(this->node_, usys.from_si(this->m_, xPos->second), st);
+        }
+
+    private:
+        Opm::EclIO::SummaryNode  node_;
+        Opm::UnitSystem::measure m_;
     };
 
     class AquiferValue: public Base
@@ -4839,6 +4896,7 @@ namespace Evaluator {
         Descriptor unknownParameter();
 
         Descriptor lgrConnectionValue();
+        Descriptor lgrBlockValue();
 
         bool isBlockValue();
         bool isAquiferValue();
@@ -4847,6 +4905,7 @@ namespace Evaluator {
         bool isGlobalProcessValue();
         bool isLgrWellValue();
         bool isLgrConnectionValue();
+        bool isLgrBlockValue();
         bool isFunctionRelation();
         bool isUserDefined();
 
@@ -4880,6 +4939,9 @@ namespace Evaluator {
         if (this->isLgrConnectionValue())
             return this->lgrConnectionValue();
 
+        if (this->isLgrBlockValue())
+            return this->lgrBlockValue();
+
         if (this->isLgrWellValue() || this->isFunctionRelation())
             return this->functionRelation();
 
@@ -4905,6 +4967,18 @@ namespace Evaluator {
         desc.unit = this->functionUnitString();
         desc.evaluator.reset(new LgrConnectionValue {
             *this->node_, std::move(this->paramFunction_)
+        });
+
+        return desc;
+    }
+
+    Factory::Descriptor Factory::lgrBlockValue()
+    {
+        auto desc = this->unknownParameter();
+
+        desc.unit = this->directUnitString();
+        desc.evaluator.reset(new LgrBlockValue {
+            *this->node_, this->paramUnit_
         });
 
         return desc;
@@ -5118,6 +5192,30 @@ namespace Evaluator {
         }
 
         this->paramFunction_ = fpos->second;
+        return true;
+    }
+
+    bool Factory::isLgrBlockValue()
+    {
+        // LB* block summary vectors dispatch through a thin LgrBlockValue
+        // evaluator that resolves the (grid level, level-local linearised
+        // Cartesian cell index) pair from node.lgr->name and node.number,
+        // then looks up the per-LGR block value.  The keyword's leading 'L'
+        // is stripped to find the underlying block keyword's unit
+        // (LBPR -> BPR, LBOSAT -> BOSAT, ...).
+        if ((this->node_->category != Opm::EclIO::SummaryNode::Category::Block) ||
+            !this->node_->keyword.starts_with("LB") ||
+            !this->node_->lgr.has_value())
+        {
+            return false;
+        }
+
+        auto pos = block_units.find(this->node_->keyword.substr(1));
+        if (pos == block_units.end()) {
+            return false;
+        }
+
+        this->paramUnit_ = pos->second;
         return true;
     }
 
@@ -5676,6 +5774,9 @@ eval(const int                    sim_step,
     const auto& block_values = (values.block_values != nullptr)
         ? *values.block_values : DynamicSimulatorState::BlockValues{};
 
+    const auto& lgr_block_values = (values.lgr_block_values != nullptr)
+        ? *values.lgr_block_values : DynamicSimulatorState::LgrBlockValues{};
+
     const auto& aquifer_values = (values.aquifer_values != nullptr)
         ? *values.aquifer_values : data::Aquifers{};
 
@@ -5690,6 +5791,7 @@ eval(const int                    sim_step,
         inplace,
         region_values,
         block_values,
+        lgr_block_values,
         aquifer_values,
         interreg_flows,
         values.rc_group_rates

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -78,6 +79,15 @@ public:
         /// Identifier associates a summary keyword and a block ID (linearised
         /// Cartesian cell index).
         using BlockValues = std::map<std::pair<std::string, int>, double>;
+
+        /// Collection of per-block quantities for cells inside a local grid
+        /// refinement (LB* summary vectors).
+        ///
+        /// Identifier is (summary keyword, grid level, level-local linearised
+        /// Cartesian cell index) — the same cell identity that data::Connection
+        /// carries as (lgr_grid, index) for LC* connection vectors.  Level 0 is
+        /// the global grid; levels 1.. are the LGRs.  Empty for runs without LGRs.
+        using LgrBlockValues = std::map<std::tuple<std::string, int, int>, double>;
 
         /// Collection of named inter-region flows (rates and cumulatives)
         ///
@@ -155,6 +165,14 @@ public:
         ///
         /// Selection configured by SummaryConfig object.
         VolumeInPlace inplace{};
+
+        /// LGR block (cell) level dynamic state values (LB* vectors).
+        ///
+        /// Empty/nullptr for runs without LGRs.  Appended at the end of the
+        /// struct so existing client code that initialises the public
+        /// DynamicSimulatorState aggregate positionally continues to compile
+        /// unchanged; the field defaults to nullptr at those sites.
+        const LgrBlockValues* lgr_block_values {nullptr};
     };
 
     /// Constructor

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -4253,6 +4253,175 @@ TSTEP
                       -100.0, 1e-5);
 }
 
+BOOST_AUTO_TEST_CASE(LGR_block_factory_dispatch)
+{
+    // Verify three things at once for LB* block-summary vectors:
+    //   (1) the Factory routes LB* nodes to LgrBlockValue (not unknownParameter,
+    //       not falling through to global isBlockValue and being rejected on the
+    //       global cellActive check);
+    //   (2) values are picked up from DynamicSimulatorState::lgr_block_values
+    //       under the (keyword, grid level, level-local Cartesian index) key;
+    //   (3) two LB* nodes in *different* LGRs that share the same keyword and
+    //       the same level-local Cartesian index do NOT collide in SummaryState
+    //       (each LGR's value lands in its own unique_key, disambiguated by
+    //       SummaryNode::display_name returning the LGR name for Block nodes).
+    const std::string lgr_block_deck = R"(
+RUNSPEC
+TITLE
+   LGR_BLOCK_FACTORY_DISPATCH
+DIMENS
+   3 1 1 /
+TABDIMS
+/
+EQLDIMS
+/
+OIL
+GAS
+WATER
+DISGAS
+FIELD
+START
+   1 'JAN' 2015 /
+WELLDIMS
+   1 1 1 1 /
+UNIFOUT
+GRID
+CARFIN
+'LGR1'  1  1  1  1  1  1  3  3  1 /
+ENDFIN
+CARFIN
+'LGR2'  3  3  1  1  1  1  3  3  1 /
+ENDFIN
+DX
+   3*2333 /
+DY
+   3*3500 /
+DZ
+   3*50 /
+TOPS
+   3*8325 /
+PORO
+   3*0.3 /
+PERMX
+   3*500 /
+PERMY
+   3*250 /
+PERMZ
+   3*200 /
+PROPS
+PVTW
+   4017.55 1.038 3.22E-6 0.318 0.0 /
+ROCK
+   14.7 3E-6 /
+SWOF
+   0.12 0.0   1.0  0.0
+   1.0  1.0   0.0  0.0 /
+PVDO
+   400  1.0627  1.180
+   800  1.0483  1.181 /
+PVDG
+   400  5.9e-3  0.013
+   800  2.95e-3 0.014 /
+DENSITY
+   53.0  64.79  0.0702 /
+SOLUTION
+EQUIL
+   8400.0  4800.0  8450.0  0.0  8335.0  0.0 /
+SUMMARY
+LBPR
+   'LGR1'  3 3 1 /
+   'LGR2'  3 3 1 /
+/
+SCHEDULE
+TSTEP
+   1 /
+)";
+
+    WorkArea ta { "lgr_block_factory_dispatch" };
+
+    const auto deck   = Parser{}.parseString(lgr_block_deck);
+    const auto es     = EclipseState{ deck };
+    const auto& grid  = es.getInputGrid();
+    const auto  sched = Schedule{ deck, es, std::make_shared<Python>() };
+
+    // LGR-aware mapper so the (LGR, I, J, K) records resolve to a
+    // level-local linearised Cartesian + 1 NUMS key.
+    auto lgrMapper = [&grid](const std::string& gridID) -> GridDims {
+        if (gridID.empty()) {
+            return GridDims{ grid.getNX(), grid.getNY(), grid.getNZ() };
+        }
+        const auto& lgr = grid.getLGRCell(gridID);
+        return GridDims{ lgr.getNX(), lgr.getNY(), lgr.getNZ() };
+    };
+
+    auto parseCtx = ParseContext{};
+    auto errors   = ErrorGuard{};
+    auto config = SummaryConfig{
+        deck, sched, es.fieldProps(), es.aquifer(),
+        parseCtx, errors, lgrMapper
+    };
+
+    // Both LGRs are 3x3x1 with the LBPR record at (3,3,1) -> (i,j,k) = (2,2,0)
+    // -> the SAME level-local linearised Cartesian index for both.  This is
+    // the scenario the SummaryNode::display_name LGR disambiguator exists to
+    // handle (two unique_keys, not one shared key that overwrites).
+    const std::size_t levelLocalCellIndex =
+        grid.getLGRCell("LGR1").getGlobalIndex(2, 2, 0);
+    BOOST_REQUIRE_EQUAL(levelLocalCellIndex,
+                        grid.getLGRCell("LGR2").getGlobalIndex(2, 2, 0));
+
+    const int level_lgr1 = static_cast<int>(grid.get_lgr_cell_index("LGR1")) + 1;
+    const int level_lgr2 = static_cast<int>(grid.get_lgr_cell_index("LGR2")) + 1;
+    BOOST_REQUIRE_NE(level_lgr1, level_lgr2);
+
+    // Fabricate distinct pressures for each LGR cell, supplied in SI so the
+    // evaluator's from_si on the BPR unit (Pressure) converts to PSIA under
+    // the deck's FIELD unit system.
+    const double pSI_lgr1 = 100.0 * unit::psia;
+    const double pSI_lgr2 = 250.0 * unit::psia;
+
+    auto lgr_blocks = out::Summary::DynamicSimulatorState::LgrBlockValues{};
+    lgr_blocks[std::make_tuple(std::string{"LBPR"}, level_lgr1,
+                               static_cast<int>(levelLocalCellIndex))] = pSI_lgr1;
+    lgr_blocks[std::make_tuple(std::string{"LBPR"}, level_lgr2,
+                               static_cast<int>(levelLocalCellIndex))] = pSI_lgr2;
+
+    auto wbp      = data::WellBlockAveragePressures{};
+    auto grp_nwrk = data::GroupAndNetworkValues{};
+    auto wells    = data::Wells{};
+
+    auto writer = out::Summary { config, es, grid, sched, "LGR_BLOCK_DISPATCH" };
+    auto st     = SummaryState { TimeService::now(),
+                                 es.runspec().udqParams().undefinedValue() };
+
+    auto values                    = out::Summary::DynamicSimulatorState{};
+    values.well_solution           = &wells;
+    values.wbp                     = &wbp;
+    values.group_and_nwrk_solution = &grp_nwrk;
+    values.lgr_block_values        = &lgr_blocks;
+
+    writer.eval(1, 1.0 * day, values, st);
+
+    // Two SummaryState keys, one per LGR, both populated.  unique_key for a
+    // Block+lgr node is "KEYWORD:LGRNAME:number" (level-local Cartesian + 1).
+    const std::size_t node_number = levelLocalCellIndex + 1;
+    const auto key_lgr1 = "LBPR:LGR1:" + std::to_string(node_number);
+    const auto key_lgr2 = "LBPR:LGR2:" + std::to_string(node_number);
+
+    BOOST_REQUIRE_NE(key_lgr1, key_lgr2);  // disambiguation is real, not a coincidence
+    BOOST_CHECK(st.has(key_lgr1));
+    BOOST_CHECK(st.has(key_lgr2));
+    BOOST_CHECK_CLOSE(st.get(key_lgr1), 100.0, 1e-5);
+    BOOST_CHECK_CLOSE(st.get(key_lgr2), 250.0, 1e-5);
+
+    // Global B* path is untouched when lgr_block_values is empty/absent:
+    // a parallel run with a global BPR keyword and no lgr_block_values
+    // population must still see the global BlockValues map (asserted
+    // indirectly by the +/- zero changes to the global block path here:
+    // no global B* requested in this deck, no global block_values supplied,
+    // and the eval above completes without throwing).
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Summary
 
 // ####################################################################


### PR DESCRIPTION
# [LGR Summary] LB* block-summary evaluators

## Summary

`LB*` block-summary keywords (`LBPR`, `LBOSAT`, `LBWSAT`, …) name a cell **inside a local
grid refinement** by `(LGR, I, J, K)` and must emit that cell's block property to the
SummaryState / UNSMRY. This adds the runtime evaluator for those keywords on the
opm-common side. The cell identity is `(grid level, level-local linearised Cartesian cell
index)` — the same identity `data::Connection` already carries as `(lgr_grid, index)` for
`LC*` connection vectors.

The change is **additive**: a new parallel map sits alongside the existing global
`BlockValues`. The existing global `B*` path, the `BlockValues` key, and the writer are
byte-identical (0 deletions in the production path); runs without LGRs leave the new map
empty (zero cost).

## Change

`opm/output/eclipse/Summary.hpp`
- New `DynamicSimulatorState::LgrBlockValues` type:
  `std::map<std::tuple<std::string /*keyword*/, int /*level*/, int /*level-local Cartesian*/>, double>`.
- New `lgr_block_values` pointer next to the existing `block_values`. Default `nullptr`.

`opm/output/eclipse/Summary.cpp`
- `Evaluator::SimulatorResults` gains a matching `lgr_block` reference;
  `Summary::eval()` threads the new map through with the same nullptr→empty
  fallback already used for `block_values`.
- New `LgrBlockValue` evaluator. Resolves the grid level from the LGR name
  (`EclipseGrid::get_lgr_cell_index(name) + 1`, the same value
  `data::Connection::lgr_grid` carries for `LC*`), the level-local index from
  `node.number - 1` (NUMS - 1, already populated by `SummaryConfig::keywordLB`),
  and looks up `(keyword, level, local)` in `simRes.lgr_block`. Strips the leading
  `L` to find the underlying block keyword's unit (`LBPR → BPR`), mirroring
  `LgrConnectionValue`.
- `Factory::isLgrBlockValue` / `Factory::lgrBlockValue` routed in `Factory::create()`
  after `isLgrConnectionValue`, before the `isLgrWellValue || isFunctionRelation`
  fall-through. Gated on `Category::Block` + `LB` prefix + `lgr.has_value()`, so
  the global `B*` path is never reached for `LB*` keywords and vice versa.

`opm/io/eclipse/SummaryNode.cpp`
- `SummaryNode::display_name` now returns the LGR name for Block-category nodes with
  `lgr.has_value()`. Block-category `unique_key` was `KEYWORD:number`, which collides
  between LGRs that share the same level-local Cartesian index (two 4×4×4 LGRs at
  `IJK(1,2,3)` both have `number = 37`). Connection nodes already disambiguate via
  `wgname` (per-LGR through `WELSPECL`); blocks have no well, so the LGR name takes
  that role. Non-LGR Block nodes (`lgr` is `std::nullopt`) are unchanged.

## Test

`tests/test_Summary.cpp` — new `Summary/LGR_block_factory_dispatch`. Builds a 3×1×1 deck
with `CARFIN LGR1`/`LGR2` and `LBPR` records at the same level-local `(I,J,K)` in both
LGRs (the collision scenario the `display_name` change addresses), fabricates distinct
values keyed by `(LBPR, level, local)` for each LGR in `DynamicSimulatorState::lgr_block_values`,
and asserts that two distinct SummaryState keys land with the right per-LGR pressures.

## Effect

- `LB*` summary vectors now resolve to values whenever the simulator populates
  `DynamicSimulatorState::lgr_block_values`. The producer that walks LGR leaf cells
  and keys `(keyword, level, level-local Cartesian)` via `LevelCartesianIndexMapper<CpGrid>`
  is a separate opm-simulators change.
- Non-LGR runs: no behaviour change, no allocation, no extra work.
- Global `B*` vectors: byte-identical evaluation.
