### PR TITLE
adding parsing support for TBOIL and TBOILS

### DIFF
--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -141,6 +141,7 @@ namespace {
             {Opm::ParserKeywords::ACFS::keywordName,   Opm::ParserKeywords::ACF::keywordName},
             {Opm::ParserKeywords::PCRITS::keywordName, Opm::ParserKeywords::PCRIT::keywordName},
             {Opm::ParserKeywords::TCRITS::keywordName, Opm::ParserKeywords::TCRIT::keywordName},
+            {Opm::ParserKeywords::TBOILS::keywordName, Opm::ParserKeywords::TBOIL::keywordName},
             {Opm::ParserKeywords::VCRITS::keywordName, Opm::ParserKeywords::VCRIT::keywordName},
             {Opm::ParserKeywords::ZCRITS::keywordName, Opm::ParserKeywords::ZCRIT::keywordName},
             {Opm::ParserKeywords::SSHIFTS::keywordName, Opm::ParserKeywords::SSHIFT::keywordName},
@@ -292,6 +293,8 @@ namespace {
             std::pair {"PCRITS"sv, section.hasKeyword<Opm::ParserKeywords::PCRITS>() },
             std::pair {"TCRIT"sv,  section.hasKeyword<Opm::ParserKeywords::TCRIT>() },
             std::pair {"TCRITS"sv, section.hasKeyword<Opm::ParserKeywords::TCRITS>() },
+            std::pair {"TBOIL"sv,  section.hasKeyword<Opm::ParserKeywords::TBOIL>() },
+            std::pair {"TBOILS"sv, section.hasKeyword<Opm::ParserKeywords::TBOILS>() },
             std::pair {"VCRIT"sv,  section.hasKeyword<Opm::ParserKeywords::VCRIT>() },
             std::pair {"SSHIFT"sv, section.hasKeyword<Opm::ParserKeywords::SSHIFT>() },
             std::pair {"SSHIFTS"sv, section.hasKeyword<Opm::ParserKeywords::SSHIFTS>() },
@@ -481,6 +484,8 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
                                           num_eos_res, this->num_comps);
     processKeyword<ParserKeywords::TCRIT>(props_section, this->critical_temperature,
                                           num_eos_res, this->num_comps);
+    processKeyword<ParserKeywords::TBOIL>(props_section, this->boiling_temperature,
+                                          num_eos_res, this->num_comps);
     processKeyword<ParserKeywords::VCRIT>(props_section, this->critical_volume,
                                           num_eos_res, this->num_comps);
     processKeyword<ParserKeywords::SSHIFT>(props_section, this->volume_shifts,
@@ -504,6 +509,9 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
                                                   num_eos_sur, num_eos_res, this->num_comps);
     processSurfaceKeyword<ParserKeywords::TCRITS>(props_section, this->critical_temperature_surf,
                                                   this->critical_temperature,
+                                                  num_eos_sur, num_eos_res, this->num_comps);
+    processSurfaceKeyword<ParserKeywords::TBOILS>(props_section, this->boiling_temperature_surf,
+                                                  this->boiling_temperature,
                                                   num_eos_sur, num_eos_res, this->num_comps);
     processSurfaceKeyword<ParserKeywords::VCRITS>(props_section, this->critical_volume_surf,
                                                   this->critical_volume,
@@ -529,6 +537,7 @@ bool CompositionalConfig::operator==(const CompositionalConfig& other) const {
            this->acentric_factors == other.acentric_factors &&
            this->critical_pressure == other.critical_pressure &&
            this->critical_temperature == other.critical_temperature &&
+           this->boiling_temperature == other.boiling_temperature &&
            this->critical_volume == other.critical_volume &&
            this->volume_shifts == other.volume_shifts &&
            this->critical_z_factor == other.critical_z_factor &&
@@ -538,6 +547,7 @@ bool CompositionalConfig::operator==(const CompositionalConfig& other) const {
            this->acentric_factors_surf == other.acentric_factors_surf &&
            this->critical_pressure_surf == other.critical_pressure_surf &&
            this->critical_temperature_surf == other.critical_temperature_surf &&
+           this->boiling_temperature_surf == other.boiling_temperature_surf &&
            this->critical_volume_surf == other.critical_volume_surf &&
            this->critical_z_factor_surf == other.critical_z_factor_surf &&
            this->volume_shifts_surf == other.volume_shifts_surf &&
@@ -557,6 +567,7 @@ CompositionalConfig CompositionalConfig::serializationTestObject() {
     result.acentric_factors = {2,  std::vector<double>(result.num_comps, 1.)};
     result.critical_pressure = {2, std::vector<double>(result.num_comps, 2.)};
     result.critical_temperature = {2, std::vector<double>(result.num_comps, 3.)};
+    result.boiling_temperature = {2, std::vector<double>(result.num_comps, 3.5)};
     result.critical_volume = {2, std::vector<double>(result.num_comps, 5.)};
     result.volume_shifts = {2, std::vector<double>(result.num_comps, 0.1)};
     result.critical_z_factor = {2, std::vector<double>(result.num_comps, 0.29)};
@@ -566,6 +577,7 @@ CompositionalConfig CompositionalConfig::serializationTestObject() {
     result.acentric_factors_surf = {3, std::vector<double>(result.num_comps, 1.1)};
     result.critical_pressure_surf = {3, std::vector<double>(result.num_comps, 2.1)};
     result.critical_temperature_surf = {3, std::vector<double>(result.num_comps, 3.1)};
+    result.boiling_temperature_surf = {3, std::vector<double>(result.num_comps, 3.6)};
     result.critical_volume_surf = {3, std::vector<double>(result.num_comps, 5.1)};
     result.critical_z_factor_surf = {3, std::vector<double>(result.num_comps, 0.3)};
     result.volume_shifts_surf = {3, std::vector<double>(result.num_comps, 0.11)};
@@ -626,6 +638,10 @@ const std::vector<double>& CompositionalConfig::criticalTemperature(std::size_t 
     return this->critical_temperature[eos_region];
 }
 
+const std::vector<double>& CompositionalConfig::boilingTemperature(std::size_t eos_region) const {
+    return this->boiling_temperature[eos_region];
+}
+
 const std::vector<double>& CompositionalConfig::criticalVolume(std::size_t eos_region) const {
     return this->critical_volume[eos_region];
 }
@@ -660,6 +676,10 @@ const std::vector<double>& CompositionalConfig::criticalPressureSurf(std::size_t
 
 const std::vector<double>& CompositionalConfig::criticalTemperatureSurf(std::size_t eos_region) const {
     return this->critical_temperature_surf[eos_region];
+}
+
+const std::vector<double>& CompositionalConfig::boilingTemperatureSurf(std::size_t eos_region) const {
+    return this->boiling_temperature_surf[eos_region];
 }
 
 const std::vector<double>& CompositionalConfig::criticalVolumeSurf(std::size_t eos_region) const {

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
@@ -62,6 +62,7 @@ public:
     const std::vector<double>& acentricFactors(std::size_t eos_region) const;
     const std::vector<double>& criticalPressure(std::size_t eos_region) const;
     const std::vector<double>& criticalTemperature(std::size_t eos_region) const;
+    const std::vector<double>& boilingTemperature(std::size_t eos_region) const;
     const std::vector<double>& criticalVolume(std::size_t eos_region) const;
     const std::vector<double>& volumeShifts(std::size_t eos_region) const;
     const std::vector<double>& binaryInteractionCoefficient(std::size_t eos_region) const;
@@ -73,6 +74,7 @@ public:
     const std::vector<double>& acentricFactorsSurf(std::size_t eos_region) const;
     const std::vector<double>& criticalPressureSurf(std::size_t eos_region) const;
     const std::vector<double>& criticalTemperatureSurf(std::size_t eos_region) const;
+    const std::vector<double>& boilingTemperatureSurf(std::size_t eos_region) const;
     const std::vector<double>& criticalVolumeSurf(std::size_t eos_region) const;
     const std::vector<double>& criticalZFactorSurf(std::size_t eos_region) const;
     const std::vector<double>& volumeShiftsSurf(std::size_t eos_region) const;
@@ -92,6 +94,7 @@ public:
         serializer(acentric_factors);
         serializer(critical_pressure);
         serializer(critical_temperature);
+        serializer(boiling_temperature);
         serializer(critical_volume);
         serializer(volume_shifts);
         serializer(critical_z_factor);
@@ -101,6 +104,7 @@ public:
         serializer(acentric_factors_surf);
         serializer(critical_pressure_surf);
         serializer(critical_temperature_surf);
+        serializer(boiling_temperature_surf);
         serializer(critical_volume_surf);
         serializer(critical_z_factor_surf);
         serializer(volume_shifts_surf);
@@ -119,6 +123,7 @@ private:
     std::vector<std::vector<double>> acentric_factors;
     std::vector<std::vector<double>> critical_pressure;
     std::vector<std::vector<double>> critical_temperature;
+    std::vector<std::vector<double>> boiling_temperature;
     std::vector<std::vector<double>> critical_volume;
     std::vector<std::vector<double>> volume_shifts;
     std::vector<std::vector<double>> critical_z_factor;
@@ -130,6 +135,7 @@ private:
     std::vector<std::vector<double>> acentric_factors_surf;
     std::vector<std::vector<double>> critical_pressure_surf;
     std::vector<std::vector<double>> critical_temperature_surf;
+    std::vector<std::vector<double>> boiling_temperature_surf;
     std::vector<std::vector<double>> critical_volume_surf;
     std::vector<std::vector<double>> critical_z_factor_surf;
     std::vector<std::vector<double>> volume_shifts_surf;

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/T/TBOIL
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/T/TBOIL
@@ -1,0 +1,19 @@
+{
+  "name": "TBOIL",
+  "sections": [
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NUM_EOS_RES"
+  },
+  "items": [
+    {
+      "name": "DATA",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": "AbsoluteTemperature"
+    }
+  ]
+}
+

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/T/TBOILS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/T/TBOILS
@@ -1,0 +1,19 @@
+{
+  "name": "TBOILS",
+  "sections": [
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NUM_EOS_SURFACE"
+  },
+  "items": [
+    {
+      "name": "DATA",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": "AbsoluteTemperature"
+    }
+  ]
+}
+

--- a/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1102,6 +1102,8 @@ set( keywords
      001_Eclipse300/S/STCOND
      001_Eclipse300/T/TCRIT
      001_Eclipse300/T/TCRITS
+     001_Eclipse300/T/TBOIL
+     001_Eclipse300/T/TBOILS
      001_Eclipse300/T/TEMPI
      001_Eclipse300/T/TEMPVD
      001_Eclipse300/T/THCGAS

--- a/tests/parser/CompositionalTests.cpp
+++ b/tests/parser/CompositionalTests.cpp
@@ -133,6 +133,10 @@ TCRIT
 600. 300. 190. /
 601. 301. 191. /
 
+TBOIL
+350. 450. 550. /
+351. 451. 551. /
+
 MW
 142.  44.  16. /
 142.1 44.1 16.1 /
@@ -173,6 +177,11 @@ TCRITS
 602. 302. 192. /
 603. 303. 193. /
 604. 304. 194. /
+
+TBOILS
+352. 452. 552. /
+353. 453. 553. /
+354. 454. 554. /
 
 MWS
 143.  45.  17. /
@@ -414,6 +423,16 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTest) {
     }
 
     {
+        const auto& bt0 = comp_config.boilingTemperature(0);
+        BOOST_CHECK_EQUAL(num_comps, bt0.size());
+        const std::vector<double> ref_bt0 = {usys.to_si(M::temperature_absolute, 350), usys.to_si(M::temperature_absolute, 450), usys.to_si(M::temperature_absolute, 550)};
+        check_vectors_close(ref_bt0, bt0, tolerance);
+        const auto& bt1 = comp_config.boilingTemperature(1);
+        const std::vector<double> ref_bt1 = {usys.to_si(M::temperature_absolute, 351), usys.to_si(M::temperature_absolute, 451), usys.to_si(M::temperature_absolute, 551)};
+        check_vectors_close(ref_bt1, bt1, tolerance);
+    }
+
+    {
         const auto& cv0 = comp_config.criticalVolume(0);
         BOOST_CHECK_EQUAL(num_comps, cv0.size());
         const std::vector<double> ref_cv0 { usys.to_si( "GeometricVolume/Moles", 0.6),
@@ -515,6 +534,21 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTest) {
         check_vectors_close(ref_cts0, comp_config.criticalTemperatureSurf(0), tolerance);
         check_vectors_close(ref_cts1, comp_config.criticalTemperatureSurf(1), tolerance);
         check_vectors_close(ref_cts2, comp_config.criticalTemperatureSurf(2), tolerance);
+    }
+
+    {
+        const std::vector<double> ref_bts0 = {usys.to_si(M::temperature_absolute, 352),
+                                              usys.to_si(M::temperature_absolute, 452),
+                                              usys.to_si(M::temperature_absolute, 552)};
+        const std::vector<double> ref_bts1 = {usys.to_si(M::temperature_absolute, 353),
+                                              usys.to_si(M::temperature_absolute, 453),
+                                              usys.to_si(M::temperature_absolute, 553)};
+        const std::vector<double> ref_bts2 = {usys.to_si(M::temperature_absolute, 354),
+                                              usys.to_si(M::temperature_absolute, 454),
+                                              usys.to_si(M::temperature_absolute, 554)};
+        check_vectors_close(ref_bts0, comp_config.boilingTemperatureSurf(0), tolerance);
+        check_vectors_close(ref_bts1, comp_config.boilingTemperatureSurf(1), tolerance);
+        check_vectors_close(ref_bts2, comp_config.boilingTemperatureSurf(2), tolerance);
     }
 
     {
@@ -1026,6 +1060,10 @@ TCRIT
 600. 300. 190. /
 601. 301. 191. /
 
+TBOIL
+350. 450. 550. /
+351. 451. 551. /
+
 VCRIT
 0.6  0.1  0.1 /
 0.61 0.11 0.11 /
@@ -1106,6 +1144,19 @@ BOOST_AUTO_TEST_CASE(SurfaceDefaultsFromReservoirTest) {
         check_vectors_close(ref_tcs0, comp_config.criticalTemperatureSurf(0), tolerance);
         check_vectors_close(ref_tcs1, comp_config.criticalTemperatureSurf(1), tolerance);
         check_vectors_close(ref_tcs1, comp_config.criticalTemperatureSurf(2), tolerance);
+    }
+
+    // Without TBOILS, boiling temperature inherits from TBOIL.
+    {
+        const std::vector<double> ref_tbs0{usys.to_si(M::temperature_absolute, 350),
+                                           usys.to_si(M::temperature_absolute, 450),
+                                           usys.to_si(M::temperature_absolute, 550)};
+        const std::vector<double> ref_tbs1{usys.to_si(M::temperature_absolute, 351),
+                                           usys.to_si(M::temperature_absolute, 451),
+                                           usys.to_si(M::temperature_absolute, 551)};
+        check_vectors_close(ref_tbs0, comp_config.boilingTemperatureSurf(0), tolerance);
+        check_vectors_close(ref_tbs1, comp_config.boilingTemperatureSurf(1), tolerance);
+        check_vectors_close(ref_tbs1, comp_config.boilingTemperatureSurf(2), tolerance);
     }
 
     // Without VCRITS, critical volume inherits from VCRIT.
@@ -1220,6 +1271,10 @@ TCRIT
 600. 300. 190. /
 601. 301. 191. /
 
+TBOIL
+350. 450. 550. /
+351. 451. 551. /
+
 VCRIT
 0.6  0.1  0.1 /
 0.61 0.11 0.11 /
@@ -1329,6 +1384,19 @@ END
                                             usys.to_si(M::temperature_absolute, 301),
                                             usys.to_si(M::temperature_absolute, 191)},
                         comp_config.criticalTemperatureSurf(2), tolerance);
+
+    check_vectors_close(std::vector<double>{usys.to_si(M::temperature_absolute, 350),
+                                            usys.to_si(M::temperature_absolute, 450),
+                                            usys.to_si(M::temperature_absolute, 550)},
+                        comp_config.boilingTemperatureSurf(0), tolerance);
+    check_vectors_close(std::vector<double>{usys.to_si(M::temperature_absolute, 351),
+                                            usys.to_si(M::temperature_absolute, 451),
+                                            usys.to_si(M::temperature_absolute, 551)},
+                        comp_config.boilingTemperatureSurf(1), tolerance);
+    check_vectors_close(std::vector<double>{usys.to_si(M::temperature_absolute, 351),
+                                            usys.to_si(M::temperature_absolute, 451),
+                                            usys.to_si(M::temperature_absolute, 551)},
+                        comp_config.boilingTemperatureSurf(2), tolerance);
 
     check_vectors_close(std::vector<double>{usys.to_si("GeometricVolume/Moles", 0.6),
                                             usys.to_si("GeometricVolume/Moles", 0.1),


### PR DESCRIPTION
it is quite routinely after https://github.com/OPM/opm-common/pull/5199 . 

the parsing of EOS related keywords should be done for now. 