### PR TITLE
<fmt/format.h> instead of <fmt/core.h>

### DIFF
--- a/opm/input/eclipse/EclipseState/InitConfig/Equil.cpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/Equil.cpp
@@ -14,7 +14,7 @@
 
 #include <stddef.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace {
 

--- a/opm/input/eclipse/EclipseState/InitConfig/FieldSep.cpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/FieldSep.cpp
@@ -33,7 +33,7 @@
 #include <optional>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace {
 

--- a/opm/input/eclipse/Schedule/Group/GuideRate.cpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.cpp
@@ -33,7 +33,7 @@
 #include <type_traits>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 double Opm::GuideRate::RateVector::eval(const Well::GuideRateTarget target) const
 {


### PR DESCRIPTION
This solves a compilation issue in clang:
```bash
error: no member named 'format' in namespace 'fmt'; did you mean 'std::format'
```