### PR TITLE
Revert 5177 without reintroducing warning

### DIFF
--- a/opm/material/fluidsystems/PhaseUsageInfo.cpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.cpp
@@ -48,14 +48,6 @@ PhaseUsageInfo<IndexTraits>::PhaseUsageInfo()
 }
 
 template <typename IndexTraits>
-short PhaseUsageInfo<IndexTraits>::canonicalToActivePhaseIdx(unsigned phaseIdx) const {
-    if (!phaseIsActive(phaseIdx)) {
-        OPM_THROW(std::logic_error, fmt::format("Canonical phase {} is not active.", phaseIdx));
-    }
-    return canonicalToActivePhaseIdx_[phaseIdx];
-}
-
-template <typename IndexTraits>
 void PhaseUsageInfo<IndexTraits>::updateIndexMapping_() {
     int activePhaseIdx = 0;
     for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {

--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -63,7 +63,7 @@ public:
         return phaseIsActive_[phaseIdx];
     }
 
-    [[nodiscard]] OPM_HOST_DEVICE __attribute__((noinline)) short canonicalToActivePhaseIdx(unsigned phaseIdx) const {
+    [[nodiscard]] OPM_HOST_DEVICE [[gnu::noinline]] short canonicalToActivePhaseIdx(unsigned phaseIdx) const {
         if (!phaseIsActive(phaseIdx)) {
             OPM_THROW(std::logic_error, "Canonical phase " + std::to_string(phaseIdx) + " is not active.");
         }

--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -63,7 +63,7 @@ public:
         return phaseIsActive_[phaseIdx];
     }
 
-    [[nodiscard]] OPM_HOST_DEVICE short canonicalToActivePhaseIdx(unsigned phaseIdx) const {
+    [[nodiscard]] OPM_HOST_DEVICE __attribute__((noinline)) short canonicalToActivePhaseIdx(unsigned phaseIdx) const {
         if (!phaseIsActive(phaseIdx)) {
             OPM_THROW(std::logic_error, "Canonical phase " + std::to_string(phaseIdx) + " is not active.");
         }

--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -29,6 +29,8 @@
 
 #include <array>
 #include <cassert>
+#include <stdexcept>
+#include <string>
 
 #include <opm/common/utility/gpuDecorators.hpp>
 
@@ -61,7 +63,12 @@ public:
         return phaseIsActive_[phaseIdx];
     }
 
-    [[nodiscard]] OPM_HOST_DEVICE short canonicalToActivePhaseIdx(unsigned phaseIdx) const;
+    [[nodiscard]] OPM_HOST_DEVICE short canonicalToActivePhaseIdx(unsigned phaseIdx) const {
+        if (!phaseIsActive(phaseIdx)) {
+            OPM_THROW(std::logic_error, "Canonical phase " + std::to_string(phaseIdx) + " is not active.");
+        }
+        return canonicalToActivePhaseIdx_[phaseIdx];
+    }
 
     [[nodiscard]] OPM_HOST_DEVICE short activeToCanonicalPhaseIdx(unsigned activePhaseIdx) const {
         assert(activePhaseIdx< numActivePhases_);

--- a/opm/material/fluidsystems/PhaseUsageInfo.hpp
+++ b/opm/material/fluidsystems/PhaseUsageInfo.hpp
@@ -63,7 +63,7 @@ public:
         return phaseIsActive_[phaseIdx];
     }
 
-    [[nodiscard]] OPM_HOST_DEVICE [[gnu::noinline]] short canonicalToActivePhaseIdx(unsigned phaseIdx) const {
+    [[nodiscard, gnu::noinline]] OPM_HOST_DEVICE  short canonicalToActivePhaseIdx(unsigned phaseIdx) const {
         if (!phaseIsActive(phaseIdx)) {
             OPM_THROW(std::logic_error, "Canonical phase " + std::to_string(phaseIdx) + " is not active.");
         }


### PR DESCRIPTION
Temporarily reverting #5177 to make building https://github.com/OPM/opm-simulators/pull/7042 easier on jenkins