### PR TITLE
adding the parsing and using of the keyword LBCCOEF

### DIFF
--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -679,11 +679,11 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
         using KW = ParserKeywords::LBCCOEF;
         const auto& record = kw->getRecord(0);
         this->lbc_coefficients = {
-            record.getItem<KW::COEF1>().get<double>(0),
-            record.getItem<KW::COEF2>().get<double>(0),
-            record.getItem<KW::COEF3>().get<double>(0),
-            record.getItem<KW::COEF4>().get<double>(0),
-            record.getItem<KW::COEF5>().get<double>(0),
+            record.getItem<KW::COEF1>().getSIDouble(0),
+            record.getItem<KW::COEF2>().getSIDouble(0),
+            record.getItem<KW::COEF3>().getSIDouble(0),
+            record.getItem<KW::COEF4>().getSIDouble(0),
+            record.getItem<KW::COEF5>().getSIDouble(0),
         };
     }
 }
@@ -740,7 +740,7 @@ CompositionalConfig CompositionalConfig::serializationTestObject() {
     result.binary_interaction_coefficient = {2, std::vector<double>(result.num_comps * (result.num_comps - 1) / 2, 6.)};
     result.omega_a = {2, std::vector<double>(result.num_comps, 0.457235529)};
     result.omega_b = {2, std::vector<double>(result.num_comps, 0.077796074)};
-    result.lbc_coefficients = {0.1023, 0.025, 0.058533, 0.01, 0.0093324};
+    result.lbc_coefficients = {1.234, -17.29, 3.1415, -2.718, 16.18};
     result.eos_types_surf = {3, EOSType::PR};
     result.molecular_weights_surf = {3, std::vector<double>(result.num_comps, 17.)};
     result.acentric_factors_surf = {3, std::vector<double>(result.num_comps, 1.1)};

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -34,6 +34,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/B.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/L.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/M.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/N.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/O.hpp>
@@ -432,6 +433,7 @@ namespace {
             std::pair {"OMEGAAS"sv, section.hasKeyword<Opm::ParserKeywords::OMEGAAS>() },
             std::pair {"OMEGAB"sv,  section.hasKeyword<Opm::ParserKeywords::OMEGAB>() },
             std::pair {"OMEGABS"sv, section.hasKeyword<Opm::ParserKeywords::OMEGABS>() },
+            std::pair {"LBCCOEF"sv, section.hasKeyword<Opm::ParserKeywords::LBCCOEF>() },
         };
 
         bool any_comp_prop_kw = false;
@@ -667,6 +669,23 @@ CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspe
     processOmegaSurfaceKeyword<ParserKeywords::OMEGABS>(props_section, this->omega_b_surf,
                                                         this->omega_b, omega_b_defaults_surf,
                                                         num_eos_sur, num_eos_res, this->num_comps);
+
+    // LBCCOEF holds a single set of dimensionless coefficients for the
+    // Lorentz-Bray-Clark viscosity correlation; defaulted items keep the
+    // standard values.
+    if (const auto* kw = getSinglePropsKeyword<ParserKeywords::LBCCOEF>(props_section);
+        kw != nullptr)
+    {
+        using KW = ParserKeywords::LBCCOEF;
+        const auto& record = kw->getRecord(0);
+        this->lbc_coefficients = {
+            record.getItem<KW::COEF1>().get<double>(0),
+            record.getItem<KW::COEF2>().get<double>(0),
+            record.getItem<KW::COEF3>().get<double>(0),
+            record.getItem<KW::COEF4>().get<double>(0),
+            record.getItem<KW::COEF5>().get<double>(0),
+        };
+    }
 }
 
 bool CompositionalConfig::operator==(const CompositionalConfig& other) const {
@@ -686,6 +705,7 @@ bool CompositionalConfig::operator==(const CompositionalConfig& other) const {
            this->binary_interaction_coefficient == other.binary_interaction_coefficient &&
            this->omega_a == other.omega_a &&
            this->omega_b == other.omega_b &&
+           this->lbc_coefficients == other.lbc_coefficients &&
            this->eos_types_surf == other.eos_types_surf &&
            this->molecular_weights_surf == other.molecular_weights_surf &&
            this->acentric_factors_surf == other.acentric_factors_surf &&
@@ -720,6 +740,7 @@ CompositionalConfig CompositionalConfig::serializationTestObject() {
     result.binary_interaction_coefficient = {2, std::vector<double>(result.num_comps * (result.num_comps - 1) / 2, 6.)};
     result.omega_a = {2, std::vector<double>(result.num_comps, 0.457235529)};
     result.omega_b = {2, std::vector<double>(result.num_comps, 0.077796074)};
+    result.lbc_coefficients = {0.1023, 0.025, 0.058533, 0.01, 0.0093324};
     result.eos_types_surf = {3, EOSType::PR};
     result.molecular_weights_surf = {3, std::vector<double>(result.num_comps, 17.)};
     result.acentric_factors_surf = {3, std::vector<double>(result.num_comps, 1.1)};
@@ -743,6 +764,15 @@ CompositionalConfig::EOSType CompositionalConfig::eosTypeFromString(const std::s
     if (str == "SRK") return EOSType::SRK;
     if (str == "ZJ") return EOSType::ZJ;
     throw std::invalid_argument("Unknown string for EOSType");
+}
+
+std::array<double, 5> CompositionalConfig::defaultLBCCoefficients() {
+    using KW = ParserKeywords::LBCCOEF;
+    return {KW::COEF1::defaultValue,
+            KW::COEF2::defaultValue,
+            KW::COEF3::defaultValue,
+            KW::COEF4::defaultValue,
+            KW::COEF5::defaultValue};
 }
 
 std::string CompositionalConfig::eosTypeToString(Opm::CompositionalConfig::EOSType eos) {
@@ -814,6 +844,10 @@ const std::vector<double>& CompositionalConfig::omegaA(std::size_t eos_region) c
 
 const std::vector<double>& CompositionalConfig::omegaB(std::size_t eos_region) const {
     return this->omega_b[eos_region];
+}
+
+const std::array<double, 5>& CompositionalConfig::lbcCoefficients() const {
+    return this->lbc_coefficients;
 }
 
 CompositionalConfig::EOSType CompositionalConfig::eosTypeSurf(std::size_t eos_region) const {

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
@@ -22,6 +22,7 @@
 
 #include <opm/input/eclipse/Units/Units.hpp>
 
+#include <array>
 #include <cstddef>
 #include <string>
 #include <vector>
@@ -44,6 +45,9 @@ public:
     static EOSType eosTypeFromString(const std::string& str);
 
     static std::string eosTypeToString(EOSType eos);
+
+    // The item defaults of the LBCCOEF keyword.
+    static std::array<double, 5> defaultLBCCoefficients();
 
     CompositionalConfig() = default;
 
@@ -69,6 +73,7 @@ public:
     const std::vector<double>& criticalZFactor(std::size_t eos_region) const;
     const std::vector<double>& omegaA(std::size_t eos_region) const;
     const std::vector<double>& omegaB(std::size_t eos_region) const;
+    const std::array<double, 5>& lbcCoefficients() const;
 
     // Accessors for surface EOS regions.
     EOSType eosTypeSurf(std::size_t eos_region) const;
@@ -105,6 +110,7 @@ public:
         serializer(binary_interaction_coefficient);
         serializer(omega_a);
         serializer(omega_b);
+        serializer(lbc_coefficients);
         serializer(eos_types_surf);
         serializer(molecular_weights_surf);
         serializer(acentric_factors_surf);
@@ -138,6 +144,10 @@ private:
     std::vector<std::vector<double>> binary_interaction_coefficient;
     std::vector<std::vector<double>> omega_a;
     std::vector<std::vector<double>> omega_b;
+
+    // Coefficients for the Lorentz-Bray-Clark viscosity correlation (LBCCOEF).
+    // A single set is used for all EOS regions.
+    std::array<double, 5> lbc_coefficients = defaultLBCCoefficients();
 
     // Surface EOS-region properties (EOSS, MWS, ACFS, PCRITS, TCRITS, VCRITS, ZCRITS, SSHIFTS, BICS).
     std::vector<EOSType> eos_types_surf;

--- a/opm/input/eclipse/Parser/ParserItem.cpp
+++ b/opm/input/eclipse/Parser/ParserItem.cpp
@@ -49,11 +49,7 @@ type_tag get_data_type_json( const std::string& str ) {
     throw std::invalid_argument( str + " cannot be converted to enum 'tag'" );
 }
 
-/*
-  std::to_string() formats with a fixed six decimals, which truncates values
-  needing more decimals (e.g. 0.0093324 -> "0.009332") and returns "0.000000"
-  for very small numbers. Format with 12 significant digits instead.
-*/
+// Format the input value with twelve digits of precision.
 std::string as_string(double value) {
     return fmt::format("{:.12}", value);
 }

--- a/opm/input/eclipse/Parser/ParserItem.cpp
+++ b/opm/input/eclipse/Parser/ParserItem.cpp
@@ -21,17 +21,16 @@
 
 #include <opm/json/JsonObject.hpp>
 
-#include <opm/input/eclipse/Parser/ParserEnums.hpp>
-
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
-#include <fmt/format.h>
-
 #include <cmath>
 #include <cstddef>
 #include <ostream>
+#include <sstream>
+
+#include <fmt/format.h>
 
 #include "raw/RawRecord.hpp"
 #include "raw/StarToken.hpp"

--- a/opm/input/eclipse/Parser/ParserItem.cpp
+++ b/opm/input/eclipse/Parser/ParserItem.cpp
@@ -27,11 +27,11 @@
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <fmt/format.h>
+
 #include <cmath>
 #include <cstddef>
-#include <iomanip>
 #include <ostream>
-#include <sstream>
 
 #include "raw/RawRecord.hpp"
 #include "raw/StarToken.hpp"
@@ -51,15 +51,12 @@ type_tag get_data_type_json( const std::string& str ) {
 }
 
 /*
-  For very small numbers std::to_string() will just return the string "0.000000"
+  std::to_string() formats with a fixed six decimals, which truncates values
+  needing more decimals (e.g. 0.0093324 -> "0.009332") and returns "0.000000"
+  for very small numbers. Format with 12 significant digits instead.
 */
 std::string as_string(double value) {
-    if (std::fabs(value) < 1e-4) {
-        std::ostringstream ss;
-        ss << std::setprecision(12) << value;
-        return ss.str();
-    } else
-        return std::to_string(value);
+    return fmt::format("{:.12}", value);
 }
 
 }

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/L/LBCCOEF
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/L/LBCCOEF
@@ -1,0 +1,39 @@
+{
+  "name": "LBCCOEF",
+  "sections": [
+    "PROPS"
+  ],
+  "size": 1,
+  "items": [
+    {
+      "name": "COEF1",
+      "value_type": "DOUBLE",
+      "dimension": "1",
+      "default": 0.1023
+    },
+    {
+      "name": "COEF2",
+      "value_type": "DOUBLE",
+      "dimension": "1",
+      "default": 0.023364
+    },
+    {
+      "name": "COEF3",
+      "value_type": "DOUBLE",
+      "dimension": "1",
+      "default": 0.058533
+    },
+    {
+      "name": "COEF4",
+      "value_type": "DOUBLE",
+      "dimension": "1",
+      "default": -0.040758
+    },
+    {
+      "name": "COEF5",
+      "value_type": "DOUBLE",
+      "dimension": "1",
+      "default": 0.0093324
+    }
+  ]
+}

--- a/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1081,6 +1081,7 @@ set( keywords
      001_Eclipse300/H/HEATCR
      001_Eclipse300/H/HEATCRT
      001_Eclipse300/H/HWELLS
+     001_Eclipse300/L/LBCCOEF
      001_Eclipse300/L/LIVEOIL
      001_Eclipse300/M/MW
      001_Eclipse300/M/MWS

--- a/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
+++ b/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
@@ -494,7 +494,7 @@ namespace Opm {
     template <class Scalar, int NumComp, bool enableWater>
     std::array<Scalar, 5>
     GenericOilGasWaterFluidSystem<Scalar, NumComp, enableWater>::lbc_coefficients_ =
-        defaultLBCCoefficients<Scalar>;
+        ViscosityModel::defaultLBCCoefficients();
 
     template <class Scalar, int NumComp, bool enableWater>
     std::shared_ptr<WaterPvtMultiplexer<Scalar> >

--- a/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
+++ b/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
@@ -167,6 +167,9 @@ namespace Opm {
                 std::ranges::copy(bic, interaction_coefficients_.begin());
             }
 
+            const auto& lbc = comp_config.lbcCoefficients();
+            lbc_coefficients_.assign(lbc.begin(), lbc.end());
+
             // Init. water pvt from deck
             waterPvt_->initFromState(eclState, schedule);
 
@@ -241,6 +244,15 @@ namespace Opm {
 
             return component_param_[compIdx].molar_mass;
         }
+
+        /*!
+         * \brief Coefficients for the Lorentz-Bray-Clark viscosity correlation.
+         *
+         * Defaults to the standard LBC coefficients unless modified
+         * with the LBCCOEF keyword.
+         */
+        static const std::vector<Scalar>& lbcCoefficients()
+        { return lbc_coefficients_; }
 
         /*!
          * \brief Returns the interaction coefficient for two components.
@@ -451,6 +463,7 @@ namespace Opm {
 
         static std::vector<ComponentParam> component_param_;
         static std::vector<Scalar> interaction_coefficients_;
+        static std::vector<Scalar> lbc_coefficients_;
         static std::shared_ptr<WaterPvt> waterPvt_;
 
     public:
@@ -476,6 +489,11 @@ namespace Opm {
     template <class Scalar, int NumComp, bool enableWater>
     std::vector<Scalar>
     GenericOilGasWaterFluidSystem<Scalar, NumComp, enableWater>::interaction_coefficients_;
+
+    template <class Scalar, int NumComp, bool enableWater>
+    std::vector<Scalar>
+    GenericOilGasWaterFluidSystem<Scalar, NumComp, enableWater>::lbc_coefficients_(
+        defaultLBCCoefficients.begin(), defaultLBCCoefficients.end());
 
     template <class Scalar, int NumComp, bool enableWater>
     std::shared_ptr<WaterPvtMultiplexer<Scalar> >

--- a/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
+++ b/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
@@ -38,6 +38,7 @@
 #include <opm/material/viscositymodels/LBC.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstddef>
 #include <string>
@@ -168,7 +169,7 @@ namespace Opm {
             }
 
             const auto& lbc = comp_config.lbcCoefficients();
-            lbc_coefficients_.assign(lbc.begin(), lbc.end());
+            std::ranges::copy(lbc, lbc_coefficients_.begin());
 
             // Init. water pvt from deck
             waterPvt_->initFromState(eclState, schedule);
@@ -251,7 +252,7 @@ namespace Opm {
          * Defaults to the standard LBC coefficients unless modified
          * with the LBCCOEF keyword.
          */
-        static const std::vector<Scalar>& lbcCoefficients()
+        static const std::array<Scalar, 5>& lbcCoefficients()
         { return lbc_coefficients_; }
 
         /*!
@@ -463,7 +464,7 @@ namespace Opm {
 
         static std::vector<ComponentParam> component_param_;
         static std::vector<Scalar> interaction_coefficients_;
-        static std::vector<Scalar> lbc_coefficients_;
+        static std::array<Scalar, 5> lbc_coefficients_;
         static std::shared_ptr<WaterPvt> waterPvt_;
 
     public:
@@ -491,9 +492,9 @@ namespace Opm {
     GenericOilGasWaterFluidSystem<Scalar, NumComp, enableWater>::interaction_coefficients_;
 
     template <class Scalar, int NumComp, bool enableWater>
-    std::vector<Scalar>
-    GenericOilGasWaterFluidSystem<Scalar, NumComp, enableWater>::lbc_coefficients_(
-        defaultLBCCoefficients.begin(), defaultLBCCoefficients.end());
+    std::array<Scalar, 5>
+    GenericOilGasWaterFluidSystem<Scalar, NumComp, enableWater>::lbc_coefficients_ =
+        defaultLBCCoefficients<Scalar>;
 
     template <class Scalar, int NumComp, bool enableWater>
     std::shared_ptr<WaterPvtMultiplexer<Scalar> >

--- a/opm/material/viscositymodels/LBC.hpp
+++ b/opm/material/viscositymodels/LBC.hpp
@@ -32,18 +32,18 @@
 
 #include <array>
 #include <cmath>
-#include <vector>
 
 namespace Opm
 {
 
 // Standard coefficients of the Lorentz-Bray-Clark viscosity correlation.
 // (Note the fourth coefficient: typo in 1964-paper has -0.40758.)
-inline constexpr std::array<double, 5> defaultLBCCoefficients {0.10230,
-                                                               0.023364,
-                                                               0.058533,
-                                                               -0.040758,
-                                                               0.0093324};
+template <class Scalar = double>
+inline constexpr std::array<Scalar, 5> defaultLBCCoefficients {Scalar(0.10230),
+                                                               Scalar(0.023364),
+                                                               Scalar(0.058533),
+                                                               Scalar(-0.040758),
+                                                               Scalar(0.0093324)};
 
 template <class Scalar, class FluidSystem>
 class ViscosityModels
@@ -115,11 +115,11 @@ public:
 
         // The default coefficients can be overridden (LBCCOEF keyword) by fluid
         // systems providing a lbcCoefficients() function.
-        std::vector<Scalar> LBC;
+        std::array<Scalar, 5> LBC;
         if constexpr (requires { FluidSystem::lbcCoefficients(); }) {
             LBC = FluidSystem::lbcCoefficients();
         } else {
-            LBC.assign(defaultLBCCoefficients.begin(), defaultLBCCoefficients.end());
+            LBC = defaultLBCCoefficients<Scalar>;
         }
 
         LhsEval sumLBC = 0.0;

--- a/opm/material/viscositymodels/LBC.hpp
+++ b/opm/material/viscositymodels/LBC.hpp
@@ -30,11 +30,21 @@
 #ifndef LBC_HPP
 #define LBC_HPP
 
+#include <array>
 #include <cmath>
 #include <vector>
 
 namespace Opm
 {
+
+// Standard coefficients of the Lorentz-Bray-Clark viscosity correlation.
+// (Note the fourth coefficient: typo in 1964-paper has -0.40758.)
+inline constexpr std::array<double, 5> defaultLBCCoefficients {0.10230,
+                                                               0.023364,
+                                                               0.058533,
+                                                               -0.040758,
+                                                               0.0093324};
+
 template <class Scalar, class FluidSystem>
 class ViscosityModels
 {
@@ -103,11 +113,14 @@ public:
         }
         my0 /= sumxrM;
 
-        std::vector<Scalar> LBC = {0.10230,
-                                   0.023364,
-                                   0.058533,
-                                   -0.040758,  // typo in 1964-paper: -0.40758
-                                   0.0093324};
+        // The default coefficients can be overridden (LBCCOEF keyword) by fluid
+        // systems providing a lbcCoefficients() function.
+        std::vector<Scalar> LBC;
+        if constexpr (requires { FluidSystem::lbcCoefficients(); }) {
+            LBC = FluidSystem::lbcCoefficients();
+        } else {
+            LBC.assign(defaultLBCCoefficients.begin(), defaultLBCCoefficients.end());
+        }
 
         LhsEval sumLBC = 0.0;
         for (int i = 0; i < 5; ++i) {

--- a/opm/material/viscositymodels/LBC.hpp
+++ b/opm/material/viscositymodels/LBC.hpp
@@ -30,26 +30,30 @@
 #ifndef LBC_HPP
 #define LBC_HPP
 
+#include <opm/common/Exceptions.hpp>
+
 #include <array>
 #include <cmath>
 
 namespace Opm
 {
 
-// Standard coefficients of the Lorentz-Bray-Clark viscosity correlation.
-// (Note the fourth coefficient: typo in 1964-paper has -0.40758.)
-template <class Scalar = double>
-inline constexpr std::array<Scalar, 5> defaultLBCCoefficients {Scalar(0.10230),
-                                                               Scalar(0.023364),
-                                                               Scalar(0.058533),
-                                                               Scalar(-0.040758),
-                                                               Scalar(0.0093324)};
-
 template <class Scalar, class FluidSystem>
 class ViscosityModels
 {
 
 public:
+
+    // Standard coefficients of the Lorentz-Bray-Clark viscosity correlation.
+    // (Note the fourth coefficient: typo in 1964-paper has -0.40758.)
+    static constexpr std::array<Scalar, 5> defaultLBCCoefficients()
+    {
+        return {Scalar(0.10230),
+                Scalar(0.023364),
+                Scalar(0.058533),
+                Scalar(-0.040758),
+                Scalar(0.0093324)};
+    }
 
     // Standard LBC model. (Lohrenz, Bray & Clark: "Calculating Viscosities of Reservoir
     //                      fluids from Their Compositions", JPT 16.10 (1964).
@@ -113,21 +117,29 @@ public:
         }
         my0 /= sumxrM;
 
-        // The default coefficients can be overridden (LBCCOEF keyword) by fluid
-        // systems providing a lbcCoefficients() function.
-        std::array<Scalar, 5> LBC;
-        if constexpr (requires { FluidSystem::lbcCoefficients(); }) {
-            LBC = FluidSystem::lbcCoefficients();
-        } else {
-            LBC = defaultLBCCoefficients<Scalar>;
-        }
+        // using reference to avoid copying the coefficients for every evaluation.
+        const auto& LBC = []() -> decltype(auto) {
+            if constexpr (requires { FluidSystem::lbcCoefficients(); }) {
+                return FluidSystem::lbcCoefficients();
+            } else {
+                static constexpr std::array<Scalar, 5> default_lbc = defaultLBCCoefficients();
+                return (default_lbc);
+            }
+        }();
 
         LhsEval sumLBC = 0.0;
         for (int i = 0; i < 5; ++i) {
             sumLBC += Opm::pow(rho_r,i)*LBC[i];
         }
 
-        return (my0 + (Opm::pow(sumLBC,4.0) - 1e-4)/zeta_tot)/1e3; // mPas-> Pas
+        const LhsEval mu = (my0 + (Opm::pow(sumLBC,4.0) - 1e-4)/zeta_tot)/1e3; // mPas-> Pas
+
+        if (mu <= 0.) {
+            throw NumericalProblem("LBC correlation produced a non-positive viscosity; "
+                                   "check the LBC coefficients");
+        }
+
+        return mu;
     }
 
 };

--- a/tests/parser/CompositionalTests.cpp
+++ b/tests/parser/CompositionalTests.cpp
@@ -225,6 +225,10 @@ OMEGABS
 0.085 0.086 1* /
 
 
+LBCCOEF
+1* 0.025 1* 0.01 /
+
+
 STCOND
 15.0 /
 
@@ -379,6 +383,11 @@ BOOST_AUTO_TEST_CASE(DefaultedCompositionalKeywordsArePopulatedWhenAbsent) {
         BOOST_CHECK_EQUAL(num_comps, volume_shift.size());
         check_vectors_close(std::vector<double>(num_comps, 0.0), volume_shift, tolerance);
     }
+
+    // Without LBCCOEF, the standard LBC coefficients apply.
+    const auto& lbc = comp_config.lbcCoefficients();
+    check_vectors_close(std::vector<double>{0.1023, 0.023364, 0.058533, -0.040758, 0.0093324},
+                        std::vector<double>(lbc.begin(), lbc.end()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(CompositionalParsingTest) {
@@ -537,6 +546,14 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTest) {
         const auto& ob1 = comp_config.omegaB(1);
         BOOST_CHECK_EQUAL(num_comps, ob1.size());
         check_vectors_close(std::vector<double>{0.09, srk_omega_b, 0.10}, ob1, tolerance);
+    }
+
+    {
+        // LBCCOEF: second and fourth coefficients overridden (1* keeps the
+        // standard LBC defaults).
+        const auto& lbc = comp_config.lbcCoefficients();
+        check_vectors_close(std::vector<double>{0.1023, 0.025, 0.058533, 0.01, 0.0093324},
+                            std::vector<double>(lbc.begin(), lbc.end()), tolerance);
     }
 
     // Surface-condition EOS region properties


### PR DESCRIPTION
It is used to set Set non-default LBC coefficients for Lorentz-Bray-Clark viscosity correlation calculation. 

`as_string()` in ParserItem.cpp is updated to avoid truncate the small default value 

```json
    {
      "name": "COEF5",
      "value_type": "DOUBLE",
      "dimension": "1",
      "default": 0.0093324
    }
```