### PR TITLE
adding surface equation-of-state keywords

### DIFF
--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -40,6 +40,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/V.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/Z.hpp>
 
 #include <fmt/format.h>
 
@@ -56,6 +57,82 @@
 
 namespace {
 
+    template <typename Keyword>
+    const Opm::DeckKeyword* getSinglePropsKeyword(const Opm::PROPSSection& props_section)
+    {
+        if (!props_section.hasKeyword<Keyword>()) {
+            return nullptr;
+        }
+
+        const auto& keywords = props_section.get<Keyword>();
+        if (keywords.size() > 1) {
+            throw Opm::OpmInputError {
+                fmt::format("there are multiple {} keyword specifications", Keyword::keywordName),
+                keywords.begin()->location()
+            };
+        }
+
+        return &keywords.back();
+    }
+
+    void validateKeywordRegionCount(const Opm::DeckKeyword& kw,
+                                    const std::size_t       num_regions,
+                                    const std::string_view  region_description,
+                                    const bool              has_default_value)
+    {
+        const auto& kw_name = kw.name();
+        if (kw.size() > num_regions) {
+            throw Opm::OpmInputError {
+                fmt::format("there are {} {}, while {} "
+                            "regions are specified in {}",
+                            num_regions, region_description, kw.size(), kw_name),
+                kw.location()
+            };
+        }
+
+        if (!has_default_value && kw.size() != num_regions) {
+            throw Opm::OpmInputError {
+                fmt::format("there are {} {}, while only {} "
+                            "regions are specified in {}",
+                            num_regions, region_description, kw.size(), kw_name),
+                kw.location()
+            };
+        }
+    }
+
+    template <typename Keyword>
+    void parsingKeywordValues(const Opm::DeckKeyword&        kw,
+                              std::vector<std::vector<double>>& target,
+                              const std::size_t              num_values,
+                              const std::optional<double>    default_value)
+    {
+        const auto& kw_name = Keyword::keywordName;
+
+        for (std::size_t i = 0; i < kw.size(); ++i) {
+            const auto& item = kw.getRecord(i).template getItem<typename Keyword::DATA>();
+            const auto& data = item.getSIDoubleData();
+
+            if (!default_value.has_value()) {
+                if (data.size() != num_values) {
+                    const auto msg = fmt::format("in keyword {}, {} values are specified, "
+                                                 "but {} values are expected",
+                                                 kw_name, data.size(), num_values);
+                    throw Opm::OpmInputError(msg, kw.location());
+                }
+            }
+            else if (data.size() > num_values) {
+                const auto msg = fmt::format("in keyword {}, {} values are specified, "
+                                             "which is bigger than the number "
+                                             "{} should be specified",
+                                             kw_name, data.size(), num_values);
+
+                throw Opm::OpmInputError(msg, kw.location());
+            }
+
+            std::ranges::copy(data, target[i].begin());
+        }
+    }
+
     // The following function is used to parse compositional related keywords:
     // MW, ACF, BIC, PCRIT, TCRIT, VCRIT and SSHIFT, and so on.
     template <typename Keyword>
@@ -65,10 +142,8 @@ namespace {
                         const std::size_t num_values,
                         const std::optional<double> default_value = std::nullopt)
     {
-        // For keywords with default values, populate the target with the default
-        // value even if the keyword is not specified.
-        // Note: This may need revisiting if more defaultable keywords are added.
-        if (! props_section.hasKeyword<Keyword>() ) {
+        const auto* kw = getSinglePropsKeyword<Keyword>(props_section);
+        if (!kw) {
             if (default_value.has_value()) {
                 target.assign(num_eos_res,std::vector(num_values, default_value.value()));
             }
@@ -78,57 +153,104 @@ namespace {
 
         target.assign(num_eos_res,std::vector(num_values, default_value.value_or(0.0)));
 
-        const auto& kw_name = Keyword::keywordName;
-        const auto& keywords = props_section.get<Keyword>();
-        // we do not allow multiple input of the keyword unless proven otherwise
-        if (keywords.size() > 1) {
-            throw Opm::OpmInputError {
-                fmt::format("there are multiple {} "
-                            "keyword specifications", kw_name),
-                keywords.begin()->location()
-            };
+        validateKeywordRegionCount(*kw, num_eos_res, "EOS regions",
+                                   default_value.has_value());
+
+        parsingKeywordValues<Keyword>(*kw, target, num_values, default_value);
+    }
+
+    // Parse one surface keyword. If absent, inherit per-region reservoir values.
+    // If present, use only keyword data/defaults (no reservoir fallback).
+    template <typename Keyword>
+    void processSurfaceKeyword(const Opm::PROPSSection& props_section,
+                               std::vector<std::vector<double>>& target,
+                               const std::vector<std::vector<double>>& res_source,
+                               const std::size_t num_eos_sur,
+                               const std::size_t num_eos_res,
+                               const std::size_t num_values,
+                               const std::optional<double> default_value = std::nullopt)
+    {
+        const auto* kw = getSinglePropsKeyword<Keyword>(props_section);
+
+        if (!kw) {
+            // Missing surface keyword: inherit from reservoir regions.
+            if (!res_source.empty()) {
+                target.resize(num_eos_sur);
+                for (std::size_t i = 0; i < num_eos_sur; ++i) {
+                    const std::size_t res_idx = std::min(i, num_eos_res - 1);
+                    target[i] = res_source[res_idx];
+                }
+            }
+            return;
         }
 
-        // there is no default value, we make sure we specify the exact
-        // number of values for all the EOS regions and components
-        const auto& kw = keywords.back();
-        if (kw.size() != num_eos_res) {
-            throw Opm::OpmInputError {
-                fmt::format("there are {} EOS regions, while only {} "
-                            "regions are specified in {}",
-                            num_eos_res, kw.size(),
-                            kw_name), kw.location()
-            };
+        // Specified surface keyword: require full region coverage if no item default exists.
+        validateKeywordRegionCount(*kw, num_eos_sur, "surface EOS regions",
+                                   default_value.has_value());
+
+        target.assign(num_eos_sur,
+                      std::vector<double>(num_values, default_value.value_or(0.0)));
+
+        parsingKeywordValues<Keyword>(*kw, target, num_values, default_value);
+    }
+
+    // Resolve EOS/EOSS from PROPS or RUNSPEC (exclusive), with at most one instance.
+    template <typename Keyword>
+    const Opm::DeckKeyword*
+    resolveEosKeyword(const Opm::PROPSSection&   props_section,
+                      const Opm::RUNSPECSection& runspec_section)
+    {
+        const auto& kw_name    = Keyword::keywordName;
+        const bool  has_props   = props_section  .hasKeyword<Keyword>();
+        const bool  has_runspec = runspec_section.hasKeyword<Keyword>();
+
+        if (!has_props && !has_runspec) {
+            return nullptr;
+        }
+
+        if (has_props && has_runspec) {
+            throw Opm::OpmInputError(
+                fmt::format("{} is specified in both RUNSPEC and PROPS sections", kw_name),
+                props_section.get<Keyword>().begin()->location());
+        }
+
+        const auto& keywords = has_props
+            ? props_section  .get<Keyword>()
+            : runspec_section.get<Keyword>();
+
+        if (keywords.size() > 1) {
+            throw Opm::OpmInputError(
+                fmt::format("there are multiple {} keyword specifications", kw_name),
+                keywords.begin()->location());
+        }
+
+        return &keywords.back();
+    }
+
+    // Parse EOS/EOSS records into pre-sized output.
+    // Defaulted EQUATION items are skipped, keeping the caller-provided default.
+    template <typename Keyword>
+    void parseEosRecords(const Opm::DeckKeyword&                         kw,
+                         std::vector<Opm::CompositionalConfig::EOSType>& out,
+                         const std::size_t                               max_regions,
+                         const std::string_view                          region_description)
+    {
+        const auto& kw_name = Keyword::keywordName;
+
+        if (kw.size() > max_regions) {
+            throw Opm::OpmInputError(
+                fmt::format("{} equations of state are specified in keyword {}, "
+                            "which is more than the number of {} regions of {}.",
+                            kw.size(), kw_name, region_description, max_regions),
+                kw.location());
         }
 
         for (std::size_t i = 0; i < kw.size(); ++i) {
-            const auto& item = kw.getRecord(i).template getItem<typename Keyword::DATA>();
-            const auto& data = item.getSIDoubleData();
-            if (! default_value.has_value()) {
-                // when there is no default values, we should specify all the values
-                if (data.size() != num_values) {
-                    const auto msg = fmt::format("in keyword {}, {} values are specified, "
-                                                 "which is different from the "
-                                                 "number of components {}",
-                                                 kw_name, data.size(), num_values);
-                    throw Opm::OpmInputError(msg, kw.location());
-                }
+            const auto& item = kw.getRecord(i).template getItem<typename Keyword::EQUATION>();
+            if (item.defaultApplied(0)) {
+                continue;
             }
-            else if (data.size() > num_values) {
-                // when there is default values, we should not specify more
-                // values than needed
-                const auto msg = fmt::format("in keyword {}, {} values are specified, "
-                                             "which is bigger than the number "
-                                             "{} should be specified",
-                                             kw_name, data.size(), num_values);
-
-                throw Opm::OpmInputError(msg, kw.location());
-            }
-
-            // using copy here to consider the situation that there is
-            // default values, we might not specify all the values and keep
-            // the rest to be the default values
-            std::ranges::copy(data, target[i].begin());
+            out[i] = Opm::CompositionalConfig::eosTypeFromString(item.getTrimmedString(0));
         }
     }
 
@@ -140,14 +262,25 @@ namespace {
             std::pair {"NCOMPS"sv, section.hasKeyword<Opm::ParserKeywords::NCOMPS>() },
             std::pair {"CNAMES"sv, section.hasKeyword<Opm::ParserKeywords::CNAMES>() },
             std::pair {"EOS"sv,    section.hasKeyword<Opm::ParserKeywords::EOS>() },
+            std::pair {"EOSS"sv,   section.hasKeyword<Opm::ParserKeywords::EOSS>() },
             std::pair {"STCOND"sv, section.hasKeyword<Opm::ParserKeywords::STCOND>() },
             std::pair {"PCRIT"sv,  section.hasKeyword<Opm::ParserKeywords::PCRIT>() },
+            std::pair {"PCRITS"sv, section.hasKeyword<Opm::ParserKeywords::PCRITS>() },
             std::pair {"TCRIT"sv,  section.hasKeyword<Opm::ParserKeywords::TCRIT>() },
+            std::pair {"TCRITS"sv, section.hasKeyword<Opm::ParserKeywords::TCRITS>() },
             std::pair {"VCRIT"sv,  section.hasKeyword<Opm::ParserKeywords::VCRIT>() },
             std::pair {"SSHIFT"sv, section.hasKeyword<Opm::ParserKeywords::SSHIFT>() },
+            std::pair {"SSHIFTS"sv, section.hasKeyword<Opm::ParserKeywords::SSHIFTS>() },
+            std::pair {"VCRITS"sv, section.hasKeyword<Opm::ParserKeywords::VCRITS>() },
+            std::pair {"ZCRIT"sv,  section.hasKeyword<Opm::ParserKeywords::ZCRIT>() },
+            std::pair {"ZCRITS"sv, section.hasKeyword<Opm::ParserKeywords::ZCRITS>() },
+            std::pair {"MW"sv,     section.hasKeyword<Opm::ParserKeywords::MW>() },
+            std::pair {"MWS"sv,    section.hasKeyword<Opm::ParserKeywords::MWS>() },
             std::pair {"ACF"sv,    section.hasKeyword<Opm::ParserKeywords::ACF>() },
+            std::pair {"ACFS"sv,   section.hasKeyword<Opm::ParserKeywords::ACFS>() },
             std::pair {"BIC"sv,    section.hasKeyword<Opm::ParserKeywords::BIC>() },
             std::pair {"PRCORR"sv, section.hasKeyword<Opm::ParserKeywords::PRCORR>() },
+            std::pair {"BICS"sv,   section.hasKeyword<Opm::ParserKeywords::BICS>() },
         };
 
         bool any_comp_prop_kw = false;
@@ -236,41 +369,43 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
 
     const Tabdims tabdims{deck};
     const std::size_t num_eos_res = tabdims.getNumEosRes();
-    // EOS keyword can also be in RUNSPEC section, we also parse the EOS in the RUNSPEC section here for simplicity
-    // might be suggested to handle in the RUNSPEC section though
+
+    // EOS may live in RUNSPEC or PROPS; parse it here.
     eos_types.resize(num_eos_res, EOSType::PR);
     {
-        const RUNSPECSection runsec_section {deck};
-        using KWEOS = ParserKeywords::EOS;
-        if (props_section.hasKeyword<KWEOS>() || runsec_section.hasKeyword<KWEOS>()) {
-            // we are not allowing EOS specified in both places
-            if (props_section.hasKeyword<KWEOS>() && runsec_section.hasKeyword<KWEOS>()) {
-                throw std::logic_error("EOS is specified in both RUNSPEC and PROP sections");
-            }
+        const RUNSPECSection runspec_section{deck};
+        if (const auto* kw = resolveEosKeyword<ParserKeywords::EOS>(
+                props_section, runspec_section))
+        {
+            parseEosRecords<ParserKeywords::EOS>(
+                *kw, eos_types, num_eos_res,
+                "reservoir-condition equation of state");
+        }
+    }
 
-            // we do not allow multiple input of the keyword EOS unless proven otherwise
-            // only one section has EOS defined when we reach here
-            const auto& keywords = props_section.hasKeyword<KWEOS>() ? props_section.get<KWEOS>() : runsec_section.get<KWEOS>();
-            if (keywords.size() > 1) {
-                throw OpmInputError("there are multiple EOS keyword specification", keywords.begin()->location());
-            }
-            const auto& kw = keywords.back();
-            if (kw.size() > num_eos_res) {
-                const auto msg = fmt::format(" {} equations of state are specified in keyword EOS, which is more than the number of"
-                                             " of equation of state regions of {}.", kw.size(), num_eos_res);
-                throw OpmInputError(msg, kw.location());
-            }
-            for (std::size_t i = 0; i < kw.size(); ++i) {
-                const auto& item = kw.getRecord(i).getItem<KWEOS::EQUATION>();
-                const auto& equ_str = item.getTrimmedString(0);
-                eos_types[i] = eosTypeFromString(equ_str);
+    // EOSS may be in RUNSPEC or PROPS.
+    // If absent, surface EOS follows reservoir EOS per region (clipped by last reservoir region).
+    const std::size_t num_eos_sur = tabdims.getNumEosSur();
+    {
+        const RUNSPECSection runspec_section{deck};
+        if (const auto* kw = resolveEosKeyword<ParserKeywords::EOSS>(
+                props_section, runspec_section))
+        {
+            eos_types_surf.assign(num_eos_sur, EOSType::PR);
+            parseEosRecords<ParserKeywords::EOSS>(
+                *kw, eos_types_surf, num_eos_sur,
+                "surface-condition equation of state");
+        }
+        else {
+            // No EOSS: inherit surface EOS from reservoir EOS.
+            eos_types_surf.resize(num_eos_sur);
+            for (std::size_t i = 0; i < num_eos_sur; ++i) {
+                eos_types_surf[i] = eos_types[std::min(i, num_eos_res - 1)];
             }
         }
     }
 
-    // PRCORR keyword: modifies the Peng-Robinson EOS. For each EOS region using
-    // PR, switch to PRCORR. For regions using a different EOS, log a message
-    // that PRCORR has no effect there.
+    // PRCORR promotes PR -> PRCORR in reservoir and surface EOS regions.
     if (props_section.hasKeyword<ParserKeywords::PRCORR>()) {
         const auto& keywords = props_section.get<ParserKeywords::PRCORR>();
         if (keywords.size() > 1) {
@@ -278,24 +413,36 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
                                 keywords.begin()->location());
         }
 
-        std::string unaffected_regions;
-        for (std::size_t i = 0; i < eos_types.size(); ++i) {
-            if (eos_types[i] == EOSType::PR) {
-                eos_types[i] = EOSType::PRCORR;
-            } else {
-                if (!unaffected_regions.empty()) {
-                    unaffected_regions += ", ";
+        auto promote = [](std::vector<EOSType>& types) {
+            std::string unaffected;
+            for (std::size_t i = 0; i < types.size(); ++i) {
+                if (types[i] == EOSType::PR) {
+                    types[i] = EOSType::PRCORR;
+                } else if (types[i] != EOSType::PRCORR) {
+                    if (!unaffected.empty()) {
+                        unaffected += ", ";
+                    }
+                    fmt::format_to(std::back_inserter(unaffected),
+                                   "{} ({})", i + 1, eosTypeToString(types[i]));
                 }
-                fmt::format_to(std::back_inserter(unaffected_regions),
-                               "{} ({})", i + 1, eosTypeToString(eos_types[i]));
             }
-        }
+            return unaffected;
+        };
 
-        if (!unaffected_regions.empty()) {
-            const auto& location = keywords.back().location();
+        const std::string unaffected_res = promote(eos_types);
+        const std::string unaffected_surf = promote(eos_types_surf);
+
+        const auto& location = keywords.back().location();
+        if (!unaffected_res.empty()) {
             const auto msg = fmt::format(
-                "PRCORR is ignored for EOS region(s) {} because their EOS is not PR.",
-                unaffected_regions);
+                "PRCORR is ignored for reservoir EOS region(s) {} because their EOS is not PR.",
+                unaffected_res);
+            OpmLog::info(Opm::Log::fileMessage(location, msg));
+        }
+        if (!unaffected_surf.empty()) {
+            const auto msg = fmt::format(
+                "PRCORR is ignored for surface EOS region(s) {} because their EOS is not PR.",
+                unaffected_surf);
             OpmLog::info(Opm::Log::fileMessage(location, msg));
         }
     }
@@ -312,10 +459,38 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
                                           num_eos_res, this->num_comps);
     processKeyword<ParserKeywords::SSHIFT>(props_section, this->volume_shifts,
                                            num_eos_res, this->num_comps, 0.);
+    processKeyword<ParserKeywords::ZCRIT>(props_section, this->critical_z_factor,
+                                          num_eos_res, this->num_comps);
 
     const std::size_t bic_size = this->num_comps * (this->num_comps - 1) / 2;
     processKeyword<ParserKeywords::BIC>(props_section, this->binary_interaction_coefficient,
                                         num_eos_res, bic_size, 0.);
+
+    // Surface keywords are sized by NMEOSS and handled independently per keyword.
+    processSurfaceKeyword<ParserKeywords::MWS>(props_section, this->molecular_weights_surf,
+                                               this->molecular_weights,
+                                               num_eos_sur, num_eos_res, this->num_comps);
+    processSurfaceKeyword<ParserKeywords::ACFS>(props_section, this->acentric_factors_surf,
+                                                this->acentric_factors,
+                                                num_eos_sur, num_eos_res, this->num_comps);
+    processSurfaceKeyword<ParserKeywords::PCRITS>(props_section, this->critical_pressure_surf,
+                                                  this->critical_pressure,
+                                                  num_eos_sur, num_eos_res, this->num_comps);
+    processSurfaceKeyword<ParserKeywords::TCRITS>(props_section, this->critical_temperature_surf,
+                                                  this->critical_temperature,
+                                                  num_eos_sur, num_eos_res, this->num_comps);
+    processSurfaceKeyword<ParserKeywords::VCRITS>(props_section, this->critical_volume_surf,
+                                                  this->critical_volume,
+                                                  num_eos_sur, num_eos_res, this->num_comps);
+    processSurfaceKeyword<ParserKeywords::ZCRITS>(props_section, this->critical_z_factor_surf,
+                                                  this->critical_z_factor,
+                                                  num_eos_sur, num_eos_res, this->num_comps);
+    processSurfaceKeyword<ParserKeywords::SSHIFTS>(props_section, this->volume_shifts_surf,
+                                                   this->volume_shifts,
+                                                   num_eos_sur, num_eos_res, this->num_comps, 0.);
+    processSurfaceKeyword<ParserKeywords::BICS>(props_section, this->binary_interaction_coefficient_surf,
+                                                this->binary_interaction_coefficient,
+                                                num_eos_sur, num_eos_res, bic_size, 0.);
 }
 
 bool CompositionalConfig::operator==(const CompositionalConfig& other) const {
@@ -330,7 +505,17 @@ bool CompositionalConfig::operator==(const CompositionalConfig& other) const {
            this->critical_temperature == other.critical_temperature &&
            this->critical_volume == other.critical_volume &&
            this->volume_shifts == other.volume_shifts &&
-           this->binary_interaction_coefficient == other.binary_interaction_coefficient;
+           this->critical_z_factor == other.critical_z_factor &&
+           this->binary_interaction_coefficient == other.binary_interaction_coefficient &&
+           this->eos_types_surf == other.eos_types_surf &&
+           this->molecular_weights_surf == other.molecular_weights_surf &&
+           this->acentric_factors_surf == other.acentric_factors_surf &&
+           this->critical_pressure_surf == other.critical_pressure_surf &&
+           this->critical_temperature_surf == other.critical_temperature_surf &&
+           this->critical_volume_surf == other.critical_volume_surf &&
+           this->critical_z_factor_surf == other.critical_z_factor_surf &&
+           this->volume_shifts_surf == other.volume_shifts_surf &&
+           this->binary_interaction_coefficient_surf == other.binary_interaction_coefficient_surf;
 }
 
 
@@ -348,7 +533,17 @@ CompositionalConfig CompositionalConfig::serializationTestObject() {
     result.critical_temperature = {2, std::vector<double>(result.num_comps, 3.)};
     result.critical_volume = {2, std::vector<double>(result.num_comps, 5.)};
     result.volume_shifts = {2, std::vector<double>(result.num_comps, 0.1)};
+    result.critical_z_factor = {2, std::vector<double>(result.num_comps, 0.29)};
     result.binary_interaction_coefficient = {2, std::vector<double>(result.num_comps * (result.num_comps - 1) / 2, 6.)};
+    result.eos_types_surf = {3, EOSType::PR};
+    result.molecular_weights_surf = {3, std::vector<double>(result.num_comps, 17.)};
+    result.acentric_factors_surf = {3, std::vector<double>(result.num_comps, 1.1)};
+    result.critical_pressure_surf = {3, std::vector<double>(result.num_comps, 2.1)};
+    result.critical_temperature_surf = {3, std::vector<double>(result.num_comps, 3.1)};
+    result.critical_volume_surf = {3, std::vector<double>(result.num_comps, 5.1)};
+    result.critical_z_factor_surf = {3, std::vector<double>(result.num_comps, 0.3)};
+    result.volume_shifts_surf = {3, std::vector<double>(result.num_comps, 0.11)};
+    result.binary_interaction_coefficient_surf = {3, std::vector<double>(result.num_comps * (result.num_comps - 1) / 2, 6.1)};
 
     return result;
 }
@@ -413,8 +608,48 @@ const std::vector<double>& CompositionalConfig::volumeShifts(std::size_t eos_reg
     return this->volume_shifts[eos_region];
 }
 
+const std::vector<double>& CompositionalConfig::criticalZFactor(std::size_t eos_region) const {
+    return this->critical_z_factor[eos_region];
+}
+
 const std::vector<double>& CompositionalConfig::binaryInteractionCoefficient(std::size_t eos_region) const {
     return this->binary_interaction_coefficient[eos_region];
+}
+
+CompositionalConfig::EOSType CompositionalConfig::eosTypeSurf(size_t eos_region) const {
+    return this->eos_types_surf[eos_region];
+}
+
+const std::vector<double>& CompositionalConfig::molecularWeightsSurf(std::size_t eos_region) const {
+    return this->molecular_weights_surf[eos_region];
+}
+
+const std::vector<double>& CompositionalConfig::acentricFactorsSurf(size_t eos_region) const {
+    return this->acentric_factors_surf[eos_region];
+}
+
+const std::vector<double>& CompositionalConfig::criticalPressureSurf(size_t eos_region) const {
+    return this->critical_pressure_surf[eos_region];
+}
+
+const std::vector<double>& CompositionalConfig::criticalTemperatureSurf(size_t eos_region) const {
+    return this->critical_temperature_surf[eos_region];
+}
+
+const std::vector<double>& CompositionalConfig::criticalVolumeSurf(size_t eos_region) const {
+    return this->critical_volume_surf[eos_region];
+}
+
+const std::vector<double>& CompositionalConfig::criticalZFactorSurf(size_t eos_region) const {
+    return this->critical_z_factor_surf[eos_region];
+}
+
+const std::vector<double>& CompositionalConfig::volumeShiftsSurf(size_t eos_region) const {
+    return this->volume_shifts_surf[eos_region];
+}
+
+const std::vector<double>& CompositionalConfig::binaryInteractionCoefficientSurf(size_t eos_region) const {
+    return this->binary_interaction_coefficient_surf[eos_region];
 }
 
 std::size_t CompositionalConfig::numComps() const {

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -52,8 +52,8 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <utility>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -68,7 +68,7 @@ namespace {
         const auto& keywords = props_section.get<Keyword>();
         if (keywords.size() > 1) {
             throw Opm::OpmInputError {
-                fmt::format("there are multiple {} keyword specifications", Keyword::keywordName),
+                fmt::format("there are multiple {} keyword specifications", keywords.front().name()),
                 keywords.begin()->location()
             };
         }
@@ -107,7 +107,7 @@ namespace {
                               const std::size_t              num_values,
                               const std::optional<double>    default_value)
     {
-        const auto& kw_name = Keyword::keywordName;
+        const auto& kw_name = kw.name();
 
         for (std::size_t i = 0; i < kw.size(); ++i) {
             const auto& item = kw.getRecord(i).template getItem<typename Keyword::DATA>();
@@ -204,7 +204,7 @@ namespace {
         if (res_source.empty()) {
             throw Opm::OpmInputError(
                 fmt::format("surface keyword {} is specified, but reservoir keyword {} is not specified",
-                            Keyword::keywordName, reservoirKeywordName(Keyword::keywordName)),
+                            kw->name(), reservoirKeywordName(kw->name())),
                 kw->location());
         }
 
@@ -224,7 +224,6 @@ namespace {
     resolveEosKeyword(const Opm::PROPSSection&   props_section,
                       const Opm::RUNSPECSection& runspec_section)
     {
-        const auto& kw_name    = Keyword::keywordName;
         const bool  has_props   = props_section  .hasKeyword<Keyword>();
         const bool  has_runspec = runspec_section.hasKeyword<Keyword>();
 
@@ -234,7 +233,8 @@ namespace {
 
         if (has_props && has_runspec) {
             throw Opm::OpmInputError(
-                fmt::format("{} is specified in both RUNSPEC and PROPS sections", kw_name),
+                fmt::format("{} is specified in both RUNSPEC and PROPS sections",
+                            props_section.get<Keyword>().front().name()),
                 props_section.get<Keyword>().begin()->location());
         }
 
@@ -244,7 +244,7 @@ namespace {
 
         if (keywords.size() > 1) {
             throw Opm::OpmInputError(
-                fmt::format("there are multiple {} keyword specifications", kw_name),
+                fmt::format("there are multiple {} keyword specifications", keywords.front().name()),
                 keywords.begin()->location());
         }
 
@@ -259,7 +259,7 @@ namespace {
                          const std::size_t                               max_regions,
                          const std::string_view                          region_description)
     {
-        const auto& kw_name = Keyword::keywordName;
+        const auto& kw_name = kw.name();
 
         if (kw.size() > max_regions) {
             throw Opm::OpmInputError(
@@ -399,7 +399,8 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
     {
         const RUNSPECSection runspec_section{deck};
         if (const auto* kw = resolveEosKeyword<ParserKeywords::EOS>(
-                props_section, runspec_section))
+                props_section, runspec_section);
+            kw != nullptr)
         {
             parseEosRecords<ParserKeywords::EOS>(
                 *kw, eos_types, num_eos_res,
@@ -413,7 +414,8 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
     {
         const RUNSPECSection runspec_section{deck};
         if (const auto* kw = resolveEosKeyword<ParserKeywords::EOSS>(
-                props_section, runspec_section))
+                props_section, runspec_section);
+            kw != nullptr)
         {
             eos_types_surf.assign(num_eos_sur, EOSType::PR);
             parseEosRecords<ParserKeywords::EOSS>(
@@ -640,7 +642,7 @@ const std::vector<double>& CompositionalConfig::binaryInteractionCoefficient(std
     return this->binary_interaction_coefficient[eos_region];
 }
 
-CompositionalConfig::EOSType CompositionalConfig::eosTypeSurf(size_t eos_region) const {
+CompositionalConfig::EOSType CompositionalConfig::eosTypeSurf(std::size_t eos_region) const {
     return this->eos_types_surf[eos_region];
 }
 
@@ -648,31 +650,31 @@ const std::vector<double>& CompositionalConfig::molecularWeightsSurf(std::size_t
     return this->molecular_weights_surf[eos_region];
 }
 
-const std::vector<double>& CompositionalConfig::acentricFactorsSurf(size_t eos_region) const {
+const std::vector<double>& CompositionalConfig::acentricFactorsSurf(std::size_t eos_region) const {
     return this->acentric_factors_surf[eos_region];
 }
 
-const std::vector<double>& CompositionalConfig::criticalPressureSurf(size_t eos_region) const {
+const std::vector<double>& CompositionalConfig::criticalPressureSurf(std::size_t eos_region) const {
     return this->critical_pressure_surf[eos_region];
 }
 
-const std::vector<double>& CompositionalConfig::criticalTemperatureSurf(size_t eos_region) const {
+const std::vector<double>& CompositionalConfig::criticalTemperatureSurf(std::size_t eos_region) const {
     return this->critical_temperature_surf[eos_region];
 }
 
-const std::vector<double>& CompositionalConfig::criticalVolumeSurf(size_t eos_region) const {
+const std::vector<double>& CompositionalConfig::criticalVolumeSurf(std::size_t eos_region) const {
     return this->critical_volume_surf[eos_region];
 }
 
-const std::vector<double>& CompositionalConfig::criticalZFactorSurf(size_t eos_region) const {
+const std::vector<double>& CompositionalConfig::criticalZFactorSurf(std::size_t eos_region) const {
     return this->critical_z_factor_surf[eos_region];
 }
 
-const std::vector<double>& CompositionalConfig::volumeShiftsSurf(size_t eos_region) const {
+const std::vector<double>& CompositionalConfig::volumeShiftsSurf(std::size_t eos_region) const {
     return this->volume_shifts_surf[eos_region];
 }
 
-const std::vector<double>& CompositionalConfig::binaryInteractionCoefficientSurf(size_t eos_region) const {
+const std::vector<double>& CompositionalConfig::binaryInteractionCoefficientSurf(std::size_t eos_region) const {
     return this->binary_interaction_coefficient_surf[eos_region];
 }
 

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -53,6 +53,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <unordered_map>
 #include <vector>
 
 namespace {
@@ -133,6 +134,22 @@ namespace {
         }
     }
 
+    std::string_view reservoirKeywordName(std::string_view surface_keyword_name)
+    {
+        static const std::unordered_map<std::string_view, std::string_view> mapping {
+            {Opm::ParserKeywords::MWS::keywordName,    Opm::ParserKeywords::MW::keywordName},
+            {Opm::ParserKeywords::ACFS::keywordName,   Opm::ParserKeywords::ACF::keywordName},
+            {Opm::ParserKeywords::PCRITS::keywordName, Opm::ParserKeywords::PCRIT::keywordName},
+            {Opm::ParserKeywords::TCRITS::keywordName, Opm::ParserKeywords::TCRIT::keywordName},
+            {Opm::ParserKeywords::VCRITS::keywordName, Opm::ParserKeywords::VCRIT::keywordName},
+            {Opm::ParserKeywords::ZCRITS::keywordName, Opm::ParserKeywords::ZCRIT::keywordName},
+            {Opm::ParserKeywords::SSHIFTS::keywordName, Opm::ParserKeywords::SSHIFT::keywordName},
+            {Opm::ParserKeywords::BICS::keywordName,   Opm::ParserKeywords::BIC::keywordName},
+        };
+
+        return mapping.at(surface_keyword_name);
+    }
+
     // The following function is used to parse compositional related keywords:
     // MW, ACF, BIC, PCRIT, TCRIT, VCRIT and SSHIFT, and so on.
     template <typename Keyword>
@@ -182,6 +199,13 @@ namespace {
                 }
             }
             return;
+        }
+
+        if (res_source.empty()) {
+            throw Opm::OpmInputError(
+                fmt::format("surface keyword {} is specified, but reservoir keyword {} is not specified",
+                            Keyword::keywordName, reservoirKeywordName(Keyword::keywordName)),
+                kw->location());
         }
 
         // Specified surface keyword: require full region coverage if no item default exists.

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
@@ -65,6 +65,19 @@ public:
     const std::vector<double>& criticalVolume(std::size_t eos_region) const;
     const std::vector<double>& volumeShifts(std::size_t eos_region) const;
     const std::vector<double>& binaryInteractionCoefficient(std::size_t eos_region) const;
+    const std::vector<double>& criticalZFactor(std::size_t eos_region) const;
+
+    // Accessors for surface EOS regions.
+    EOSType eosTypeSurf(std::size_t eos_region) const;
+    const std::vector<double>& molecularWeightsSurf(std::size_t eos_region) const;
+    const std::vector<double>& acentricFactorsSurf(std::size_t eos_region) const;
+    const std::vector<double>& criticalPressureSurf(std::size_t eos_region) const;
+    const std::vector<double>& criticalTemperatureSurf(std::size_t eos_region) const;
+    const std::vector<double>& criticalVolumeSurf(std::size_t eos_region) const;
+    const std::vector<double>& criticalZFactorSurf(std::size_t eos_region) const;
+    const std::vector<double>& volumeShiftsSurf(std::size_t eos_region) const;
+    const std::vector<double>& binaryInteractionCoefficientSurf(std::size_t eos_region) const;
+
     std::size_t numComps() const;
 
     template<class Serializer>
@@ -81,7 +94,17 @@ public:
         serializer(critical_temperature);
         serializer(critical_volume);
         serializer(volume_shifts);
+        serializer(critical_z_factor);
         serializer(binary_interaction_coefficient);
+        serializer(eos_types_surf);
+        serializer(molecular_weights_surf);
+        serializer(acentric_factors_surf);
+        serializer(critical_pressure_surf);
+        serializer(critical_temperature_surf);
+        serializer(critical_volume_surf);
+        serializer(critical_z_factor_surf);
+        serializer(volume_shifts_surf);
+        serializer(binary_interaction_coefficient_surf);
     }
 
 private:
@@ -98,7 +121,19 @@ private:
     std::vector<std::vector<double>> critical_temperature;
     std::vector<std::vector<double>> critical_volume;
     std::vector<std::vector<double>> volume_shifts;
+    std::vector<std::vector<double>> critical_z_factor;
     std::vector<std::vector<double>> binary_interaction_coefficient;
+
+    // Surface EOS-region properties (EOSS, MWS, ACFS, PCRITS, TCRITS, VCRITS, ZCRITS, SSHIFTS, BICS).
+    std::vector<EOSType> eos_types_surf;
+    std::vector<std::vector<double>> molecular_weights_surf;
+    std::vector<std::vector<double>> acentric_factors_surf;
+    std::vector<std::vector<double>> critical_pressure_surf;
+    std::vector<std::vector<double>> critical_temperature_surf;
+    std::vector<std::vector<double>> critical_volume_surf;
+    std::vector<std::vector<double>> critical_z_factor_surf;
+    std::vector<std::vector<double>> volume_shifts_surf;
+    std::vector<std::vector<double>> binary_interaction_coefficient_surf;
 };
 
 }

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/A/ACFS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/A/ACFS
@@ -1,5 +1,5 @@
 {
-  "name": "MWS",
+  "name": "ACFS",
   "sections": [
     "PROPS"
   ],
@@ -12,7 +12,7 @@
       "name": "DATA",
       "value_type": "DOUBLE",
       "size_type": "ALL",
-      "dimension": "Mass/Moles"
+      "dimension": "1"
     }
   ]
 }

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/B/BICS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/B/BICS
@@ -1,5 +1,5 @@
 {
-  "name": "MWS",
+  "name": "BICS",
   "sections": [
     "PROPS"
   ],
@@ -12,7 +12,8 @@
       "name": "DATA",
       "value_type": "DOUBLE",
       "size_type": "ALL",
-      "dimension": "Mass/Moles"
+      "dimension": "1",
+      "default" : 0
     }
   ]
 }

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/E/EOSS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/E/EOSS
@@ -1,6 +1,7 @@
 {
-  "name": "MWS",
+  "name": "EOSS",
   "sections": [
+    "RUNSPEC",
     "PROPS"
   ],
   "size": {
@@ -9,10 +10,9 @@
   },
   "items": [
     {
-      "name": "DATA",
-      "value_type": "DOUBLE",
-      "size_type": "ALL",
-      "dimension": "Mass/Moles"
+      "name": "EQUATION",
+      "value_type": "STRING",
+      "default": "PR"
     }
   ]
 }

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/P/PCRITS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/P/PCRITS
@@ -1,5 +1,5 @@
 {
-  "name": "MWS",
+  "name": "PCRITS",
   "sections": [
     "PROPS"
   ],
@@ -12,7 +12,7 @@
       "name": "DATA",
       "value_type": "DOUBLE",
       "size_type": "ALL",
-      "dimension": "Mass/Moles"
+      "dimension": "Pressure"
     }
   ]
 }

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/S/SSHIFTS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/S/SSHIFTS
@@ -1,5 +1,5 @@
 {
-  "name": "MWS",
+  "name": "SSHIFTS",
   "sections": [
     "PROPS"
   ],
@@ -12,7 +12,8 @@
       "name": "DATA",
       "value_type": "DOUBLE",
       "size_type": "ALL",
-      "dimension": "Mass/Moles"
+      "dimension": "1",
+      "default" : 0
     }
   ]
 }

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/T/TCRITS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/T/TCRITS
@@ -1,5 +1,5 @@
 {
-  "name": "MWS",
+  "name": "TCRITS",
   "sections": [
     "PROPS"
   ],
@@ -12,7 +12,7 @@
       "name": "DATA",
       "value_type": "DOUBLE",
       "size_type": "ALL",
-      "dimension": "Mass/Moles"
+      "dimension": "AbsoluteTemperature"
     }
   ]
 }

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/V/VCRITS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/V/VCRITS
@@ -1,5 +1,5 @@
 {
-  "name": "MWS",
+  "name": "VCRITS",
   "sections": [
     "PROPS"
   ],
@@ -12,7 +12,7 @@
       "name": "DATA",
       "value_type": "DOUBLE",
       "size_type": "ALL",
-      "dimension": "Mass/Moles"
+      "dimension": "GeometricVolume/Moles"
     }
   ]
 }

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZCRIT
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZCRIT
@@ -1,18 +1,18 @@
 {
-  "name": "MWS",
+  "name": "ZCRIT",
   "sections": [
     "PROPS"
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_EOS_SURFACE"
+    "item": "NUM_EOS_RES"
   },
   "items": [
     {
       "name": "DATA",
       "value_type": "DOUBLE",
       "size_type": "ALL",
-      "dimension": "Mass/Moles"
+      "dimension": "1"
     }
   ]
 }

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZCRITS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZCRITS
@@ -1,5 +1,5 @@
 {
-  "name": "MWS",
+  "name": "ZCRITS",
   "sections": [
     "PROPS"
   ],
@@ -12,7 +12,7 @@
       "name": "DATA",
       "value_type": "DOUBLE",
       "size_type": "ALL",
-      "dimension": "Mass/Moles"
+      "dimension": "1"
     }
   ]
 }

--- a/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1049,8 +1049,10 @@ set( keywords
      000_Eclipse100/Z/ZIPP2OFF
 
      001_Eclipse300/A/ACF
+     001_Eclipse300/A/ACFS
      001_Eclipse300/A/ACTCO2S
      001_Eclipse300/B/BIC
+     001_Eclipse300/B/BICS
      001_Eclipse300/B/BLOCK_PROBE300
      001_Eclipse300/C/CIRCLE
      001_Eclipse300/C/CNAMES
@@ -1070,6 +1072,7 @@ set( keywords
      001_Eclipse300/D/DREFS
      001_Eclipse300/D/DZV
      001_Eclipse300/E/EOS
+     001_Eclipse300/E/EOSS
      001_Eclipse300/E/EOSNUM
      001_Eclipse300/F/FIELDSEP
      001_Eclipse300/G/GASVISCT
@@ -1087,6 +1090,7 @@ set( keywords
      001_Eclipse300/O/OILVTIM
      001_Eclipse300/O/OPTIONS3
      001_Eclipse300/P/PCRIT
+     001_Eclipse300/P/PCRITS
      001_Eclipse300/P/PRCORR
      001_Eclipse300/P/PREF
      001_Eclipse300/P/PREFS
@@ -1094,8 +1098,10 @@ set( keywords
      001_Eclipse300/S/SALINITY
      001_Eclipse300/S/SOLID
      001_Eclipse300/S/SSHIFT
+     001_Eclipse300/S/SSHIFTS
      001_Eclipse300/S/STCOND
      001_Eclipse300/T/TCRIT
+     001_Eclipse300/T/TCRITS
      001_Eclipse300/T/TEMPI
      001_Eclipse300/T/TEMPVD
      001_Eclipse300/T/THCGAS
@@ -1107,6 +1113,7 @@ set( keywords
      001_Eclipse300/T/TREF
      001_Eclipse300/T/TREFS
      001_Eclipse300/V/VCRIT
+     001_Eclipse300/V/VCRITS
      001_Eclipse300/V/VISCAQA
      001_Eclipse300/W/WELLSTRE
      001_Eclipse300/W/WELL_PROBE_COMP
@@ -1116,6 +1123,8 @@ set( keywords
      001_Eclipse300/W/WSF
      001_Eclipse300/X/XMF
      001_Eclipse300/Y/YMF
+     001_Eclipse300/Z/ZCRIT
+     001_Eclipse300/Z/ZCRITS
      001_Eclipse300/Z/ZFACT1
      001_Eclipse300/Z/ZFACT1S
      001_Eclipse300/Z/ZFACTOR

--- a/tests/parser/CompositionalTests.cpp
+++ b/tests/parser/CompositionalTests.cpp
@@ -109,6 +109,11 @@ EOS
 PR /
 SRK /
 
+EOSS
+PRCORR /
+RK /
+ZJ /
+
 BIC
 0
 1 2 /
@@ -138,6 +143,56 @@ VCRIT
 SSHIFT
 0.1 0.2 0.3 /
 0.11 0.21 0.31 /
+
+
+ZCRIT
+0.28 0.25 0.26 /
+0.29 0.26 0.27 /
+
+
+BICS
+0
+0.1 0.2 /
+0.05
+0.15 0.25 /
+0.06
+0.16 0.26 /
+
+ACFS
+0.41 0.21 0.011 /
+0.51 0.31 0.031 /
+0.52 0.32 0.032 /
+
+PCRITS
+22. 72. 42. /
+23. 73. 43. /
+24. 74. 44. /
+
+TCRITS
+602. 302. 192. /
+603. 303. 193. /
+604. 304. 194. /
+
+MWS
+143.  45.  17. /
+143.1 45.1 17.1 /
+143.2 45.2 17.2 /
+
+VCRITS
+0.62 0.12 0.12 /
+0.63 0.13 0.13 /
+0.64 0.14 0.14 /
+
+ZCRITS
+0.30 0.27 0.28 /
+0.31 0.28 0.29 /
+0.32 0.29 0.30 /
+
+
+SSHIFTS
+0.12 0.22 0.32 /
+0.13 0.23 0.33 /
+0.14 0.24 0.34 /
 
 
 STCOND
@@ -339,63 +394,78 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTest) {
     {
         const auto& cp0 = comp_config.criticalPressure(0);
         BOOST_CHECK_EQUAL(num_comps, cp0.size());
-        const std::vector<double> ref_cp0 = {usys.to_si(M::pressure, 20), usys.to_si(M::pressure, 70), usys.to_si(M::pressure, 40)};
+        const std::vector<double> ref_cp0 = {usys.to_si(M::pressure, 20), usys.to_si(M::pressure, 70),
+                                             usys.to_si(M::pressure, 40)};
         check_vectors_close(ref_cp0, cp0, tolerance);
         const auto& cp1 = comp_config.criticalPressure(1);
         BOOST_CHECK_EQUAL(num_comps, cp1.size());
-        const std::vector<double> ref_cp1 = {usys.to_si(M::pressure, 21), usys.to_si(M::pressure, 71), usys.to_si(M::pressure, 41)};
+        const std::vector<double> ref_cp1 = {usys.to_si(M::pressure, 21), usys.to_si(M::pressure, 71),
+                                             usys.to_si(M::pressure, 41)};
         check_vectors_close(ref_cp1, cp1, tolerance);
     }
 
     {
         const auto& ct0 = comp_config.criticalTemperature(0);
         BOOST_CHECK_EQUAL(num_comps, ct0.size());
-        const std::vector<double> ref_ct0 = {usys.to_si(M::temperature_absolute, 600), usys.to_si(M::temperature_absolute, 300), usys.to_si(M::temperature_absolute, 190)};
+        const std::vector<double> ref_ct0 = {usys.to_si(M::temperature_absolute, 600),
+                                             usys.to_si(M::temperature_absolute, 300),
+                                             usys.to_si(M::temperature_absolute, 190)};
         check_vectors_close(ref_ct0, ct0, tolerance);
         const auto& ct1 = comp_config.criticalTemperature(1);
-        const std::vector<double> ref_ct1 = {usys.to_si(M::temperature_absolute, 601), usys.to_si(M::temperature_absolute, 301), usys.to_si(M::temperature_absolute, 191)};
+        const std::vector<double> ref_ct1 = {usys.to_si(M::temperature_absolute, 601),
+                                             usys.to_si(M::temperature_absolute, 301),
+                                             usys.to_si(M::temperature_absolute, 191)};
         check_vectors_close(ref_ct1, ct1, tolerance);
     }
 
     {
         const auto& cv0 = comp_config.criticalVolume(0);
         BOOST_CHECK_EQUAL(num_comps, cv0.size());
-        const std::vector<double> ref_cv0 { usys.to_si( "GeometricVolume/Moles", 0.6),
-                                            usys.to_si( "GeometricVolume/Moles", 0.1),
-                                            usys.to_si( "GeometricVolume/Moles", 0.1) };
+        const std::vector<double> ref_cv0{usys.to_si("GeometricVolume/Moles", 0.6),
+                                          usys.to_si("GeometricVolume/Moles", 0.1),
+                                          usys.to_si("GeometricVolume/Moles", 0.1)};
         check_vectors_close(ref_cv0, cv0, tolerance);
         const auto& cv1 = comp_config.criticalVolume(1);
         BOOST_CHECK_EQUAL(num_comps, cv1.size());
-        const std::vector<double> ref_cv1 { usys.to_si( "GeometricVolume/Moles", 0.61),
-                                            usys.to_si( "GeometricVolume/Moles", 0.11),
-                                            usys.to_si( "GeometricVolume/Moles", 0.11) };
+        const std::vector<double> ref_cv1{usys.to_si("GeometricVolume/Moles", 0.61),
+                                          usys.to_si("GeometricVolume/Moles", 0.11),
+                                          usys.to_si("GeometricVolume/Moles", 0.11)};
         check_vectors_close(ref_cv1, cv1, tolerance);
+    }
+
+    {
+        const auto& zc0 = comp_config.criticalZFactor(0);
+        BOOST_CHECK_EQUAL(num_comps, zc0.size());
+        check_vectors_close(std::vector<double>{0.28, 0.25, 0.26}, zc0, tolerance);
+        const auto& zc1 = comp_config.criticalZFactor(1);
+        BOOST_CHECK_EQUAL(num_comps, zc1.size());
+        check_vectors_close(std::vector<double>{0.29, 0.26, 0.27}, zc1, tolerance);
     }
 
     {
         const auto& bic0 = comp_config.binaryInteractionCoefficient(0);
         constexpr std::size_t bic_size = num_comps * (num_comps - 1) / 2;
         BOOST_CHECK_EQUAL(bic_size, bic0.size());
-        const std::vector<double> ref_bic0 {0, 1, 2};
+        const std::vector<double> ref_bic0{0, 1, 2};
         check_vectors_close(ref_bic0, bic0, tolerance);
         const auto& bic1 = comp_config.binaryInteractionCoefficient(1);
         BOOST_CHECK_EQUAL(bic_size, bic1.size());
-        const std::vector<double> ref_bic1 {1, 2, 3};
+        const std::vector<double> ref_bic1{1, 2, 3};
         check_vectors_close(ref_bic1, bic1, tolerance);
     }
 
     {
         const auto& mw0 = comp_config.molecularWeights(0);
         BOOST_CHECK_EQUAL(num_comps, mw0.size());
-        const std::vector<double> ref_mw0 { usys.to_si( "Mass/Moles", 142.),
-                                            usys.to_si( "Mass/Moles", 44.),
-                                            usys.to_si( "Mass/Moles", 16) };
+        const std::vector<double> ref_mw0{usys.to_si("Mass/Moles", 142.),
+                                          usys.to_si("Mass/Moles", 44.),
+                                          usys.to_si("Mass/Moles", 16)};
         check_vectors_close(ref_mw0, mw0, tolerance);
         const auto& mw1 = comp_config.molecularWeights(1);
         BOOST_CHECK_EQUAL(num_comps, mw1.size());
-        const std::vector<double> ref_mw1 { usys.to_si( "Mass/Moles", 142.1),
-                                            usys.to_si( "Mass/Moles", 44.1),
-                                            usys.to_si( "Mass/Moles", 16.1) };
+        const std::vector<double> ref_mw1{usys.to_si("Mass/Moles", 142.1),
+                                          usys.to_si("Mass/Moles", 44.1),
+                                          usys.to_si("Mass/Moles", 16.1)};
         check_vectors_close(ref_mw1, mw1, tolerance);
     }
 
@@ -406,6 +476,83 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTest) {
         const auto& vs1 = comp_config.volumeShifts(1);
         BOOST_CHECK_EQUAL(num_comps, vs1.size());
         check_vectors_close(std::vector<double>{0.11, 0.21, 0.31}, vs1, tolerance);
+    }
+
+    // Surface-condition EOS region properties
+    BOOST_CHECK(CompositionalConfig::EOSType::PRCORR == comp_config.eosTypeSurf(0));
+    BOOST_CHECK(CompositionalConfig::EOSType::RK     == comp_config.eosTypeSurf(1));
+    BOOST_CHECK(CompositionalConfig::EOSType::ZJ     == comp_config.eosTypeSurf(2));
+
+    {
+        const auto& acfs0 = comp_config.acentricFactorsSurf(0);
+        BOOST_CHECK_EQUAL(num_comps, acfs0.size());
+        check_vectors_close(std::vector<double>{0.41, 0.21, 0.011}, acfs0, tolerance);
+        const auto& acfs2 = comp_config.acentricFactorsSurf(2);
+        check_vectors_close(std::vector<double>{0.52, 0.32, 0.032}, acfs2, tolerance);
+    }
+
+    {
+        const auto& cps0 = comp_config.criticalPressureSurf(0);
+        const std::vector<double> ref_cps0 = {usys.to_si(M::pressure, 22), usys.to_si(M::pressure, 72),
+                                              usys.to_si(M::pressure, 42)};
+        check_vectors_close(ref_cps0, cps0, tolerance);
+        const auto& cps2 = comp_config.criticalPressureSurf(2);
+        const std::vector<double> ref_cps2 = {usys.to_si(M::pressure, 24), usys.to_si(M::pressure, 74),
+                                              usys.to_si(M::pressure, 44)};
+        check_vectors_close(ref_cps2, cps2, tolerance);
+    }
+
+    {
+        const auto& cts0 = comp_config.criticalTemperatureSurf(0);
+        const std::vector<double> ref_cts0 = {usys.to_si(M::temperature_absolute, 602),
+                                              usys.to_si(M::temperature_absolute, 302),
+                                              usys.to_si(M::temperature_absolute, 192)};
+        check_vectors_close(ref_cts0, cts0, tolerance);
+    }
+
+    {
+        const auto& cvs1 = comp_config.criticalVolumeSurf(1);
+        const std::vector<double> ref_cvs1{usys.to_si("GeometricVolume/Moles", 0.63),
+                                           usys.to_si("GeometricVolume/Moles", 0.13),
+                                           usys.to_si("GeometricVolume/Moles", 0.13)};
+        check_vectors_close(ref_cvs1, cvs1, tolerance);
+    }
+
+    {
+        const auto& zcs0 = comp_config.criticalZFactorSurf(0);
+        check_vectors_close(std::vector<double>{0.30, 0.27, 0.28}, zcs0, tolerance);
+        const auto& zcs2 = comp_config.criticalZFactorSurf(2);
+        check_vectors_close(std::vector<double>{0.32, 0.29, 0.30}, zcs2, tolerance);
+    }
+
+    {
+        const auto& bics0 = comp_config.binaryInteractionCoefficientSurf(0);
+        constexpr std::size_t bic_size = num_comps * (num_comps - 1) / 2;
+        BOOST_CHECK_EQUAL(bic_size, bics0.size());
+        check_vectors_close(std::vector<double>{0, 0.1, 0.2}, bics0, tolerance);
+        const auto& bics2 = comp_config.binaryInteractionCoefficientSurf(2);
+        check_vectors_close(std::vector<double>{0.06, 0.16, 0.26}, bics2, tolerance);
+    }
+
+    {
+        const auto& mws0 = comp_config.molecularWeightsSurf(0);
+        const std::vector<double> ref_mws0{usys.to_si("Mass/Moles", 143.),
+                                           usys.to_si("Mass/Moles", 45.),
+                                           usys.to_si("Mass/Moles", 17.)};
+        check_vectors_close(ref_mws0, mws0, tolerance);
+        const auto& mws2 = comp_config.molecularWeightsSurf(2);
+        const std::vector<double> ref_mws2{usys.to_si("Mass/Moles", 143.2),
+                                           usys.to_si("Mass/Moles", 45.2),
+                                           usys.to_si("Mass/Moles", 17.2)};
+        check_vectors_close(ref_mws2, mws2, tolerance);
+    }
+
+    {
+        const auto& vss0 = comp_config.volumeShiftsSurf(0);
+        BOOST_CHECK_EQUAL(num_comps, vss0.size());
+        check_vectors_close(std::vector<double>{0.12, 0.22, 0.32}, vss0, tolerance);
+        const auto& vss2 = comp_config.volumeShiftsSurf(2);
+        check_vectors_close(std::vector<double>{0.14, 0.24, 0.34}, vss2, tolerance);
     }
 
     EclipseState es(deck);
@@ -541,6 +688,56 @@ VCRIT
 SSHIFT
 0.1 0.2 0.3 /
 0.11 0.21 0.31 /
+
+
+ZCRIT
+0.28 0.25 0.26 /
+0.29 0.26 0.27 /
+
+
+BICS
+0
+0.1 0.2 /
+0.05
+0.15 0.25 /
+0.06
+0.16 0.26 /
+
+ACFS
+0.41 0.21 0.011 /
+0.51 0.31 0.031 /
+0.52 0.32 0.032 /
+
+PCRITS
+22. 72. 42. /
+23. 73. 43. /
+24. 74. 44. /
+
+TCRITS
+602. 302. 192. /
+603. 303. 193. /
+604. 304. 194. /
+
+MWS
+143.  45.  17. /
+143.1 45.1 17.1 /
+143.2 45.2 17.2 /
+
+VCRITS
+0.62 0.12 0.12 /
+0.63 0.13 0.13 /
+0.64 0.14 0.14 /
+
+ZCRITS
+0.30 0.27 0.28 /
+0.31 0.28 0.29 /
+0.32 0.29 0.30 /
+
+
+SSHIFTS
+0.12 0.22 0.32 /
+0.13 0.23 0.33 /
+0.14 0.24 0.34 /
 
 
 STCOND
@@ -720,10 +917,7 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTestZMF) {
 }
 
 BOOST_AUTO_TEST_CASE(PRCORRKeywordTest) {
-    // Minimal compositional deck used to verify the handling of the PRCORR
-    // keyword. There are two EOS regions: the first uses PR (and must be
-    // promoted to PRCORR by PRCORR), the second uses SRK (and must be left
-    // unchanged by PRCORR).
+    // Minimal deck: PR region should be promoted by PRCORR, SRK region should not.
     const std::string deck_string = R"(
 RUNSPEC
 
@@ -783,6 +977,346 @@ END
     BOOST_CHECK(CompositionalConfig::EOSType::PRCORR == comp_config.eosType(0));
     // PRCORR should have no effect on the second region since it is SRK.
     BOOST_CHECK(CompositionalConfig::EOSType::SRK == comp_config.eosType(1));
+
+    // PRCORR also affects surface EOS regions inherited from reservoir EOS.
+    BOOST_CHECK(CompositionalConfig::EOSType::PRCORR == comp_config.eosTypeSurf(0));
+    BOOST_CHECK(CompositionalConfig::EOSType::SRK    == comp_config.eosTypeSurf(1));
+    BOOST_CHECK(CompositionalConfig::EOSType::SRK    == comp_config.eosTypeSurf(2));
+}
+
+Deck createCompositionalDeckSurfaceDefaults()
+{
+    // NMEOSR=2, NMEOSS=3, no surface keywords: surface values must inherit from reservoir values.
+    return Parser{}.parseString(R"(
+RUNSPEC
+TITLE
+   SURFACE DEFAULTS TEST
+
+METRIC
+
+TABDIMS
+8* 2 3/
+
+OIL
+GAS
+DIMENS
+4 1 1
+/
+
+COMPS
+3 /
+
+GRID
+DX
+4*10 /
+DY
+4*1 /
+DZ
+4*1 /
+TOPS
+4*0 /
+PERMX
+4*100 /
+PERMY
+4*100 /
+PERMZ
+4*100 /
+PORO
+4*0.1 /
+
+PROPS
+
+CNAMES
+DECANE
+CO2
+METHANE
+/
+
+EOS
+PR /
+SRK /
+
+MW
+142.  44.  16. /
+142.1 44.1 16.1 /
+
+ACF
+0.4 0.2 0.01 /
+0.5 0.3 0.03 /
+
+PCRIT
+20. 70. 40. /
+21. 71. 41. /
+
+TCRIT
+600. 300. 190. /
+601. 301. 191. /
+
+VCRIT
+0.6  0.1  0.1 /
+0.61 0.11 0.11 /
+
+ZCRIT
+0.28 0.25 0.26 /
+0.29 0.26 0.27 /
+
+SSHIFT
+0.1 0.2 0.3 /
+0.11 0.21 0.31 /
+
+BIC
+0
+1 2 /
+1
+2 3 /
+
+END
+)");
+}
+
+BOOST_AUTO_TEST_CASE(SurfaceDefaultsFromReservoirTest) {
+    const Deck deck = createCompositionalDeckSurfaceDefaults();
+    const Runspec runspec{deck};
+    const CompositionalConfig comp_config{deck, runspec};
+
+    constexpr std::size_t num_comps = 3;
+    constexpr double tolerance = 1.e-5;
+    const auto& usys = deck.getActiveUnitSystem();
+    using M = UnitSystem::measure;
+
+    // Without EOSS, surface EOS types inherit from reservoir EOS (last region repeated).
+    BOOST_CHECK(CompositionalConfig::EOSType::PR  == comp_config.eosTypeSurf(0));
+    BOOST_CHECK(CompositionalConfig::EOSType::SRK == comp_config.eosTypeSurf(1));
+    BOOST_CHECK(CompositionalConfig::EOSType::SRK == comp_config.eosTypeSurf(2));
+
+    // Without MWS, molecular weights inherit from MW.
+    {
+        const auto& mws0 = comp_config.molecularWeightsSurf(0);
+        const auto& mws1 = comp_config.molecularWeightsSurf(1);
+        const auto& mws2 = comp_config.molecularWeightsSurf(2);
+        BOOST_CHECK_EQUAL(num_comps, mws0.size());
+        check_vectors_close(comp_config.molecularWeights(0), mws0, tolerance);
+        check_vectors_close(comp_config.molecularWeights(1), mws1, tolerance);
+        check_vectors_close(comp_config.molecularWeights(1), mws2, tolerance);
+    }
+
+    // Without ACFS, acentric factors inherit from ACF.
+    check_vectors_close(std::vector<double>{0.4, 0.2, 0.01},
+                        comp_config.acentricFactorsSurf(0), tolerance);
+    check_vectors_close(std::vector<double>{0.5, 0.3, 0.03},
+                        comp_config.acentricFactorsSurf(1), tolerance);
+    check_vectors_close(std::vector<double>{0.5, 0.3, 0.03},
+                        comp_config.acentricFactorsSurf(2), tolerance);
+
+    // Without PCRITS, critical pressure inherits from PCRIT.
+    {
+        const std::vector<double> ref_pcs0{usys.to_si(M::pressure, 20),
+                                           usys.to_si(M::pressure, 70),
+                                           usys.to_si(M::pressure, 40)};
+        const std::vector<double> ref_pcs1{usys.to_si(M::pressure, 21),
+                                           usys.to_si(M::pressure, 71),
+                                           usys.to_si(M::pressure, 41)};
+        check_vectors_close(ref_pcs0, comp_config.criticalPressureSurf(0), tolerance);
+        check_vectors_close(ref_pcs1, comp_config.criticalPressureSurf(1), tolerance);
+        check_vectors_close(ref_pcs1, comp_config.criticalPressureSurf(2), tolerance);
+    }
+
+    // Without TCRITS, critical temperature inherits from TCRIT.
+    {
+        const std::vector<double> ref_tcs1{usys.to_si(M::temperature_absolute, 601),
+                                           usys.to_si(M::temperature_absolute, 301),
+                                           usys.to_si(M::temperature_absolute, 191)};
+        check_vectors_close(ref_tcs1, comp_config.criticalTemperatureSurf(1), tolerance);
+        check_vectors_close(ref_tcs1, comp_config.criticalTemperatureSurf(2), tolerance);
+    }
+
+    // Without VCRITS, critical volume inherits from VCRIT.
+    {
+        const std::vector<double> ref_vcs1{usys.to_si("GeometricVolume/Moles", 0.61),
+                                           usys.to_si("GeometricVolume/Moles", 0.11),
+                                           usys.to_si("GeometricVolume/Moles", 0.11)};
+        check_vectors_close(ref_vcs1, comp_config.criticalVolumeSurf(1), tolerance);
+        check_vectors_close(ref_vcs1, comp_config.criticalVolumeSurf(2), tolerance);
+    }
+
+    // Without ZCRITS, critical Z-factor inherits from ZCRIT.
+    check_vectors_close(std::vector<double>{0.28, 0.25, 0.26},
+                        comp_config.criticalZFactorSurf(0), tolerance);
+    check_vectors_close(std::vector<double>{0.29, 0.26, 0.27},
+                        comp_config.criticalZFactorSurf(1), tolerance);
+    check_vectors_close(std::vector<double>{0.29, 0.26, 0.27},
+                        comp_config.criticalZFactorSurf(2), tolerance);
+
+    // Without SSHIFTS, volume shifts inherit from SSHIFT.
+    check_vectors_close(std::vector<double>{0.1, 0.2, 0.3},
+                        comp_config.volumeShiftsSurf(0), tolerance);
+    check_vectors_close(std::vector<double>{0.11, 0.21, 0.31},
+                        comp_config.volumeShiftsSurf(1), tolerance);
+    check_vectors_close(std::vector<double>{0.11, 0.21, 0.31},
+                        comp_config.volumeShiftsSurf(2), tolerance);
+
+    // Without BICS, BIC values inherit from BIC.
+    {
+        constexpr std::size_t bic_size = num_comps * (num_comps - 1) / 2;
+        BOOST_CHECK_EQUAL(bic_size, comp_config.binaryInteractionCoefficientSurf(0).size());
+        check_vectors_close(std::vector<double>{0, 1, 2},
+                            comp_config.binaryInteractionCoefficientSurf(0), tolerance);
+        check_vectors_close(std::vector<double>{1, 2, 3},
+                            comp_config.binaryInteractionCoefficientSurf(1), tolerance);
+        // Last surface region repeats the last reservoir region.
+        check_vectors_close(std::vector<double>{1, 2, 3},
+                            comp_config.binaryInteractionCoefficientSurf(2), tolerance);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(SurfacePartialSpecificationTest) {
+    // Partial surface keyword input: specified keywords use keyword defaults, not reservoir fallback.
+    const std::string deck_string = R"(
+RUNSPEC
+TITLE
+   SURFACE PARTIAL TEST
+
+METRIC
+
+TABDIMS
+8* 2 3/
+
+OIL
+GAS
+DIMENS
+4 1 1
+/
+
+COMPS
+3 /
+
+GRID
+DX
+4*10 /
+DY
+4*1 /
+DZ
+4*1 /
+TOPS
+4*0 /
+PERMX
+4*100 /
+PERMY
+4*100 /
+PERMZ
+4*100 /
+PORO
+4*0.1 /
+
+PROPS
+
+CNAMES
+DECANE
+CO2
+METHANE
+/
+
+EOS
+PR /
+SRK /
+
+MW
+142.  44.  16. /
+142.1 44.1 16.1 /
+
+ACF
+0.4 0.2 0.01 /
+0.5 0.3 0.03 /
+
+PCRIT
+20. 70. 40. /
+21. 71. 41. /
+
+TCRIT
+600. 300. 190. /
+601. 301. 191. /
+
+VCRIT
+0.6  0.1  0.1 /
+0.61 0.11 0.11 /
+
+ZCRIT
+0.28 0.25 0.26 /
+0.29 0.26 0.27 /
+
+SSHIFT
+0.1 0.2 0.3 /
+0.11 0.21 0.31 /
+
+BIC
+0
+1 2 /
+1
+2 3 /
+
+-- Partial EOSS: unspecified records use keyword default PR, not reservoir EOS.
+EOSS
+ZJ /
+/
+/
+
+-- Partial SSHIFTS: unspecified values use keyword default 0.0.
+SSHIFTS
+0.5 /
+/
+/
+
+-- Partial BICS: unspecified values use keyword default 0.0.
+BICS
+0.7 /
+/
+/
+
+END
+)";
+
+    const Deck deck = Parser{}.parseString(deck_string);
+    const Runspec runspec{deck};
+    const CompositionalConfig comp_config{deck, runspec};
+
+    constexpr std::size_t num_comps = 3;
+    constexpr double tolerance = 1.e-5;
+
+    // Partial EOSS: unspecified records use EOSS default (PR), not reservoir EOS.
+    BOOST_CHECK(CompositionalConfig::EOSType::ZJ == comp_config.eosTypeSurf(0));
+    BOOST_CHECK(CompositionalConfig::EOSType::PR == comp_config.eosTypeSurf(1));
+    BOOST_CHECK(CompositionalConfig::EOSType::PR == comp_config.eosTypeSurf(2));
+
+    // Partial SSHIFTS: missing entries default to 0.0.
+    {
+        const auto& vss0 = comp_config.volumeShiftsSurf(0);
+        BOOST_CHECK_EQUAL(num_comps, vss0.size());
+        check_vectors_close(std::vector<double>{0.5, 0.0, 0.0}, vss0, tolerance);
+        check_vectors_close(std::vector<double>{0.0, 0.0, 0.0},
+                            comp_config.volumeShiftsSurf(1), tolerance);
+        check_vectors_close(std::vector<double>{0.0, 0.0, 0.0},
+                            comp_config.volumeShiftsSurf(2), tolerance);
+    }
+
+    // Partial BICS: same defaulting behavior.
+    {
+        constexpr std::size_t bic_size = num_comps * (num_comps - 1) / 2;
+        const auto& bics0 = comp_config.binaryInteractionCoefficientSurf(0);
+        BOOST_CHECK_EQUAL(bic_size, bics0.size());
+        check_vectors_close(std::vector<double>{0.7, 0.0, 0.0}, bics0, tolerance);
+        check_vectors_close(std::vector<double>{0.0, 0.0, 0.0},
+                            comp_config.binaryInteractionCoefficientSurf(1), tolerance);
+        check_vectors_close(std::vector<double>{0.0, 0.0, 0.0},
+                            comp_config.binaryInteractionCoefficientSurf(2), tolerance);
+    }
+
+    // Keywords not provided at all still inherit from reservoir values.
+    check_vectors_close(comp_config.molecularWeights(0),
+                        comp_config.molecularWeightsSurf(0), tolerance);
+    check_vectors_close(comp_config.molecularWeights(1),
+                        comp_config.molecularWeightsSurf(1), tolerance);
+    check_vectors_close(comp_config.molecularWeights(1),
+                        comp_config.molecularWeightsSurf(2), tolerance);
 }
 
 }

--- a/tests/parser/CompositionalTests.cpp
+++ b/tests/parser/CompositionalTests.cpp
@@ -479,74 +479,96 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTest) {
 
     {
         const auto& acfs0 = comp_config.acentricFactorsSurf(0);
-        BOOST_CHECK_EQUAL(num_comps, acfs0.size());
-        check_vectors_close(std::vector<double>{0.41, 0.21, 0.011}, acfs0, tolerance);
+        const auto& acfs1 = comp_config.acentricFactorsSurf(1);
         const auto& acfs2 = comp_config.acentricFactorsSurf(2);
+        BOOST_CHECK_EQUAL(num_comps, acfs0.size());
+        BOOST_CHECK_EQUAL(num_comps, acfs1.size());
+        BOOST_CHECK_EQUAL(num_comps, acfs2.size());
+        check_vectors_close(std::vector<double>{0.41, 0.21, 0.011}, acfs0, tolerance);
+        check_vectors_close(std::vector<double>{0.51, 0.31, 0.031}, acfs1, tolerance);
         check_vectors_close(std::vector<double>{0.52, 0.32, 0.032}, acfs2, tolerance);
     }
 
     {
-        const auto& cps0 = comp_config.criticalPressureSurf(0);
         const std::vector<double> ref_cps0 = {usys.to_si(M::pressure, 22), usys.to_si(M::pressure, 72),
                                               usys.to_si(M::pressure, 42)};
-        check_vectors_close(ref_cps0, cps0, tolerance);
-        const auto& cps2 = comp_config.criticalPressureSurf(2);
+        const std::vector<double> ref_cps1 = {usys.to_si(M::pressure, 23), usys.to_si(M::pressure, 73),
+                                              usys.to_si(M::pressure, 43)};
         const std::vector<double> ref_cps2 = {usys.to_si(M::pressure, 24), usys.to_si(M::pressure, 74),
                                               usys.to_si(M::pressure, 44)};
-        check_vectors_close(ref_cps2, cps2, tolerance);
+        check_vectors_close(ref_cps0, comp_config.criticalPressureSurf(0), tolerance);
+        check_vectors_close(ref_cps1, comp_config.criticalPressureSurf(1), tolerance);
+        check_vectors_close(ref_cps2, comp_config.criticalPressureSurf(2), tolerance);
     }
 
     {
-        const auto& cts0 = comp_config.criticalTemperatureSurf(0);
         const std::vector<double> ref_cts0 = {usys.to_si(M::temperature_absolute, 602),
                                               usys.to_si(M::temperature_absolute, 302),
                                               usys.to_si(M::temperature_absolute, 192)};
-        check_vectors_close(ref_cts0, cts0, tolerance);
+        const std::vector<double> ref_cts1 = {usys.to_si(M::temperature_absolute, 603),
+                                              usys.to_si(M::temperature_absolute, 303),
+                                              usys.to_si(M::temperature_absolute, 193)};
+        const std::vector<double> ref_cts2 = {usys.to_si(M::temperature_absolute, 604),
+                                              usys.to_si(M::temperature_absolute, 304),
+                                              usys.to_si(M::temperature_absolute, 194)};
+        check_vectors_close(ref_cts0, comp_config.criticalTemperatureSurf(0), tolerance);
+        check_vectors_close(ref_cts1, comp_config.criticalTemperatureSurf(1), tolerance);
+        check_vectors_close(ref_cts2, comp_config.criticalTemperatureSurf(2), tolerance);
     }
 
     {
-        const auto& cvs1 = comp_config.criticalVolumeSurf(1);
+        const std::vector<double> ref_cvs0{usys.to_si("GeometricVolume/Moles", 0.62),
+                                           usys.to_si("GeometricVolume/Moles", 0.12),
+                                           usys.to_si("GeometricVolume/Moles", 0.12)};
         const std::vector<double> ref_cvs1{usys.to_si("GeometricVolume/Moles", 0.63),
                                            usys.to_si("GeometricVolume/Moles", 0.13),
                                            usys.to_si("GeometricVolume/Moles", 0.13)};
-        check_vectors_close(ref_cvs1, cvs1, tolerance);
+        const std::vector<double> ref_cvs2{usys.to_si("GeometricVolume/Moles", 0.64),
+                                           usys.to_si("GeometricVolume/Moles", 0.14),
+                                           usys.to_si("GeometricVolume/Moles", 0.14)};
+        check_vectors_close(ref_cvs0, comp_config.criticalVolumeSurf(0), tolerance);
+        check_vectors_close(ref_cvs1, comp_config.criticalVolumeSurf(1), tolerance);
+        check_vectors_close(ref_cvs2, comp_config.criticalVolumeSurf(2), tolerance);
     }
 
     {
-        const auto& zcs0 = comp_config.criticalZFactorSurf(0);
-        check_vectors_close(std::vector<double>{0.30, 0.27, 0.28}, zcs0, tolerance);
-        const auto& zcs2 = comp_config.criticalZFactorSurf(2);
-        check_vectors_close(std::vector<double>{0.32, 0.29, 0.30}, zcs2, tolerance);
+        check_vectors_close(std::vector<double>{0.30, 0.27, 0.28}, comp_config.criticalZFactorSurf(0), tolerance);
+        check_vectors_close(std::vector<double>{0.31, 0.28, 0.29}, comp_config.criticalZFactorSurf(1), tolerance);
+        check_vectors_close(std::vector<double>{0.32, 0.29, 0.30}, comp_config.criticalZFactorSurf(2), tolerance);
     }
 
     {
-        const auto& bics0 = comp_config.binaryInteractionCoefficientSurf(0);
         constexpr std::size_t bic_size = num_comps * (num_comps - 1) / 2;
-        BOOST_CHECK_EQUAL(bic_size, bics0.size());
-        check_vectors_close(std::vector<double>{0, 0.1, 0.2}, bics0, tolerance);
+        const auto& bics0 = comp_config.binaryInteractionCoefficientSurf(0);
+        const auto& bics1 = comp_config.binaryInteractionCoefficientSurf(1);
         const auto& bics2 = comp_config.binaryInteractionCoefficientSurf(2);
+        BOOST_CHECK_EQUAL(bic_size, bics0.size());
+        BOOST_CHECK_EQUAL(bic_size, bics1.size());
+        BOOST_CHECK_EQUAL(bic_size, bics2.size());
+        check_vectors_close(std::vector<double>{0, 0.1, 0.2}, bics0, tolerance);
+        check_vectors_close(std::vector<double>{0.05, 0.15, 0.25}, bics1, tolerance);
         check_vectors_close(std::vector<double>{0.06, 0.16, 0.26}, bics2, tolerance);
     }
 
     {
-        const auto& mws0 = comp_config.molecularWeightsSurf(0);
         const std::vector<double> ref_mws0{usys.to_si("Mass/Moles", 143.),
                                            usys.to_si("Mass/Moles", 45.),
                                            usys.to_si("Mass/Moles", 17.)};
-        check_vectors_close(ref_mws0, mws0, tolerance);
-        const auto& mws2 = comp_config.molecularWeightsSurf(2);
+        const std::vector<double> ref_mws1{usys.to_si("Mass/Moles", 143.1),
+                                           usys.to_si("Mass/Moles", 45.1),
+                                           usys.to_si("Mass/Moles", 17.1)};
         const std::vector<double> ref_mws2{usys.to_si("Mass/Moles", 143.2),
                                            usys.to_si("Mass/Moles", 45.2),
                                            usys.to_si("Mass/Moles", 17.2)};
-        check_vectors_close(ref_mws2, mws2, tolerance);
+        check_vectors_close(ref_mws0, comp_config.molecularWeightsSurf(0), tolerance);
+        check_vectors_close(ref_mws1, comp_config.molecularWeightsSurf(1), tolerance);
+        check_vectors_close(ref_mws2, comp_config.molecularWeightsSurf(2), tolerance);
     }
 
     {
-        const auto& vss0 = comp_config.volumeShiftsSurf(0);
-        BOOST_CHECK_EQUAL(num_comps, vss0.size());
-        check_vectors_close(std::vector<double>{0.12, 0.22, 0.32}, vss0, tolerance);
-        const auto& vss2 = comp_config.volumeShiftsSurf(2);
-        check_vectors_close(std::vector<double>{0.14, 0.24, 0.34}, vss2, tolerance);
+        check_vectors_close(std::vector<double>{0.12, 0.22, 0.32}, comp_config.volumeShiftsSurf(0), tolerance);
+        check_vectors_close(std::vector<double>{0.13, 0.23, 0.33}, comp_config.volumeShiftsSurf(1), tolerance);
+        check_vectors_close(std::vector<double>{0.14, 0.24, 0.34}, comp_config.volumeShiftsSurf(2), tolerance);
     }
 
     EclipseState es(deck);
@@ -687,52 +709,6 @@ SSHIFT
 ZCRIT
 0.28 0.25 0.26 /
 0.29 0.26 0.27 /
-
-
-BICS
-0
-0.1 0.2 /
-0.05
-0.15 0.25 /
-0.06
-0.16 0.26 /
-
-ACFS
-0.41 0.21 0.011 /
-0.51 0.31 0.031 /
-0.52 0.32 0.032 /
-
-PCRITS
-22. 72. 42. /
-23. 73. 43. /
-24. 74. 44. /
-
-TCRITS
-602. 302. 192. /
-603. 303. 193. /
-604. 304. 194. /
-
-MWS
-143.  45.  17. /
-143.1 45.1 17.1 /
-143.2 45.2 17.2 /
-
-VCRITS
-0.62 0.12 0.12 /
-0.63 0.13 0.13 /
-0.64 0.14 0.14 /
-
-ZCRITS
-0.30 0.27 0.28 /
-0.31 0.28 0.29 /
-0.32 0.29 0.30 /
-
-
-SSHIFTS
-0.12 0.22 0.32 /
-0.13 0.23 0.33 /
-0.14 0.24 0.34 /
-
 
 STCOND
 15.0 /
@@ -1120,18 +1096,26 @@ BOOST_AUTO_TEST_CASE(SurfaceDefaultsFromReservoirTest) {
 
     // Without TCRITS, critical temperature inherits from TCRIT.
     {
+        const std::vector<double> ref_tcs0{usys.to_si(M::temperature_absolute, 600),
+                                           usys.to_si(M::temperature_absolute, 300),
+                                           usys.to_si(M::temperature_absolute, 190)};
         const std::vector<double> ref_tcs1{usys.to_si(M::temperature_absolute, 601),
                                            usys.to_si(M::temperature_absolute, 301),
                                            usys.to_si(M::temperature_absolute, 191)};
+        check_vectors_close(ref_tcs0, comp_config.criticalTemperatureSurf(0), tolerance);
         check_vectors_close(ref_tcs1, comp_config.criticalTemperatureSurf(1), tolerance);
         check_vectors_close(ref_tcs1, comp_config.criticalTemperatureSurf(2), tolerance);
     }
 
     // Without VCRITS, critical volume inherits from VCRIT.
     {
+        const std::vector<double> ref_vcs0{usys.to_si("GeometricVolume/Moles", 0.6),
+                                           usys.to_si("GeometricVolume/Moles", 0.1),
+                                           usys.to_si("GeometricVolume/Moles", 0.1)};
         const std::vector<double> ref_vcs1{usys.to_si("GeometricVolume/Moles", 0.61),
                                            usys.to_si("GeometricVolume/Moles", 0.11),
                                            usys.to_si("GeometricVolume/Moles", 0.11)};
+        check_vectors_close(ref_vcs0, comp_config.criticalVolumeSurf(0), tolerance);
         check_vectors_close(ref_vcs1, comp_config.criticalVolumeSurf(1), tolerance);
         check_vectors_close(ref_vcs1, comp_config.criticalVolumeSurf(2), tolerance);
     }
@@ -1156,6 +1140,8 @@ BOOST_AUTO_TEST_CASE(SurfaceDefaultsFromReservoirTest) {
     {
         constexpr std::size_t bic_size = num_comps * (num_comps - 1) / 2;
         BOOST_CHECK_EQUAL(bic_size, comp_config.binaryInteractionCoefficientSurf(0).size());
+        BOOST_CHECK_EQUAL(bic_size, comp_config.binaryInteractionCoefficientSurf(1).size());
+        BOOST_CHECK_EQUAL(bic_size, comp_config.binaryInteractionCoefficientSurf(2).size());
         check_vectors_close(std::vector<double>{0, 1, 2},
                             comp_config.binaryInteractionCoefficientSurf(0), tolerance);
         check_vectors_close(std::vector<double>{1, 2, 3},
@@ -1278,6 +1264,8 @@ END
 
     constexpr std::size_t num_comps = 3;
     constexpr double tolerance = 1.e-5;
+    const auto& usys = deck.getActiveUnitSystem();
+    using M = UnitSystem::measure;
 
     // Partial EOSS: unspecified records use EOSS default (PR), not reservoir EOS.
     BOOST_CHECK(CompositionalConfig::EOSType::ZJ == comp_config.eosTypeSurf(0));
@@ -1308,6 +1296,59 @@ END
     }
 
     // Keywords not provided at all still inherit from reservoir values.
+    check_vectors_close(std::vector<double>{0.4, 0.2, 0.01},
+                        comp_config.acentricFactorsSurf(0), tolerance);
+    check_vectors_close(std::vector<double>{0.5, 0.3, 0.03},
+                        comp_config.acentricFactorsSurf(1), tolerance);
+    check_vectors_close(std::vector<double>{0.5, 0.3, 0.03},
+                        comp_config.acentricFactorsSurf(2), tolerance);
+
+    check_vectors_close(std::vector<double>{usys.to_si(M::pressure, 20),
+                                            usys.to_si(M::pressure, 70),
+                                            usys.to_si(M::pressure, 40)},
+                        comp_config.criticalPressureSurf(0), tolerance);
+    check_vectors_close(std::vector<double>{usys.to_si(M::pressure, 21),
+                                            usys.to_si(M::pressure, 71),
+                                            usys.to_si(M::pressure, 41)},
+                        comp_config.criticalPressureSurf(1), tolerance);
+    check_vectors_close(std::vector<double>{usys.to_si(M::pressure, 21),
+                                            usys.to_si(M::pressure, 71),
+                                            usys.to_si(M::pressure, 41)},
+                        comp_config.criticalPressureSurf(2), tolerance);
+
+    check_vectors_close(std::vector<double>{usys.to_si(M::temperature_absolute, 600),
+                                            usys.to_si(M::temperature_absolute, 300),
+                                            usys.to_si(M::temperature_absolute, 190)},
+                        comp_config.criticalTemperatureSurf(0), tolerance);
+    check_vectors_close(std::vector<double>{usys.to_si(M::temperature_absolute, 601),
+                                            usys.to_si(M::temperature_absolute, 301),
+                                            usys.to_si(M::temperature_absolute, 191)},
+                        comp_config.criticalTemperatureSurf(1), tolerance);
+    check_vectors_close(std::vector<double>{usys.to_si(M::temperature_absolute, 601),
+                                            usys.to_si(M::temperature_absolute, 301),
+                                            usys.to_si(M::temperature_absolute, 191)},
+                        comp_config.criticalTemperatureSurf(2), tolerance);
+
+    check_vectors_close(std::vector<double>{usys.to_si("GeometricVolume/Moles", 0.6),
+                                            usys.to_si("GeometricVolume/Moles", 0.1),
+                                            usys.to_si("GeometricVolume/Moles", 0.1)},
+                        comp_config.criticalVolumeSurf(0), tolerance);
+    check_vectors_close(std::vector<double>{usys.to_si("GeometricVolume/Moles", 0.61),
+                                            usys.to_si("GeometricVolume/Moles", 0.11),
+                                            usys.to_si("GeometricVolume/Moles", 0.11)},
+                        comp_config.criticalVolumeSurf(1), tolerance);
+    check_vectors_close(std::vector<double>{usys.to_si("GeometricVolume/Moles", 0.61),
+                                            usys.to_si("GeometricVolume/Moles", 0.11),
+                                            usys.to_si("GeometricVolume/Moles", 0.11)},
+                        comp_config.criticalVolumeSurf(2), tolerance);
+
+    check_vectors_close(std::vector<double>{0.28, 0.25, 0.26},
+                        comp_config.criticalZFactorSurf(0), tolerance);
+    check_vectors_close(std::vector<double>{0.29, 0.26, 0.27},
+                        comp_config.criticalZFactorSurf(1), tolerance);
+    check_vectors_close(std::vector<double>{0.29, 0.26, 0.27},
+                        comp_config.criticalZFactorSurf(2), tolerance);
+
     check_vectors_close(comp_config.molecularWeights(0),
                         comp_config.molecularWeightsSurf(0), tolerance);
     check_vectors_close(comp_config.molecularWeights(1),

--- a/tests/parser/CompositionalTests.cpp
+++ b/tests/parser/CompositionalTests.cpp
@@ -394,42 +394,36 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTest) {
     {
         const auto& cp0 = comp_config.criticalPressure(0);
         BOOST_CHECK_EQUAL(num_comps, cp0.size());
-        const std::vector<double> ref_cp0 = {usys.to_si(M::pressure, 20), usys.to_si(M::pressure, 70),
-                                             usys.to_si(M::pressure, 40)};
+        const std::vector<double> ref_cp0 = {usys.to_si(M::pressure, 20), usys.to_si(M::pressure, 70), usys.to_si(M::pressure, 40)};
         check_vectors_close(ref_cp0, cp0, tolerance);
         const auto& cp1 = comp_config.criticalPressure(1);
         BOOST_CHECK_EQUAL(num_comps, cp1.size());
-        const std::vector<double> ref_cp1 = {usys.to_si(M::pressure, 21), usys.to_si(M::pressure, 71),
-                                             usys.to_si(M::pressure, 41)};
+        const std::vector<double> ref_cp1 = {usys.to_si(M::pressure, 21), usys.to_si(M::pressure, 71), usys.to_si(M::pressure, 41)};
         check_vectors_close(ref_cp1, cp1, tolerance);
     }
 
     {
         const auto& ct0 = comp_config.criticalTemperature(0);
         BOOST_CHECK_EQUAL(num_comps, ct0.size());
-        const std::vector<double> ref_ct0 = {usys.to_si(M::temperature_absolute, 600),
-                                             usys.to_si(M::temperature_absolute, 300),
-                                             usys.to_si(M::temperature_absolute, 190)};
+        const std::vector<double> ref_ct0 = {usys.to_si(M::temperature_absolute, 600), usys.to_si(M::temperature_absolute, 300), usys.to_si(M::temperature_absolute, 190)};
         check_vectors_close(ref_ct0, ct0, tolerance);
         const auto& ct1 = comp_config.criticalTemperature(1);
-        const std::vector<double> ref_ct1 = {usys.to_si(M::temperature_absolute, 601),
-                                             usys.to_si(M::temperature_absolute, 301),
-                                             usys.to_si(M::temperature_absolute, 191)};
+        const std::vector<double> ref_ct1 = {usys.to_si(M::temperature_absolute, 601), usys.to_si(M::temperature_absolute, 301), usys.to_si(M::temperature_absolute, 191)};
         check_vectors_close(ref_ct1, ct1, tolerance);
     }
 
     {
         const auto& cv0 = comp_config.criticalVolume(0);
         BOOST_CHECK_EQUAL(num_comps, cv0.size());
-        const std::vector<double> ref_cv0{usys.to_si("GeometricVolume/Moles", 0.6),
-                                          usys.to_si("GeometricVolume/Moles", 0.1),
-                                          usys.to_si("GeometricVolume/Moles", 0.1)};
+        const std::vector<double> ref_cv0 { usys.to_si( "GeometricVolume/Moles", 0.6),
+                                            usys.to_si( "GeometricVolume/Moles", 0.1),
+                                            usys.to_si( "GeometricVolume/Moles", 0.1) };
         check_vectors_close(ref_cv0, cv0, tolerance);
         const auto& cv1 = comp_config.criticalVolume(1);
         BOOST_CHECK_EQUAL(num_comps, cv1.size());
-        const std::vector<double> ref_cv1{usys.to_si("GeometricVolume/Moles", 0.61),
-                                          usys.to_si("GeometricVolume/Moles", 0.11),
-                                          usys.to_si("GeometricVolume/Moles", 0.11)};
+        const std::vector<double> ref_cv1 { usys.to_si( "GeometricVolume/Moles", 0.61),
+                                            usys.to_si( "GeometricVolume/Moles", 0.11),
+                                            usys.to_si( "GeometricVolume/Moles", 0.11) };
         check_vectors_close(ref_cv1, cv1, tolerance);
     }
 
@@ -446,26 +440,26 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTest) {
         const auto& bic0 = comp_config.binaryInteractionCoefficient(0);
         constexpr std::size_t bic_size = num_comps * (num_comps - 1) / 2;
         BOOST_CHECK_EQUAL(bic_size, bic0.size());
-        const std::vector<double> ref_bic0{0, 1, 2};
+        const std::vector<double> ref_bic0 {0, 1, 2};
         check_vectors_close(ref_bic0, bic0, tolerance);
         const auto& bic1 = comp_config.binaryInteractionCoefficient(1);
         BOOST_CHECK_EQUAL(bic_size, bic1.size());
-        const std::vector<double> ref_bic1{1, 2, 3};
+        const std::vector<double> ref_bic1 {1, 2, 3};
         check_vectors_close(ref_bic1, bic1, tolerance);
     }
 
     {
         const auto& mw0 = comp_config.molecularWeights(0);
         BOOST_CHECK_EQUAL(num_comps, mw0.size());
-        const std::vector<double> ref_mw0{usys.to_si("Mass/Moles", 142.),
-                                          usys.to_si("Mass/Moles", 44.),
-                                          usys.to_si("Mass/Moles", 16)};
+        const std::vector<double> ref_mw0 { usys.to_si( "Mass/Moles", 142.),
+                                            usys.to_si( "Mass/Moles", 44.),
+                                            usys.to_si( "Mass/Moles", 16) };
         check_vectors_close(ref_mw0, mw0, tolerance);
         const auto& mw1 = comp_config.molecularWeights(1);
         BOOST_CHECK_EQUAL(num_comps, mw1.size());
-        const std::vector<double> ref_mw1{usys.to_si("Mass/Moles", 142.1),
-                                          usys.to_si("Mass/Moles", 44.1),
-                                          usys.to_si("Mass/Moles", 16.1)};
+        const std::vector<double> ref_mw1 { usys.to_si( "Mass/Moles", 142.1),
+                                            usys.to_si( "Mass/Moles", 44.1),
+                                            usys.to_si( "Mass/Moles", 16.1) };
         check_vectors_close(ref_mw1, mw1, tolerance);
     }
 
@@ -917,7 +911,10 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTestZMF) {
 }
 
 BOOST_AUTO_TEST_CASE(PRCORRKeywordTest) {
-    // Minimal deck: PR region should be promoted by PRCORR, SRK region should not.
+    // Minimal compositional deck used to verify the handling of the PRCORR
+    // keyword. There are two EOS regions: the first uses PR (and must be
+    // promoted to PRCORR by PRCORR), the second uses SRK (and must be left
+    // unchanged by PRCORR).
     const std::string deck_string = R"(
 RUNSPEC
 

--- a/tests/parser/CompositionalTests.cpp
+++ b/tests/parser/CompositionalTests.cpp
@@ -26,6 +26,7 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
 
 #include <cstddef>
 #include <initializer_list>
@@ -1355,6 +1356,71 @@ END
                         comp_config.molecularWeightsSurf(1), tolerance);
     check_vectors_close(comp_config.molecularWeights(1),
                         comp_config.molecularWeightsSurf(2), tolerance);
+}
+
+BOOST_AUTO_TEST_CASE(SurfaceKeywordRequiresReservoirKeywordTest) {
+    const std::string deck_string = R"(
+RUNSPEC
+TITLE
+   SURFACE REQUIRES RESERVOIR TEST
+
+METRIC
+
+TABDIMS
+8* 2 3/
+
+OIL
+GAS
+DIMENS
+4 1 1
+/
+
+COMPS
+3 /
+
+GRID
+DX
+4*10 /
+DY
+4*1 /
+DZ
+4*1 /
+TOPS
+4*0 /
+PERMX
+4*100 /
+PERMY
+4*100 /
+PERMZ
+4*100 /
+PORO
+4*0.1 /
+
+PROPS
+
+CNAMES
+DECANE
+CO2
+METHANE
+/
+
+EOS
+PR /
+SRK /
+
+MWS
+143. 45. 17. /
+143.1 45.1 17.1 /
+143.2 45.2 17.2 /
+
+END
+)";
+
+    const Deck deck = Parser{}.parseString(deck_string);
+    const Runspec runspec{deck};
+
+    const auto construct = [&]() { CompositionalConfig config{deck, runspec}; };
+    BOOST_CHECK_THROW(construct(), OpmInputError);
 }
 
 }


### PR DESCRIPTION
ACFS, BICS, EOSS, MWS, PCRITS, SSHIFTS, TCRITS, VCRITS, ZCRITS.

ZCRIT is added along the development.

When surface equation-of-state keywords are not specified, they will use the value from the reservoir equation-of-state keywords if it is specified. 

For a case, not necessarily that we will use all the keywords, but if we have surface equation-of-state keyword, we also make sure its corresponding reservoir equation-of-state keyword is also defined. 

In this development, we assume as long as the surface keyword (-S ending) is specified, we do not copy the values from their reservoir equation-of-state keywords anymore. We use the default value from the keywords themselves. 

These design might need to be revised with more testing case show up. 