### PR TITLE
Implement EQUALREG for regions/ints

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -1615,6 +1615,22 @@ Note that this might cause problems for PINCH option 4 or 5 being ALL.)", target
         }
 
         if (FieldProps::supported<int>(target_kw)) {
+            auto& field_data = this->init_get<int>(target_kw);
+
+            const auto reg_name = this->region_name(record.getItem("REGION_NAME"));
+            const auto& [index_list, all_active] = this->region_index(reg_name, region_value);
+            if (index_list.empty()) {
+                log_empty_region(keyword, reg_name, region_value, target_kw);
+                continue;
+            }
+
+            const auto scalar_value =
+                static_cast<int>(record.getItem(1).get<double>(0));
+
+            apply(operation, keyword.location(), target_kw,
+                  field_data.data, field_data.value_status,
+                  scalar_value, index_list);
+
             continue;
         }
     }

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -2785,6 +2785,96 @@ EQUALREG
     }
 }
 
+BOOST_AUTO_TEST_CASE(EQUALREG_PVTNUM) {
+     const std::string valid_pvtnum_region { R"(
+GRID
+
+PORO
+    27*0.10 /
+
+ACTNUM
+    27*1 /
+
+PVTNUM
+    27*1 /
+
+FLUXNUM
+    27*1 /
+
+EQUALREG
+    PVTNUM 2 1 F/
+/
+
+)" };
+
+     const std::string valid_pvtnum_addreg { R"(
+GRID
+
+PORO
+    27*0.10 /
+
+ACTNUM
+    27*1 /
+
+PVTNUM
+    27*1 /
+
+FLUXNUM
+    27*1 /
+
+ADDREG
+    PVTNUM 2 1 F/
+/
+
+)" };
+
+     const std::string valid_pvtnum_multireg { R"(
+GRID
+
+PORO
+    27*0.10 /
+
+ACTNUM
+    27*1 /
+
+PVTNUM
+    27*1 /
+
+FLUXNUM
+    27*1 /
+
+MULTIREG
+    PVTNUM 2 1 F/
+/
+
+)" };
+
+     const auto& fp = make_fp(valid_pvtnum_region);
+     const auto& pvtnum = fp.get_int("PVTNUM");
+
+     for (const auto value : pvtnum) {
+          BOOST_CHECK_EQUAL(value, 2);
+     }
+
+     {
+        const auto& addreg_fp = make_fp(valid_pvtnum_addreg);
+        const auto& addreg_pvtnum = addreg_fp.get_int("PVTNUM");
+
+        for (const auto value : addreg_pvtnum) {
+               BOOST_CHECK_EQUAL(value, 3);
+          }
+     }
+
+     {
+        const auto& multireg_fp = make_fp(valid_pvtnum_multireg);
+        const auto& multireg_pvtnum = multireg_fp.get_int("PVTNUM");
+
+        for (const auto value : multireg_pvtnum) {
+               BOOST_CHECK_EQUAL(value, 2);
+          }
+     }
+}
+
 
 
 BOOST_AUTO_TEST_CASE(TRAN_Calculator) {


### PR DESCRIPTION
I noticed that support for EQUALREG didn't work for REGIONS. 
The OPM manual says it does.
