### PR TITLE
 Add FIELDSEP keyword support in EclipseState (InitConfig)

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -136,6 +136,7 @@ list(APPEND MAIN_SOURCE_FILES
   opm/input/eclipse/EclipseState/Grid/TranCalculator.cpp
   opm/input/eclipse/EclipseState/Grid/TransMult.cpp
   opm/input/eclipse/EclipseState/InitConfig/Equil.cpp
+  opm/input/eclipse/EclipseState/InitConfig/FieldSep.cpp
   opm/input/eclipse/EclipseState/InitConfig/FoamConfig.cpp
   opm/input/eclipse/EclipseState/InitConfig/InitConfig.cpp
   opm/input/eclipse/EclipseState/IOConfig/FIPConfig.cpp
@@ -979,6 +980,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/input/eclipse/EclipseState/IOConfig/FIPConfig.hpp
   opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp
   opm/input/eclipse/EclipseState/InitConfig/Equil.hpp
+  opm/input/eclipse/EclipseState/InitConfig/FieldSep.hpp
   opm/input/eclipse/EclipseState/InitConfig/FoamConfig.hpp
   opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp
   opm/input/eclipse/EclipseState/Phase.hpp

--- a/opm/input/eclipse/EclipseState/InitConfig/FieldSep.cpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/FieldSep.cpp
@@ -1,0 +1,207 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/EclipseState/InitConfig/FieldSep.hpp>
+
+#include <opm/common/OpmLog/KeywordLocation.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
+
+#include <opm/input/eclipse/Deck/DeckItem.hpp>
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/input/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/input/eclipse/Parser/ParserKeywords/F.hpp>
+
+#include <cassert>
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+#include <fmt/core.h>
+
+namespace {
+
+    // FIELDSEP items 8/9/10 (surface EoS number, NGL-density T/P) have no JSON
+    // default; a defaulted record leaves them without a value.  Express the
+    // absence directly as std::nullopt instead of a sentinel -- 0 is a valid
+    // (0-based) EoS number and so cannot double as "not given".
+    std::optional<int> optInt(const Opm::DeckItem& item)
+    {
+        return item.hasValue(0) ? std::optional<int>{ item.get<int>(0) }
+                                : std::nullopt;
+    }
+
+    std::optional<double> optSIDouble(const Opm::DeckItem& item)
+    {
+        return item.hasValue(0) ? std::optional<double>{ item.getSIDouble(0) }
+                                : std::nullopt;
+    }
+
+    // STAGE (item 1) has no JSON default and must be supplied explicitly.
+    int requiredStage(const Opm::DeckItem& item, const Opm::KeywordLocation& location)
+    {
+        if (! item.hasValue(0)) {
+            throw Opm::OpmInputError {
+                "The stage index (item 1) of a FIELDSEP record must be specified.",
+                location
+            };
+        }
+
+        return item.get<int>(0);
+    }
+
+} // Anonymous namespace
+
+namespace Opm {
+
+    FieldSepRecord::FieldSepRecord(const DeckRecord& record, const KeywordLocation& location)
+        : m_stage                  (requiredStage(record.getItem<ParserKeywords::FIELDSEP::STAGE>(), location))
+        , m_temperature            (record.getItem<ParserKeywords::FIELDSEP::TEMPERATURE>().getSIDouble(0))
+        , m_pressure               (record.getItem<ParserKeywords::FIELDSEP::PRESSURE>().getSIDouble(0))
+        , m_liquid_destination     (record.getItem<ParserKeywords::FIELDSEP::LIQ_DESTINATION>().get<int>(0))
+        , m_vapor_destination      (record.getItem<ParserKeywords::FIELDSEP::VAP_DESTINATION>().get<int>(0))
+        , m_kvalue_table_number    (record.getItem<ParserKeywords::FIELDSEP::KVAL_TABLE_NUM>().get<int>(0))
+        , m_gas_plant_table_number (record.getItem<ParserKeywords::FIELDSEP::GAS_PLANT_TABLE_NUM>().get<int>(0))
+        , m_surface_eos_number     (optInt(record.getItem<ParserKeywords::FIELDSEP::SURFACE_EOS_NUMBER>()))
+        , m_ngl_density_temperature(optSIDouble(record.getItem<ParserKeywords::FIELDSEP::NGL_DENSITY_TEMP>()))
+        , m_ngl_density_pressure   (optSIDouble(record.getItem<ParserKeywords::FIELDSEP::NGL_DENSITY_PRES>()))
+    {}
+
+    FieldSepRecord FieldSepRecord::serializationTestObject()
+    {
+        FieldSepRecord result;
+        result.m_stage = 1;
+        result.m_temperature = 323.15;
+        result.m_pressure = 1.0e6;
+        result.m_liquid_destination = 0;
+        result.m_vapor_destination = 0;
+        result.m_kvalue_table_number = 0;
+        result.m_gas_plant_table_number = 7;
+        result.m_surface_eos_number = 2;
+        result.m_ngl_density_temperature = 288.71;
+        result.m_ngl_density_pressure = 101325.0;
+
+        return result;
+    }
+
+    int FieldSepRecord::stage() const {
+        return this->m_stage;
+    }
+
+    double FieldSepRecord::temperature() const {
+        return this->m_temperature;
+    }
+
+    double FieldSepRecord::pressure() const {
+        return this->m_pressure;
+    }
+
+    int FieldSepRecord::liquidDestination() const {
+        return this->m_liquid_destination;
+    }
+
+    int FieldSepRecord::vaporDestination() const {
+        return this->m_vapor_destination;
+    }
+
+    int FieldSepRecord::kvalueTableNumber() const {
+        return this->m_kvalue_table_number;
+    }
+
+    int FieldSepRecord::gasPlantTableNumber() const {
+        return this->m_gas_plant_table_number;
+    }
+
+    std::optional<int> FieldSepRecord::surfaceEosNumber() const {
+        return this->m_surface_eos_number;
+    }
+
+    std::optional<double> FieldSepRecord::nglDensityTemperature() const {
+        return this->m_ngl_density_temperature;
+    }
+
+    std::optional<double> FieldSepRecord::nglDensityPressure() const {
+        return this->m_ngl_density_pressure;
+    }
+
+    bool FieldSepRecord::operator==(const FieldSepRecord& data) const {
+        return this->m_stage == data.m_stage
+            && this->m_temperature == data.m_temperature
+            && this->m_pressure == data.m_pressure
+            && this->m_liquid_destination == data.m_liquid_destination
+            && this->m_vapor_destination == data.m_vapor_destination
+            && this->m_kvalue_table_number == data.m_kvalue_table_number
+            && this->m_gas_plant_table_number == data.m_gas_plant_table_number
+            && this->m_surface_eos_number == data.m_surface_eos_number
+            && this->m_ngl_density_temperature == data.m_ngl_density_temperature
+            && this->m_ngl_density_pressure == data.m_ngl_density_pressure;
+    }
+
+    /* ----------------------------------------------------------------- */
+
+    FieldSep::FieldSep(const DeckKeyword& keyword)
+    {
+        int previous_stage = 0;
+        for (const auto& record : keyword) {
+            this->m_records.emplace_back(record, keyword.location());
+
+            const int current_stage = this->m_records.back().stage();
+            if (current_stage < 1) {
+                throw OpmInputError {
+                    fmt::format("FIELDSEP stage indices must be positive, "
+                                "but got stage {}.", current_stage),
+                    keyword.location()
+                };
+            }
+
+            // previous_stage starts at 0, so this also rejects a non-increasing
+            // first stage.
+            if (current_stage <= previous_stage) {
+                throw OpmInputError {
+                    fmt::format("FIELDSEP stages must be given in strictly increasing "
+                                "order, but stage {} follows stage {}.",
+                                current_stage, previous_stage),
+                    keyword.location()
+                };
+            }
+
+            previous_stage = current_stage;
+        }
+    }
+
+    FieldSep FieldSep::serializationTestObject()
+    {
+        FieldSep result;
+        result.m_records = { FieldSepRecord::serializationTestObject() };
+
+        return result;
+    }
+
+    const FieldSepRecord& FieldSep::getRecord(std::size_t id) const {
+        // Callers are expected to index within size(); an out-of-range id is a
+        // programming error rather than a recoverable input condition.
+        assert(id < this->m_records.size());
+        return this->m_records[id];
+    }
+
+    bool FieldSep::operator==(const FieldSep& data) const {
+        return this->m_records == data.m_records;
+    }
+
+} // namespace Opm

--- a/opm/input/eclipse/EclipseState/InitConfig/FieldSep.hpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/FieldSep.hpp
@@ -1,0 +1,129 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_FIELDSEP_HPP
+#define OPM_FIELDSEP_HPP
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+namespace Opm {
+    class DeckKeyword;
+    class DeckRecord;
+    class KeywordLocation;
+} // namespace Opm
+
+namespace Opm {
+
+    /// One stage of a field separator (a single FIELDSEP record).
+    class FieldSepRecord {
+    public:
+        FieldSepRecord() = default;
+        FieldSepRecord(const DeckRecord& record, const KeywordLocation& location);
+
+        static FieldSepRecord serializationTestObject();
+
+        /// Stage index (FIELDSEP records are given in increasing order).
+        int stage() const;
+        /// Stage temperature (SI).
+        double temperature() const;
+        /// Stage pressure (SI).
+        double pressure() const;
+        /// Liquid destination: 0 => next stage (stock tank for the last
+        /// stage); -1 => add to stock-tank oil.
+        int liquidDestination() const;
+        /// Vapour destination: 0 => stock tank / surface gas.
+        int vaporDestination() const;
+        /// K-value table number (0 => use the equation of state).
+        int kvalueTableNumber() const;
+        /// Gas-plant table number, references a GPTABLE (0 => use the EoS).
+        int gasPlantTableNumber() const;
+        /// Surface equation-of-state region number.  Nullopt if defaulted:
+        /// 0 is a valid (0-based) EoS number, so absence is expressed directly.
+        std::optional<int> surfaceEosNumber() const;
+        /// NGL-density-evaluation temperature (SI).  Nullopt if defaulted.
+        std::optional<double> nglDensityTemperature() const;
+        /// NGL-density-evaluation pressure (SI).  Nullopt if defaulted.
+        std::optional<double> nglDensityPressure() const;
+
+        bool operator==(const FieldSepRecord& data) const;
+
+        template<class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(m_stage);
+            serializer(m_temperature);
+            serializer(m_pressure);
+            serializer(m_liquid_destination);
+            serializer(m_vapor_destination);
+            serializer(m_kvalue_table_number);
+            serializer(m_gas_plant_table_number);
+            serializer(m_surface_eos_number);
+            serializer(m_ngl_density_temperature);
+            serializer(m_ngl_density_pressure);
+        }
+
+    private:
+        int m_stage = 0;
+        double m_temperature = 0.0;
+        double m_pressure = 0.0;
+        int m_liquid_destination = 0;
+        int m_vapor_destination = 0;
+        int m_kvalue_table_number = 0;
+        int m_gas_plant_table_number = 0;
+        std::optional<int> m_surface_eos_number{};
+        std::optional<double> m_ngl_density_temperature{};
+        std::optional<double> m_ngl_density_pressure{};
+    };
+
+    /// A multi-stage field separator (the FIELDSEP keyword).
+    ///
+    /// Mirrors the EquilContainer interface, but is a dedicated container: a
+    /// field separator needs no Phases / compositional / region arguments.
+    class FieldSep {
+    public:
+        FieldSep() = default;
+        explicit FieldSep(const DeckKeyword& keyword);
+
+        static FieldSep serializationTestObject();
+
+        const FieldSepRecord& getRecord(std::size_t id) const;
+
+        std::size_t size()  const { return this->m_records.size(); }
+        bool        empty() const { return this->m_records.empty(); }
+
+        auto begin() const { return this->m_records.begin(); }
+        auto end()   const { return this->m_records.end(); }
+
+        bool operator==(const FieldSep& data) const;
+
+        template<class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(m_records);
+        }
+
+    private:
+        std::vector<FieldSepRecord> m_records;
+    };
+
+} // namespace Opm
+
+#endif // OPM_FIELDSEP_HPP

--- a/opm/input/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -22,6 +22,7 @@
 #include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/EclipseState/InitConfig/Equil.hpp>
+#include <opm/input/eclipse/EclipseState/InitConfig/FieldSep.hpp>
 #include <opm/input/eclipse/EclipseState/InitConfig/FoamConfig.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
@@ -54,6 +55,17 @@ namespace {
         };
     }
 
+    Opm::FieldSep fieldseps(const Opm::Deck& deck)
+    {
+        if (! deck.hasKeyword<Opm::ParserKeywords::FIELDSEP>()) {
+            return {};
+        }
+
+        return Opm::FieldSep {
+            deck.get<Opm::ParserKeywords::FIELDSEP>().back()
+        };
+    }
+
     Opm::DeckKeyword stressequils(const Opm::Deck& deck)
     {
         if (! deck.hasKeyword<Opm::ParserKeywords::STREQUIL>()) {
@@ -69,6 +81,7 @@ namespace Opm {
 
     InitConfig::InitConfig(const Deck& deck, const Phases& phases, bool compositional)
         : equil        { equils(deck, phases, compositional) }
+        , fieldsep     { fieldseps(deck) }
         , stress_equil { stressequils(deck), phases, compositional }
         , foamconfig   { deck }
         , m_filleps    { PROPSSection{deck}.hasKeyword(ParserKeywords::FILLEPS::keywordName) }
@@ -81,6 +94,7 @@ namespace Opm {
     {
         InitConfig result;
         result.equil = Equil::serializationTestObject();
+        result.fieldsep = FieldSep::serializationTestObject();
         result.stress_equil = StressEquil::serializationTestObject();
         result.foamconfig = FoamConfig::serializationTestObject();
         result.m_filleps = true;
@@ -136,6 +150,22 @@ namespace Opm {
         return this->equil;
     }
 
+    bool InitConfig::hasFieldSep() const
+    {
+        return !this->fieldsep.empty();
+    }
+
+    const FieldSep& InitConfig::getFieldSep() const
+    {
+        if (!this->hasFieldSep()) {
+            throw std::runtime_error {
+                "Error: No 'FIELDSEP' present"
+            };
+        }
+
+        return this->fieldsep;
+    }
+
     bool InitConfig::hasStressEquil() const
     {
         return !this->stress_equil.empty();
@@ -172,6 +202,7 @@ namespace Opm {
     bool InitConfig::operator==(const InitConfig& data) const
     {
         return (this->equil == data.equil)
+            && (this->fieldsep == data.fieldsep)
             && (this->stress_equil == data.stress_equil)
             && (this->foamconfig == data.foamconfig)
             && (this->m_filleps == data.m_filleps)

--- a/opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp
@@ -21,6 +21,7 @@
 #define OPM_INIT_CONFIG_HPP
 
 #include <opm/input/eclipse/EclipseState/InitConfig/Equil.hpp>
+#include <opm/input/eclipse/EclipseState/InitConfig/FieldSep.hpp>
 #include <opm/input/eclipse/EclipseState/InitConfig/FoamConfig.hpp>
 
 #include <string>
@@ -99,6 +100,15 @@ namespace Opm {
         /// Only meaningful if hasEquil() returns true.
         const Equil& getEquil() const;
 
+        /// Whether or not run specifies field separator stages (FIELDSEP
+        /// keyword).
+        bool hasFieldSep() const;
+
+        /// Field separator specification.
+        ///
+        /// Only meaningful if hasFieldSep() returns true.
+        const FieldSep& getFieldSep() const;
+
         /// Whether or not run initialises its mechanical stresses by an
         /// equilibration procedure (STREQUIL keyword).
         ///
@@ -169,6 +179,7 @@ namespace Opm {
         void serializeOp(Serializer& serializer)
         {
             serializer(equil);
+            serializer(fieldsep);
             serializer(stress_equil);
             serializer(foamconfig);
             serializer(m_filleps);
@@ -182,6 +193,9 @@ namespace Opm {
     private:
         /// Run's gravity equilibration specification.
         Equil equil{};
+
+        /// Run's field separator specification.
+        FieldSep fieldsep{};
 
         /// Run's mechanical stress equilibration specification.
         StressEquil stress_equil{};

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/F/FIELDSEP
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/F/FIELDSEP
@@ -26,18 +26,19 @@
     {
       "item": 4,
       "name": "LIQ_DESTINATION",
-      "value_type": "INT"
+      "value_type": "INT",
+      "default": 0
     },
     {
       "item": 5,
       "name": "VAP_DESTINATION",
-      "value_type":  "INT"
+      "value_type": "INT",
+      "default": 0
     },
     {
         "item": 6,
-        "name": "KVALUE",
-        "value_type": "DOUBLE",
-        "dimension": "1",
+        "name": "KVAL_TABLE_NUM",
+        "value_type": "INT",
         "default": 0
       },
       {

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/F/FIELDSEP
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/F/FIELDSEP
@@ -43,24 +43,24 @@
       },
       {
         "item": 7,
-        "name": "TABLE_NUM",
+        "name": "GAS_PLANT_TABLE_NUM",
         "value_type": "INT",
         "default": 0
       },
       {
         "item": 8,
-        "name": "EOS_NUM",
+        "name": "SURFACE_EOS_NUMBER",
         "value_type": "INT"
       },
       {
         "item": 9,
-        "name": "REF_TEMP",
+        "name": "NGL_DENSITY_TEMP",
         "value_type": "DOUBLE",
         "dimension": "Temperature"
       },
       {
         "item": 10,
-        "name": "REF_PRESS",
+        "name": "NGL_DENSITY_PRES",
         "value_type": "DOUBLE",
         "dimension": "Pressure"
       }

--- a/tests/parser/InitConfigTest.cpp
+++ b/tests/parser/InitConfigTest.cpp
@@ -851,3 +851,114 @@ END
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_CASE(FIELDSEP_parse_and_retrieve)
+{
+    const auto deck = Parser{}.parseString(R"(
+RUNSPEC
+DIMENS
+  1 1 1 /
+OIL
+GAS
+COMPS
+  3 /
+SOLUTION
+FIELDSEP
+-- stage  T(C)   P(bar)  Ldest Vdest Kvtab GPtab EoS
+   1      50.0   10.0    /                          -- items 4-10 defaulted
+   2      15.56  1.01325 1     0     0     7     2 /
+/
+)");
+    const Runspec    runspec{ deck };
+    const InitConfig init{ deck, runspec.phases(), runspec.compositionalMode() };
+
+    BOOST_CHECK( init.hasFieldSep() );
+    const auto& fsep = init.getFieldSep();
+    BOOST_REQUIRE_EQUAL( fsep.size(), std::size_t{2} );
+
+    const auto& s1 = fsep.getRecord(0);                      // corrected defaults (the JSON fix)
+    BOOST_CHECK_EQUAL ( s1.stage(),               1 );
+    BOOST_CHECK_CLOSE ( s1.temperature(),         50.0 + 273.15, 1e-6 );  // 323.15 K
+    BOOST_CHECK_CLOSE ( s1.pressure(),            10.0 * 1e5,    1e-6 );   // 1.0e6 Pa
+    BOOST_CHECK_EQUAL ( s1.liquidDestination(),   0 );                     // item 4 default
+    BOOST_CHECK_EQUAL ( s1.vaporDestination(),    0 );                     // item 5 default
+    BOOST_CHECK_EQUAL ( s1.kvalueTableNumber(),   0 );                     // item 6 INT default
+    BOOST_CHECK_EQUAL ( s1.gasPlantTableNumber(), 0 );
+    BOOST_CHECK ( ! s1.surfaceEosNumber().has_value() );                   // items 8/9/10 defaulted => nullopt
+    BOOST_CHECK ( ! s1.nglDensityTemperature().has_value() );
+    BOOST_CHECK ( ! s1.nglDensityPressure().has_value() );
+
+    const auto& s2 = fsep.getRecord(1);                      // explicit values
+    BOOST_CHECK_EQUAL ( s2.stage(),               2 );
+    BOOST_CHECK_CLOSE ( s2.temperature(),         15.56 + 273.15, 1e-6 );
+    BOOST_CHECK_CLOSE ( s2.pressure(),            1.01325 * 1e5,  1e-6 );  // 101325 Pa
+    BOOST_CHECK_EQUAL ( s2.liquidDestination(),   1 );
+    BOOST_CHECK_EQUAL ( s2.gasPlantTableNumber(), 7 );                     // links to a GPTABLE
+    BOOST_REQUIRE ( s2.surfaceEosNumber().has_value() );                   // item 8 provided (0 is valid => optional)
+    BOOST_CHECK_EQUAL ( *s2.surfaceEosNumber(),   2 );
+}
+
+BOOST_AUTO_TEST_CASE(FIELDSEP_absent_throws_on_get)
+{
+    const auto deck = Parser{}.parseString("RUNSPEC\nDIMENS\n1 1 1 /\nSOLUTION\n");
+    const Runspec    rs{ deck };
+    const InitConfig init{ deck, rs.phases(), rs.compositionalMode() };
+
+    BOOST_CHECK( ! init.hasFieldSep() );
+    BOOST_CHECK_THROW( init.getFieldSep(), std::exception );  // mirrors getEquil()
+}
+
+BOOST_AUTO_TEST_CASE(FIELDSEP_stages_must_increase)
+{
+    const auto deck = Parser{}.parseString(R"(
+RUNSPEC
+DIMENS
+ 1 1 1 /
+COMPS
+ 3 /
+SOLUTION
+FIELDSEP
+  2  15.56 1.01325 /
+  1  50.0  10.0    /
+/
+)");
+    const Runspec rs{ deck };
+    BOOST_CHECK_THROW( InitConfig(deck, rs.phases(), rs.compositionalMode()),
+                       OpmInputError );                       // stage-order validation
+}
+
+BOOST_AUTO_TEST_CASE(FIELDSEP_stage_must_be_positive)
+{
+    const auto deck = Parser{}.parseString(R"(
+RUNSPEC
+DIMENS
+ 1 1 1 /
+COMPS
+ 3 /
+SOLUTION
+FIELDSEP
+  0  50.0 10.0 /
+/
+)");
+    const Runspec rs{ deck };
+    BOOST_CHECK_THROW( InitConfig(deck, rs.phases(), rs.compositionalMode()),
+                       OpmInputError );                       // stage index must be >= 1
+}
+
+BOOST_AUTO_TEST_CASE(FIELDSEP_stage_must_be_specified)
+{
+    const auto deck = Parser{}.parseString(R"(
+RUNSPEC
+DIMENS
+ 1 1 1 /
+COMPS
+ 3 /
+SOLUTION
+FIELDSEP
+  1* 50.0 10.0 /
+/
+)");
+    const Runspec rs{ deck };
+    BOOST_CHECK_THROW( InitConfig(deck, rs.phases(), rs.compositionalMode()),
+                       OpmInputError );                       // STAGE (item 1) cannot be defaulted
+}

--- a/tests/test_Serialization.cpp
+++ b/tests/test_Serialization.cpp
@@ -49,6 +49,7 @@
 #include <opm/input/eclipse/EclipseState/Grid/TransMult.hpp>
 #include <opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/input/eclipse/EclipseState/InitConfig/Equil.hpp>
+#include <opm/input/eclipse/EclipseState/InitConfig/FieldSep.hpp>
 #include <opm/input/eclipse/EclipseState/InitConfig/FoamConfig.hpp>
 #include <opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
@@ -258,6 +259,7 @@ TEST_FOR_TYPE(EclipseConfig)
 TEST_FOR_TYPE(EndpointScaling)
 TEST_FOR_TYPE(Eqldims)
 TEST_FOR_TYPE(Equil)
+TEST_FOR_TYPE(FieldSep)
 TEST_FOR_TYPE(TLMixpar)
 TEST_FOR_TYPE(Ppcwmax)
 TEST_FOR_TYPE(Events)


### PR DESCRIPTION
# Add FIELDSEP keyword support in EclipseState (InitConfig)


## Summary

The `FIELDSEP` keyword (a multi-stage field separator, SOLUTION section) is recognised by the
parser but has no consumer — the parsed data is currently inert. This PR gives it a typed
representation in `EclipseState` and corrects three defects in the keyword's JSON definition.
**Parse and represent only — no separation physics.**

## Motivation

`FIELDSEP` defines the field separator stages used to determine separator oil and gas. Today the
keyword is parsed but unused (it appears only in opm-simulators' unsupported-keywords list). This
change makes the stage data available through `EclipseState`, in the same idiom as `EQUIL`, so
downstream code can consume it.

## Changes

**Keyword definition (JSON)**
- `LIQ_DESTINATION` (item 4) and `VAP_DESTINATION` (item 5): add the missing default `0`.
- Item 6 is the K-value table number — an integer index — so it becomes an `INT` named
  `KVAL_TABLE_NUM` (previously a dimensionless `DOUBLE`). This renames a generated
  `ParserKeywords::FIELDSEP` symbol; there were no references to the old one.

**New representation (`opm/input/eclipse/EclipseState/InitConfig`)**
- `FieldSepRecord` — one separator stage, with typed accessors (temperature/pressure returned in
  SI; the K-value and gas-plant table numbers and surface EoS region as integers).
- `FieldSep` — the ordered collection of stages. It validates that stage indices are strictly
  increasing (throws `OpmInputError` otherwise). It is a dedicated container exposing the same
  interface as `EquilContainer`, without the `Phases`/`compositional` arguments it does not need.
- `InitConfig::hasFieldSep()` / `getFieldSep()`, mirroring `hasEquil()` / `getEquil()`. No new
  public surface on `EclipseState` — it is reached through `getInitConfig()`.
- `operator==`, `serializeOp`, and `serializationTestObject` for both new types.

## Scope

Parse and represent only. Applying the separation (the flash, and resolving the K-value /
gas-plant table references) is out of scope and unchanged. Because the keyword had no consumer
before, existing behaviour is unaffected.

## Testing

- `tests/parser/InitConfigTest.cpp`: parse a multi-stage `FIELDSEP` and read every field back,
  including the corrected defaults; absent-keyword behaviour (`getFieldSep()` throws, like
  `getEquil()`); and the stage-order validation (out-of-order stages ⇒ `OpmInputError`).
- `tests/test_Serialization.cpp`: a `FieldSep` serialization round-trip.
