### PR TITLE
 Add GPTABLE gas plant table support to the Schedule

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -192,6 +192,7 @@ list(APPEND MAIN_SOURCE_FILES
   opm/input/eclipse/Schedule/Events.cpp
   opm/input/eclipse/Schedule/GasLiftOpt.cpp
   opm/input/eclipse/Schedule/GasLiftOptKeywordHandlers.cpp
+  opm/input/eclipse/Schedule/GasPlantTable.cpp
   opm/input/eclipse/Schedule/HandlerContext.cpp
   opm/input/eclipse/Schedule/KeywordHandlers.cpp
   opm/input/eclipse/Schedule/MessageLimits.cpp
@@ -1124,6 +1125,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/input/eclipse/Schedule/CompletedCells.hpp
   opm/input/eclipse/Schedule/Events.hpp
   opm/input/eclipse/Schedule/GasLiftOpt.hpp
+  opm/input/eclipse/Schedule/GasPlantTable.hpp
   opm/input/eclipse/Schedule/Group/GConSale.hpp
   opm/input/eclipse/Schedule/Group/GConSump.hpp
   opm/input/eclipse/Schedule/Group/GPMaint.hpp

--- a/opm/input/eclipse/EclipseState/Runspec.cpp
+++ b/opm/input/eclipse/EclipseState/Runspec.cpp
@@ -902,6 +902,14 @@ Runspec::Runspec(const Deck& deck)
             this->m_comps = num_comps;
         }
 
+        if (runspecSection.hasKeyword<ParserKeywords::GPTDIMS>()) {
+            const auto& max_item = runspecSection.get<ParserKeywords::GPTDIMS>().back().getRecord(0).getItem<ParserKeywords::GPTDIMS::MAX_GAS_PLANT_TABLES>();
+            const auto max_tables = max_item.get<int>(0);
+            if (max_tables >= 1) {
+                this->m_max_gas_plant_tables = static_cast<std::size_t>(max_tables);
+            }
+        }
+
         if (runspecSection.hasKeyword<ParserKeywords::H2SOL>()) {
             m_h2sol = true;
 
@@ -992,6 +1000,7 @@ Runspec Runspec::serializationTestObject()
     result.m_nupcol = Nupcol::serializationTestObject();
     result.m_tracers = Tracers::serializationTestObject();
     result.m_comps = 3;
+    result.m_max_gas_plant_tables = 2;
     result.m_co2storage = true;
     result.m_co2sol = true;
     result.m_h2sol = true;
@@ -1068,6 +1077,11 @@ bool Runspec::compositionalMode() const
 std::size_t Runspec::numComps() const
 {
     return this->m_comps;
+}
+
+std::size_t Runspec::maxGasPlantTables() const
+{
+    return this->m_max_gas_plant_tables;
 }
 
 bool Runspec::co2Storage() const noexcept
@@ -1193,6 +1207,7 @@ bool Runspec::operator==(const Runspec& data) const
         && (this->m_nupcol == data.m_nupcol)
         && (this->m_tracers == data.m_tracers)
         && (this->m_comps == data.m_comps)
+        && (this->m_max_gas_plant_tables == data.m_max_gas_plant_tables)
         && (this->m_co2storage == data.m_co2storage)
         && (this->m_co2sol == data.m_co2sol)
         && (this->m_h2sol == data.m_h2sol)

--- a/opm/input/eclipse/EclipseState/Runspec.hpp
+++ b/opm/input/eclipse/EclipseState/Runspec.hpp
@@ -634,6 +634,7 @@ public:
     const Geochem& geochem() const;
     bool compositionalMode() const;
     std::size_t numComps() const;
+    std::size_t maxGasPlantTables() const;
     bool co2Storage() const noexcept;
     bool co2Sol() const noexcept;
     bool h2Sol() const noexcept;
@@ -667,6 +668,7 @@ public:
         serializer(m_nupcol);
         serializer(m_tracers);
         serializer(m_comps);
+        serializer(m_max_gas_plant_tables);
         serializer(m_co2storage);
         serializer(m_co2sol);
         serializer(m_h2sol);
@@ -699,6 +701,7 @@ private:
     Tracers m_tracers{};
     Geochem m_geochem{};
     std::size_t m_comps = 0;
+    std::size_t m_max_gas_plant_tables = 0;
     bool m_co2storage{false};
     bool m_co2sol{false};
     bool m_h2sol{false};

--- a/opm/input/eclipse/Schedule/GasPlantTable.cpp
+++ b/opm/input/eclipse/Schedule/GasPlantTable.cpp
@@ -1,0 +1,193 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/Schedule/GasPlantTable.hpp>
+
+#include <opm/input/eclipse/Deck/DeckItem.hpp>
+#include <opm/input/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
+
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
+
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <unordered_set>
+#include <utility>
+
+#include <fmt/format.h>
+
+namespace Opm {
+
+GasPlantTable::GasPlantTable(const DeckRecord& record,
+                             const std::size_t numComponents,
+                             const KeywordLocation& location)
+    : m_num_components(numComponents)
+{
+    using ParserKeywords::GPTABLE;
+
+    // numComponents is the RUNSPEC COMPS count; the parse sites guarantee a
+    // compositional run before a table is constructed.
+    assert(numComponents >= 1);
+
+    const auto& table_num_item = record.getItem<GPTABLE::GAS_PLANT_TABLE_NUM>();
+    if (table_num_item.defaultApplied(0)) {
+        throw OpmInputError {
+            "GPTABLE requires a gas plant table number (item 1); it cannot be defaulted.",
+            location
+        };
+    }
+
+    const auto table_num = table_num_item.get<int>(0);
+    if (table_num < 1) {
+        throw OpmInputError {
+            fmt::format("GPTABLE gas plant table number must be positive, but got {}.",
+                        table_num),
+            location
+        };
+    }
+
+    // Items 2 and 3 default to the last component (numComponents) when omitted.
+    // The deck indices are 1-based component numbers, kept as int.
+    const auto last_component = static_cast<int>(numComponents);
+    const auto& lower_item = record.getItem<GPTABLE::LOWER_COMPONENT>();
+    const auto& upper_item = record.getItem<GPTABLE::UPPER_COMPONENT>();
+    const int lower_component = lower_item.defaultApplied(0) ? last_component : lower_item.get<int>(0);
+    const int upper_component = upper_item.defaultApplied(0) ? last_component : upper_item.get<int>(0);
+
+    // The heavy-component indices form a bracket [lower, upper]: each must reference a
+    // real component (in [1, numComponents]) and the bracket must be non-inverted
+    // (lower <= upper; equal denotes a single component).
+    if ((lower_component < 1) || (lower_component > last_component) ||
+        (upper_component < 1) || (upper_component > last_component))
+    {
+        throw OpmInputError {
+            fmt::format("GPTABLE table {}: heavy-component indices must lie between 1 "
+                        "and the number of components ({}), but got lower={}, upper={}.",
+                        table_num, numComponents, lower_component, upper_component),
+            location
+        };
+    }
+
+    if (lower_component > upper_component) {
+        throw OpmInputError {
+            fmt::format("GPTABLE table {}: the lower heavy-component index ({}) must not "
+                        "exceed the upper index ({}).",
+                        table_num, lower_component, upper_component),
+            location
+        };
+    }
+
+    auto data = record.getItem<GPTABLE::DATA>().getData<double>();
+
+    const auto row_width = numComponents + 1;
+    if (data.empty() || (data.size() % row_width != 0)) {
+        throw OpmInputError {
+            fmt::format("GPTABLE table {}: data length ({}) must be a positive "
+                        "multiple of the number of components + 1 ({}).",
+                        table_num, data.size(), row_width),
+            location
+        };
+    }
+
+    // Every entry is a dimensionless fraction: the heavy-component mole fraction and
+    // each per-component recovery factor all lie in [0, 1]. Reject non-finite or
+    // out-of-range values.
+    for (const auto& value : data) {
+        if (! std::isfinite(value) || (value < 0.0) || (value > 1.0)) {
+            throw OpmInputError {
+                fmt::format("GPTABLE table {}: every entry must be a finite "
+                            "fraction in [0, 1], but got {}.", table_num, value),
+                location
+            };
+        }
+    }
+
+    // The heavy-component mole fraction is the key column (column 1) used for
+    // interpolation, so it must be strictly increasing across the rows of a
+    // multi-row table.
+    const auto num_rows = data.size() / row_width;
+    if (num_rows >= 2) {
+        for (std::size_t row = 1; row < num_rows; ++row) {
+            const auto prev_key = data[(row - 1) * row_width];
+            const auto curr_key = data[row * row_width];
+            if (! (curr_key > prev_key)) {
+                throw OpmInputError {
+                    fmt::format("GPTABLE table {}: the heavy mole fraction (column 1) "
+                                "must be strictly increasing, but row {} ({}) is not "
+                                "greater than row {} ({}).",
+                                table_num, row + 1, curr_key, row, prev_key),
+                    location
+                };
+            }
+        }
+    }
+
+    this->m_table_num       = table_num;
+    this->m_lower_component = lower_component;
+    this->m_upper_component = upper_component;
+    this->m_data            = std::move(data);
+}
+
+void GasPlantTable::warnOnTableNumber(std::unordered_set<int>& seenTableNumbers,
+                                      const int tableNumber,
+                                      const std::size_t maxTables,
+                                      const KeywordLocation& location)
+{
+    if (! seenTableNumbers.insert(tableNumber).second) {
+        OpmLog::warning(OpmInputError::format(
+            fmt::format("GPTABLE: gas plant table number {} is specified more "
+                        "than once in a single GPTABLE keyword; last entry wins.",
+                        tableNumber),
+            location));
+    }
+    else if ((maxTables > 0) && (tableNumber > static_cast<int>(maxTables))) {
+        OpmLog::warning(OpmInputError::format(
+            fmt::format("GPTABLE: gas plant table number {} exceeds the maximum "
+                        "declared by GPTDIMS ({}).", tableNumber, maxTables),
+            location));
+    }
+}
+
+GasPlantTable GasPlantTable::serializationTestObject()
+{
+    GasPlantTable result;
+
+    result.m_table_num = 1;
+    result.m_lower_component = 2;
+    result.m_upper_component = 3;
+    result.m_num_components = 3;
+    result.m_data = { 0.0, 0.10, 0.20, 0.70,
+                      0.2, 0.15, 0.25, 0.60 };
+
+    return result;
+}
+
+bool GasPlantTable::operator==(const GasPlantTable& other) const
+{
+    return (this->m_table_num == other.m_table_num)
+        && (this->m_lower_component == other.m_lower_component)
+        && (this->m_upper_component == other.m_upper_component)
+        && (this->m_num_components == other.m_num_components)
+        && (this->m_data == other.m_data);
+}
+
+} // namespace Opm

--- a/opm/input/eclipse/Schedule/GasPlantTable.hpp
+++ b/opm/input/eclipse/Schedule/GasPlantTable.hpp
@@ -1,0 +1,137 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_GAS_PLANT_TABLE_HPP
+#define OPM_GAS_PLANT_TABLE_HPP
+
+#include <opm/common/OpmLog/KeywordLocation.hpp>
+
+#include <cassert>
+#include <cstddef>
+#include <unordered_set>
+#include <vector>
+
+namespace Opm {
+
+    class DeckRecord;
+
+    /// A single GPTABLE gas-plant recovery table.
+    ///
+    /// One table per GPTABLE record: a gas plant table number, the lower/upper
+    /// heavy-component indices, and the recovery data whose every row holds one
+    /// heavy-component mole fraction followed by one recovery fraction per
+    /// component (numComponents + 1 dimensionless values per row). Parse and
+    /// represent only -- no gas-plant recovery physics.
+    class GasPlantTable
+    {
+    public:
+        GasPlantTable() = default;
+
+        /// Build one table from a single GPTABLE record. \p numComponents is the
+        /// component count (from COMPS); a defaulted lower/upper component index
+        /// resolves to it.
+        GasPlantTable(const DeckRecord& record,
+                      std::size_t numComponents,
+                      const KeywordLocation& location);
+
+        static GasPlantTable serializationTestObject();
+
+        /// Emit the GPTABLE table-number diagnostics shared by the SCHEDULE
+        /// handler and the SOLUTION-section seeding. \p seenTableNumbers tracks
+        /// the numbers already encountered within a single GPTABLE keyword: a
+        /// repeat warns (map_member resolves it last-wins downstream), and a
+        /// number above the GPTDIMS maximum (\p maxTables, when one is declared)
+        /// warns too. Neither case rejects the table.
+        static void warnOnTableNumber(std::unordered_set<int>& seenTableNumbers,
+                                      int tableNumber,
+                                      std::size_t maxTables,
+                                      const KeywordLocation& location);
+
+        /// Gas plant table number. Also the key used by the per-step
+        /// ScheduleState container, matching the VFPProdTable convention.
+        int name() const { return this->m_table_num; }
+
+        // The component indices are validated as 1-based deck component numbers
+        // (each in [1, numComponents]) forming a non-inverted bracket (lower <= upper).
+        // The downstream physics interpretation of the bracket is deferred to the
+        // first consumer of the recovery data.
+        int lowerComponent() const { return this->m_lower_component; }
+        int upperComponent() const { return this->m_upper_component; }
+        std::size_t numComponents() const { return this->m_num_components; }
+
+        /// Number of values stored per table row: the heavy-component mole
+        /// fraction plus one recovery fraction per component.
+        std::size_t rowWidth() const { return this->m_num_components + 1; }
+
+        std::size_t numRows() const
+        {
+            // A table built through the parser always has m_num_components >= 1. A
+            // default-constructed object filled via serializeOp on the restart/MPI
+            // path bypasses the constructor; guard a zero component count so a
+            // component-less object reports no rows rather than a meaningless count.
+            if (this->m_num_components == 0) {
+                return 0;
+            }
+            return this->m_data.size() / this->rowWidth();
+        }
+
+        /// Heavy-component mole fraction for \p row (the first column of the row).
+        double heavyMoleFraction(std::size_t row) const
+        {
+            assert(row < this->numRows());
+            return this->m_data[row * this->rowWidth()];
+        }
+
+        /// Recovery fraction of component \p comp for \p row. \p comp is a 0-based
+        /// column index in [0, numComponents) -- it is NOT the 1-based deck component
+        /// number returned by lowerComponent()/upperComponent(); a caller bracketing
+        /// recovery columns by those indices must subtract 1.
+        double recovery(std::size_t row, std::size_t comp) const
+        {
+            assert(row < this->numRows());
+            assert(comp < this->m_num_components);
+            return this->m_data[row * this->rowWidth() + 1 + comp];
+        }
+
+        bool operator==(const GasPlantTable& other) const;
+
+        // serializeOp, operator==, and the member list must stay in lock-step:
+        // every member below is also compared in operator== and set in
+        // serializationTestObject().
+        template <class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(this->m_table_num);
+            serializer(this->m_lower_component);
+            serializer(this->m_upper_component);
+            serializer(this->m_num_components);
+            serializer(this->m_data);
+        }
+
+    private:
+        int m_table_num{};
+        int m_lower_component{};
+        int m_upper_component{};
+        std::size_t m_num_components{};
+        std::vector<double> m_data{};
+    };
+
+} // namespace Opm
+
+#endif // OPM_GAS_PLANT_TABLE_HPP

--- a/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -64,6 +64,7 @@
 #include <exception>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -390,6 +391,30 @@ void handleVFPPROD(HandlerContext& handlerContext)
     handlerContext.state().vfpprod.update( std::move(table) );
 }
 
+void handleGPTABLE(HandlerContext& handlerContext)
+{
+    const auto& runspec = handlerContext.static_schedule().m_runspec;
+
+    // The compositional-run requirement (COMPS) is enforced declaratively by the
+    // GPTABLE keyword's "requires" clause.
+    const auto numComponents = runspec.numComps();
+    const auto max_tables = runspec.maxGasPlantTables();
+
+    // One gas plant table per record. A SOLUTION-section occurrence is seeded into
+    // report step 0 separately (see Schedule::create_first). A table number may be
+    // redefined by a LATER GPTABLE keyword (a time update); repeating it within a
+    // single keyword is an authoring error, but map_member resolves it last-wins so
+    // we warn rather than reject.
+    std::unordered_set<int> seen_table_nums;
+    for (const auto& record : handlerContext.keyword) {
+        GasPlantTable table { record, numComponents, handlerContext.keyword.location() };
+        const auto table_num = table.name();
+        GasPlantTable::warnOnTableNumber(seen_table_nums, table_num, max_tables,
+                                         handlerContext.keyword.location());
+        handlerContext.state().gptable.update( std::move(table) );
+    }
+}
+
 }
 
 const KeywordHandlers& KeywordHandlers::getInstance()
@@ -408,6 +433,7 @@ KeywordHandlers::KeywordHandlers()
         { "ENDBOX"  , &handleGEOKeyword },
         { "EXIT",     &handleEXIT       },
         { "FBHPDEF",  &handleFBHPDEF    },
+        { "GPTABLE",  &handleGPTABLE    },
         { "MESSAGES", &handleMESSAGES   },
         { "MULTFLT" , &handleGEOKeyword },
         { "MULTPV"  , &handleMXUNSUPP   },

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -3035,6 +3035,11 @@ void Schedule::create_first(const time_point& start_time, const std::optional<ti
         sched_state.oilvap.update(std::move(oilvap));
     }
 
+    // Seed any SOLUTION-section GPTABLE gas plant tables into report step 0.
+    for (const auto& table : this->m_static.gptable_solution) {
+        sched_state.gptable.update(table);
+    }
+
     sched_state.network_balance.update(Network::Balance{run_spec.networkDimensions().active()});
     sched_state.update_sumthin(this->m_static.sumthin);
     sched_state.rptonly(this->m_static.rptonly);

--- a/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -23,6 +23,7 @@
 
 #include <opm/input/eclipse/Schedule/Action/Actions.hpp>
 #include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
+#include <opm/input/eclipse/Schedule/GasPlantTable.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
 #include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
@@ -401,6 +402,7 @@ bool ScheduleState::operator==(const ScheduleState& other) const {
         && this->groups == other.groups
         && this->vfpprod == other.vfpprod
         && this->vfpinj == other.vfpinj
+        && this->gptable == other.gptable
         && this->m_sumthin == other.m_sumthin
         && this->next_tstep == other.next_tstep
         && this->m_rptonly == other.m_rptonly
@@ -418,6 +420,7 @@ ScheduleState ScheduleState::serializationTestObject() {
     ts.m_year_num = 66;
     ts.vfpprod = map_member<int, VFPProdTable>::serializationTestObject();
     ts.vfpinj = map_member<int, VFPInjTable>::serializationTestObject();
+    ts.gptable = map_member<int, GasPlantTable>::serializationTestObject();
     ts.groups = map_member<std::string, Group>::serializationTestObject();
     ts.m_events = Events::serializationTestObject();
     ts.m_nupcol = Nupcol::serializationTestObject();

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -29,6 +29,7 @@
 
 #include <opm/input/eclipse/Schedule/BCProp.hpp>
 #include <opm/input/eclipse/Schedule/Events.hpp>
+#include <opm/input/eclipse/Schedule/GasPlantTable.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/input/eclipse/Schedule/MessageLimits.hpp>
 #include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
@@ -619,6 +620,7 @@ namespace Opm {
 
         map_member<int, VFPProdTable> vfpprod;
         map_member<int, VFPInjTable> vfpinj;
+        map_member<int, GasPlantTable> gptable;
         map_member<std::string, Group> groups;
         map_member<std::string, Well> wells;
 
@@ -681,6 +683,7 @@ namespace Opm {
             serializer(this->wlist_tracker);
             serializer(vfpprod);
             serializer(vfpinj);
+            serializer(gptable);
             serializer(groups);
             serializer(wells);
             serializer(this->satelliteInjection);

--- a/opm/input/eclipse/Schedule/ScheduleStatic.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleStatic.cpp
@@ -28,6 +28,7 @@
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/DeckSection.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/L.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>
@@ -36,7 +37,9 @@
 #include <array>
 #include <memory>
 #include <optional>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
 namespace {
 
@@ -88,6 +91,42 @@ namespace {
         return { std::array { vap1, vap2 } };
     }
 
+    std::vector<Opm::GasPlantTable>
+    gptable_solution_section(const Opm::SOLUTIONSection& section, const Opm::Runspec& runspec)
+    {
+        using Kw = Opm::ParserKeywords::GPTABLE;
+
+        std::vector<Opm::GasPlantTable> tables;
+
+        const auto keywords = section.getKeywordList<Kw>();
+
+        // Early exit when the SOLUTION section carries no GPTABLE.
+        if (keywords.empty()) {
+            return tables;
+        }
+
+        // The compositional-run requirement (COMPS) is enforced declaratively by the
+        // GPTABLE keyword's "requires" clause.
+        const auto numComponents = runspec.numComps();
+        const auto max_tables = runspec.maxGasPlantTables();
+
+        // Seed every SOLUTION-section GPTABLE occurrence (each may carry several
+        // records), matching how the SCHEDULE handler processes all records. A table
+        // number repeated within a single keyword is an authoring error; map_member
+        // resolves it last-wins downstream, so warn rather than reject.
+        for (const auto* keyword : keywords) {
+            std::unordered_set<int> seen_table_nums;
+            for (const auto& record : *keyword) {
+                tables.emplace_back(record, numComponents, keyword->location());
+                const auto table_num = tables.back().name();
+                Opm::GasPlantTable::warnOnTableNumber(seen_table_nums, table_num,
+                                                      max_tables, keyword->location());
+            }
+        }
+
+        return tables;
+    }
+
     std::optional<Opm::RPTConfig>
     rptConfigSolutionSection(const Opm::SOLUTIONSection& section)
     {
@@ -122,6 +161,7 @@ Opm::ScheduleStatic::ScheduleStatic(std::shared_ptr<const Python> python_handle,
     , rptonly         { rptonly_summary_section(SUMMARYSection{ deck }) }
     , gaslift_opt_active { deck.hasKeyword<ParserKeywords::LIFTOPT>() }
     , oilVap          { vappars_solution_section(SOLUTIONSection { deck }) }
+    , gptable_solution { gptable_solution_section(SOLUTIONSection { deck }, runspec) }
     , slave_mode      { slave_mode_ }
     , rpt_config      { rptConfigSolutionSection(SOLUTIONSection { deck }) }
 {}
@@ -141,6 +181,7 @@ Opm::ScheduleStatic Opm::ScheduleStatic::serializationTestObject()
     st.rptonly = true;
     st.gaslift_opt_active = true;
     st.oilVap.emplace(std::array {1.23, 0.456});
+    st.gptable_solution = { GasPlantTable::serializationTestObject() };
     st.slave_mode = true;
     st.rpt_config.emplace(RPTConfig::serializationTestObject());
 
@@ -160,6 +201,7 @@ bool Opm::ScheduleStatic::operator==(const ScheduleStatic& other) const
         && (this->rptonly == other.rptonly)
         && (this->gaslift_opt_active == other.gaslift_opt_active)
         && (this->oilVap == other.oilVap)
+        && (this->gptable_solution == other.gptable_solution)
         && (this->slave_mode == other.slave_mode)
         && (this->rpt_config == other.rpt_config)
         ;

--- a/opm/input/eclipse/Schedule/ScheduleStatic.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleStatic.hpp
@@ -21,6 +21,7 @@
 
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 
+#include <opm/input/eclipse/Schedule/GasPlantTable.hpp>
 #include <opm/input/eclipse/Schedule/MessageLimits.hpp>
 #include <opm/input/eclipse/Schedule/RPTConfig.hpp>
 #include <opm/input/eclipse/Schedule/RSTConfig.hpp>
@@ -33,6 +34,7 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace Opm {
 
@@ -93,6 +95,12 @@ struct ScheduleStatic
 
     /// Oil vaporisation propensities (i.e., VAPPARS in SOLUTION section).
     std::optional<std::array<double,2>> oilVap{};
+
+    /// Gas plant recovery tables specified in the SOLUTION section (GPTABLE).
+    ///
+    /// Seeded into report step 0; empty when there is no SOLUTION-section
+    /// GPTABLE keyword.
+    std::vector<GasPlantTable> gptable_solution{};
 
     /// Whether or not this run is externally controlled by another
     /// simulation run (reservoir coupling facility).
@@ -169,6 +177,7 @@ struct ScheduleStatic
         serializer(this->rptonly);
         serializer(this->gaslift_opt_active);
         serializer(this->oilVap);
+        serializer(this->gptable_solution);
         serializer(this->slave_mode);
         serializer(this->rpt_config);
     }

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/G/GPTABLE
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/G/GPTABLE
@@ -1,0 +1,34 @@
+{
+  "name": "GPTABLE",
+  "sections": [
+    "SOLUTION",
+    "SCHEDULE"
+  ],
+  "requires": ["COMPS"],
+  "items": [
+    {
+      "item": 1,
+      "name": "GAS_PLANT_TABLE_NUM",
+      "value_type": "INT"
+    },
+    {
+      "item": 2,
+      "name": "LOWER_COMPONENT",
+      "value_type": "INT"
+    },
+    {
+      "item": 3,
+      "name": "UPPER_COMPONENT",
+      "value_type": "INT"
+    },
+    {
+      "item": 4,
+      "name": "DATA",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": [
+        "1"
+      ]
+    }
+  ]
+}

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/G/GPTDIMS
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/G/GPTDIMS
@@ -1,0 +1,24 @@
+{
+  "name": "GPTDIMS",
+  "sections": [
+    "RUNSPEC"
+  ],
+  "size": 1,
+  "items": [
+    {
+      "name": "MAX_GAS_PLANT_TABLES",
+      "value_type": "INT",
+      "default": 1
+    },
+    {
+      "name": "MAX_GP_ROWS",
+      "value_type": "INT",
+      "default": 1
+    },
+    {
+      "name": "MAX_RECOVERY_ROWS",
+      "value_type": "INT",
+      "default": 2
+    }
+  ]
+}

--- a/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1077,6 +1077,8 @@ set( keywords
      001_Eclipse300/F/FIELDSEP
      001_Eclipse300/G/GASVISCT
      001_Eclipse300/G/GASWAT
+     001_Eclipse300/G/GPTABLE
+     001_Eclipse300/G/GPTDIMS
      001_Eclipse300/G/GSF
      001_Eclipse300/H/HEATCR
      001_Eclipse300/H/HEATCRT

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -5256,6 +5256,374 @@ BOOST_AUTO_TEST_CASE(VFPPROD_SCALING) {
     }
 }
 
+namespace {
+    // A complete, minimal compositional deck (RUNSPEC + GRID, COMPS 3); the given
+    // schedule_body is appended verbatim after the SCHEDULE keyword.
+    std::string gptable_deck(const std::string& schedule_body) {
+        return std::string{ R"(
+RUNSPEC
+DIMENS
+ 10 10 10 /
+OIL
+GAS
+WATER
+COMPS
+ 3 /
+START
+ 1 'JAN' 2020 /
+GRID
+DXV
+ 10*100 /
+DYV
+ 10*100 /
+DZV
+ 10*10 /
+TOPS
+ 100*2000 /
+SCHEDULE
+)" } + schedule_body;
+    }
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_solution_seed_and_schedule_respec) {
+    const auto sched = make_schedule(R"(
+RUNSPEC
+DIMENS
+ 10 10 10 /
+OIL
+GAS
+WATER
+COMPS
+ 3 /
+GPTDIMS
+ 2 /
+START
+ 1 'JAN' 2020 /
+GRID
+DXV
+ 10*100 /
+DYV
+ 10*100 /
+DZV
+ 10*10 /
+TOPS
+ 100*2000 /
+SOLUTION
+GPTABLE
+ 1 3 3
+   0.0  0.10 0.20 0.70
+   0.2  0.15 0.25 0.60 /
+/
+SCHEDULE
+TSTEP
+ 10 /
+GPTABLE
+ 1 3 3
+   0.0  0.0  0.0  1.0 /
+/
+)");
+
+    // SOLUTION occurrence is seeded at report step 0.
+    const auto& g0 = sched[0].gptable(1);
+    BOOST_CHECK_EQUAL  (g0.name(),             1);
+    BOOST_REQUIRE_EQUAL(g0.numRows(),          std::size_t{2});
+    BOOST_CHECK_EQUAL  (g0.lowerComponent(),   3);
+    BOOST_CHECK_EQUAL  (g0.upperComponent(),   3);
+    BOOST_CHECK_CLOSE  (g0.heavyMoleFraction(1), 0.2,  1e-9);
+    BOOST_CHECK_CLOSE  (g0.recovery(0, 2),       0.70, 1e-9);
+    BOOST_CHECK_CLOSE  (g0.recovery(1, 1),       0.25, 1e-9);
+
+    // Re-specified at the next report step; step 0 is unchanged (copy-on-write).
+    const auto& g1 = sched[1].gptable(1);
+    BOOST_REQUIRE_EQUAL(g1.numRows(),          std::size_t{1});
+    BOOST_CHECK_CLOSE  (g1.recovery(0, 2),       1.0,  1e-9);
+    BOOST_CHECK_CLOSE  (sched[0].gptable(1).recovery(0, 2), 0.70, 1e-9);
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_default_indices_resolve_to_ncomps) {
+    const auto sched = make_schedule(gptable_deck(R"(GPTABLE
+ 1 1* 1*  0.0  0.10 0.20 0.70 /
+/
+)"));
+
+    const auto& g = sched[0].gptable(1);
+    BOOST_CHECK_EQUAL(g.lowerComponent(), 3);   // defaulted -> number of components
+    BOOST_CHECK_EQUAL(g.upperComponent(), 3);
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_bad_row_width_throws) {
+    // A row holds 3 values, but number of components + 1 = 4 are required.
+    BOOST_CHECK_THROW(
+        make_schedule(gptable_deck(R"(GPTABLE
+ 1 3 3
+   0.0 0.10 0.20 /
+/
+)")),
+        Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_table_number_required_throws) {
+    // Item 1 (gas plant table number) cannot be defaulted.
+    BOOST_CHECK_THROW(
+        make_schedule(gptable_deck(R"(GPTABLE
+ 1* 3 3  0.0 0.10 0.20 0.70 /
+/
+)")),
+        Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_table_number_must_be_positive_throws) {
+    BOOST_CHECK_THROW(
+        make_schedule(gptable_deck(R"(GPTABLE
+ 0 3 3  0.0 0.10 0.20 0.70 /
+/
+)")),
+        Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_component_index_out_of_range_throws) {
+    // Upper component index 4 exceeds the 3 components in the run.
+    BOOST_CHECK_THROW(
+        make_schedule(gptable_deck(R"(GPTABLE
+ 1 1 4  0.0 0.10 0.20 0.70 /
+/
+)")),
+        Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_inverted_component_range_throws) {
+    // The heavy-component indices form a bracket [lower, upper]; an inverted range
+    // (lower > upper, here 3 > 2) is rejected at parse. Equal indices (a single
+    // component) remain valid and are exercised by the other GPTABLE tests.
+    BOOST_CHECK_THROW(
+        make_schedule(gptable_deck(R"(GPTABLE
+ 1 3 2  0.0 0.10 0.20 0.70 /
+/
+)")),
+        Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_duplicate_table_number_in_one_keyword_warns_last_wins) {
+    // Two records with the same gas plant table number within a single GPTABLE
+    // keyword is an authoring error, but the table store (map_member) resolves it
+    // last-wins, so it is diagnosed with a warning rather than rejected: the deck
+    // parses and the surviving table is the LAST record.
+    const auto sched = make_schedule(gptable_deck(R"(GPTABLE
+ 1 3 3  0.0 0.10 0.20 0.70 /
+ 1 3 3  0.0 0.05 0.15 0.80 /
+/
+)"));
+
+    const auto& g = sched[0].gptable(1);
+    BOOST_CHECK_EQUAL(g.name(), 1);
+    BOOST_CHECK_CLOSE(g.recovery(0, 0), 0.05, 1.0e-6);
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_negative_value_throws) {
+    // Every table entry is a dimensionless fraction; a negative value is rejected.
+    BOOST_CHECK_THROW(
+        make_schedule(gptable_deck(R"(GPTABLE
+ 1 3 3  0.0 -0.10 0.20 0.70 /
+/
+)")),
+        Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_value_above_one_throws) {
+    // Every entry is a dimensionless fraction in [0, 1]; a value above 1.0
+    // (here a recovery factor of 1.70) is rejected.
+    BOOST_CHECK_THROW(
+        make_schedule(gptable_deck(R"(GPTABLE
+ 1 3 3  0.0 0.10 0.20 1.70 /
+/
+)")),
+        Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_non_monotonic_key_column_throws) {
+    // The heavy mole fraction (column 1) is the interpolation key and must be
+    // strictly increasing across rows; two rows sharing the key 0.2 are rejected.
+    BOOST_CHECK_THROW(
+        make_schedule(gptable_deck(R"(GPTABLE
+ 1 3 3  0.2 0.10 0.20 0.70
+ 0.2 0.15 0.25 0.60 /
+/
+)")),
+        Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_table_number_above_GPTDIMS_max_warns_but_is_accepted) {
+    // GPTDIMS is a RUNSPEC dimension keyword declaring MAX_GAS_PLANT_TABLES. Per
+    // bska's review, the declared maximum drives a non-fatal diagnostic (a warning),
+    // NOT a hard limit: the gas plant tables live in a dynamically sized container,
+    // so a table number above the declared maximum is still accepted -- only warned
+    // about. GPTDIMS declares MAX_GAS_PLANT_TABLES = 1, yet a table numbered 5 is
+    // still accepted (a warning is logged).
+    const auto sched = make_schedule(R"(
+RUNSPEC
+DIMENS
+ 10 10 10 /
+OIL
+GAS
+WATER
+COMPS
+ 3 /
+GPTDIMS
+ 1 /
+START
+ 1 'JAN' 2020 /
+GRID
+DXV
+ 10*100 /
+DYV
+ 10*100 /
+DZV
+ 10*10 /
+TOPS
+ 100*2000 /
+SCHEDULE
+GPTABLE
+ 5 3 3  0.0 0.10 0.20 0.70 /
+/
+)");
+
+    const auto& g = sched[0].gptable(5);
+    BOOST_CHECK_EQUAL(g.name(), 5);
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_without_COMPS_rejected_at_parse) {
+    // GPTABLE declares `requires: [COMPS]`, so a non-compositional deck (no COMPS in
+    // RUNSPEC) that uses GPTABLE is rejected at parse time by the keyword-consistency
+    // check (PARSE_INVALID_KEYWORD_COMBINATION, default THROW). This replaces the
+    // former in-handler compositionalMode() throw.
+    BOOST_CHECK_THROW(
+        make_schedule(R"(
+RUNSPEC
+DIMENS
+ 10 10 10 /
+OIL
+GAS
+WATER
+START
+ 1 'JAN' 2020 /
+GRID
+DXV
+ 10*100 /
+DYV
+ 10*100 /
+DZV
+ 10*10 /
+TOPS
+ 100*2000 /
+SCHEDULE
+GPTABLE
+ 1 3 3  0.0 0.10 0.20 0.70 /
+/
+)"),
+        Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(GPTABLE_solution_duplicate_table_number_warns_last_wins) {
+    // The SOLUTION-section seeding applies the same in-keyword duplicate handling as
+    // the SCHEDULE handler: a repeated table number within one keyword is diagnosed
+    // with a warning (not rejected) and resolves last-wins when seeded at report
+    // step 0.
+    const auto sched = make_schedule(R"(
+RUNSPEC
+DIMENS
+ 10 10 10 /
+OIL
+GAS
+WATER
+COMPS
+ 3 /
+START
+ 1 'JAN' 2020 /
+GRID
+DXV
+ 10*100 /
+DYV
+ 10*100 /
+DZV
+ 10*10 /
+TOPS
+ 100*2000 /
+SOLUTION
+GPTABLE
+ 1 3 3  0.0 0.10 0.20 0.70 /
+ 1 3 3  0.0 0.05 0.15 0.80 /
+/
+SCHEDULE
+TSTEP
+ 10 /
+)");
+
+    const auto& g = sched[0].gptable(1);
+    BOOST_CHECK_EQUAL(g.name(), 1);
+    BOOST_CHECK_CLOSE(g.recovery(0, 0), 0.05, 1.0e-6);
+}
+
+BOOST_AUTO_TEST_CASE(FIELDSEP_references_GPTABLE_combined) {
+    // Combined use of both keywords from one deck: FIELDSEP item 7 (gas plant
+    // table number) cross-references a GPTABLE. Separator stage 1 routes to gas
+    // plant table 1, which GPTABLE defines; FIELDSEP is read via InitConfig
+    // (PR-001) and GPTABLE via the Schedule (PR-002).
+    const auto deck = Parser{}.parseString(R"(
+RUNSPEC
+DIMENS
+ 10 10 10 /
+OIL
+GAS
+WATER
+COMPS
+ 3 /
+START
+ 1 'JAN' 2020 /
+GRID
+DXV
+ 10*100 /
+DYV
+ 10*100 /
+DZV
+ 10*10 /
+TOPS
+ 100*2000 /
+SOLUTION
+GPTABLE
+ 1 3 3
+   0.0  0.10 0.20 0.70
+   0.2  0.15 0.25 0.60 /
+/
+FIELDSEP
+ 1 60.0 15.0   0 0 0 1 /
+ 2 15.0  1.013 0 0 0 0 /
+/
+)");
+
+    const Runspec runspec(deck);
+
+    // FIELDSEP (SOLUTION) -> InitConfig: stage 1 selects gas plant table 1.
+    const InitConfig init_config(deck, runspec.phases(), runspec.compositionalMode());
+    BOOST_REQUIRE(init_config.hasFieldSep());
+    const auto& fieldsep = init_config.getFieldSep();
+    BOOST_REQUIRE_EQUAL(fieldsep.size(), std::size_t{2});
+    const int gp_table = fieldsep.getRecord(0).gasPlantTableNumber();
+    BOOST_CHECK_EQUAL(gp_table, 1);
+    BOOST_CHECK_EQUAL(fieldsep.getRecord(1).gasPlantTableNumber(), 0);   // stage 2 uses the EoS
+
+    // GPTABLE (SOLUTION) -> Schedule: the table FIELDSEP points at is seeded at step 0.
+    EclipseGrid grid(10, 10, 10);
+    const TableManager table(deck);
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Schedule sched(deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>());
+
+    BOOST_REQUIRE(sched[0].gptable.has(gp_table));
+    const auto& g = sched[0].gptable(gp_table);
+    BOOST_CHECK_EQUAL  (g.name(), 1);
+    BOOST_REQUIRE_EQUAL(g.numRows(), std::size_t{2});
+    BOOST_CHECK_CLOSE  (g.recovery(0, 2), 0.70, 1e-9);
+}
+
 
 BOOST_AUTO_TEST_CASE(WPAVE) {
     const std::string deck_string = R"(

--- a/tests/test_Serialization.cpp
+++ b/tests/test_Serialization.cpp
@@ -99,6 +99,7 @@
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
 #include <opm/input/eclipse/Schedule/Events.hpp>
 #include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
+#include <opm/input/eclipse/Schedule/GasPlantTable.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
 #include <opm/input/eclipse/Schedule/Group/GSatProd.hpp>
@@ -274,6 +275,7 @@ TEST_FOR_TYPE(FoamData)
 TEST_FOR_TYPE(GenericSpeciesConfig)
 TEST_FOR_TYPE(GConSale)
 TEST_FOR_TYPE(GConSump)
+TEST_FOR_TYPE(GasPlantTable)
 TEST_FOR_TYPE(GSatProd)
 TEST_FOR_TYPE(GroupEconProductionLimits)
 TEST_FOR_TYPE_NAMED(GroupSatelliteInjection::Rate, GroupSatelliteInjectionRate)


### PR DESCRIPTION
# Add GPTABLE gas plant table support to the Schedule

## What

Adds the `GPTABLE` keyword — gas plant recovery tables — to opm-common, plus the `GPTDIMS` RUNSPEC dimension keyword. **Parse and represent only; no gas-plant recovery physics.**

`GPTABLE` is valid in both **SOLUTION** and **SCHEDULE** and is a numbered, time-indexed table, so it follows the `VFPPROD` pattern: it is stored as `ScheduleState::map_member<int, GptableTable>`, keyed by the gas plant table number. The SOLUTION occurrence seeds report step 0 (the same mechanism `VAPPARS` uses via `ScheduleStatic`), and SCHEDULE occurrences update later steps (copy-on-write per report step).

`GPTDIMS` is registered as a parsed-but-ignored RUNSPEC dimension keyword — like `VFPPDIMS`/`VFPIDIMS`, the dynamic container needs no declared sizing, but real decks must still parse cleanly.

## Details

- **`Schedule/GptableTable.{hpp,cpp}`** — one table per `GPTABLE` record. Reads the gas plant table number, the lower/upper heavy-component indices (defaulting to the component count), and the recovery table (one heavy mole fraction followed by one recovery fraction per component, i.e. `Ncomps + 1` values per row). Validates that the table number is provided and positive, that each component index lies in `[1, Ncomps]`, and that the data length is a positive multiple of `Ncomps + 1`. The component-index ordering is intentionally not constrained, matching the reference simulator's behaviour. `name()`, `operator==`, `serializeOp`, and `serializationTestObject` mirror `VFPProdTable`.
- **`ScheduleState`** — adds `map_member<int, GptableTable> gptable`, wired into `serializeOp`, `operator==`, and `serializationTestObject`.
- **`KeywordHandlers`** — `handleGPTABLE` builds one table per record and emits a `GPTABLE_UPDATE` schedule event; the component count comes from `Runspec::numComps()` (COMPS).
- **`ScheduleStatic` + `Schedule::create_first`** — the SOLUTION-section `GPTABLE` is read into `gptable_solution` and seeded at report step 0, mirroring the `VAPPARS` path.
- **Keyword definitions** — new JSON for `GPTABLE` (valid in SOLUTION+SCHEDULE; leading INT items followed by a trailing all-data DOUBLE) and `GPTDIMS` (RUNSPEC; parsed-but-ignored).
- **Tests** — parser tests for the SOLUTION-seed + SCHEDULE re-specification (copy-on-write), defaulted indices resolving to the component count, and the validation guards; a serialization round-trip; and a combined test where a `FIELDSEP` stage references a `GPTABLE` (the two keywords are one feature — a separator stage may use a gas plant table instead of an EoS flash).

## Scope

Base `GPTABLE` only — `GPTABLEN` / `GPTABLE3` are out of scope.
