### PR TITLE
Support OPERATER on integer region arrays (e.g. SATNUM).

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -1456,6 +1456,83 @@ void FieldProps::operate(const DeckRecord&                   record,
     }
 }
 
+void FieldProps::operate_int_target(const DeckRecord&                   record,
+                                    Fieldprops::FieldData<int>&           target_data,
+                                    const std::string&                    src_kw,
+                                    const std::vector<Box::cell_index>&   index_list,
+                                    const bool                            global)
+{
+    const auto func_name    = record.getItem("OPERATION").getTrimmedString(0);
+    const auto check_target = (func_name == "MULTIPLY") || (func_name == "POLY");
+    const auto alpha        = record.getItem("PARAM1").get<double>(0);
+    const auto beta         = record.getItem("PARAM2").get<double>(0);
+    const auto func         = Operate::get(func_name, alpha, beta);
+
+    auto& to_data   = global ? *target_data.global_data : target_data.data;
+    auto& to_status = global ? *target_data.global_value_status
+                             : target_data.value_status;
+
+    auto apply = [&](const auto& from_data, const auto& from_status,
+                     const auto  srcDim)
+    {
+        for (const auto& cell_index : index_list) {
+            const auto ix = cell_index.active_index;
+
+            if (!value::has_value(from_status[ix])) {
+                throw std::invalid_argument {
+                    "Tried to use unset property value in "
+                    "OPERATE/OPERATER keyword"
+                };
+            }
+
+            if (check_target && !value::has_value(to_status[ix])) {
+                throw std::invalid_argument {
+                    "Tried to use unset property value "
+                    "in OPERATE/OPERATER keyword"
+                };
+            }
+
+            const auto tgt_raw = static_cast<double>(to_data[ix]);
+            const auto src_raw = srcDim.convertSiToRaw(from_data[ix]);
+            const auto val     = func(tgt_raw, src_raw);
+
+            to_data[ix]   = static_cast<int>(val);
+            to_status[ix] = from_status[ix];
+        }
+    };
+
+    if (FieldProps::supported<double>(src_kw)) {
+        const auto& src_data = this->init_get<double>(src_kw);
+        const auto srcDim = src_data.kw_info.unit.has_value()
+            ? this->unit_system.parse(*src_data.kw_info.unit)
+            : Dimension { 1.0 };
+
+        if (global && src_data.global_data) {
+            apply(*src_data.global_data, *src_data.global_value_status, srcDim);
+        }
+        else {
+            apply(src_data.data, src_data.value_status, srcDim);
+        }
+    }
+    else if (FieldProps::supported<int>(src_kw)) {
+        const Dimension srcDim { 1.0 };
+        const auto& src_data = this->init_get<int>(src_kw);
+
+        if (global && src_data.global_data) {
+            apply(*src_data.global_data, *src_data.global_value_status, srcDim);
+        }
+        else {
+            apply(src_data.data, src_data.value_status, srcDim);
+        }
+    }
+    else {
+        throw std::invalid_argument {
+            fmt::format("Array {} in OPERATE/OPERATER keyword is not supported.",
+                        src_kw)
+        };
+    }
+}
+
 void FieldProps::handle_operateR(const Section section,
                                  const DeckKeyword& keyword)
 {
@@ -1476,12 +1553,6 @@ void FieldProps::handle_operateR(const Section section,
         const auto target_kw = Fieldprops::keywords::
             get_keyword_from_alias(record.getItem(0).getTrimmedString(0));
 
-        if (! FieldProps::supported<double>(target_kw) &&
-            ! Fieldprops::keywords::is_work(target_kw))
-        {
-            continue;
-        }
-
         if (this->tran.find(target_kw) != this->tran.end()) {
             throw std::logic_error {
                 "The region operations cannot be used for "
@@ -1490,8 +1561,6 @@ void FieldProps::handle_operateR(const Section section,
         }
 
         const int region_value = record.getItem("REGION_NUMBER").get<int>(0);
-
-        auto& field_data = this->init_get<double>(target_kw);
 
         // For the OPERATER keyword we fetch the region name from the deck
         // record with no extra hoops.
@@ -1504,33 +1573,64 @@ void FieldProps::handle_operateR(const Section section,
             continue;
         }
 
-        const auto& src_data = this->init_get<double>(src_kw);
-        FieldProps::operate(record, field_data, src_data, index_list);
+        if (FieldProps::supported<double>(target_kw) ||
+            Fieldprops::keywords::is_work(target_kw))
+        {
+            auto& field_data = this->init_get<double>(target_kw);
 
-        if ((section == Section::EDIT) && (target_kw == "DEPTH")) {
-            this->depth_edited_ = true;
-        }
+            const auto& src_data = this->init_get<double>(src_kw);
+            FieldProps::operate(record, field_data, src_data, index_list);
 
-        // Supporting region operations on global storage arrays would
-        // require global storage for the *NUM region set arrays (i.e.,
-        // FLUXNUM, MULTNUM, OPERNUM).  In order to avoid global storage
-        // for a significant portion of the property arrays we have
-        // decided, as a project policy, to not support such operations
-        // at this time.  There is, however, no technical reason for why
-        // the current implementation could not be extended to support
-        // region operations on global storage arrays.
-        // For now regions do not 100% support global storage.
-        // Make sure that the global storage at least reflects the local one.
-        if (field_data.global_data) {
-            if (!all_active) {
-                const auto message =
-                    fmt::format(R"(Region operation on 3D field {} with global storage will not update inactive cells.
+            if ((section == Section::EDIT) && (target_kw == "DEPTH")) {
+                this->depth_edited_ = true;
+            }
+
+            // Supporting region operations on global storage arrays would
+            // require global storage for the *NUM region set arrays (i.e.,
+            // FLUXNUM, MULTNUM, OPERNUM).  In order to avoid global storage
+            // for a significant portion of the property arrays we have
+            // decided, as a project policy, to not support such operations
+            // at this time.  There is, however, no technical reason for why
+            // the current implementation could not be extended to support
+            // region operations on global storage arrays.
+            // For now regions do not 100% support global storage.
+            // Make sure that the global storage at least reflects the local one.
+            if (field_data.global_data) {
+                if (!all_active) {
+                    const auto message =
+                        fmt::format(R"(Region operation on 3D field {} with global storage will not update inactive cells.
 Note that this might cause problems for PINCH option 4 or 5 being ALL.)", target_kw);
 
-                OpmLog::warning(Log::fileMessage(keyword.location(), message));
+                    OpmLog::warning(Log::fileMessage(keyword.location(), message));
+                }
+                update_global_from_local(field_data, index_list);
             }
-            update_global_from_local(field_data, index_list);
+            continue;
         }
+
+        if (FieldProps::supported<int>(target_kw)) {
+            auto& field_data = this->init_get<int>(target_kw);
+
+            this->operate_int_target(record, field_data, src_kw, index_list);
+
+            if (field_data.global_data) {
+                if (!all_active) {
+                    const auto message =
+                        fmt::format(R"(Region operation on 3D field {} with global storage will not update inactive cells.
+Note that this might cause problems for PINCH option 4 or 5 being ALL.)", target_kw);
+
+                    OpmLog::warning(Log::fileMessage(keyword.location(), message));
+                }
+                update_global_from_local(field_data, index_list);
+            }
+            continue;
+        }
+
+        const auto message =
+            fmt::format(R"(Target array {} in {} is not supported.)",
+                        target_kw, keyword.name());
+
+        OpmLog::warning(Log::fileMessage(keyword.location(), message));
     }
 }
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -541,7 +541,7 @@ void update_global_from_local(Fieldprops::FieldData<T>& data,
     if(data.global_data)
     {
         auto& to = *data.global_data;
-        auto to_st = *data.global_value_status;
+        auto& to_st = *data.global_value_status;
         const auto& from = data.data;
         const auto& from_st = data.value_status;
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -752,6 +752,12 @@ private:
                  const std::vector<Box::cell_index>& index_list,
                  const bool global = false);
 
+    void operate_int_target(const DeckRecord& record,
+                            Fieldprops::FieldData<int>& target_data,
+                            const std::string& src_kw,
+                            const std::vector<Box::cell_index>& index_list,
+                            const bool global = false);
+
     template <typename T>
     Fieldprops::FieldData<T>&
     init_get(const std::string& keyword, bool allow_unsupported = false);

--- a/tests/parser/OperateTests.cpp
+++ b/tests/parser/OperateTests.cpp
@@ -95,6 +95,16 @@ PORV 12 MULTP    PERMY 4 5 /
 PORV 13 ABS      PERMY /
 PORV 14 MULTIPLY PERMY /
 /
+REGIONS
+SATNUM
+14*1 /
+OPERATER
+SATNUM  1  MULTA   PORO 10000 -2222 /
+SATNUM  1 MINLIM SATNUM     0 /
+SATNUM  1   ADDX SATNUM     1 /
+SATNUM  1 MAXLIM SATNUM     2 /
+SATNUM 14   ADDX SATNUM     1 /
+/
 SOLUTION
 PRESSURE
 14*3 /
@@ -132,6 +142,7 @@ BOOST_AUTO_TEST_CASE(Test_metric) {
     const auto& permy = fp.get_double("PERMY");
     const auto& poro = fp.get_double("PORO");
     const auto& pressure = fp.get_double("PRESSURE");
+    const auto& satnum = fp.get_int("SATNUM");
 
     auto perm_to_si = [&unit_system](double raw_value) { return unit_system.to_si(UnitSystem::measure::permeability, raw_value); };
     auto perm_from_si = [&unit_system](double raw_value) { return unit_system.from_si(UnitSystem::measure::permeability, raw_value); };
@@ -182,6 +193,22 @@ BOOST_AUTO_TEST_CASE(Test_metric) {
     BOOST_CHECK_EQUAL(pressure[11], pres_to_si(4.0 * pow(perm_from_si(permy[11]), 5.0)));
     BOOST_CHECK_EQUAL(pressure[12], pres_to_si(std::abs(perm_from_si(permy[12]))));
     BOOST_CHECK_CLOSE(pressure[13], pres_to_si(3.0 * perm_from_si(permy[13])), 1.0e-10);
+
+    // REGIONS OPERATER on integer SATNUM (PINCHHELL-style porosity threshold + ADDX).
+    BOOST_CHECK_EQUAL(satnum[0], 2);   // OPERNUM=1, PORO above threshold
+    BOOST_CHECK_EQUAL(satnum[1], 1);
+    BOOST_CHECK_EQUAL(satnum[2], 1);
+    BOOST_CHECK_EQUAL(satnum[3], 1);
+    BOOST_CHECK_EQUAL(satnum[4], 1);
+    BOOST_CHECK_EQUAL(satnum[5], 1);
+    BOOST_CHECK_EQUAL(satnum[6], 1);
+    BOOST_CHECK_EQUAL(satnum[7], 1);
+    BOOST_CHECK_EQUAL(satnum[8], 1);
+    BOOST_CHECK_EQUAL(satnum[9], 1);
+    BOOST_CHECK_EQUAL(satnum[10], 1);
+    BOOST_CHECK_EQUAL(satnum[11], 1);
+    BOOST_CHECK_EQUAL(satnum[12], 1);
+    BOOST_CHECK_EQUAL(satnum[13], 2);  // OPERNUM=14, ADDX SATNUM 1
 }
 
 BOOST_AUTO_TEST_CASE(Test_field) {


### PR DESCRIPTION
Fixes OPM/opm-simulators#7166



## Summary
- Extend `handle_operateR()` for integer targets (e.g. `SATNUM`) via `operate_int_target()`
- Warn when `OPERATER` target is unsupported (replaces silent skip)
- Unit test in `OperateTests.cpp` (porosity threshold + `ADDX` on `OPERNUM`)

## Integration check
Expected SATNUM is in `PINCHHELL_SATNUM.GRDECL` (attached on the simulators issue).
After this fix, Flow INIT matches except ~16 active cells at `PORO = 0.2222`
(strict `>` in `MULTA` vs inclusive threshold in the reference run).