### PR TITLE
Extract TRACK Ordering Into Open-Path TSP Solver

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -296,6 +296,7 @@ list(APPEND MAIN_SOURCE_FILES
   opm/input/eclipse/Schedule/Well/PAvgCalculator.cpp
   opm/input/eclipse/Schedule/Well/PAvgCalculatorCollection.cpp
   opm/input/eclipse/Schedule/Well/PAvgDynamicSourceData.cpp
+  opm/input/eclipse/Schedule/Well/TrackOrderingTSP.cpp
   opm/input/eclipse/Schedule/Well/WCYCLE.cpp
   opm/input/eclipse/Schedule/Well/Well.cpp
   opm/input/eclipse/Schedule/Well/WellBrineProperties.cpp
@@ -647,6 +648,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/parser/TableContainerTests.cpp
   tests/parser/TableManagerTests.cpp
   tests/parser/TableSchemaTests.cpp
+  tests/parser/TestTrackOrderingTSP.cpp
   tests/parser/ThresholdPressureTest.cpp
   tests/parser/TracerTests.cpp
   tests/parser/TransMultTests.cpp
@@ -1203,6 +1205,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp
   opm/input/eclipse/Schedule/Well/PAvgCalculatorCollection.hpp
   opm/input/eclipse/Schedule/Well/PAvgDynamicSourceData.hpp
+  opm/input/eclipse/Schedule/Well/TrackOrderingTSP.hpp
   opm/input/eclipse/Schedule/Well/WCYCLE.hpp
   opm/input/eclipse/Schedule/Well/WDFAC.hpp
   opm/input/eclipse/Schedule/Well/WINJMULT.hpp

--- a/opm/input/eclipse/Schedule/Well/TrackOrderingTSP.cpp
+++ b/opm/input/eclipse/Schedule/Well/TrackOrderingTSP.cpp
@@ -1,0 +1,408 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/Schedule/Well/TrackOrderingTSP.hpp>
+
+#include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <compare>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <ranges>
+#include <stdexcept>
+#include <span>
+#include <utility>
+#include <vector>
+
+namespace {
+
+    /// Compute the penalty for taking a step that is not aligned with the
+    /// dominant geometric direction of the completion.
+    ///
+    /// \param[in] dir Completion direction being evaluated.
+    /// \param[in] abs_di Absolute logical I-step length.
+    /// \param[in] abs_dj Absolute logical J-step length.
+    /// \param[in] abs_dz_ij Depth contribution scaled into the I/J metric.
+    ///
+    /// \return A value in $[0, 1]$ where zero means fully aligned.
+    double directionStepPenalty(const Opm::Connection::Direction dir,
+                                const double                     abs_di,
+                                const double                     abs_dj,
+                                const double                     abs_dz_ij)
+    {
+        constexpr auto eps = 1.0e-12;
+
+        const auto total = abs_di + abs_dj + abs_dz_ij;
+        if (total < eps) {
+            return 0.0;
+        }
+
+        auto dominant = 0.0;
+        switch (dir) {
+        case Opm::Connection::Direction::X:
+            dominant = abs_di;
+            break;
+
+        case Opm::Connection::Direction::Y:
+            dominant = abs_dj;
+            break;
+
+        case Opm::Connection::Direction::Z:
+            dominant = abs_dz_ij;
+            break;
+        }
+
+        return 1.0 - dominant / total;
+    }
+
+    /// Compute the weighted edge cost used by the TRACK-ordering heuristic.
+    ///
+    /// \param[in] a First connection in the edge.
+    /// \param[in] b Second connection in the edge.
+    /// \param[in] w Cost weights controlling the distance terms.
+    ///
+    /// \return Weighted cost of moving from \p a to \p b.
+    std::int_least64_t
+    trackEdgeCost(const Opm::Connection&                         a,
+                  const Opm::Connection&                         b,
+                  const Opm::TrackOrderingTSP::TrackCostWeights& w)
+    {
+        constexpr auto max_cost = std::numeric_limits<std::int_least64_t>::max();
+
+        const auto di = std::abs(static_cast<double>(b.getI() - a.getI()));
+        const auto dj = std::abs(static_cast<double>(b.getJ() - a.getJ()));
+        const auto dk = std::abs(static_cast<double>(b.getK() - a.getK()));
+        const auto dz = std::abs(b.depth() - a.depth());
+
+        const auto abs_dz_ij = std::abs(w.z_to_ij_scale) * dz;
+        const auto ij = std::hypot(di, dj);
+
+        const auto dir_penalty = 0.5 *
+            (directionStepPenalty(a.dir(), di, dj, abs_dz_ij) +
+             directionStepPenalty(b.dir(), di, dj, abs_dz_ij));
+
+        const auto raw_cost = w.w_ij  * ij +
+                              w.w_z   * dz +
+                              w.w_k   * dk +
+                              w.w_dir * dir_penalty;
+
+        if (! std::isfinite(raw_cost)) {
+            // Handle potential numerical issues by treating non-finite costs as
+            // very high.
+            return max_cost;
+        }
+
+        // The multiplicative factor 1.0e9 effectively imposes a 1.0e-9
+        // improvement threshold.
+        const auto scaled_cost = 1.0e9 * raw_cost;
+
+        if (scaled_cost > static_cast<double>(max_cost) ||
+            scaled_cost < static_cast<double>(std::numeric_limits<std::int_least64_t>::min()))
+        {
+            // Handle potential overflow by treating excessively high costs as
+            // the maximum representable cost.
+            return max_cost;
+        }
+
+        return static_cast<std::int_least64_t>(scaled_cost);
+    }
+
+    /// Build an initial greedy path by repeatedly selecting the cheapest
+    /// unvisited successor.
+    ///
+    /// \param[in] connections Connections to order.
+    ///
+    /// \param[in] heel Index of well heel connection.  This connection
+    /// is always the first path element.
+    ///
+    /// \param[in] first Index of the first connection other than \p heel
+    /// in the path.  Ignored if same as \p heel.
+    ///
+    /// \param[in] w Cost weights controlling candidate selection.
+    ///
+    /// \param[in,out] path Greedy path permutation starting at \p heel,
+    /// and with \p first as the second element if different from
+    /// \p heel.  Path is cleared and rebuilt from scratch.
+    void
+    initialTrackPath(std::span<const Opm::Connection>               connections,
+                     const std::size_t                              heel,
+                     const std::size_t                              first,
+                     const Opm::TrackOrderingTSP::TrackCostWeights& w,
+                     std::vector<std::size_t>&                      path)
+    {
+        const auto n = static_cast<std::size_t>(connections.size());
+
+        path.clear();
+        path.reserve(n);
+
+        auto visited = std::vector<bool>(n, false);
+
+        path.push_back(heel);
+        visited[heel] = true;
+
+        if (first != heel) {
+            path.push_back(first);
+            visited[first] = true;
+        }
+
+        while (path.size() < n) {
+            const auto cur = path.back();
+
+            auto best = n; // Invalid index used as sentinel.
+            auto best_cost = std::numeric_limits<std::int_least64_t>::max();
+
+            for (auto cand = std::size_t{0}; cand < n; ++cand) {
+                if (visited[cand]) {
+                    continue;
+                }
+
+                const auto cost = trackEdgeCost(connections[cur], connections[cand], w);
+                if ((best == n) || (cost < best_cost)) {
+                    best_cost = cost;
+                    best = cand;
+                }
+            }
+
+            assert (best != n); // Should always find an unvisited candidate.
+
+            visited[best] = true;
+            path.push_back(best);
+        }
+    }
+
+    /// Improve a path with a 2-opt pass while keeping the heel fixed.
+    ///
+    /// \param[in] connections Connections referenced by the path.
+    /// \param[in] w Cost weights controlling the edge costs.
+    /// \param[in,out] path Path permutation to improve in place.
+    void
+    improveTrackPathOpen2Opt(std::span<const Opm::Connection>               connections,
+                             const Opm::TrackOrderingTSP::TrackCostWeights& w,
+                             std::vector<std::size_t>&                      path)
+    {
+        if (path.size() < 4) {
+            return;
+        }
+
+        const auto n = static_cast<std::size_t>(path.size());
+
+        // Fix path[0] as the heel candidate; optimize only the suffix.
+        auto improved = true;
+        while (improved) {
+            improved = false;
+
+            for (auto i = std::size_t{1}; i + 1 < n; ++i) {
+                for (auto k = i + 1; k < n; ++k) {
+                    const auto a = path[i - 1];
+                    const auto b = path[i];
+                    const auto c = path[k];
+
+                    const auto max_cost = std::numeric_limits<std::int_least64_t>::max();
+
+                    const auto ab = trackEdgeCost(connections[a], connections[b], w);
+                    const auto ac = trackEdgeCost(connections[a], connections[c], w);
+
+                    auto old_cost = ab;
+                    auto new_cost = ac;
+
+                    // Interior reversal [i, k] changes two boundary edges:
+                    // (a, b), (c, d) -> (a, c), (b, d), where d = path[k+1].
+                    // For suffix reversal [i, n-1], there is no trailing edge,
+                    // so only (a, b) -> (a, c) changes.
+                    if (k + 1 < n) {
+                        const auto d = path[k + 1];
+                        const auto cd = trackEdgeCost(connections[c], connections[d], w);
+                        const auto bd = trackEdgeCost(connections[b], connections[d], w);
+
+                        old_cost = (ab == max_cost || cd == max_cost || ab > (max_cost - cd))
+                            ? max_cost
+                            : (ab + cd);
+
+                        new_cost = (ac == max_cost || bd == max_cost || ac > (max_cost - bd))
+                            ? max_cost
+                            : (ac + bd);
+                    }
+
+                    if (new_cost < old_cost) {
+                        std::reverse(path.begin() + static_cast<std::ptrdiff_t>(i),
+                                     path.begin() + static_cast<std::ptrdiff_t>(k + 1));
+
+                        improved = true;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Compute the total cost of a TRACK-order path.
+    ///
+    /// \param[in] connections Connections referenced by the path.
+    /// \param[in] path Path permutation to evaluate.
+    /// \param[in] w Cost weights controlling the edge costs.
+    ///
+    /// \return Sum of all edge costs along \p path.
+    std::int_least64_t
+    trackPathCost(std::span<const Opm::Connection>               connections,
+                  const std::vector<std::size_t>&                path,
+                  const Opm::TrackOrderingTSP::TrackCostWeights& w)
+    {
+        auto total = std::int_least64_t{0};
+        if (path.size() < 2) {
+            return total;
+        }
+
+        constexpr auto max_cost = std::numeric_limits<std::int_least64_t>::max();
+
+        for (auto i = std::size_t{1}; i < path.size(); ++i) {
+            const auto edge_cost = trackEdgeCost(connections[path[i - 1]], connections[path[i]], w);
+            if ((edge_cost == max_cost) || (total > (max_cost - edge_cost))) {
+                return max_cost;
+            }
+
+            total += edge_cost;
+        }
+
+        return total;
+    }
+
+} // Anonymous namespace
+
+namespace Opm {
+
+    TrackOrderingTSP::TrackOrderingTSP(const int headI, const int headJ)
+        : headI_ { headI }
+        , headJ_ { headJ }
+    {}
+
+    TrackOrderingTSP&
+    TrackOrderingTSP::numberOfStartPoints(const std::size_t numStarts)
+    {
+        // We always use the connection that's closest to the well head as a
+        // start point, so the number of start points is always at least
+        // one.
+        this->numStartPoints_ = std::max(std::size_t{1}, numStarts);
+
+        return *this;
+    }
+
+    std::vector<std::size_t>
+    TrackOrderingTSP::order(std::span<const Connection> connections) const
+    {
+        return this->order(connections, TrackCostWeights{});
+    }
+
+    std::vector<std::size_t>
+    TrackOrderingTSP::order(std::span<const Connection> connections,
+                            const TrackCostWeights&     weights) const
+    {
+        auto best_path = std::vector<std::size_t>{};
+        best_path.reserve(connections.size());
+
+        if (connections.empty()) {
+            return best_path;
+        }
+
+        if (connections.size() == 1) {
+            best_path.push_back(0);
+            return best_path;
+        }
+
+        if (! weights.isValid()) {
+            throw std::invalid_argument {
+                "Invalid TrackCostWeights: all weights must be "
+                "non-negative and at least one weight must be "
+                "strictly positive."
+            };
+        }
+
+        auto curr_path = best_path;
+        auto best_cost = std::numeric_limits<std::int_least64_t>::max();
+
+        const auto start_candidates = this->determineStartPoints(connections);
+        const auto heel = start_candidates.front().index;
+
+        assert (start_candidates.size() <= this->numStartPoints_);
+
+        auto start_points = start_candidates
+            | std::views::transform([](const auto& candidate) { return candidate.index; });
+
+        for (const auto& start_point : start_points) {
+            initialTrackPath(connections, heel, start_point, weights, curr_path);
+            improveTrackPathOpen2Opt(connections, weights, curr_path);
+
+            const auto cost = trackPathCost(connections, curr_path, weights);
+            if (best_path.empty() || (cost < best_cost)) {
+                best_cost = cost;
+                best_path.swap(curr_path);
+            }
+        }
+
+        return best_path;
+    }
+
+    std::vector<TrackOrderingTSP::CandidateStart>
+    TrackOrderingTSP::determineStartPoints(std::span<const Connection> connections) const
+    {
+        auto start_candidates = std::vector<CandidateStart>{};
+
+        assert (this->numStartPoints_ >= std::size_t{1});
+
+        const auto num_conns = static_cast<std::size_t>(connections.size());
+        start_candidates.reserve(num_conns);
+
+        auto candidate_sequence = std::views::iota(std::size_t{0}, num_conns)
+            | std::views::transform([surface_z = 0.0, this, connections](const auto idx)
+            {
+                const auto& c = connections[idx];
+                const auto di = static_cast<std::int_least64_t>(c.getI() - this->headI_);
+                const auto dj = static_cast<std::int_least64_t>(c.getJ() - this->headJ_);
+
+                return CandidateStart {
+                    .ijdist2 = di * di + dj * dj,
+                    .zdiff   = std::abs(c.depth() - surface_z),
+                    .index   = idx
+                };
+            });
+
+        for (const auto& candidate : candidate_sequence) {
+            start_candidates.push_back(candidate);
+        }
+
+        // The path search start points are those 'numStartPoints_'
+        // connections that are closest to the well head.
+        const auto num_starts = std::min(num_conns, this->numStartPoints_);
+
+        if (auto mid = start_candidates.begin() + num_starts;
+            mid != start_candidates.end())
+        {
+            std::ranges::nth_element(start_candidates, mid);
+            start_candidates.erase(mid, start_candidates.end());
+        }
+
+        // Sort selected candidates deterministically (ijdist2, zdiff, index).
+        std::ranges::sort(start_candidates);
+
+        return start_candidates;
+    }
+
+} // namespace Opm

--- a/opm/input/eclipse/Schedule/Well/TrackOrderingTSP.hpp
+++ b/opm/input/eclipse/Schedule/Well/TrackOrderingTSP.hpp
@@ -1,0 +1,206 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_TRACK_ORDERING_TSP_HPP
+#define OPM_TRACK_ORDERING_TSP_HPP
+
+#include <algorithm>
+#include <compare>
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <span>
+#include <type_traits>
+#include <vector>
+
+namespace Opm {
+    class Connection;
+} // namespace Opm
+
+namespace Opm {
+
+/// Multi-start nearest-neighbour + 2-opt TSP heuristic for TRACK ordering
+/// of well connections.
+class TrackOrderingTSP
+{
+public:
+    /// Cost weights controlling the TRACK edge-cost function.
+    struct TrackCostWeights
+    {
+        /// Weight for horizontal logical-grid distance in the I/J plane.
+        double w_ij {1.0};
+
+        /// Weight for logical K-index step distance.
+        double w_k {0.5};
+
+        /// Weight for geometric depth difference.
+        double w_z {0.05};
+
+        /// Weight for direction-misalignment penalty between successive
+        /// connections and their step vector.
+        double w_dir {0.25};
+
+        /// Scale factor that maps depth differences into the I/J distance
+        /// metric used by the direction penalty term.
+        ///
+        /// Depth differences (dZ in meters) and horizontal grid distances
+        /// (hypot(dI, dJ) in grid cells) are measured in different units and
+        /// typically different magnitudes. When computing the direction penalty,
+        /// we need to determine which component (horizontal vs. vertical) is
+        /// dominant in the step vector to decide whether a connection follows
+        /// the well trajectory. This requires a dimensionless comparison.
+        ///
+        /// The z_to_ij_scale factor normalizes depth into equivalent I/J units:
+        /// equivalent_ij_distance = |dZ| * z_to_ij_scale. For example, with
+        /// z_to_ij_scale = 0.05, a depth increase of 20 meters becomes 1 unit
+        /// of equivalent horizontal distance. This ensures that the direction
+        /// penalty treats depth and horizontal components on equal footing,
+        /// allowing the heuristic to balance vertical and horizontal progression
+        /// appropriately.
+        double z_to_ij_scale {0.05};
+
+        /// Check if the weights are valid for use in the edge-cost function.
+        ///
+        /// All weights must be non-negative and at least one weight must be
+        /// positive to ensure that the edge-cost function is well-defined
+        /// and can effectively guide the TSP heuristic.
+        ///
+        /// \return Whether or not the weights are valid.
+        [[nodiscard]] constexpr bool isValid() const noexcept
+        {
+            auto&& [ij, k, z, dir, z_scale] = *this;
+
+            []<typename... Ts>(Ts&&...) {
+                static_assert((std::same_as<double, std::decay_t<Ts>> && ...),
+                              "TrackCostWeights must only contain double members.");
+            }(ij, k, z, dir, z_scale);
+
+            const auto all_nonneg = std::ranges::
+                all_of(std::initializer_list {ij, k, z, dir, z_scale},
+                       [](const auto w) { return w >= 0.0; });
+
+            // Note: z_scale (z_to_ij_scale) is intentionally omitted from
+            // the check that at least one weight is positive.  It is not a
+            // direct cost weight but rather a scale factor.  If only the
+            // z_scale is positive, the edge cost function would be
+            // identically zero and thus not well-defined.  The z_scale must
+            // still be non-negative, but that requirement is enforced by
+            // the all_nonneg check.
+            return all_nonneg
+                && std::ranges::any_of(std::initializer_list {ij, k, z, dir},
+                                       [](const auto w) { return w > 0.0; });
+        }
+    };
+
+    /// Construct with the well-head logical cartesian indices.
+    TrackOrderingTSP(int headI, int headJ);
+
+    /// Set number of start points from which to explore path creation.
+    ///
+    /// \param[in] numStarts Number of start points.  Note that regardless
+    /// of \p numStarts, the algorithm will always use at least one start
+    /// point--the connection that's closest to the well head defined in the
+    /// constructor.  Furthermore, for any particular ordering problem, the
+    /// algorithm will never use more start points than the number of
+    /// connections passed to order().
+    ///
+    /// \return \code *this. \endcode
+    TrackOrderingTSP& numberOfStartPoints(std::size_t numStarts);
+
+    /// Return the permutation that puts \p connections in TRACK order,
+    /// using default-constructed TrackCostWeights.
+    ///
+    /// \param[in] connections The connections to order.
+    ///
+    /// \return Index permutation \p p such that \c connections[p[0]] is
+    /// the heel and subsequent entries follow the optimised path.
+    std::vector<std::size_t>
+    order(std::span<const Connection> connections) const;
+
+    /// Return the permutation that puts \p connections in TRACK order,
+    /// using the supplied cost weights.
+    ///
+    /// \param[in] connections  The connections to order.
+    /// \param[in] weights Cost weights for the edge-cost function.
+    ///
+    /// \return Index permutation \p p such that \c connections[p[0]] is
+    /// the heel and subsequent entries follow the optimised path.
+    std::vector<std::size_t>
+    order(std::span<const Connection> connections,
+          const TrackCostWeights&     weights) const;
+
+private:
+    /// A start point candidate.
+    ///
+    /// Distilled distance measure relative to the well head for the current
+    /// sequence of Connection objects passed to member function order().
+    /// Actual start point identified by the sequence index which doubles as
+    /// a tie-breaker for sorting purposes.
+    struct CandidateStart
+    {
+        /// Squared Euclidean IJ distance.
+        ///
+        /// Primary sort key.
+        std::int_least64_t ijdist2 {};
+
+        /// Connection depth difference relative to reference depth.
+        ///
+        /// Satisfies std::isfinite().
+        ///
+        /// Secondary sort key.
+        double zdiff {};
+
+        /// Connection sequence index.
+        ///
+        /// Tie-break for sorting.
+        std::size_t index {};
+
+        /// Object ordering operator.
+        ///
+        /// Implies a lexicographical ordering (same as std::tuple<>'s
+        /// operator<()) over (ijdist2, zdiff, index).
+        auto operator<=>(const CandidateStart&) const = default;
+    };
+
+    /// I-axis location of well head.
+    int headI_{};
+
+    /// J-axis location of well head.
+    int headJ_{};
+
+    /// Number of path search start points.
+    ///
+    /// Always at least one since we always include the connection that's
+    /// closest to the well head as a start point.
+    std::size_t numStartPoints_{1};
+
+    /// Determine start point candidates closest to the well head.
+    ///
+    /// \param[in] connections The connections to search.
+    ///
+    /// \return Start point candidates.  At most \p numStartPoints_
+    /// candidates, ordered by increasing distance to the well head.
+    std::vector<CandidateStart>
+    determineStartPoints(std::span<const Connection> connections) const;
+};
+
+} // namespace Opm
+
+#endif // OPM_TRACK_ORDERING_TSP_HPP

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -33,6 +33,7 @@
 
 #include <opm/input/eclipse/Schedule/ScheduleGrid.hpp>
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+#include <opm/input/eclipse/Schedule/Well/TrackOrderingTSP.hpp>
 #include <opm/input/eclipse/Schedule/Well/WDFAC.hpp>
 
 #include <opm/input/eclipse/Units/Units.hpp>
@@ -56,10 +57,8 @@
 
 #include <algorithm>
 #include <array>
-#include <cassert>
 #include <cmath>
 #include <cstddef>
-#include <limits>
 #include <numbers>
 #include <optional>
 #include <span>
@@ -1099,56 +1098,20 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
 
     void WellConnections::orderTRACK()
     {
-        // Find the first connection and swap it into the 0-position.
-        const double surface_z = 0.0;
-        std::size_t first_index = findClosestConnection(this->headI, this->headJ, surface_z, 0);
-        std::swap(m_connections[first_index], m_connections[0]);
-
-        // Repeat for remaining connections.
-        //
-        // Note that since findClosestConnection() is O(n), this is an
-        // O(n^2) algorithm.  However, it should be acceptable since the
-        // expected number of connections is fairly low (< 100).
-
-        if (this->m_connections.empty()) {
+        if (this->m_connections.size() < 2) {
             return;
         }
 
-        for (std::size_t pos = 1; pos < m_connections.size() - 1; ++pos) {
-            const auto& prev = m_connections[pos - 1];
-            const double prevz = prev.depth();
-            std::size_t next_index = findClosestConnection(prev.getI(), prev.getJ(), prevz, pos);
-            std::swap(m_connections[next_index], m_connections[pos]);
-        }
-    }
+        const auto tsp = TrackOrderingTSP { this->headI, this->headJ };
+        const auto indices = tsp.order(this->m_connections);
 
-    std::size_t WellConnections::findClosestConnection(int oi, int oj, double oz, std::size_t start_pos)
-    {
-        std::size_t closest = std::numeric_limits<std::size_t>::max();
-        int min_ijdist2 = std::numeric_limits<int>::max();
-        double min_zdiff = std::numeric_limits<double>::max();
-        for (std::size_t pos = start_pos; pos < m_connections.size(); ++pos) {
-            const auto& connection = m_connections[ pos ];
-
-            const double depth = connection.depth();
-            const int ci = connection.getI();
-            const int cj = connection.getJ();
-            // Using square of distance to avoid non-integer arithmetics.
-            const int ijdist2 = (ci - oi) * (ci - oi) + (cj - oj) * (cj - oj);
-            if (ijdist2 < min_ijdist2) {
-                min_ijdist2 = ijdist2;
-                min_zdiff = std::abs(depth - oz);
-                closest = pos;
-            } else if (ijdist2 == min_ijdist2) {
-                const double zdiff = std::abs(depth - oz);
-                if (zdiff < min_zdiff) {
-                    min_zdiff = zdiff;
-                    closest = pos;
-                }
-            }
+        auto reordered = std::vector<Connection>{};
+        reordered.reserve(this->m_connections.size());
+        for (const auto idx : indices) {
+            reordered.push_back(std::move(this->m_connections[idx]));
         }
-        assert(closest != std::numeric_limits<std::size_t>::max());
-        return closest;
+
+        this->m_connections.swap(reordered);
     }
 
     void WellConnections::orderDEPTH()

--- a/opm/input/eclipse/Schedule/Well/WellConnections.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.hpp
@@ -147,18 +147,23 @@ namespace Opm {
         auto begin() { return this->m_connections.begin(); }
         auto end() { return this->m_connections.end(); }
         bool allConnectionsShut() const;
-        /// Order connections irrespective of input order.
-        /// The algorithm used is the following:
-        ///     1. The connection nearest to the given (well_i, well_j)
-        ///        coordinates in terms of the connection's (i, j) is chosen
-        ///        to be the first connection. If non-unique, choose one with
-        ///        lowest z-depth (shallowest).
-        ///     2. Choose next connection to be nearest to current in (i, j) sense.
-        ///        If non-unique choose closest in z-depth (not logical cartesian k).
+
+        /// Order connections along well bore.
         ///
-        /// \param[in] well_i  logical cartesian i-coordinate of well head
-        /// \param[in] well_j  logical cartesian j-coordinate of well head
-        /// \param[in] grid    EclipseGrid object, used for cell depths
+        /// There are three distinct cases.
+        ///
+        ///  -# Multi-segmented wells order connections according to branch
+        ///     ID and measured depths along the branch.
+        ///
+        ///  -# TRACK ordering (COMPORD keyword, default) orders connections
+        ///     starting from the well heel using a path travelling salesman
+        ///     algorithm with 2-opt ordering and directional penalties.
+        ///
+        ///  -# DEPTH ordering (COMPORD keyword) orders the connections
+        ///     according to the block centre point depths.
+        ///
+        /// This is a somewhat expensive operation that should typically be
+        /// invoked only at the end of applying all pertinent connection updates.
         void order();
 
         bool operator==( const WellConnections& ) const;
@@ -220,7 +225,6 @@ namespace Opm {
                            int lgr_grid_number,
                            const bool defaultSatTabId);
 
-        std::size_t findClosestConnection(int oi, int oj, double oz, std::size_t start_pos);
         void orderTRACK();
         void orderMSW();
         void orderDEPTH();

--- a/tests/parser/TestTrackOrderingTSP.cpp
+++ b/tests/parser/TestTrackOrderingTSP.cpp
@@ -1,0 +1,596 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE TrackOrderingTSPTests
+#include <boost/test/unit_test.hpp>
+
+#include <opm/input/eclipse/Schedule/Well/TrackOrderingTSP.hpp>
+
+#include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <numeric>
+#include <ranges>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+    /// Helper: build a Connection with the minimal fields required for
+    /// TrackOrderingTSP (I, J, K, depth, direction).
+    Opm::Connection makeConn(const int i, const int j, const int k,
+                             const double depth,
+                             const Opm::Connection::Direction dir
+                                 = Opm::Connection::Direction::Z)
+    {
+        return Opm::Connection {
+            i, j, k,
+            /*global_index=*/static_cast<std::size_t>(i * 1000 + j * 100 + k),
+            /*complnum=*/1,
+            Opm::Connection::State::OPEN,
+            dir,
+            Opm::Connection::CTFKind::DeckValue,
+            /*satTableId=*/0,
+            depth,
+            Opm::Connection::CTFProperties{},
+            /*sort_value=*/0,
+            /*defaultSatTabId=*/true
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // Proxy path cost for an ordered sequence of connections.  Used only
+    // for relative comparisons in tests.
+    // -----------------------------------------------------------------------
+    double pathCostFromOrder(std::span<const Opm::Connection> conns,
+                             const std::vector<std::size_t>&  perm)
+    {
+        if (perm.size() < 2) {
+            return 0.0;
+        }
+
+        // Replicate enough of the cost function for validation purposes.
+        //
+        // Using Euclidean XY distance avoids introducing a proxy metric
+        // that can reorder paths relative to TrackOrderingTSP's objective.
+        auto cost = 0.0;
+
+        for (const std::size_t i : std::views::iota(std::size_t{0}, perm.size() - 1)) {
+            const auto& conn_left  = conns[perm[i + 0]];
+            const auto& conn_right = conns[perm[i + 1]];
+
+            const auto dx = static_cast<double>(conn_right.getI() - conn_left.getI());
+            const auto dy = static_cast<double>(conn_right.getJ() - conn_left.getJ());
+            const auto dz = std::abs(conn_right.depth() - conn_left.depth());
+
+            cost += std::hypot(dx, dy) + 0.05 * dz;
+        }
+
+        return cost;
+    }
+
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// Test 1: Empty connection list – no crash; returns empty permutation.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(empty_connections)
+{
+    const auto tsp = Opm::TrackOrderingTSP { 5, 5 };
+
+    const auto connections = std::vector<Opm::Connection>{};
+    const auto perm = tsp.order(connections);
+
+    BOOST_CHECK(perm.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Single connection – returns {0}.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(single_connection)
+{
+    const auto tsp = Opm::TrackOrderingTSP { 5, 5 };
+
+    const auto connections = std::vector { makeConn(5, 5, 1, 100.0) };
+    const auto perm = tsp.order(connections);
+
+    BOOST_REQUIRE_EQUAL(perm.size(), 1u);
+    BOOST_CHECK_EQUAL(perm[0], 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Two connections – heel (closest to head) comes first.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(two_connections_heel_first)
+{
+    // Head at (5,5); connection 0 is far, connection 1 is at the head.
+    const auto tsp = Opm::TrackOrderingTSP { 5, 5 };
+
+    const auto connections = std::vector {
+        makeConn(10, 10, 1, 200.0),  // index 0, far from head
+        makeConn( 5,  5, 1, 100.0),  // index 1, at head
+    };
+    const auto perm = tsp.order(connections);
+
+    BOOST_REQUIRE_EQUAL(perm.size(), 2u);
+
+    // index 1 (the heel) must come first
+    BOOST_CHECK_EQUAL(perm[0], 1u);
+    BOOST_CHECK_EQUAL(perm[1], 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Vertical well (same I,J; varying K/depth).
+// Expected: output proceeds monotonically from shallowest to deepest.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(vertical_well_top_to_bottom)
+{
+    // Head at (5,5); connections stored in reversed depth order.
+    const auto tsp = Opm::TrackOrderingTSP { 5, 5 };
+
+    const auto connections = std::vector {
+        makeConn(5, 5, 4, 400.0),   // index 0, deepest
+        makeConn(5, 5, 2, 200.0),   // index 1
+        makeConn(5, 5, 1, 100.0),   // index 2, shallowest / heel
+        makeConn(5, 5, 3, 300.0),   // index 3
+    };
+    const auto perm = tsp.order(connections);
+
+    BOOST_REQUIRE_EQUAL(perm.size(), 4u);
+
+    // Verify that depths appear in non-decreasing order in the output.
+    for (auto i = std::size_t{1}; i < perm.size(); ++i) {
+        BOOST_CHECK_GE(connections[perm[i]].depth(), connections[perm[i-1]].depth());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Horizontal well (same J, K; increasing I).
+// Expected: heel-end (closest I to head) is first in the result.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(horizontal_well_heel_first)
+{
+    // Head at (2,5); connections along I at J=5.
+    const auto tsp = Opm::TrackOrderingTSP { 2, 5 };
+
+    const auto connections = std::vector {
+        makeConn(6, 5, 1, 150.0, Opm::Connection::Direction::X),   // index 0, far
+        makeConn(4, 5, 1, 150.0, Opm::Connection::Direction::X),   // index 1
+        makeConn(3, 5, 1, 150.0, Opm::Connection::Direction::X),   // index 2, closest
+        makeConn(5, 5, 1, 150.0, Opm::Connection::Direction::X),   // index 3
+    };
+    const auto perm = tsp.order(connections);
+
+    BOOST_REQUIRE_EQUAL(perm.size(), 4u);
+
+    // First element must be the one with I=3 (closest to head I=2).
+    BOOST_CHECK_EQUAL(connections[perm[0]].getI(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: L-shaped path – nearest-neighbour picks a sensible route without
+// returning to the start of each arm.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(l_shaped_path_no_backtrack)
+{
+    // Head at (0,0); arm1 goes along I, arm2 turns along J.
+    //   (0,0) -> (1,0) -> (2,0) -> (2,1) -> (2,2)
+    const auto tsp = Opm::TrackOrderingTSP { 0, 0 };
+
+    const auto connections = std::vector {
+        makeConn(2, 2, 1, 100.0),   // index 0, far end of arm 2
+        makeConn(1, 0, 1, 100.0),   // index 1
+        makeConn(0, 0, 1, 100.0),   // index 2, heel
+        makeConn(2, 0, 1, 100.0),   // index 3, corner
+        makeConn(2, 1, 1, 100.0),   // index 4
+    };
+    const auto perm = tsp.order(connections);
+
+    BOOST_REQUIRE_EQUAL(perm.size(), 5u);
+
+    // Heel must be first.
+    BOOST_CHECK_EQUAL(connections[perm[0]].getI(), 0);
+    BOOST_CHECK_EQUAL(connections[perm[0]].getJ(), 0);
+
+    // The identity permutation {2,1,3,4,0} follows the natural L path; verify
+    // that the cost of the returned permutation is no worse than that.
+    const auto natural_perm = std::vector<std::size_t>{ 2, 1, 3, 4, 0 };
+    BOOST_CHECK_LE(pathCostFromOrder(connections, perm),
+                   pathCostFromOrder(connections, natural_perm) + 1.0e-9);
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: Direction penalty – with w_dir > 0, an X-directed connection
+// incurs a higher cost on a step in the Y direction than on a step in X.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(direction_penalty_favours_aligned_step)
+{
+    using Dir = Opm::Connection::Direction;
+    using W   = Opm::TrackOrderingTSP::TrackCostWeights;
+
+    // Two candidate successors for an X-directed connection at (0,0):
+    //   option A: step in X direction (aligned)
+    //   option B: step in Y direction (misaligned)
+    // Both have equal I/J distance = 1.
+    const auto tsp = Opm::TrackOrderingTSP { 0, 0 };
+
+    const auto connections = std::vector {
+        makeConn(0, 0, 1, 100.0, Dir::X),  // index 0, heel / start
+        makeConn(1, 0, 1, 100.0, Dir::X),  // index 1, aligned step (delta I = 1)
+        makeConn(0, 1, 1, 100.0, Dir::X),  // index 2, misaligned step (delta J = 1)
+    };
+
+    // Use high w_dir to amplify the direction penalty.
+    W weights{};
+    weights.w_dir = 10.0;
+
+    const auto perm = tsp.order(connections, weights);
+
+    BOOST_REQUIRE_EQUAL(perm.size(), 3u);
+
+    // Heel first.
+    BOOST_CHECK_EQUAL(perm[0], 0u);
+
+    // Aligned step (index 1) must precede misaligned step (index 2).
+    BOOST_CHECK_EQUAL(perm[1], 1u);
+    BOOST_CHECK_EQUAL(perm[2], 2u);
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: 2-opt improvement – a deliberately crossed path must be uncrossed.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(two_opt_decrosses_path)
+{
+    // Non-collinear layout with deterministic single-start NN path
+    //   0 -> 1 -> 2 -> 5 -> 4 -> 3
+    // where edge (2,5) crosses edge (4,3).  Open-path 2-opt should
+    // remove the crossing and yield a strictly lower path cost.
+    //
+    // Coordinates:
+    //   0: (0,0)  heel (closest to head)
+    //   1: (0,1)
+    //   2: (0,2)
+    //   3: (0,4)
+    //   4: (1,0)
+    //   5: (1,1)
+    const auto tsp = Opm::TrackOrderingTSP { 0, 0 };
+
+    const auto connections = std::array {
+        makeConn(0, 0, 1, 100.0),   // index 0, heel
+        makeConn(0, 1, 1, 100.0),   // index 1
+        makeConn(0, 2, 1, 100.0),   // index 2
+        makeConn(0, 4, 1, 100.0),   // index 3
+        makeConn(1, 0, 1, 100.0),   // index 4
+        makeConn(1, 1, 1, 100.0),   // index 5
+    };
+
+    const auto perm = tsp.order(connections);
+    BOOST_REQUIRE_EQUAL(perm.size(), connections.size());
+
+    // Crossed NN order for this point set.
+    const auto crossed_perm = std::vector<std::size_t>{ 0, 1, 2, 5, 4, 3 };
+
+    // 2-opt should strictly improve over the crossed path.
+    BOOST_CHECK_LT(pathCostFromOrder(connections, perm),
+                   pathCostFromOrder(connections, crossed_perm));
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: Reproducibility – same input yields same output across two calls.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(reproducibility)
+{
+    const auto tsp = Opm::TrackOrderingTSP { 3, 3 };
+
+    const auto connections = std::vector {
+        makeConn(5, 7, 2, 300.0),
+        makeConn(3, 3, 1, 100.0),
+        makeConn(6, 4, 3, 400.0),
+        makeConn(4, 5, 2, 200.0),
+        makeConn(3, 4, 1, 150.0),
+    };
+
+    const auto perm1 = tsp.order(connections);
+    const auto perm2 = tsp.order(connections);
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(perm1.begin(), perm1.end(),
+                                  perm2.begin(), perm2.end());
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: Custom weights (w_dir=0) – direction no longer influences ordering.
+// Use a setup where w_dir > 0 changes the first choice relative to pure
+// geometry, then verify that w_dir=0 follows the direction-agnostic path.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(custom_weights_zero_dir)
+{
+    using Dir = Opm::Connection::Direction;
+
+    const auto tsp = Opm::TrackOrderingTSP { 0, 0 };
+
+    // Candidate 1: farther but aligned with X-direction stepping.
+    // Candidate 2: nearer but misaligned with X-direction stepping.
+    //
+    // With w_dir=0 the nearer point should be selected first.
+    // With sufficiently large w_dir the aligned point should be selected first.
+    const auto connections = std::vector {
+        makeConn(0, 0, 1, 100.0, Dir::X),  // index 0, heel
+        makeConn(2, 0, 1, 100.0, Dir::X),  // index 1, aligned but farther
+        makeConn(0, 1, 1, 100.0, Dir::X),  // index 2, misaligned but nearer
+    };
+
+    // Same geometry as above, but different per-connection directions.
+    // If w_dir=0, this must produce the same ordering as 'connections'.
+    const auto connections_flipped_dirs = std::vector {
+        makeConn(0, 0, 1, 100.0, Dir::Z),
+        makeConn(2, 0, 1, 100.0, Dir::Y),
+        makeConn(0, 1, 1, 100.0, Dir::Z),
+    };
+
+    Opm::TrackOrderingTSP::TrackCostWeights w_with_dir{};
+    w_with_dir.w_dir = 2.0;
+
+    Opm::TrackOrderingTSP::TrackCostWeights w_no_dir{};
+    w_no_dir.w_dir = 0.0;
+
+    const auto perm_with = tsp.order(connections, w_with_dir);
+    const auto perm_no = tsp.order(connections, w_no_dir);
+    const auto perm_no_flipped = tsp.order(connections_flipped_dirs, w_no_dir);
+
+    const auto expected_no_dir = std::vector<std::size_t>{ 0, 2, 1 };
+
+    // Direction-agnostic ordering: choose the nearer candidate first.
+    BOOST_REQUIRE_EQUAL(perm_no.size(), 3u);
+    BOOST_CHECK_EQUAL_COLLECTIONS(perm_no.begin(), perm_no.end(),
+                                  expected_no_dir.begin(), expected_no_dir.end());
+
+    // With w_dir=0, changing per-connection directions must not matter.
+    BOOST_CHECK_EQUAL_COLLECTIONS(perm_no.begin(), perm_no.end(),
+                                  perm_no_flipped.begin(), perm_no_flipped.end());
+
+    // With w_dir>0, ordering should change for this setup.
+    BOOST_CHECK(! std::ranges::equal(perm_with, perm_no));
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: Custom weights invalid (negative w_dir) – must throw std::invalid_argument.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(custom_weights_invalid_negative_dir)
+{
+    const auto tsp = Opm::TrackOrderingTSP { 0, 0 };
+
+    const auto connections = std::vector {
+        makeConn(0, 0, 1, 100.0),
+        makeConn(1, 0, 1, 100.0),
+    };
+
+    Opm::TrackOrderingTSP::TrackCostWeights invalid_weights{};
+    invalid_weights.w_dir = -1.0; // Negative weight is invalid.
+
+    BOOST_CHECK_THROW(tsp.order(connections, invalid_weights), std::invalid_argument);
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: Custom weights invalid (all zero) – must throw std::invalid_argument.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(custom_weights_invalid_all_zero)
+{
+    const auto tsp = Opm::TrackOrderingTSP { 0, 0 };
+
+    const auto connections = std::vector {
+        makeConn(0, 0, 1, 100.0),
+        makeConn(1, 0, 1, 100.0),
+    };
+
+    Opm::TrackOrderingTSP::TrackCostWeights invalid_weights{};
+    invalid_weights.w_ij = 0.0;
+    invalid_weights.w_k = 0.0;
+    invalid_weights.w_z = 0.0;
+    invalid_weights.w_dir = 0.0;
+    invalid_weights.z_to_ij_scale = 0.0; // All weights zero is invalid.
+
+    BOOST_CHECK_THROW(tsp.order(connections, invalid_weights), std::invalid_argument);
+}
+
+// ---------------------------------------------------------------------------
+// Test 13: numberOfStartPoints(0) is silently clamped to 1.
+// Setting zero start points must produce the same result as the default
+// (one start point).
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(num_starts_zero_clamped_to_one)
+{
+    const auto connections = std::vector {
+        makeConn(0, 0, 1, 100.0),   // heel
+        makeConn(6, 0, 1, 100.0),
+        makeConn(2, 0, 1, 100.0),
+        makeConn(9, 0, 1, 100.0),
+        makeConn(4, 0, 1, 100.0),
+    };
+
+    const auto perm_default = Opm::TrackOrderingTSP { 0, 0 }
+        .order(connections);
+
+    const auto perm_zero = Opm::TrackOrderingTSP { 0, 0 }
+        .numberOfStartPoints(0)
+        .order(connections);
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(perm_default.begin(), perm_default.end(),
+                                  perm_zero.begin(),    perm_zero.end());
+}
+
+// ---------------------------------------------------------------------------
+// Test 14: numberOfStartPoints(1) is identical to the default.
+// An explicit setting of one start point must reproduce the default output
+// exactly.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(num_starts_one_same_as_default)
+{
+    const auto connections = std::vector {
+        makeConn(0, 0, 1, 100.0),   // heel
+        makeConn(6, 0, 1, 100.0),
+        makeConn(2, 0, 1, 100.0),
+        makeConn(9, 0, 1, 100.0),
+        makeConn(4, 0, 1, 100.0),
+    };
+
+    const auto perm_default = Opm::TrackOrderingTSP { 0, 0 }
+        .order(connections);
+
+    const auto perm_one = Opm::TrackOrderingTSP { 0, 0 }
+        .numberOfStartPoints(1)
+        .order(connections);
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(perm_default.begin(), perm_default.end(),
+                                  perm_one.begin(),     perm_one.end());
+}
+
+// ---------------------------------------------------------------------------
+// Test 15: numberOfStartPoints larger than the connection count.
+// The algorithm must not crash and must return a valid permutation even
+// when the requested number of start points exceeds the number of
+// connections.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(num_starts_exceeds_connection_count)
+{
+    const auto connections = std::vector {
+        makeConn(0, 0, 1, 100.0),
+        makeConn(3, 0, 1, 100.0),
+        makeConn(1, 0, 1, 100.0),
+        makeConn(2, 0, 1, 100.0),
+    };
+
+    const auto perm = Opm::TrackOrderingTSP { 0, 0 }
+        .numberOfStartPoints(1'000)
+        .order(connections);
+
+    // Result must be a valid permutation of {0, 1, 2, 3}.
+    BOOST_REQUIRE_EQUAL(perm.size(), connections.size());
+
+    auto sorted_perm = perm;
+    std::ranges::sort(sorted_perm);
+    for (auto i = std::size_t{0}; i < sorted_perm.size(); ++i) {
+        BOOST_CHECK_EQUAL(sorted_perm[i], i);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 16: More start points never worsen the result.
+// The minimum path cost over N start points is always ≤ the cost from a
+// single start point, since the single-start result is a candidate in the
+// multi-start search.
+//
+// Connection layout: collinear along I with J = K = depth constant, so
+// the proxy cost (Manhattan I distance) and the actual edge cost are
+// proportional and rank paths identically.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(more_starts_never_worsens_result)
+{
+    // All connections share J=0, K=1, depth=100 so the only cost
+    // contributor between pairs is the I-axis distance.
+    const auto connections = std::vector {
+        makeConn(0, 0, 1, 100.0),   // heel (closest to head at I=0)
+        makeConn(7, 0, 1, 100.0),
+        makeConn(2, 0, 1, 100.0),
+        makeConn(9, 0, 1, 100.0),
+        makeConn(4, 0, 1, 100.0),
+        makeConn(6, 0, 1, 100.0),
+    };
+
+    const auto perm_one = Opm::TrackOrderingTSP { 0, 0 }
+        .numberOfStartPoints(1)
+        .order(connections);
+
+    const auto perm_all = Opm::TrackOrderingTSP { 0, 0 }
+        .numberOfStartPoints(connections.size())
+        .order(connections);
+
+    // More starts search a strictly larger space, so cost can only stay
+    // equal or improve.
+    BOOST_CHECK_LE(pathCostFromOrder(connections, perm_all),
+                   pathCostFromOrder(connections, perm_one) + 1.0e-9);
+}
+
+// ---------------------------------------------------------------------------
+// Test 17: Fluent interface – numberOfStartPoints() returns *this.
+// The setter must be usable in a call chain with the constructor and
+// order().
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(fluent_api_chaining)
+{
+    const auto connections = std::vector {
+        makeConn(0, 0, 1, 100.0),   // heel
+        makeConn(2, 0, 1, 100.0),
+        makeConn(1, 0, 1, 100.0),
+    };
+
+    // Construct, configure, and order in a single expression.
+    const auto perm = Opm::TrackOrderingTSP { 0, 0 }
+        .numberOfStartPoints(2)
+        .order(connections);
+
+    BOOST_REQUIRE_EQUAL(perm.size(), 3u);
+
+    // Verify it produces a valid permutation.
+    auto sorted_perm = perm;
+    std::ranges::sort(sorted_perm);
+    for (auto i = std::size_t{0}; i < sorted_perm.size(); ++i) {
+        BOOST_CHECK_EQUAL(sorted_perm[i], i);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 18: Open 2-opt must allow suffix-to-end reversal (k = n - 1).
+//
+// This is a regression test for a case where interior-only 2-opt gets stuck
+// in a worse local minimum and requires reversing [i, n-1] to improve.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(two_opt_suffix_reversal_regression)
+{
+    const auto tsp = Opm::TrackOrderingTSP { 0, 0 };
+
+    // Reproducer from review discussion:
+    //   idx:  0      1      2(heel) 3      4      5
+    //   IJ : (5,1), (3,4), (2,1),  (0,4), (6,0), (4,6)
+    const auto connections = std::array {
+        makeConn(5, 1, 1, 100.0),   // index 0
+        makeConn(3, 4, 1, 100.0),   // index 1
+        makeConn(2, 1, 1, 100.0),   // index 2, heel
+        makeConn(0, 4, 1, 100.0),   // index 3
+        makeConn(6, 0, 1, 100.0),   // index 4
+        makeConn(4, 6, 1, 100.0),   // index 5
+    };
+
+    const auto perm = tsp.order(connections);
+    BOOST_REQUIRE_EQUAL(perm.size(), connections.size());
+
+    // Expected best ordering for this geometry under default weights.
+    const auto expected_perm = std::vector<std::size_t>{ 2, 3, 5, 1, 0, 4 };
+    BOOST_CHECK_EQUAL_COLLECTIONS(perm.begin(), perm.end(),
+                                  expected_perm.begin(), expected_perm.end());
+
+    // Confirm strict improvement over the interior-only local minimum seen
+    // before enabling suffix-to-end reversals.
+    const auto interior_only_perm = std::vector<std::size_t>{ 2, 4, 0, 1, 5, 3 };
+    BOOST_CHECK_LT(pathCostFromOrder(connections, perm),
+                   pathCostFromOrder(connections, interior_only_perm));
+}


### PR DESCRIPTION
Move TRACK completion ordering out of `WellConnections` and into a new `TrackOrderingTSP` class.

The key change is to treat TRACK ordering as an open (path) travelling salesman problem over connections, rather than as a pure nearest-neighbour search inside `WellConnections`.  The solver returns a permutation of input indices, and `WellConnections::orderTRACK()` is now only a thin adapter that applies that permutation.

Heuristic choices and optimisation strategy:

  * Define a weighted edge cost over (I, J, K, depth, direction):
       w_xy  * hypot(dI, dJ) +
       w_k   * |dK| +
       w_z   * |dZ| +
       w_dir * direction_penalty.

  * Keep existing heel semantics by picking the heel as the completion closest to (headI, headJ), tie-broken by shallowest depth.

  * Use multi-start nearest-neighbour construction: user configurable number of starting point candidates, though always at least one--the well heel--sorted by IJ distance, then depth.

  * Improve each candidate path with open-path 2-opt; reverse only suffix segments when a strict cost reduction is found.

  * Select the minimum-cost path over all starts to get deterministic, reproducible ordering.

Also add focused unit coverage in TestTrackOrderingTSP for empty/single inputs, heel selection, vertical/horizontal/L-shaped paths, direction penalty behavior, 2-opt de-crossing, reproducibility, and custom weights.