### PR TITLE
add return values to quell warnings

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -409,6 +409,7 @@ public:
     {
 #if OPM_IS_INSIDE_DEVICE_FUNCTION
         assert(false && "Requested the saturation pressure for the brine-co2 pvt module. Not yet implemented.");
+        return {}; // unreachable
 #else
         throw std::runtime_error("Requested the saturation pressure for the brine-co2 pvt module. "
                                  "Not yet implemented.");
@@ -429,6 +430,7 @@ public:
     {
 #if OPM_IS_INSIDE_DEVICE_FUNCTION
         assert(false && "Requested the saturation pressure for the brine-co2 pvt module. Not yet implemented.");
+        return {}; // unreachable
 #else
         throw std::runtime_error("Requested the saturation pressure for the brine-co2 pvt module. "
                                  "Not yet implemented.");


### PR DESCRIPTION
Quell nvcc warning while building flow_gpu_thermal_gaswater;
```
/home/akva/kode/opm/opm-common/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp(436): 
warning #940-D: missing return statement at end of non-void function "Opm::BrineCo2Pvt<Scalar, Storage>::saturationPressure"
```