### PR TITLE
Adding parsing support for OMEGAA, OMEGAB, OMEGAAS and OMEGABS

### DIFF
--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -36,6 +36,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/M.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/N.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/O.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/P.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
@@ -218,6 +219,128 @@ namespace {
         parsingKeywordValues<Keyword>(*kw, target, num_values, default_value);
     }
 
+    // EOS-constant defaults (OMEGAA, OMEGAB) depend on the EOS type of a region.
+    // Returns {omega_a_default, omega_b_default}.
+    std::pair<double, double>
+    omegaDefaultsForEosType(Opm::CompositionalConfig::EOSType eos)
+    {
+        using EOSType = Opm::CompositionalConfig::EOSType;
+        switch (eos) {
+            case EOSType::PR:
+            case EOSType::PRCORR:
+                return {0.457235529, 0.077796074};
+            case EOSType::RK:
+            case EOSType::SRK:
+            case EOSType::ZJ:
+                return {0.4274802, 0.08664035};
+        }
+        throw std::invalid_argument("Unknown EOSType for OMEGAA/OMEGAB defaults");
+    }
+
+    // Build the per-region OMEGAA/OMEGAB defaults for a set of EOS types.
+    void buildOmegaDefaults(const std::vector<Opm::CompositionalConfig::EOSType>& types,
+                            std::vector<double>& omega_a_def,
+                            std::vector<double>& omega_b_def)
+    {
+        omega_a_def.resize(types.size());
+        omega_b_def.resize(types.size());
+        for (std::size_t r = 0; r < types.size(); ++r) {
+            const auto [a, b] = omegaDefaultsForEosType(types[r]);
+            omega_a_def[r] = a;
+            omega_b_def[r] = b;
+        }
+    }
+
+    // OMEGAA/OMEGAB use the keyword item default (-1) as a sentinel: only strictly
+    // positive deck values override the EOS-type-dependent per-region default.
+    template <typename Keyword>
+    void applyPositiveOmegaOverride(const Opm::DeckKeyword& kw,
+                                    std::vector<std::vector<double>>& target,
+                                    const std::size_t num_values)
+    {
+        for (std::size_t i = 0; i < kw.size(); ++i) {
+            const auto& item = kw.getRecord(i).template getItem<typename Keyword::DATA>();
+            const auto& data = item.getSIDoubleData();
+            if (data.size() > num_values) {
+                throw Opm::OpmInputError(
+                    fmt::format("in keyword {}, {} values are specified, which is bigger "
+                                "than the number {} should be specified",
+                                kw.name(), data.size(), num_values),
+                    kw.location());
+            }
+            for (std::size_t c = 0; c < data.size(); ++c) {
+                if (data[c] > 0.0) {
+                    target[i][c] = data[c];
+                }
+            }
+        }
+    }
+
+    // Parse a reservoir EOS-constant keyword (OMEGAA/OMEGAB). The target is
+    // pre-populated with the per-region defaults so it always holds valid data,
+    // even when the keyword is absent. Only positive deck values override.
+    template <typename Keyword>
+    void processOmegaKeyword(const Opm::PROPSSection& props_section,
+                             std::vector<std::vector<double>>& target,
+                             const std::vector<double>& region_defaults,
+                             const std::size_t num_eos_res,
+                             const std::size_t num_values)
+    {
+        target.resize(num_eos_res);
+        for (std::size_t r = 0; r < num_eos_res; ++r) {
+            target[r].assign(num_values, region_defaults[r]);
+        }
+
+        const auto* kw = getSinglePropsKeyword<Keyword>(props_section);
+        if (!kw) {
+            return;
+        }
+
+        // OMEGAA/OMEGAB always carry an item default, so fewer than num_eos_res
+        // regions is allowed; the remaining regions keep their defaults.
+        validateKeywordRegionCount(*kw, num_eos_res, "EOS regions",
+                                   /*has_default_value=*/true);
+
+        applyPositiveOmegaOverride<Keyword>(*kw, target, num_values);
+    }
+
+    // Parse a surface EOS-constant keyword (OMEGAAS/OMEGABS). If absent, inherit
+    // from the reservoir omega regions; if present, pre-populate with the surface
+    // EOS-type defaults and let only positive deck values override.
+    template <typename Keyword>
+    void processOmegaSurfaceKeyword(const Opm::PROPSSection& props_section,
+                                    std::vector<std::vector<double>>& target,
+                                    const std::vector<std::vector<double>>& res_source,
+                                    const std::vector<double>& region_defaults_surf,
+                                    const std::size_t num_eos_sur,
+                                    const std::size_t num_eos_res,
+                                    const std::size_t num_values)
+    {
+        const auto* kw = getSinglePropsKeyword<Keyword>(props_section);
+
+        if (!kw) {
+            // Missing surface keyword: inherit from reservoir omega regions.
+            if (!res_source.empty()) {
+                target.resize(num_eos_sur);
+                for (std::size_t i = 0; i < num_eos_sur; ++i) {
+                    const std::size_t res_idx = std::min(i, num_eos_res - 1);
+                    target[i] = res_source[res_idx];
+                }
+            }
+            return;
+        }
+
+        target.resize(num_eos_sur);
+        for (std::size_t r = 0; r < num_eos_sur; ++r) {
+            target[r].assign(num_values, region_defaults_surf[r]);
+        }
+
+        validateKeywordRegionCount(*kw, num_eos_sur, "surface EOS regions",
+                                   /*has_default_value=*/true);
+
+        applyPositiveOmegaOverride<Keyword>(*kw, target, num_values);
+    }
+
     // Resolve EOS/EOSS from PROPS or RUNSPEC (exclusive), with at most one instance.
     template <typename Keyword>
     const Opm::DeckKeyword*
@@ -305,6 +428,10 @@ namespace {
             std::pair {"BIC"sv,    section.hasKeyword<Opm::ParserKeywords::BIC>() },
             std::pair {"PRCORR"sv, section.hasKeyword<Opm::ParserKeywords::PRCORR>() },
             std::pair {"BICS"sv,   section.hasKeyword<Opm::ParserKeywords::BICS>() },
+            std::pair {"OMEGAA"sv,  section.hasKeyword<Opm::ParserKeywords::OMEGAA>() },
+            std::pair {"OMEGAAS"sv, section.hasKeyword<Opm::ParserKeywords::OMEGAAS>() },
+            std::pair {"OMEGAB"sv,  section.hasKeyword<Opm::ParserKeywords::OMEGAB>() },
+            std::pair {"OMEGABS"sv, section.hasKeyword<Opm::ParserKeywords::OMEGABS>() },
         };
 
         bool any_comp_prop_kw = false;
@@ -517,6 +644,24 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
     processSurfaceKeyword<ParserKeywords::BICS>(props_section, this->binary_interaction_coefficient_surf,
                                                 this->binary_interaction_coefficient,
                                                 num_eos_sur, num_eos_res, bic_size, 0.);
+
+    // OMEGAA/OMEGAB hold EOS-constant multipliers whose defaults depend on the
+    // EOS type of each region; only positive deck values override those defaults.
+    std::vector<double> omega_a_defaults, omega_b_defaults;
+    buildOmegaDefaults(this->eos_types, omega_a_defaults, omega_b_defaults);
+    processOmegaKeyword<ParserKeywords::OMEGAA>(props_section, this->omega_a,
+                                                omega_a_defaults, num_eos_res, this->num_comps);
+    processOmegaKeyword<ParserKeywords::OMEGAB>(props_section, this->omega_b,
+                                                omega_b_defaults, num_eos_res, this->num_comps);
+
+    std::vector<double> omega_a_defaults_surf, omega_b_defaults_surf;
+    buildOmegaDefaults(this->eos_types_surf, omega_a_defaults_surf, omega_b_defaults_surf);
+    processOmegaSurfaceKeyword<ParserKeywords::OMEGAAS>(props_section, this->omega_a_surf,
+                                                        this->omega_a, omega_a_defaults_surf,
+                                                        num_eos_sur, num_eos_res, this->num_comps);
+    processOmegaSurfaceKeyword<ParserKeywords::OMEGABS>(props_section, this->omega_b_surf,
+                                                        this->omega_b, omega_b_defaults_surf,
+                                                        num_eos_sur, num_eos_res, this->num_comps);
 }
 
 bool CompositionalConfig::operator==(const CompositionalConfig& other) const {
@@ -533,6 +678,8 @@ bool CompositionalConfig::operator==(const CompositionalConfig& other) const {
            this->volume_shifts == other.volume_shifts &&
            this->critical_z_factor == other.critical_z_factor &&
            this->binary_interaction_coefficient == other.binary_interaction_coefficient &&
+           this->omega_a == other.omega_a &&
+           this->omega_b == other.omega_b &&
            this->eos_types_surf == other.eos_types_surf &&
            this->molecular_weights_surf == other.molecular_weights_surf &&
            this->acentric_factors_surf == other.acentric_factors_surf &&
@@ -541,7 +688,9 @@ bool CompositionalConfig::operator==(const CompositionalConfig& other) const {
            this->critical_volume_surf == other.critical_volume_surf &&
            this->critical_z_factor_surf == other.critical_z_factor_surf &&
            this->volume_shifts_surf == other.volume_shifts_surf &&
-           this->binary_interaction_coefficient_surf == other.binary_interaction_coefficient_surf;
+           this->binary_interaction_coefficient_surf == other.binary_interaction_coefficient_surf &&
+           this->omega_a_surf == other.omega_a_surf &&
+           this->omega_b_surf == other.omega_b_surf;
 }
 
 
@@ -561,8 +710,9 @@ CompositionalConfig CompositionalConfig::serializationTestObject() {
     result.volume_shifts = {2, std::vector<double>(result.num_comps, 0.1)};
     result.critical_z_factor = {2, std::vector<double>(result.num_comps, 0.29)};
     result.binary_interaction_coefficient = {2, std::vector<double>(result.num_comps * (result.num_comps - 1) / 2, 6.)};
-    result.eos_types_surf = {3, EOSType::PR};
-    result.molecular_weights_surf = {3, std::vector<double>(result.num_comps, 17.)};
+    result.omega_a = {2, std::vector<double>(result.num_comps, 0.457235529)};
+    result.omega_b = {2, std::vector<double>(result.num_comps, 0.077796074)};
+    result.eos_types_surf = {3, EOSType::PR};    result.molecular_weights_surf = {3, std::vector<double>(result.num_comps, 17.)};
     result.acentric_factors_surf = {3, std::vector<double>(result.num_comps, 1.1)};
     result.critical_pressure_surf = {3, std::vector<double>(result.num_comps, 2.1)};
     result.critical_temperature_surf = {3, std::vector<double>(result.num_comps, 3.1)};
@@ -570,6 +720,8 @@ CompositionalConfig CompositionalConfig::serializationTestObject() {
     result.critical_z_factor_surf = {3, std::vector<double>(result.num_comps, 0.3)};
     result.volume_shifts_surf = {3, std::vector<double>(result.num_comps, 0.11)};
     result.binary_interaction_coefficient_surf = {3, std::vector<double>(result.num_comps * (result.num_comps - 1) / 2, 6.1)};
+    result.omega_a_surf = {3, std::vector<double>(result.num_comps, 0.4274802)};
+    result.omega_b_surf = {3, std::vector<double>(result.num_comps, 0.08664035)};
 
     return result;
 }
@@ -642,6 +794,14 @@ const std::vector<double>& CompositionalConfig::binaryInteractionCoefficient(std
     return this->binary_interaction_coefficient[eos_region];
 }
 
+const std::vector<double>& CompositionalConfig::omegaA(std::size_t eos_region) const {
+    return this->omega_a[eos_region];
+}
+
+const std::vector<double>& CompositionalConfig::omegaB(std::size_t eos_region) const {
+    return this->omega_b[eos_region];
+}
+
 CompositionalConfig::EOSType CompositionalConfig::eosTypeSurf(std::size_t eos_region) const {
     return this->eos_types_surf[eos_region];
 }
@@ -676,6 +836,14 @@ const std::vector<double>& CompositionalConfig::volumeShiftsSurf(std::size_t eos
 
 const std::vector<double>& CompositionalConfig::binaryInteractionCoefficientSurf(std::size_t eos_region) const {
     return this->binary_interaction_coefficient_surf[eos_region];
+}
+
+const std::vector<double>& CompositionalConfig::omegaASurf(std::size_t eos_region) const {
+    return this->omega_a_surf[eos_region];
+}
+
+const std::vector<double>& CompositionalConfig::omegaBSurf(std::size_t eos_region) const {
+    return this->omega_b_surf[eos_region];
 }
 
 std::size_t CompositionalConfig::numComps() const {

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -124,10 +124,8 @@ namespace {
             }
             else if (data.size() > num_values) {
                 const auto msg = fmt::format("in keyword {}, {} values are specified, "
-                                             "which is bigger than the number "
-                                             "{} should be specified",
-                                             kw_name, data.size(), num_values);
-
+                                                   "but at most {} values are expected",
+                                                   kw_name, data.size(), num_values);
                 throw Opm::OpmInputError(msg, kw.location());
             }
 
@@ -262,11 +260,10 @@ namespace {
             const auto& item = kw.getRecord(i).template getItem<typename Keyword::DATA>();
             const auto& data = item.getSIDoubleData();
             if (data.size() > num_values) {
-                throw Opm::OpmInputError(
-                    fmt::format("in keyword {}, {} values are specified, which is bigger "
-                                "than the number {} should be specified",
-                                kw.name(), data.size(), num_values),
-                    kw.location());
+                const auto msg = fmt::format("in keyword {}, {} values are specified, "
+                                             "but at most {} values are expected",
+                                             kw.name(), data.size(), num_values);
+                throw Opm::OpmInputError(msg, kw.location());
             }
             for (std::size_t c = 0; c < data.size(); ++c) {
                 if (data[c] > 0.0) {

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -712,7 +712,8 @@ CompositionalConfig CompositionalConfig::serializationTestObject() {
     result.binary_interaction_coefficient = {2, std::vector<double>(result.num_comps * (result.num_comps - 1) / 2, 6.)};
     result.omega_a = {2, std::vector<double>(result.num_comps, 0.457235529)};
     result.omega_b = {2, std::vector<double>(result.num_comps, 0.077796074)};
-    result.eos_types_surf = {3, EOSType::PR};    result.molecular_weights_surf = {3, std::vector<double>(result.num_comps, 17.)};
+    result.eos_types_surf = {3, EOSType::PR};
+    result.molecular_weights_surf = {3, std::vector<double>(result.num_comps, 17.)};
     result.acentric_factors_surf = {3, std::vector<double>(result.num_comps, 1.1)};
     result.critical_pressure_surf = {3, std::vector<double>(result.num_comps, 2.1)};
     result.critical_temperature_surf = {3, std::vector<double>(result.num_comps, 3.1)};

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
@@ -66,6 +66,8 @@ public:
     const std::vector<double>& volumeShifts(std::size_t eos_region) const;
     const std::vector<double>& binaryInteractionCoefficient(std::size_t eos_region) const;
     const std::vector<double>& criticalZFactor(std::size_t eos_region) const;
+    const std::vector<double>& omegaA(std::size_t eos_region) const;
+    const std::vector<double>& omegaB(std::size_t eos_region) const;
 
     // Accessors for surface EOS regions.
     EOSType eosTypeSurf(std::size_t eos_region) const;
@@ -77,6 +79,8 @@ public:
     const std::vector<double>& criticalZFactorSurf(std::size_t eos_region) const;
     const std::vector<double>& volumeShiftsSurf(std::size_t eos_region) const;
     const std::vector<double>& binaryInteractionCoefficientSurf(std::size_t eos_region) const;
+    const std::vector<double>& omegaASurf(std::size_t eos_region) const;
+    const std::vector<double>& omegaBSurf(std::size_t eos_region) const;
 
     std::size_t numComps() const;
 
@@ -96,6 +100,8 @@ public:
         serializer(volume_shifts);
         serializer(critical_z_factor);
         serializer(binary_interaction_coefficient);
+        serializer(omega_a);
+        serializer(omega_b);
         serializer(eos_types_surf);
         serializer(molecular_weights_surf);
         serializer(acentric_factors_surf);
@@ -105,6 +111,8 @@ public:
         serializer(critical_z_factor_surf);
         serializer(volume_shifts_surf);
         serializer(binary_interaction_coefficient_surf);
+        serializer(omega_a_surf);
+        serializer(omega_b_surf);
     }
 
 private:
@@ -123,6 +131,8 @@ private:
     std::vector<std::vector<double>> volume_shifts;
     std::vector<std::vector<double>> critical_z_factor;
     std::vector<std::vector<double>> binary_interaction_coefficient;
+    std::vector<std::vector<double>> omega_a;
+    std::vector<std::vector<double>> omega_b;
 
     // Surface EOS-region properties (EOSS, MWS, ACFS, PCRITS, TCRITS, VCRITS, ZCRITS, SSHIFTS, BICS).
     std::vector<EOSType> eos_types_surf;
@@ -134,6 +144,8 @@ private:
     std::vector<std::vector<double>> critical_z_factor_surf;
     std::vector<std::vector<double>> volume_shifts_surf;
     std::vector<std::vector<double>> binary_interaction_coefficient_surf;
+    std::vector<std::vector<double>> omega_a_surf;
+    std::vector<std::vector<double>> omega_b_surf;
 };
 
 }

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGAA
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGAA
@@ -1,5 +1,6 @@
 {
   "name": "OMEGAA",
+  "description": "Item default -1 is a parser sentinel. Effective defaults are EOS-type dependent and applied per EOS region unless a strictly positive value is provided.",
   "sections": [
     "PROPS"
   ],

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGAA
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGAA
@@ -1,0 +1,20 @@
+{
+  "name": "OMEGAA",
+  "sections": [
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NUM_EOS_RES"
+  },
+  "items": [
+    {
+      "name": "DATA",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": "1",
+      "default": -1
+    }
+  ]
+}
+

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGAAS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGAAS
@@ -1,0 +1,20 @@
+{
+  "name": "OMEGAAS",
+  "sections": [
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NUM_EOS_SURFACE"
+  },
+  "items": [
+    {
+      "name": "DATA",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": "1",
+      "default": -1
+    }
+  ]
+}
+

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGAAS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGAAS
@@ -1,5 +1,6 @@
 {
   "name": "OMEGAAS",
+  "description": "Item default -1 is a parser sentinel. Effective defaults are EOS-type dependent and applied per surface EOS region unless a strictly positive value is provided.",
   "sections": [
     "PROPS"
   ],

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGAB
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGAB
@@ -1,5 +1,6 @@
 {
   "name": "OMEGAB",
+  "description": "Item default -1 is a parser sentinel. Effective defaults are EOS-type dependent and applied per EOS region unless a strictly positive value is provided.",
   "sections": [
     "PROPS"
   ],

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGAB
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGAB
@@ -1,0 +1,20 @@
+{
+  "name": "OMEGAB",
+  "sections": [
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NUM_EOS_RES"
+  },
+  "items": [
+    {
+      "name": "DATA",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": "1",
+      "default": -1
+    }
+  ]
+}
+

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGABS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGABS
@@ -1,0 +1,20 @@
+{
+  "name": "OMEGABS",
+  "sections": [
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NUM_EOS_SURFACE"
+  },
+  "items": [
+    {
+      "name": "DATA",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": "1",
+      "default": -1
+    }
+  ]
+}
+

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGABS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/O/OMEGABS
@@ -1,5 +1,6 @@
 {
   "name": "OMEGABS",
+  "description": "Item default -1 is a parser sentinel. Effective defaults are EOS-type dependent and applied per surface EOS region unless a strictly positive value is provided.",
   "sections": [
     "PROPS"
   ],

--- a/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1088,6 +1088,10 @@ set( keywords
      001_Eclipse300/O/OILCOMPR
      001_Eclipse300/O/OILMW
      001_Eclipse300/O/OILVTIM
+     001_Eclipse300/O/OMEGAA
+     001_Eclipse300/O/OMEGAAS
+     001_Eclipse300/O/OMEGAB
+     001_Eclipse300/O/OMEGABS
      001_Eclipse300/O/OPTIONS3
      001_Eclipse300/P/PCRIT
      001_Eclipse300/P/PCRITS

--- a/tests/parser/CompositionalTests.cpp
+++ b/tests/parser/CompositionalTests.cpp
@@ -151,6 +151,15 @@ ZCRIT
 0.29 0.26 0.27 /
 
 
+OMEGAA
+0.5 1* 0.45 /
+1* /
+
+OMEGAB
+1* 0.08 -1 /
+0.09 1* 0.10 /
+
+
 BICS
 0
 0.1 0.2 /
@@ -194,6 +203,17 @@ SSHIFTS
 0.12 0.22 0.32 /
 0.13 0.23 0.33 /
 0.14 0.24 0.34 /
+
+
+OMEGAAS
+1* 0.5 1* /
+0.6 1* 0.7 /
+1* /
+
+OMEGABS
+0.09 1* -1 /
+1* /
+0.085 0.086 1* /
 
 
 STCOND
@@ -473,6 +493,33 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTest) {
         check_vectors_close(std::vector<double>{0.11, 0.21, 0.31}, vs1, tolerance);
     }
 
+    {
+        // OMEGAA / OMEGAB: region 0 uses PR defaults, region 1 uses SRK defaults.
+        // Only positive deck values override the EOS-type-dependent defaults; the
+        // keyword item default (-1) and 1* keep the per-region default.
+        constexpr double pr_omega_a  = 0.457235529;
+        constexpr double pr_omega_b  = 0.077796074;
+        constexpr double srk_omega_a = 0.4274802;
+        constexpr double srk_omega_b = 0.08664035;
+
+        const auto& oa0 = comp_config.omegaA(0);
+        BOOST_CHECK_EQUAL(num_comps, oa0.size());
+        // second value defaulted (1*), first/third overridden
+        check_vectors_close(std::vector<double>{0.5, pr_omega_a, 0.45}, oa0, tolerance);
+        const auto& oa1 = comp_config.omegaA(1);
+        BOOST_CHECK_EQUAL(num_comps, oa1.size());
+        // entire region defaulted -> SRK defaults
+        check_vectors_close(std::vector<double>{srk_omega_a, srk_omega_a, srk_omega_a}, oa1, tolerance);
+
+        const auto& ob0 = comp_config.omegaB(0);
+        BOOST_CHECK_EQUAL(num_comps, ob0.size());
+        // first value defaulted, second overridden, third explicitly -1 (kept as default)
+        check_vectors_close(std::vector<double>{pr_omega_b, 0.08, pr_omega_b}, ob0, tolerance);
+        const auto& ob1 = comp_config.omegaB(1);
+        BOOST_CHECK_EQUAL(num_comps, ob1.size());
+        check_vectors_close(std::vector<double>{0.09, srk_omega_b, 0.10}, ob1, tolerance);
+    }
+
     // Surface-condition EOS region properties
     BOOST_CHECK(CompositionalConfig::EOSType::PRCORR == comp_config.eosTypeSurf(0));
     BOOST_CHECK(CompositionalConfig::EOSType::RK     == comp_config.eosTypeSurf(1));
@@ -570,6 +617,37 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTest) {
         check_vectors_close(std::vector<double>{0.12, 0.22, 0.32}, comp_config.volumeShiftsSurf(0), tolerance);
         check_vectors_close(std::vector<double>{0.13, 0.23, 0.33}, comp_config.volumeShiftsSurf(1), tolerance);
         check_vectors_close(std::vector<double>{0.14, 0.24, 0.34}, comp_config.volumeShiftsSurf(2), tolerance);
+    }
+
+    {
+        // OMEGAAS / OMEGABS: surface EOS regions are PRCORR, RK, ZJ.
+        // Defaults follow the surface EOS type; only positive values override.
+        constexpr double prcorr_omega_a = 0.457235529;
+        constexpr double prcorr_omega_b = 0.077796074;
+        constexpr double rk_omega_a     = 0.4274802;
+        constexpr double rk_omega_b     = 0.08664035;
+        constexpr double zj_omega_a     = 0.4274802;
+        constexpr double zj_omega_b     = 0.08664035;
+
+        // OMEGAAS region 0: defaulted, 0.5, defaulted -> PRCORR defaults except second.
+        check_vectors_close(std::vector<double>{prcorr_omega_a, 0.5, prcorr_omega_a},
+                            comp_config.omegaASurf(0), tolerance);
+        // region 1: 0.6, defaulted, 0.7 -> RK default in the middle.
+        check_vectors_close(std::vector<double>{0.6, rk_omega_a, 0.7},
+                            comp_config.omegaASurf(1), tolerance);
+        // region 2: fully defaulted -> ZJ defaults.
+        check_vectors_close(std::vector<double>{zj_omega_a, zj_omega_a, zj_omega_a},
+                            comp_config.omegaASurf(2), tolerance);
+
+        // OMEGABS region 0: 0.09, defaulted, explicit -1 (kept default).
+        check_vectors_close(std::vector<double>{0.09, prcorr_omega_b, prcorr_omega_b},
+                            comp_config.omegaBSurf(0), tolerance);
+        // region 1: fully defaulted -> RK defaults.
+        check_vectors_close(std::vector<double>{rk_omega_b, rk_omega_b, rk_omega_b},
+                            comp_config.omegaBSurf(1), tolerance);
+        // region 2: 0.085, 0.086, defaulted -> ZJ default last.
+        check_vectors_close(std::vector<double>{0.085, 0.086, zj_omega_b},
+                            comp_config.omegaBSurf(2), tolerance);
     }
 
     EclipseState es(deck);


### PR DESCRIPTION
-1 is used for default for these keyword definitions. 

Technically, if we do not give a default value, it is also work, because the default value will be 0 with the current code, because only strictly positive value will be used. 

Just let me know if you prefer to remove the default -1 value for the keyword definitions. 