### PR TITLE
Support finding Zoltan automatically on RH

### DIFF
--- a/cmake/Modules/FindZOLTAN.cmake
+++ b/cmake/Modules/FindZOLTAN.cmake
@@ -33,6 +33,7 @@ find_path (ZOLTAN_INCLUDE_DIR
   PATH_SUFFIXES
     include
     trilinos
+    zoltan
   ${ZOLTAN_NO_DEFAULT_PATH}
 )
 


### PR DESCRIPTION
For that we need to search also in path suffix zoltan. Without this zoltan.h is not found unless users correctly set one of the variables ZOLTAN_ROOT, ZOLTAN_SEARCH_PATH or ZOLTAN_INCLUDE_DIR (with correct type PATH).