### PR TITLE
adding water_gas_ratio to UnitSystem

### DIFF
--- a/opm/input/eclipse/Units/UnitSystem.cpp
+++ b/opm/input/eclipse/Units/UnitSystem.cpp
@@ -97,6 +97,7 @@ namespace {
         0.0,
         0.0,
         0.0,
+        0.0,
         0.0
     };
 
@@ -128,6 +129,7 @@ namespace {
         1 / ( Metric::Mass / Metric::Time ),
         1, /* gas-oil ratio */
         1, /* oil-gas ratio */
+        1, /* water-gas ratio */
         1, /* water cut */
         1, /* gas formation volume factor */
         1, /* oil formation volume factor */
@@ -179,6 +181,7 @@ namespace {
         Metric::Mass / Metric::Time,
         1, /* gas-oil ratio */
         1, /* oil-gas ratio */
+        1, /* water-gas ratio */
         1, /* water cut */
         1, /* gas formation volume factor */
         1, /* oil formation volume factor */
@@ -230,6 +233,7 @@ namespace {
         "KG/DAY",
         "SM3/SM3",
         "SM3/SM3",
+        "SM3/SM3", /* water-gas ratio */
         "",
         "RM3/SM3", /* gas formation volume factor */
         "RM3/SM3", /* oil formation volume factor */
@@ -321,6 +325,7 @@ namespace {
         0.0,
         0.0,
         0.0,
+        0.0,
         0.0
     };
 
@@ -352,6 +357,7 @@ namespace {
         1 / ( Field::Mass / Field::Time ),
         1 / ( Field::GasSurfaceVolume / Field::LiquidSurfaceVolume ), /* gas-oil ratio */
         1 / ( Field::LiquidSurfaceVolume / Field::GasSurfaceVolume ), /* oil-gas ratio */
+        1 / ( Field::LiquidSurfaceVolume / Field::GasSurfaceVolume ), /* water-gas ratio */
         1, /* water cut */
         1 / (Field::ReservoirVolume / Field::GasSurfaceVolume), /* gas formation volume factor */
         1, /* oil formation volume factor */
@@ -403,6 +409,7 @@ namespace {
          Field::Mass / Field::Time,
          Field::GasSurfaceVolume / Field::LiquidSurfaceVolume, /* gas-oil ratio */
          Field::LiquidSurfaceVolume / Field::GasSurfaceVolume, /* oil-gas ratio */
+         Field::LiquidSurfaceVolume / Field::GasSurfaceVolume, /* water-gas ratio */
          1, /* water cut */
          Field::ReservoirVolume / Field::GasSurfaceVolume, /* gas formation volume factor */
          1, /* oil formation volume factor */
@@ -454,6 +461,7 @@ namespace {
         "LB/DAY",
         "MSCF/STB",
         "STB/MSCF",
+        "STB/MSCF", /* water-gas ratio */
         "",
         "RB/MSCF", /* gas formation volume factor */
         "RB/STB", /* oil formation volume factor */
@@ -545,6 +553,7 @@ namespace {
         0.0,
         0.0,
         0.0,
+        0.0,
         0.0
     };
 
@@ -576,6 +585,7 @@ namespace {
         1 / ( Lab::Mass / Lab::Time ),
         1 / Lab::GasDissolutionFactor, /* gas-oil ratio */
         1 / Lab::OilDissolutionFactor, /* oil-gas ratio */
+        1 / Lab::OilDissolutionFactor, /* water-gas ratio */
         1, /* water cut */
         1, /* gas formation volume factor */
         1, /* oil formation volume factor */
@@ -627,6 +637,7 @@ namespace {
         Lab::Mass / Lab::Time,
         Lab::GasDissolutionFactor,  /* gas-oil ratio */
         Lab::OilDissolutionFactor,  /* oil-gas ratio */
+        Lab::OilDissolutionFactor,  /* water-gas ratio */
         1, /* water cut */
         1, /* gas formation volume factor */
         1, /* oil formation volume factor */
@@ -678,6 +689,7 @@ namespace {
         "G/HR",
         "SCC/SCC",
         "SCC/SCC",
+        "SCC/SCC", /* water-gas ratio */
         "",
         "RCC/SCC", /* gas formation volume factor */
         "RCC/SCC", /* oil formation volume factor */
@@ -769,6 +781,7 @@ namespace {
         0.0,
         0.0,
         0.0,
+        0.0,
         0.0
     };
 
@@ -800,6 +813,7 @@ namespace {
         1 / ( PVT_M::Mass / PVT_M::Time ),
         1 / (PVT_M::GasSurfaceVolume / PVT_M::LiquidSurfaceVolume), // Rs
         1 / (PVT_M::LiquidSurfaceVolume / PVT_M::GasSurfaceVolume), // Rv
+        1 / (PVT_M::LiquidSurfaceVolume / PVT_M::GasSurfaceVolume), // Rvw (water-gas ratio)
         1, /* water cut */
         1 / (PVT_M::ReservoirVolume / PVT_M::GasSurfaceVolume), /* Bg */
         1 / (PVT_M::ReservoirVolume / PVT_M::LiquidSurfaceVolume), /* Bo */
@@ -851,6 +865,7 @@ namespace {
         PVT_M::Mass / PVT_M::Time,
         PVT_M::GasSurfaceVolume / PVT_M::LiquidSurfaceVolume, // Rs
         PVT_M::LiquidSurfaceVolume / PVT_M::GasSurfaceVolume, // Rv
+        PVT_M::LiquidSurfaceVolume / PVT_M::GasSurfaceVolume, // Rvw (water-gas ratio)
         1, /* water cut */
         PVT_M::ReservoirVolume / PVT_M::GasSurfaceVolume, /* Bg */
         PVT_M::ReservoirVolume / PVT_M::LiquidSurfaceVolume, /* Bo */
@@ -902,6 +917,7 @@ namespace {
         "KG/DAY",
         "SM3/SM3",
         "SM3/SM3",
+        "SM3/SM3", /* water-gas ratio */
         "",
         "RM3/SM3", /* gas formation volume factor */
         "RM3/SM3", /* oil formation volume factor */
@@ -946,6 +962,7 @@ namespace {
     // INPUT Unit Conventions
 
     static const double from_input_offset[] = {
+        0.0,
         0.0,
         0.0,
         0.0,
@@ -1044,10 +1061,12 @@ namespace {
         1,
         1,
         1,
+        1,
         1
     };
 
     static const double from_input[] = {
+        1,
         1,
         1,
         1,
@@ -1126,6 +1145,7 @@ namespace {
         "KG/DAY",
         "SM3/SM3",
         "SM3/SM3",
+        "SM3/SM3", /* water-gas ratio */
         "",
         "RM3/SM3", /* gas formation volume factor */
         "RM3/SM3", /* oil formation volume factor */

--- a/opm/input/eclipse/Units/UnitSystem.cpp
+++ b/opm/input/eclipse/Units/UnitSystem.cpp
@@ -357,7 +357,7 @@ namespace {
         1 / ( Field::Mass / Field::Time ),
         1 / ( Field::GasSurfaceVolume / Field::LiquidSurfaceVolume ), /* gas-oil ratio */
         1 / ( Field::LiquidSurfaceVolume / Field::GasSurfaceVolume ), /* oil-gas ratio */
-        1 / ( Field::LiquidSurfaceVolume / Field::GasSurfaceVolume ), /* water-gas ratio */
+        1 / Field::WaterVaporizationFactor, /* water-gas ratio */
         1, /* water cut */
         1 / (Field::ReservoirVolume / Field::GasSurfaceVolume), /* gas formation volume factor */
         1, /* oil formation volume factor */
@@ -409,7 +409,7 @@ namespace {
          Field::Mass / Field::Time,
          Field::GasSurfaceVolume / Field::LiquidSurfaceVolume, /* gas-oil ratio */
          Field::LiquidSurfaceVolume / Field::GasSurfaceVolume, /* oil-gas ratio */
-         Field::LiquidSurfaceVolume / Field::GasSurfaceVolume, /* water-gas ratio */
+         Field::WaterVaporizationFactor, /* water-gas ratio */
          1, /* water cut */
          Field::ReservoirVolume / Field::GasSurfaceVolume, /* gas formation volume factor */
          1, /* oil formation volume factor */
@@ -585,7 +585,7 @@ namespace {
         1 / ( Lab::Mass / Lab::Time ),
         1 / Lab::GasDissolutionFactor, /* gas-oil ratio */
         1 / Lab::OilDissolutionFactor, /* oil-gas ratio */
-        1 / Lab::OilDissolutionFactor, /* water-gas ratio */
+        1 / Lab::WaterVaporizationFactor, /* water-gas ratio */
         1, /* water cut */
         1, /* gas formation volume factor */
         1, /* oil formation volume factor */
@@ -637,7 +637,7 @@ namespace {
         Lab::Mass / Lab::Time,
         Lab::GasDissolutionFactor,  /* gas-oil ratio */
         Lab::OilDissolutionFactor,  /* oil-gas ratio */
-        Lab::OilDissolutionFactor,  /* water-gas ratio */
+        Lab::WaterVaporizationFactor,  /* water-gas ratio */
         1, /* water cut */
         1, /* gas formation volume factor */
         1, /* oil formation volume factor */
@@ -813,7 +813,7 @@ namespace {
         1 / ( PVT_M::Mass / PVT_M::Time ),
         1 / (PVT_M::GasSurfaceVolume / PVT_M::LiquidSurfaceVolume), // Rs
         1 / (PVT_M::LiquidSurfaceVolume / PVT_M::GasSurfaceVolume), // Rv
-        1 / (PVT_M::LiquidSurfaceVolume / PVT_M::GasSurfaceVolume), // Rvw (water-gas ratio)
+        1 / PVT_M::WaterVaporizationFactor, // Rvw (water-gas ratio)
         1, /* water cut */
         1 / (PVT_M::ReservoirVolume / PVT_M::GasSurfaceVolume), /* Bg */
         1 / (PVT_M::ReservoirVolume / PVT_M::LiquidSurfaceVolume), /* Bo */
@@ -865,7 +865,7 @@ namespace {
         PVT_M::Mass / PVT_M::Time,
         PVT_M::GasSurfaceVolume / PVT_M::LiquidSurfaceVolume, // Rs
         PVT_M::LiquidSurfaceVolume / PVT_M::GasSurfaceVolume, // Rv
-        PVT_M::LiquidSurfaceVolume / PVT_M::GasSurfaceVolume, // Rvw (water-gas ratio)
+        PVT_M::WaterVaporizationFactor, // Rvw (water-gas ratio)
         1, /* water cut */
         PVT_M::ReservoirVolume / PVT_M::GasSurfaceVolume, /* Bg */
         PVT_M::ReservoirVolume / PVT_M::LiquidSurfaceVolume, /* Bo */

--- a/opm/input/eclipse/Units/UnitSystem.hpp
+++ b/opm/input/eclipse/Units/UnitSystem.hpp
@@ -69,6 +69,7 @@ namespace Opm {
             mass_rate,
             gas_oil_ratio,
             oil_gas_ratio,
+            water_gas_ratio,
             water_cut,
             gas_formation_volume_factor,
             oil_formation_volume_factor,

--- a/opm/input/eclipse/Units/Units.hpp
+++ b/opm/input/eclipse/Units/Units.hpp
@@ -278,6 +278,7 @@ namespace Opm {
         constexpr double GeomVolume           = cubic(meter);
         constexpr double GasDissolutionFactor = GasSurfaceVolume/LiquidSurfaceVolume;
         constexpr double OilDissolutionFactor = LiquidSurfaceVolume/GasSurfaceVolume;
+        constexpr double WaterVaporizationFactor = LiquidSurfaceVolume/GasSurfaceVolume;
         constexpr double Density              = kilogram/cubic(meter);
         constexpr double Concentration        = kilogram/cubic(meter);
         constexpr double FoamDensity          = kilogram/cubic(meter);
@@ -313,6 +314,7 @@ namespace Opm {
         constexpr double GeomVolume           = cubic(feet);
         constexpr double GasDissolutionFactor = GasSurfaceVolume/LiquidSurfaceVolume;
         constexpr double OilDissolutionFactor = LiquidSurfaceVolume/GasSurfaceVolume;
+        constexpr double WaterVaporizationFactor = LiquidSurfaceVolume/GasSurfaceVolume;
         constexpr double Density              = pound/cubic(feet);
         constexpr double Concentration        = pound/stb;
         constexpr double FoamDensity          = pound/GasSurfaceVolume;
@@ -348,6 +350,7 @@ namespace Opm {
         constexpr double GeomVolume           = cubic(centi*meter);
         constexpr double GasDissolutionFactor = GasSurfaceVolume/LiquidSurfaceVolume;
         constexpr double OilDissolutionFactor = LiquidSurfaceVolume/GasSurfaceVolume;
+        constexpr double WaterVaporizationFactor = LiquidSurfaceVolume/GasSurfaceVolume;
         constexpr double Density              = gram/cubic(centi*meter);
         constexpr double Concentration        = gram/cubic(centi*meter);
         constexpr double FoamDensity          = gram/cubic(centi*meter);
@@ -383,6 +386,7 @@ namespace Opm {
         constexpr double GeomVolume           = cubic(meter);
         constexpr double GasDissolutionFactor = GasSurfaceVolume/LiquidSurfaceVolume;
         constexpr double OilDissolutionFactor = LiquidSurfaceVolume/GasSurfaceVolume;
+        constexpr double WaterVaporizationFactor = LiquidSurfaceVolume/GasSurfaceVolume;
         constexpr double Density              = kilogram/cubic(meter);
         constexpr double Concentration        = kilogram/cubic(meter);
         constexpr double FoamDensity          = kilogram/cubic(meter);

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/G/GECON
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/G/GECON
@@ -28,12 +28,14 @@
     {
       "name": "MAX_GOR",
       "value_type": "UDA",
-      "default": 0
+      "default": 0,
+      "dimension": "GasSurfaceVolume/LiquidSurfaceVolume"
     },
     {
       "name": "MAX_WATER_GAS_RATIO",
       "value_type": "UDA",
-      "default": 0
+      "default": 0,
+      "dimension": "LiquidSurfaceVolume/GasSurfaceVolume"
     },
     {
       "name": "WORKOVER",

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -892,6 +892,37 @@ GCONSUMP
 
 }
 
+BOOST_AUTO_TEST_CASE(GECON_FIELD_UNITS) {
+    const std::string input = R"(
+START             -- 0
+31 AUG 1993 /
+FIELD
+SCHEDULE
+
+GRUPTREE
+  'G1'  'FIELD' /
+/
+
+GECON
+ 'G1'  2*  0.7  5.0  0.1  /
+/)";
+
+    auto schedule = create_schedule(input);
+    SummaryState st(TimeService::now(), 0.0);
+
+    const double gor_to_si = 178.1076066790352;     // MSCF/STB -> SM3/SM3
+    const double wgr_to_si = 5.614583333333335e-03; // STB/MSCF -> SM3/SM3
+
+    const auto& gecon = schedule[0].gecon.get();
+    const GroupEconProductionLimits::GEconGroupProp group = gecon.get_group_prop(schedule, st, "G1");
+    BOOST_CHECK(group.maxWaterCut().has_value());
+    BOOST_CHECK_CLOSE(group.maxWaterCut().value(), 0.7, 1.0e-10);
+    BOOST_CHECK(group.maxGasOilRatio().has_value());
+    BOOST_CHECK_CLOSE(group.maxGasOilRatio().value(), 5.0 * gor_to_si, 1.0e-10);
+    BOOST_CHECK(group.maxWaterGasRatio().has_value());
+    BOOST_CHECK_CLOSE(group.maxWaterGasRatio().value(), 0.1 * wgr_to_si, 1.0e-10);
+}
+
 BOOST_AUTO_TEST_CASE(GCONINJE_MULTIPLE_PHASES) {
     const std::string input = R"(
 START             -- 0

--- a/tests/parser/UnitTests.cpp
+++ b/tests/parser/UnitTests.cpp
@@ -308,6 +308,7 @@ BOOST_AUTO_TEST_CASE(METRIC_UNITS)
     BOOST_CHECK_CLOSE( metric.to_si( Meas::mass_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::water_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::gas_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
@@ -352,6 +353,7 @@ BOOST_AUTO_TEST_CASE(METRIC_UNITS)
     BOOST_CHECK_CLOSE( metric.from_si( Meas::mass_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::water_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::gas_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
@@ -406,6 +408,7 @@ BOOST_AUTO_TEST_CASE(FIELD_UNITS)
     BOOST_CHECK_CLOSE( field.to_si( Meas::mass_rate , 1.0 ) , 5.249911689814815e-06 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::gas_oil_ratio , 1.0 ) , 178.1076066790352 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::oil_gas_ratio , 1.0 ) , 5.614583333333335e-03 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::water_gas_ratio , 1.0 ) , 5.614583333333335e-03 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::gas_formation_volume_factor , 1.0 ) , 5.614583333333335e-03 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
@@ -450,6 +453,7 @@ BOOST_AUTO_TEST_CASE(FIELD_UNITS)
     BOOST_CHECK_CLOSE( field.from_si( Meas::mass , 1.0 ) , 2.204622621848776e+00 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::gas_oil_ratio , 1.0 ) , 5.614583333333335e-03 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::oil_gas_ratio , 1.0 ) , 178.1076066790352 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::water_gas_ratio , 1.0 ) , 178.1076066790352 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::gas_formation_volume_factor , 1.0 ) , 178.1076066790352 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
@@ -504,6 +508,7 @@ BOOST_AUTO_TEST_CASE(LAB_UNITS)
     BOOST_CHECK_CLOSE( lab.to_si( Meas::mass_rate , 1.0 ) , 2.777777777777778e-07 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::water_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::gas_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
@@ -549,6 +554,7 @@ BOOST_AUTO_TEST_CASE(LAB_UNITS)
     BOOST_CHECK_CLOSE( lab.from_si( Meas::mass_rate , 1.0 ) , 3.6e+06 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::water_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::gas_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
@@ -603,6 +609,7 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::mass_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::water_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::gas_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
@@ -648,6 +655,7 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::mass_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::water_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::gas_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );


### PR DESCRIPTION
adding the water_gas_ratio to UnitSystem to deal the max water gas ratio in GECON keyword.

an alternative is  to have a liquid_gas_ratio for both water_gas_ratio and oil_gas_ratio.  let me know if that is preferred. 

When writing the message, I realized that we should add units to GECON keyword definition. 