### PR TITLE
Replace strings with templates when using getItem()

### DIFF
--- a/opm/input/eclipse/EclipseState/Aquifer/Aquancon.cpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/Aquancon.cpp
@@ -142,6 +142,7 @@ namespace Opm {
 
     Aquancon::Aquancon(const EclipseGrid& grid, const Deck& deck)
     {
+        using Kw = ParserKeywords::AQUANCON;
         std::map<std::size_t, Aquancon::AquancCell> work;
         const std::vector<int>& actnum = grid.getACTNUM();
         for (std::size_t iaq = 0; iaq < deck.count("AQUANCON"); iaq++) {
@@ -149,19 +150,19 @@ namespace Opm {
             OpmLog::info(OpmInputError::format("Initializing aquifer connections from {keyword} in {file} line {line}", aquanconKeyword.location()));
             int num_connections_to_inactive_cells = 0;
             for (const auto& aquanconRecord : aquanconKeyword) {
-                const int aquiferID = aquanconRecord.getItem("AQUIFER_ID").get<int>(0);
-                const int i1 = aquanconRecord.getItem("I1").get<int>(0) - 1;
-                const int i2 = aquanconRecord.getItem("I2").get<int>(0) - 1;
-                const int j1 = aquanconRecord.getItem("J1").get<int>(0) - 1;
-                const int j2 = aquanconRecord.getItem("J2").get<int>(0) - 1;
-                const int k1 = aquanconRecord.getItem("K1").get<int>(0) - 1;
-                const int k2 = aquanconRecord.getItem("K2").get<int>(0) - 1;
-                const double influx_mult = aquanconRecord.getItem("INFLUX_MULT").getSIDouble(0);
+                const int aquiferID = aquanconRecord.getItem<Kw::AQUIFER_ID>().get<int>(0);
+                const int i1 = aquanconRecord.getItem<Kw::I1>().get<int>(0) - 1;
+                const int i2 = aquanconRecord.getItem<Kw::I2>().get<int>(0) - 1;
+                const int j1 = aquanconRecord.getItem<Kw::J1>().get<int>(0) - 1;
+                const int j2 = aquanconRecord.getItem<Kw::J2>().get<int>(0) - 1;
+                const int k1 = aquanconRecord.getItem<Kw::K1>().get<int>(0) - 1;
+                const int k2 = aquanconRecord.getItem<Kw::K2>().get<int>(0) - 1;
+                const double influx_mult = aquanconRecord.getItem<Kw::INFLUX_MULT>().getSIDouble(0);
                 const FaceDir::DirEnum faceDir
-                    = FaceDir::FromString(aquanconRecord.getItem("FACE").getTrimmedString(0));
+                    = FaceDir::FromString(aquanconRecord.getItem<Kw::FACE>().getTrimmedString(0));
 
                 const std::string& str_inside_reservoir
-                    = aquanconRecord.getItem("CONNECT_ADJOINING_ACTIVE_CELL").getTrimmedString(0);
+                    = aquanconRecord.getItem<Kw::CONNECT_ADJOINING_ACTIVE_CELL>().getTrimmedString(0);
                 const bool allow_aquifer_inside_reservoir = DeckItem::to_bool(str_inside_reservoir);
 
                 // Loop over the cartesian indices to convert to the global grid index
@@ -172,8 +173,8 @@ namespace Opm {
                                 if (allow_aquifer_inside_reservoir
                                     || !AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, faceDir, actnum)) {
                                     std::optional<double> influx_coeff;
-                                    if (aquanconRecord.getItem("INFLUX_COEFF").hasValue(0))
-                                        influx_coeff = aquanconRecord.getItem("INFLUX_COEFF").getSIDouble(0);
+                                    if (aquanconRecord.getItem<Kw::INFLUX_COEFF>().hasValue(0))
+                                        influx_coeff = aquanconRecord.getItem<Kw::INFLUX_COEFF>().getSIDouble(0);
 
                                     auto global_index = grid.getGlobalIndex(i,j,k);
                                     add_cell(aquanconKeyword.location(), work, grid, aquiferID, global_index, influx_coeff, influx_mult, faceDir);

--- a/opm/input/eclipse/EclipseState/Co2StoreConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Co2StoreConfig.cpp
@@ -63,7 +63,8 @@ namespace {
                     throw Opm::OpmInputError(msg, keyword.location());
                 }
                 // Check if table has entries for queried cname
-                if (3 * static_cast<std::size_t>(index) + 3 > record.getItem("DATA").data_size()) {
+                // Shared backend for DENAQA and VISCAQA; both define DATA identically.
+                if (3 * static_cast<std::size_t>(index) + 3 > record.getItem<Opm::ParserKeywords::DENAQA::DATA>().data_size()) {
                     auto msg = keyword_name + " does not have C0, C1 and C2 entries for CNAMES = " + cname;
                     throw Opm::OpmInputError(msg, keyword.location());
                 }
@@ -134,17 +135,17 @@ namespace Opm {
 
         // SALINITY or SALTMF convert to mass fraction.
         if (props_section.hasKeyword<ParserKeywords::SALINITY>()) {
-            const auto& molality = deck["SALINITY"].back().getRecord(0).getItem("MOLALITY").get<double>(0);
+            const auto& molality = deck["SALINITY"].back().getRecord(0).getItem<ParserKeywords::SALINITY::MOLALITY>().get<double>(0);
             salt = 1.0 / (1.0 + 1.0 / (molality * MmNaCl));
         }
         else if (props_section.hasKeyword<ParserKeywords::SALTMF>()) {
-            const auto& mole_frac = deck["SALTMF"].back().getRecord(0).getItem("MOLE_FRACTION").get<double>(0);
+            const auto& mole_frac = deck["SALTMF"].back().getRecord(0).getItem<ParserKeywords::SALTMF::MOLE_FRACTION>().get<double>(0);
             salt = mole_frac * MmNaCl / (mole_frac * (MmNaCl - MmH2O) + MmH2O);
         }
 
         // ACTCO2S
         if (props_section.hasKeyword<ParserKeywords::ACTCO2S>()) {
-            activityModel = deck["ACTCO2S"].back().getRecord(0).getItem("ACTIVITY_MODEL").get<int>(0);
+            activityModel = deck["ACTCO2S"].back().getRecord(0).getItem<ParserKeywords::ACTCO2S::ACTIVITY_MODEL>().get<int>(0);
         }
         else {
             activityModel = ParserKeywords::ACTCO2S::ACTIVITY_MODEL::defaultValue;

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -627,14 +627,15 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
 
     void EclipseGrid::initBinaryGrid(const Deck& deck)
     {
+        using Kw = ParserKeywords::GDFILE;
         const auto& gdfile = deck["GDFILE"].back().getRecord(0);
 
         const auto formatted = EclIO::EclFile::Formatted {
-            gdfile.getItem("formatted").getTrimmedString(0).front() == 'F'
+            gdfile.getItem<Kw::formatted>().getTrimmedString(0).front() == 'F'
         };
 
         auto filename = deck
-            .makeDeckPath(gdfile.getItem("filename").getTrimmedString(0));
+            .makeDeckPath(gdfile.getItem<Kw::filename>().getTrimmedString(0));
 
         std::unique_ptr<EclIO::EclFile> egridfile{};
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -42,6 +42,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/B.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/M.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/O.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/P.hpp>
@@ -272,7 +273,7 @@ std::string default_region_keyword(const Deck& deck)
     if (deck.hasKeyword("GRIDOPTS")) {
         const auto& gridOpts = deck["GRIDOPTS"].back();
         const auto& record = gridOpts.getRecord(0);
-        const auto& nrmult_item = record.getItem("NRMULT");
+        const auto& nrmult_item = record.getItem<ParserKeywords::GRIDOPTS::NRMULT>();
 
         if (nrmult_item.get<int>(0) > 0) {
             return "MULTNUM"; // GRIDOPTS and positive NRMULT
@@ -1397,7 +1398,10 @@ void FieldProps::operate(const DeckRecord&                   record,
                          const std::vector<Box::cell_index>& index_list,
                          const bool                          global)
 {
-    const auto target_array = record.getItem("TARGET_ARRAY").getTrimmedString(0);
+    // Shared backend for OPERATE and OPERATER; both define
+    // TARGET_ARRAY/OPERATION/PARAM1/PARAM2 identically.
+    using Kw = ParserKeywords::OPERATE;
+    const auto target_array = record.getItem<Kw::TARGET_ARRAY>().getTrimmedString(0);
     if (this->tran.find(target_array) != this->tran.end()) {
         throw std::logic_error {
             "The OPERATE keyword cannot be used for "
@@ -1415,11 +1419,11 @@ void FieldProps::operate(const DeckRecord&                   record,
     const auto srcDim = parseDim(src_data);
     const auto dstDim = parseDim(target_data);
 
-    const auto func_name    = record.getItem("OPERATION").getTrimmedString(0);
+    const auto func_name    = record.getItem<Kw::OPERATION>().getTrimmedString(0);
     const auto check_target = (func_name == "MULTIPLY") || (func_name == "POLY");
 
-    const auto alpha = record.getItem("PARAM1").get<double>(0);
-    const auto beta  = record.getItem("PARAM2").get<double>(0);
+    const auto alpha = record.getItem<Kw::PARAM1>().get<double>(0);
+    const auto beta  = record.getItem<Kw::PARAM2>().get<double>(0);
     const auto func  = Operate::get(func_name, alpha, beta);
 
     auto& to_data = global? *target_data.global_data : target_data.data;
@@ -1462,10 +1466,13 @@ void FieldProps::operate_int_target(const DeckRecord&                   record,
                                     const std::vector<Box::cell_index>&   index_list,
                                     const bool                            global)
 {
-    const auto func_name    = record.getItem("OPERATION").getTrimmedString(0);
+    // Shared backend for OPERATE and OPERATER; both define
+    // OPERATION/PARAM1/PARAM2 identically.
+    using Kw = ParserKeywords::OPERATE;
+    const auto func_name    = record.getItem<Kw::OPERATION>().getTrimmedString(0);
     const auto check_target = (func_name == "MULTIPLY") || (func_name == "POLY");
-    const auto alpha        = record.getItem("PARAM1").get<double>(0);
-    const auto beta         = record.getItem("PARAM2").get<double>(0);
+    const auto alpha        = record.getItem<Kw::PARAM1>().get<double>(0);
+    const auto beta         = record.getItem<Kw::PARAM2>().get<double>(0);
     const auto func         = Operate::get(func_name, alpha, beta);
 
     auto& to_data   = global ? *target_data.global_data : target_data.data;
@@ -1549,6 +1556,7 @@ void FieldProps::handle_operateR(const Section section,
     // values overwrite the corresponding elements of the result/target
     // array (ResArray).
 
+    using Kw = ParserKeywords::OPERATER;
     for (const auto& record : keyword) {
         const auto target_kw = Fieldprops::keywords::
             get_keyword_from_alias(record.getItem(0).getTrimmedString(0));
@@ -1560,12 +1568,12 @@ void FieldProps::handle_operateR(const Section section,
             };
         }
 
-        const int region_value = record.getItem("REGION_NUMBER").get<int>(0);
+        const int region_value = record.getItem<Kw::REGION_NUMBER>().get<int>(0);
 
         // For the OPERATER keyword we fetch the region name from the deck
         // record with no extra hoops.
-        const auto reg_name = record.getItem("REGION_NAME").getTrimmedString(0);
-        const auto src_kw = record.getItem("ARRAY_PARAMETER").getTrimmedString(0);
+        const auto reg_name = record.getItem<Kw::REGION_NAME>().getTrimmedString(0);
+        const auto src_kw = record.getItem<Kw::ARRAY_PARAMETER>().getTrimmedString(0);
 
         const auto& [index_list, all_active] = this->region_index(reg_name, region_value);
         if (index_list.empty()) {
@@ -1752,6 +1760,7 @@ void FieldProps::handle_OPERATE(const Section section,
     // values overwrite the corresponding elements of the result/target
     // array (ResArray).
 
+    using Kw = ParserKeywords::OPERATE;
     for (const auto& record : keyword) {
         box.update(record);
 
@@ -1765,7 +1774,7 @@ void FieldProps::handle_OPERATE(const Section section,
             };
         }
 
-        const auto src_kw = record.getItem("ARRAY_PARAMETER").getTrimmedString(0);
+        const auto src_kw = record.getItem<Kw::ARRAY_PARAMETER>().getTrimmedString(0);
 
         if (FieldProps::supported<double>(target_kw) ||
             Fieldprops::keywords::is_work(target_kw))

--- a/opm/input/eclipse/EclipseState/Grid/GridDims.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/GridDims.cpp
@@ -144,11 +144,13 @@ namespace Opm {
     // keyword must be DIMENS or SPECGRID
     inline std::array<int, 3> readDims(const DeckKeyword& keyword)
     {
+        // Shared backend for DIMENS and SPECGRID; both define NX/NY/NZ identically.
+        using Kw = ParserKeywords::DIMENS;
         const auto& record = keyword.getRecord(0);
         return {
-            record.getItem("NX").get<int>(0),
-            record.getItem("NY").get<int>(0),
-            record.getItem("NZ").get<int>(0)
+            record.getItem<Kw::NX>().get<int>(0),
+            record.getItem<Kw::NY>().get<int>(0),
+            record.getItem<Kw::NZ>().get<int>(0)
         };
     }
 
@@ -163,7 +165,7 @@ namespace Opm {
     void GridDims::binary_init(const Deck& deck)
     {
         const DeckKeyword& gdfile_kw = deck["GDFILE"].back();
-        const std::string& gdfile_arg = gdfile_kw.getRecord(0).getItem("filename").getTrimmedString(0);
+        const std::string& gdfile_arg = gdfile_kw.getRecord(0).getItem<ParserKeywords::GDFILE::filename>().getTrimmedString(0);
         const EclIO::EGrid egrid( deck.makeDeckPath(gdfile_arg) );
 
         const auto& dimens = egrid.dimension();

--- a/opm/input/eclipse/EclipseState/Grid/readKeywordCarfin.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/readKeywordCarfin.cpp
@@ -14,19 +14,23 @@
  */
 
 #include "readKeywordCarfin.hpp"
+
+#include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
+
 namespace Opm {
 
     void readKeywordCarfin( const DeckRecord& deckRecord, CarfinManager& carfinManager) {
-        const auto& NAMEItem = deckRecord.getItem("NAME");
-        const auto& I1Item = deckRecord.getItem("I1");
-        const auto& I2Item = deckRecord.getItem("I2");
-        const auto& J1Item = deckRecord.getItem("J1");
-        const auto& J2Item = deckRecord.getItem("J2");
-        const auto& K1Item = deckRecord.getItem("K1");
-        const auto& K2Item = deckRecord.getItem("K2");
-        const auto& NXItem = deckRecord.getItem("NX");
-        const auto& NYItem = deckRecord.getItem("NY");
-        const auto& NZItem = deckRecord.getItem("NZ");
+        using Kw = ParserKeywords::CARFIN;
+        const auto& NAMEItem = deckRecord.getItem<Kw::NAME>();
+        const auto& I1Item = deckRecord.getItem<Kw::I1>();
+        const auto& I2Item = deckRecord.getItem<Kw::I2>();
+        const auto& J1Item = deckRecord.getItem<Kw::J1>();
+        const auto& J2Item = deckRecord.getItem<Kw::J2>();
+        const auto& K1Item = deckRecord.getItem<Kw::K1>();
+        const auto& K2Item = deckRecord.getItem<Kw::K2>();
+        const auto& NXItem = deckRecord.getItem<Kw::NX>();
+        const auto& NYItem = deckRecord.getItem<Kw::NY>();
+        const auto& NZItem = deckRecord.getItem<Kw::NZ>();
  //       const auto& NWMAXItem = deckRecord.getItem("NWMAX");
  //       const auto& PARENTItem = deckRecord.getItem("PARENT");
 

--- a/opm/input/eclipse/EclipseState/Grid/setKeywordBox.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/setKeywordBox.cpp
@@ -18,16 +18,20 @@
  */
 
 #include "setKeywordBox.hpp"
+
+#include <opm/input/eclipse/Parser/ParserKeywords/B.hpp>
+
 namespace Opm {
 
     void setKeywordBox( const DeckRecord& deckRecord,
                         BoxManager& boxManager) {
-        const auto& I1Item = deckRecord.getItem("I1");
-        const auto& I2Item = deckRecord.getItem("I2");
-        const auto& J1Item = deckRecord.getItem("J1");
-        const auto& J2Item = deckRecord.getItem("J2");
-        const auto& K1Item = deckRecord.getItem("K1");
-        const auto& K2Item = deckRecord.getItem("K2");
+        using Kw = ParserKeywords::BOX;
+        const auto& I1Item = deckRecord.getItem<Kw::I1>();
+        const auto& I2Item = deckRecord.getItem<Kw::I2>();
+        const auto& J1Item = deckRecord.getItem<Kw::J1>();
+        const auto& J2Item = deckRecord.getItem<Kw::J2>();
+        const auto& K1Item = deckRecord.getItem<Kw::K1>();
+        const auto& K2Item = deckRecord.getItem<Kw::K2>();
 
         const auto& active_box = boxManager.getActiveBox();
 

--- a/opm/input/eclipse/EclipseState/Runspec.cpp
+++ b/opm/input/eclipse/EclipseState/Runspec.cpp
@@ -31,6 +31,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/A.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/B.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/F.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/H.hpp>
@@ -410,13 +411,14 @@ EclHysterConfig::EclHysterConfig(const Opm::Deck& deck)
        * 1: use the Carlson model for relative permeability hysteresis of the non-wetting
        *    phase and the imbibition curve for the relperm of the wetting phase
        */
+        using Kw = ParserKeywords::EHYSTR;
         const auto& ehystrKeyword = deck["EHYSTR"].back();
-        std::string whereFlag = ehystrKeyword.getRecord(0).getItem("limiting_hyst_flag").getTrimmedString(0);
+        std::string whereFlag = ehystrKeyword.getRecord(0).getItem<Kw::limiting_hyst_flag>().getTrimmedString(0);
 
         if (deck.hasKeyword("NOHYKR") || whereFlag == "PC")
             krHystMod = -1;
         else {
-            krHystMod = ehystrKeyword.getRecord(0).getItem("relative_perm_hyst").get<int>(0);
+            krHystMod = ehystrKeyword.getRecord(0).getItem<Kw::relative_perm_hyst>().get<int>(0);
         }
 
         // this is slightly screwed: it is possible to specify contradicting hysteresis
@@ -434,7 +436,7 @@ EclHysterConfig::EclHysterConfig(const Opm::Deck& deck)
             // if capillary pressure hysteresis is enabled, Eclipse always uses the
             // Killough model
             pcHystMod = 0;
-            curvatureCapPrsValue = ehystrKeyword.getRecord(0).getItem("curvature_capillary_pressure_hyst").get<double>(0);
+            curvatureCapPrsValue = ehystrKeyword.getRecord(0).getItem<Kw::curvature_capillary_pressure_hyst>().get<double>(0);
             if (curvatureCapPrsValue <= 0.0)
                 throw std::runtime_error(
                     "Only positive values allowed for the 'capillary pressure curvature parameter' "
@@ -443,10 +445,10 @@ EclHysterConfig::EclHysterConfig(const Opm::Deck& deck)
 
         // Killough model: Regularisation for trapped critical saturation calculations
         if (pcHystMod == 0 || krHystMod == 2 || krHystMod == 3)
-            modParamTrappedValue = ehystrKeyword.getRecord(0).getItem("mod_param_trapped").get<double>(0);
+            modParamTrappedValue = ehystrKeyword.getRecord(0).getItem<Kw::mod_param_trapped>().get<double>(0);
 
         if (krHystMod >= 0) {
-            const int fix_wetting_phase_killough = ehystrKeyword.getRecord(0).getItem("fix_wetting_phase_killough").get<int>(0);
+            const int fix_wetting_phase_killough = ehystrKeyword.getRecord(0).getItem<Kw::fix_wetting_phase_killough>().get<int>(0);
             if (fix_wetting_phase_killough != 0 && fix_wetting_phase_killough != 1) {
                 throw std::runtime_error(
                     "Only 0 and 1 allowed for the 'fix wetting phase killough flag' "
@@ -456,7 +458,7 @@ EclHysterConfig::EclHysterConfig(const Opm::Deck& deck)
         }
 
         if (pcHystMod >= 0) {
-            const int pc_scaling_value = ehystrKeyword.getRecord(0).getItem("enable_pc_scaling").get<int>(0);
+            const int pc_scaling_value = ehystrKeyword.getRecord(0).getItem<Kw::enable_pc_scaling>().get<int>(0);
             if (pc_scaling_value != 0 && pc_scaling_value != 1) {
                 throw std::runtime_error(
                     "Only 0 and 1 allowed for the 'capillary pressure scaling parameter' "

--- a/opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -155,8 +155,9 @@ namespace Opm {
             for (std::size_t recordIdx = 0; recordIdx < thpresft.size(); ++ recordIdx) {
                 const DeckRecord& record = thpresft.getRecord(recordIdx);
 
-                const std::string& faultName = record.getItem("FAULT_NAME").getTrimmedString(0);
-                double thpresValue = record.getItem("VALUE").getSIDouble(0);
+                using Kw = ParserKeywords::THPRESFT;
+                const std::string& faultName = record.getItem<Kw::FAULT_NAME>().getTrimmedString(0);
+                double thpresValue = record.getItem<Kw::VALUE>().getSIDouble(0);
 
                 for (std::size_t faultIdx = 0; faultIdx < faults.size(); faultIdx++) {
                     auto& fault = faults.getFault(faultIdx);

--- a/opm/input/eclipse/EclipseState/Tables/Aqudims.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Aqudims.cpp
@@ -42,15 +42,16 @@ Aqudims::Aqudims(const Deck& deck) :
     Aqudims()
 {
     if (deck.hasKeyword("AQUDIMS")) {
+        using Kw = ParserKeywords::AQUDIMS;
         const auto& record = deck[ "AQUDIMS" ][0].getRecord( 0 );
-        m_mxnaqn  = record.getItem("MXNAQN").get<int>(0);
-        m_mxnaqc  = record.getItem("MXNAQC").get<int>(0);
-        m_niftbl  = record.getItem("NIFTBL").get<int>(0);
-        m_nriftb  = record.getItem("NRIFTB").get<int>(0);
-        m_nanaqu  = record.getItem("NANAQU").get<int>(0);
-        m_ncamax  = record.getItem("NCAMAX").get<int>(0);
-        m_mxnali  = record.getItem("MXNALI").get<int>(0);
-        m_mxaaql  = record.getItem("MXAAQL").get<int>(0);
+        m_mxnaqn  = record.getItem<Kw::MXNAQN>().get<int>(0);
+        m_mxnaqc  = record.getItem<Kw::MXNAQC>().get<int>(0);
+        m_niftbl  = record.getItem<Kw::NIFTBL>().get<int>(0);
+        m_nriftb  = record.getItem<Kw::NRIFTB>().get<int>(0);
+        m_nanaqu  = record.getItem<Kw::NANAQU>().get<int>(0);
+        m_ncamax  = record.getItem<Kw::NCAMAX>().get<int>(0);
+        m_mxnali  = record.getItem<Kw::MXNALI>().get<int>(0);
+        m_mxaaql  = record.getItem<Kw::MXAAQL>().get<int>(0);
     }
 }
 

--- a/opm/input/eclipse/EclipseState/Tables/Bdensity.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Bdensity.cpp
@@ -23,6 +23,8 @@
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/P.hpp>
+
 #include <cstddef>
 #include <vector>
 
@@ -36,9 +38,10 @@ namespace Opm {
         void PvtwsaltTable::init(const Opm::DeckRecord& record0, const Opm::DeckRecord& record1)
         {
 
-            m_pRefValues = record0.getItem("P_REF").getSIDoubleData()[0];
-            m_saltConsRefValues = record0.getItem("SALT_CONCENTRATION_REF").getSIDoubleData()[0];
-            m_tableValues = record1.getItem("DATA").getSIDoubleData();
+            using Kw = ParserKeywords::PVTWSALT;
+            m_pRefValues = record0.getItem<Kw::P_REF>().getSIDoubleData()[0];
+            m_saltConsRefValues = record0.getItem<Kw::SALT_CONCENTRATION_REF>().getSIDoubleData()[0];
+            m_tableValues = record1.getItem<Kw::DATA>().getSIDoubleData();
         }
 
         std::size_t PvtwsaltTable::size() const

--- a/opm/input/eclipse/EclipseState/Tables/BrineDensityTable.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/BrineDensityTable.cpp
@@ -23,6 +23,8 @@
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/B.hpp>
+
 #include <vector>
 
 namespace Opm {
@@ -36,7 +38,8 @@ namespace Opm {
 
         void BrineDensityTable::init(const Opm::DeckRecord& record )
         {
-            m_tableValues = record.getItem("BRINE_DENSITY").getSIDoubleData();
+            using Kw = ParserKeywords::BDENSITY;
+            m_tableValues = record.getItem<Kw::BRINE_DENSITY>().getSIDoubleData();
         }
 
         const std::vector<double>& BrineDensityTable::getBrineDensityColumn() const

--- a/opm/input/eclipse/EclipseState/Tables/JFunc.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/JFunc.cpp
@@ -35,9 +35,10 @@ namespace Opm {
 
     JFunc::JFunc(const Deck& deck)
     {
-        const auto& kw = *deck.getKeywordList<ParserKeywords::JFUNC>()[0];
+        using Kw = ParserKeywords::JFUNC;
+        const auto& kw = *deck.getKeywordList<Kw>()[0];
         const auto& rec = kw.getRecord(0);
-        const auto& kw_flag = rec.getItem("FLAG").get<std::string>(0);
+        const auto& kw_flag = rec.getItem<Kw::FLAG>().get<std::string>(0);
         if (kw_flag == "BOTH")
             m_flag = Flag::BOTH;
         else if (kw_flag == "WATER")
@@ -48,15 +49,15 @@ namespace Opm {
             throw std::invalid_argument("Illegal JFUNC FLAG, must be BOTH, WATER, or GAS.  Was \"" + kw_flag + "\".");
 
         if (m_flag != Flag::WATER)
-            m_goSurfaceTension = rec.getItem("GO_SURFACE_TENSION").get<double>(0);
+            m_goSurfaceTension = rec.getItem<Kw::GO_SURFACE_TENSION>().get<double>(0);
 
         if (m_flag != Flag::GAS)
-            m_owSurfaceTension = rec.getItem("OW_SURFACE_TENSION").get<double>(0);
+            m_owSurfaceTension = rec.getItem<Kw::OW_SURFACE_TENSION>().get<double>(0);
 
-        m_alphaFactor = rec.getItem("ALPHA_FACTOR").get<double>(0);
-        m_betaFactor = rec.getItem("BETA_FACTOR").get<double>(0);
+        m_alphaFactor = rec.getItem<Kw::ALPHA_FACTOR>().get<double>(0);
+        m_betaFactor = rec.getItem<Kw::BETA_FACTOR>().get<double>(0);
 
-        const auto kw_dir = rec.getItem("DIRECTION").get<std::string>(0);
+        const auto kw_dir = rec.getItem<Kw::DIRECTION>().get<std::string>(0);
         if (kw_dir == "XY")
             m_direction = Direction::XY;
         else if (kw_dir == "X")

--- a/opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.cpp
@@ -23,6 +23,8 @@
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/P.hpp>
+
 #include <cstddef>
 #include <vector>
 
@@ -46,9 +48,10 @@ namespace Opm {
         void PvtwsaltTable::init(const Opm::DeckRecord& record0, const Opm::DeckRecord& record1)
         {
 
-            m_pRefValues = record0.getItem("P_REF").getSIDoubleData()[0];
-            m_saltConsRefValues = record0.getItem("SALT_CONCENTRATION_REF").getSIDoubleData()[0];
-            m_tableValues = record1.getItem("DATA").getSIDoubleData();
+            using Kw = ParserKeywords::PVTWSALT;
+            m_pRefValues = record0.getItem<Kw::P_REF>().getSIDoubleData()[0];
+            m_saltConsRefValues = record0.getItem<Kw::SALT_CONCENTRATION_REF>().getSIDoubleData()[0];
+            m_tableValues = record1.getItem<Kw::DATA>().getSIDoubleData();
         }
 
         std::size_t PvtwsaltTable::size() const

--- a/opm/input/eclipse/EclipseState/Tables/Regdims.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Regdims.cpp
@@ -38,12 +38,13 @@ Regdims::Regdims(const Deck& deck) :
     Regdims()
 {
     if (deck.hasKeyword("REGDIMS")) {
+        using Kw = ParserKeywords::REGDIMS;
         const auto& record = deck["REGDIMS"][0].getRecord( 0 );
-        m_NTFIP   = record.getItem("NTFIP").get<int>(0);
-        m_NMFIPR  = record.getItem("NMFIPR").get<int>(0);
-        m_NRFREG  = record.getItem("NRFREG").get<int>(0);
-        m_NTFREG  = record.getItem("NTFREG").get<int>(0);
-        m_NPLMIX  = record.getItem("NPLMIX").get<int>(0);
+        m_NTFIP   = record.getItem<Kw::NTFIP>().get<int>(0);
+        m_NMFIPR  = record.getItem<Kw::NMFIPR>().get<int>(0);
+        m_NRFREG  = record.getItem<Kw::NRFREG>().get<int>(0);
+        m_NTFREG  = record.getItem<Kw::NTFREG>().get<int>(0);
+        m_NPLMIX  = record.getItem<Kw::NPLMIX>().get<int>(0);
     }
 }
 

--- a/opm/input/eclipse/EclipseState/Tables/Rock2dTable.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Rock2dTable.cpp
@@ -23,6 +23,8 @@
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
+
 #include <vector>
 #include <cstddef>
 
@@ -43,8 +45,9 @@ namespace Opm {
 
         void Rock2dTable::init(const DeckRecord& record, std::size_t /* tableIdx */)
         {
-            m_pressureValues.push_back(record.getItem("PRESSURE").getSIDoubleData()[0]);
-            m_pvmultValues.push_back(record.getItem("PVMULT").getSIDoubleData());
+            using Kw = ParserKeywords::ROCK2D;
+            m_pressureValues.push_back(record.getItem<Kw::PRESSURE>().getSIDoubleData()[0]);
+            m_pvmultValues.push_back(record.getItem<Kw::PVMULT>().getSIDoubleData());
         }
 
         std::size_t Rock2dTable::size() const

--- a/opm/input/eclipse/EclipseState/Tables/Rock2dtrTable.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Rock2dtrTable.cpp
@@ -23,6 +23,8 @@
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
+
 #include <vector>
 #include <cstddef>
 
@@ -44,8 +46,9 @@ namespace Opm {
 
         void Rock2dtrTable::init(const DeckRecord& record, std::size_t /* tableIdx */)
         {
-            m_pressureValues.push_back(record.getItem("PRESSURE").getSIDoubleData()[0]);
-            m_transMultValues.push_back(record.getItem("TRANSMULT").getSIDoubleData());
+            using Kw = ParserKeywords::ROCK2DTR;
+            m_pressureValues.push_back(record.getItem<Kw::PRESSURE>().getSIDoubleData()[0]);
+            m_transMultValues.push_back(record.getItem<Kw::TRANSMULT>().getSIDoubleData());
         }
 
         std::size_t Rock2dtrTable::size() const

--- a/opm/input/eclipse/EclipseState/Tables/SolventDensityTable.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/SolventDensityTable.cpp
@@ -22,6 +22,7 @@
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/SolventDensityTable.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>
 
 namespace Opm {
         SolventDensityTable SolventDensityTable::serializationTestObject()
@@ -34,7 +35,8 @@ namespace Opm {
 
         void SolventDensityTable::init(const Opm::DeckRecord& record )
         {
-            m_tableValues = record.getItem("SOLVENT_DENSITY").getSIDoubleData();
+            using Kw = ParserKeywords::SDENSITY;
+            m_tableValues = record.getItem<Kw::SOLVENT_DENSITY>().getSIDoubleData();
         }
 
         const std::vector<double>& SolventDensityTable::getSolventDensityColumn() const

--- a/opm/input/eclipse/EclipseState/Tables/Tabdims.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Tabdims.cpp
@@ -42,15 +42,16 @@ Tabdims::Tabdims(const Deck& deck) :
     Tabdims()
 {
     if (deck.hasKeyword("TABDIMS")) {
+        using Kw = ParserKeywords::TABDIMS;
         const auto& record = deck["TABDIMS"][0].getRecord(0);
-        m_ntsfun = record.getItem("NTSFUN").get<int>(0);
-        m_ntpvt  = record.getItem("NTPVT").get<int>(0);
-        m_nssfun = record.getItem("NSSFUN").get<int>(0);
-        m_nppvt  = record.getItem("NPPVT").get<int>(0);
-        m_ntfip  = record.getItem("NTFIP").get<int>(0);
-        m_nrpvt  = record.getItem("NRPVT").get<int>(0);
-        m_neosres = record.getItem("NUM_EOS_RES").get<int>(0);
-        m_neossur = record.getItem("NUM_EOS_SURFACE").get<int>(0);
+        m_ntsfun = record.getItem<Kw::NTSFUN>().get<int>(0);
+        m_ntpvt  = record.getItem<Kw::NTPVT>().get<int>(0);
+        m_nssfun = record.getItem<Kw::NSSFUN>().get<int>(0);
+        m_nppvt  = record.getItem<Kw::NPPVT>().get<int>(0);
+        m_ntfip  = record.getItem<Kw::NTFIP>().get<int>(0);
+        m_nrpvt  = record.getItem<Kw::NRPVT>().get<int>(0);
+        m_neosres = record.getItem<Kw::NUM_EOS_RES>().get<int>(0);
+        m_neossur = record.getItem<Kw::NUM_EOS_SURFACE>().get<int>(0);
     }
 }
 

--- a/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -212,12 +212,12 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             this->m_swofletTable = SwofletTable( deck["SWOFLET"].back() );
 
         if( deck.hasKeyword( "RTEMP" ) )
-            m_rtemp = deck["RTEMP"].back().getRecord(0).getItem("TEMP").getSIDouble( 0 );
+            m_rtemp = deck["RTEMP"].back().getRecord(0).getItem<ParserKeywords::RTEMP::TEMP>().getSIDouble( 0 );
         else if (deck.hasKeyword( "RTEMPA" ) )
-            m_rtemp = deck["RTEMPA"].back().getRecord(0).getItem("TEMP").getSIDouble( 0 );
+            m_rtemp = deck["RTEMPA"].back().getRecord(0).getItem<ParserKeywords::RTEMPA::TEMP>().getSIDouble( 0 );
 
         if( deck.hasKeyword( "SALINITY" ) )
-            m_salinity = deck["SALINITY"].back().getRecord(0).getItem("MOLALITY").get<double>( 0 ); //unit independent of unit systems
+            m_salinity = deck["SALINITY"].back().getRecord(0).getItem<ParserKeywords::SALINITY::MOLALITY>().get<double>( 0 ); //unit independent of unit systems
 
         if ( deck.hasKeyword( "ROCK2D") )
             initRockTables(deck, "ROCK2D", m_rock2dTables );
@@ -256,9 +256,10 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             this->watJT = JouleThomson( deck.get<ParserKeywords::WATJT>().back());
 
         if (deck.hasKeyword<ParserKeywords::STCOND>()) {
+            using Kw = ParserKeywords::STCOND;
             auto stcondKeyword = deck["STCOND"].back();
-            this->stcond.temperature = stcondKeyword.getRecord(0).getItem("TEMPERATURE").getSIDouble(0);
-            this->stcond.pressure = stcondKeyword.getRecord(0).getItem("PRESSURE").getSIDouble(0);
+            this->stcond.temperature = stcondKeyword.getRecord(0).getItem<Kw::TEMPERATURE>().getSIDouble(0);
+            this->stcond.pressure = stcondKeyword.getRecord(0).getItem<Kw::PRESSURE>().getSIDouble(0);
         }
 
         if (deck.hasKeyword<ParserKeywords::PLMIXPAR>()) {
@@ -675,7 +676,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         for (std::size_t tableIdx = 0; tableIdx < keyword.size(); ++tableIdx) {
             const auto& tableRecord = keyword.getRecord(tableIdx);
-            const auto& dataItem = tableRecord.getItem("DATA");
+            const auto& dataItem = tableRecord.getItem<ParserKeywords::ZMFVD::DATA>();
             if (dataItem.data_size() > 0) {
                 auto table = std::make_shared<ZmfvdTable>(
                     dataItem, static_cast<int>(tableIdx), numComponents, keyword.location());
@@ -719,7 +720,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         for (std::size_t tableIdx = 0; tableIdx < keyword.size(); ++tableIdx) {
             const auto& tableRecord = keyword.getRecord(tableIdx);
-            const auto& dataItem = tableRecord.getItem("DATA");
+            const auto& dataItem = tableRecord.getItem<ParserKeywords::COMPVD::DATA>();
             if (dataItem.data_size() > 0) {
                 auto table = std::make_shared<CompvdTable>(
                     dataItem, static_cast<int>(tableIdx), numComponents, usys, keyword.location());
@@ -1648,7 +1649,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         const auto& rockcompKeyword = deck["ROCKCOMP"].back();
         const auto& record = rockcompKeyword.getRecord( 0 );
-        std::size_t numTables = record.getItem("NTROCC").get< int >(0);
+        std::size_t numTables = record.getItem<ParserKeywords::ROCKCOMP::NTROCC>().get< int >(0);
         rocktable.resize(numTables);
 
         const auto& keyword = deck[keywordName].back();

--- a/opm/input/eclipse/EclipseState/checkDeck.cpp
+++ b/opm/input/eclipse/EclipseState/checkDeck.cpp
@@ -32,6 +32,8 @@
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/F.hpp>
+
 #include <cstddef>
 
 namespace Opm {
@@ -60,7 +62,7 @@ bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& pars
 
     const std::string& deckUnitSystem = uppercase(deck.getActiveUnitSystem().getName());
     for (const auto& keyword : deck.getKeywordList("FILEUNIT")) {
-        const std::string& fileUnitSystem = uppercase(keyword->getRecord(0).getItem("FILE_UNIT_SYSTEM").getTrimmedString(0));
+        const std::string& fileUnitSystem = uppercase(keyword->getRecord(0).getItem<ParserKeywords::FILEUNIT::FILE_UNIT_SYSTEM>().getTrimmedString(0));
         if (fileUnitSystem != deckUnitSystem) {
             const auto& location = keyword->location();
             std::string msg_fmt = "Unit system mismatch\n"

--- a/opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.cpp
+++ b/opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.cpp
@@ -19,6 +19,8 @@
 
 #include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
+
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 
@@ -115,18 +117,19 @@ std::size_t GroupEconProductionLimits::size() const {
 /* Methods for inner class GEconGroup */
 
 GroupEconProductionLimits::GEconGroup::GEconGroup(const DeckRecord &record, const int report_step)
-    : m_min_oil_rate{record.getItem("MIN_OIL_RATE").get<UDAValue>(0)}
-    , m_min_gas_rate{record.getItem("MIN_GAS_RATE").get<UDAValue>(0)}
-    , m_max_water_cut{record.getItem("MAX_WCT").get<UDAValue>(0)}
-    , m_max_gas_oil_ratio{record.getItem("MAX_GOR").get<UDAValue>(0)}
-    , m_max_water_gas_ratio{record.getItem("MAX_WATER_GAS_RATIO").get<UDAValue>(0)}
-    , m_workover{econWorkoverFromString(record.getItem("WORKOVER").getTrimmedString(0))}
+    : m_min_oil_rate{record.getItem<ParserKeywords::GECON::MIN_OIL_RATE>().get<UDAValue>(0)}
+    , m_min_gas_rate{record.getItem<ParserKeywords::GECON::MIN_GAS_RATE>().get<UDAValue>(0)}
+    , m_max_water_cut{record.getItem<ParserKeywords::GECON::MAX_WCT>().get<UDAValue>(0)}
+    , m_max_gas_oil_ratio{record.getItem<ParserKeywords::GECON::MAX_GOR>().get<UDAValue>(0)}
+    , m_max_water_gas_ratio{record.getItem<ParserKeywords::GECON::MAX_WATER_GAS_RATIO>().get<UDAValue>(0)}
+    , m_workover{econWorkoverFromString(record.getItem<ParserKeywords::GECON::WORKOVER>().getTrimmedString(0))}
     , m_end_run{false}
-    , m_max_open_wells{record.getItem("MAX_OPEN_WELLS").get<int>(0)}
+    , m_max_open_wells{record.getItem<ParserKeywords::GECON::MAX_OPEN_WELLS>().get<int>(0)}
     , m_report_step{report_step}
 {
-    if (record.getItem("END_RUN").hasValue(0)) {
-        std::string string_endrun = record.getItem("END_RUN").getTrimmedString(0);
+    using Kw = ParserKeywords::GECON;
+    if (record.getItem<Kw::END_RUN>().hasValue(0)) {
+        std::string string_endrun = record.getItem<Kw::END_RUN>().getTrimmedString(0);
         if (string_endrun == "YES") {
             m_end_run = true;
         } else if (string_endrun != "NO") {

--- a/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
@@ -187,9 +187,9 @@ void handleGCONINJE(HandlerContext& handlerContext)
 
         std::optional<std::string> guide_rate_str;
         {
-            const auto& item = record.getItem("GUIDE_RATE_DEF");
+            const auto& item = record.getItem<GI::GUIDE_RATE_DEF>();
             if (item.hasValue(0)) {
-                const auto& string_value = record.getItem("GUIDE_RATE_DEF").getTrimmedString(0);
+                const auto& string_value = record.getItem<GI::GUIDE_RATE_DEF>().getTrimmedString(0);
                 if (string_value.size() > 0)
                     guide_rate_str = string_value;
             }
@@ -204,7 +204,7 @@ void handleGCONINJE(HandlerContext& handlerContext)
             if (!is_field) {
                 if (guide_rate_str) {
                     guide_rate_def = Group::GuideRateInjTargetFromString(guide_rate_str.value());
-                    guide_rate = record.getItem("GUIDE_RATE").get<double>(0);
+                    guide_rate = record.getItem<GI::GUIDE_RATE>().get<double>(0);
                 }
             }
 
@@ -224,23 +224,23 @@ void handleGCONINJE(HandlerContext& handlerContext)
                 injection.guide_rate_def = guide_rate_def;
                 injection.available_group_control = availableForGroupControl;
 
-                if (!record.getItem("SURFACE_TARGET").defaultApplied(0))
+                if (!record.getItem<GI::SURFACE_TARGET>().defaultApplied(0))
                     injection.injection_controls += static_cast<int>(Group::InjectionCMode::RATE);
 
-                if (!record.getItem("RESV_TARGET").defaultApplied(0))
+                if (!record.getItem<GI::RESV_TARGET>().defaultApplied(0))
                     injection.injection_controls += static_cast<int>(Group::InjectionCMode::RESV);
 
-                if (!record.getItem("REINJ_TARGET").defaultApplied(0))
+                if (!record.getItem<GI::REINJ_TARGET>().defaultApplied(0))
                     injection.injection_controls += static_cast<int>(Group::InjectionCMode::REIN);
 
-                if (!record.getItem("VOIDAGE_TARGET").defaultApplied(0))
+                if (!record.getItem<GI::VOIDAGE_TARGET>().defaultApplied(0))
                     injection.injection_controls += static_cast<int>(Group::InjectionCMode::VREP);
 
-                if (record.getItem("REINJECT_GROUP").hasValue(0))
-                    injection.reinj_group = record.getItem("REINJECT_GROUP").getTrimmedString(0);
+                if (record.getItem<GI::REINJECT_GROUP>().hasValue(0))
+                    injection.reinj_group = record.getItem<GI::REINJECT_GROUP>().getTrimmedString(0);
 
-                if (record.getItem("VOIDAGE_GROUP").hasValue(0))
-                    injection.voidage_group = record.getItem("VOIDAGE_GROUP").getTrimmedString(0);
+                if (record.getItem<GI::VOIDAGE_GROUP>().hasValue(0))
+                    injection.voidage_group = record.getItem<GI::VOIDAGE_GROUP>().getTrimmedString(0);
 
                 if (new_group.updateInjection(injection)) {
                     auto new_config = handlerContext.state().guide_rate();
@@ -262,53 +262,54 @@ void handleGCONINJE(HandlerContext& handlerContext)
 
 void handleGCONPROD(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::GCONPROD;
     const auto& keyword = handlerContext.keyword;
     for (const auto& record : keyword) {
-        const std::string& groupNamePattern = record.getItem("GROUP").getTrimmedString(0);
+        const std::string& groupNamePattern = record.getItem<Kw::GROUP>().getTrimmedString(0);
         const auto group_names = handlerContext.groupNames(groupNamePattern);
         if (group_names.empty()) {
             handlerContext.invalidNamePattern(groupNamePattern);
         }
 
-        const Group::ProductionCMode controlMode = Group::ProductionCModeFromString(record.getItem("CONTROL_MODE").getTrimmedString(0));
+        const Group::ProductionCMode controlMode = Group::ProductionCModeFromString(record.getItem<Kw::CONTROL_MODE>().getTrimmedString(0));
 
         // Set the group limit actions. Item 7 (EXCEED_PROC) gives the general action, items 11-13 (WATER_EXCEED_PROCEDURE etc.)
         // can override this for water, gas or liquid rate limits.
         Group::GroupLimitAction groupLimitAction;
-        groupLimitAction.allRates = Group::ExceedActionFromString(record.getItem("EXCEED_PROC").getTrimmedString(0));
+        groupLimitAction.allRates = Group::ExceedActionFromString(record.getItem<Kw::EXCEED_PROC>().getTrimmedString(0));
         // \Note: we do not use the allRates anymore. Instead, we have explicit definition of actions for all the possible rate limits
         // \Note: the allRates is here for backward compatibility for the RESTART file output
         const auto& allRates = groupLimitAction.allRates;
         groupLimitAction.oil = allRates;
-        groupLimitAction.water = record.getItem("WATER_EXCEED_PROCEDURE").defaultApplied(0)
+        groupLimitAction.water = record.getItem<Kw::WATER_EXCEED_PROCEDURE>().defaultApplied(0)
             ? allRates
-            : Group::ExceedActionFromString(record.getItem("WATER_EXCEED_PROCEDURE").getTrimmedString(0));
-        groupLimitAction.gas = record.getItem("GAS_EXCEED_PROCEDURE").defaultApplied(0)
+            : Group::ExceedActionFromString(record.getItem<Kw::WATER_EXCEED_PROCEDURE>().getTrimmedString(0));
+        groupLimitAction.gas = record.getItem<Kw::GAS_EXCEED_PROCEDURE>().defaultApplied(0)
             ? allRates
-            : Group::ExceedActionFromString(record.getItem("GAS_EXCEED_PROCEDURE").getTrimmedString(0));
-        groupLimitAction.liquid = record.getItem("LIQUID_EXCEED_PROCEDURE").defaultApplied(0)
+            : Group::ExceedActionFromString(record.getItem<Kw::GAS_EXCEED_PROCEDURE>().getTrimmedString(0));
+        groupLimitAction.liquid = record.getItem<Kw::LIQUID_EXCEED_PROCEDURE>().defaultApplied(0)
             ? allRates
-            : Group::ExceedActionFromString(record.getItem("LIQUID_EXCEED_PROCEDURE").getTrimmedString(0));
+            : Group::ExceedActionFromString(record.getItem<Kw::LIQUID_EXCEED_PROCEDURE>().getTrimmedString(0));
 
-        const bool respond_to_parent = DeckItem::to_bool(record.getItem("RESPOND_TO_PARENT").getTrimmedString(0));
+        const bool respond_to_parent = DeckItem::to_bool(record.getItem<Kw::RESPOND_TO_PARENT>().getTrimmedString(0));
 
-        const auto oil_target = record.getItem("OIL_TARGET").get<UDAValue>(0);
-        const auto gas_target = record.getItem("GAS_TARGET").get<UDAValue>(0);
-        const auto water_target = record.getItem("WATER_TARGET").get<UDAValue>(0);
-        const auto liquid_target = record.getItem("LIQUID_TARGET").get<UDAValue>(0);
-        const auto resv_target = record.getItem("RESERVOIR_FLUID_TARGET").get<UDAValue>(0);
+        const auto oil_target = record.getItem<Kw::OIL_TARGET>().get<UDAValue>(0);
+        const auto gas_target = record.getItem<Kw::GAS_TARGET>().get<UDAValue>(0);
+        const auto water_target = record.getItem<Kw::WATER_TARGET>().get<UDAValue>(0);
+        const auto liquid_target = record.getItem<Kw::LIQUID_TARGET>().get<UDAValue>(0);
+        const auto resv_target = record.getItem<Kw::RESERVOIR_FLUID_TARGET>().get<UDAValue>(0);
 
-        const bool apply_default_oil_target = record.getItem("OIL_TARGET").defaultApplied(0);
-        const bool apply_default_gas_target = record.getItem("GAS_TARGET").defaultApplied(0);
-        const bool apply_default_water_target = record.getItem("WATER_TARGET").defaultApplied(0);
-        const bool apply_default_liquid_target = record.getItem("LIQUID_TARGET").defaultApplied(0);
-        const bool apply_default_resv_target = record.getItem("RESERVOIR_FLUID_TARGET").defaultApplied(0);
+        const bool apply_default_oil_target = record.getItem<Kw::OIL_TARGET>().defaultApplied(0);
+        const bool apply_default_gas_target = record.getItem<Kw::GAS_TARGET>().defaultApplied(0);
+        const bool apply_default_water_target = record.getItem<Kw::WATER_TARGET>().defaultApplied(0);
+        const bool apply_default_liquid_target = record.getItem<Kw::LIQUID_TARGET>().defaultApplied(0);
+        const bool apply_default_resv_target = record.getItem<Kw::RESERVOIR_FLUID_TARGET>().defaultApplied(0);
 
         std::optional<std::string> guide_rate_str;
         {
-            const auto& item = record.getItem("GUIDE_RATE_DEF");
+            const auto& item = record.getItem<Kw::GUIDE_RATE_DEF>();
             if (item.hasValue(0)) {
-                const auto& string_value = record.getItem("GUIDE_RATE_DEF").getTrimmedString(0);
+                const auto& string_value = record.getItem<Kw::GUIDE_RATE_DEF>().getTrimmedString(0);
                 if (string_value.size() > 0)
                     guide_rate_str = string_value;
             }
@@ -335,7 +336,7 @@ void handleGCONPROD(HandlerContext& handlerContext)
                         auto& errors = handlerContext.errors;
                         parseContext.handleError(ParseContext::SCHEDULE_IGNORED_GUIDE_RATE, msg_fmt, keyword.location(), errors);
                     } else {
-                        guide_rate = record.getItem("GUIDE_RATE").get<double>(0);
+                        guide_rate = record.getItem<Kw::GUIDE_RATE>().get<double>(0);
                         if (guide_rate == 0)
                             guide_rate_def = Group::GuideRateProdTarget::POTN;
                     }
@@ -465,13 +466,14 @@ void handleGCONPROD(HandlerContext& handlerContext)
 
 void handleGCONSALE(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::GCONSALE;
     auto new_gconsale = handlerContext.state().gconsale.get();
     for (const auto& record : handlerContext.keyword) {
-        const std::string& groupName = record.getItem("GROUP").getTrimmedString(0);
-        auto sales_target = record.getItem("SALES_TARGET").get<UDAValue>(0);
-        auto max_rate = record.getItem("MAX_SALES_RATE").get<UDAValue>(0);
-        auto min_rate = record.getItem("MIN_SALES_RATE").get<UDAValue>(0);
-        std::string procedure = record.getItem("MAX_PROC").getTrimmedString(0);
+        const std::string& groupName = record.getItem<Kw::GROUP>().getTrimmedString(0);
+        auto sales_target = record.getItem<Kw::SALES_TARGET>().get<UDAValue>(0);
+        auto max_rate = record.getItem<Kw::MAX_SALES_RATE>().get<UDAValue>(0);
+        auto min_rate = record.getItem<Kw::MIN_SALES_RATE>().get<UDAValue>(0);
+        std::string procedure = record.getItem<Kw::MAX_PROC>().getTrimmedString(0);
         auto udq_undefined = handlerContext.state().udq.get().params().undefinedValue();
 
         new_gconsale.add(groupName, sales_target, max_rate, min_rate, procedure,
@@ -488,14 +490,15 @@ void handleGCONSALE(HandlerContext& handlerContext)
 
 void handleGCONSUMP(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::GCONSUMP;
     auto new_gconsump = handlerContext.state().gconsump.get();
     for (const auto& record : handlerContext.keyword) {
-        const std::string& groupName = record.getItem("GROUP").getTrimmedString(0);
-        auto consumption_rate = record.getItem("GAS_CONSUMP_RATE").get<UDAValue>(0);
-        auto import_rate = record.getItem("GAS_IMPORT_RATE").get<UDAValue>(0);
+        const std::string& groupName = record.getItem<Kw::GROUP>().getTrimmedString(0);
+        auto consumption_rate = record.getItem<Kw::GAS_CONSUMP_RATE>().get<UDAValue>(0);
+        auto import_rate = record.getItem<Kw::GAS_IMPORT_RATE>().get<UDAValue>(0);
 
         std::string network_node_name;
-        auto network_node = record.getItem("NETWORK_NODE");
+        auto network_node = record.getItem<Kw::NETWORK_NODE>();
         if (!network_node.defaultApplied(0))
             network_node_name = network_node.getTrimmedString(0);
 
@@ -528,15 +531,16 @@ void handleGECON(HandlerContext& handlerContext)
 
 void handleGEFAC(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::GEFAC;
     for (const auto& record : handlerContext.keyword) {
-        const std::string& groupNamePattern = record.getItem("GROUP").getTrimmedString(0);
+        const std::string& groupNamePattern = record.getItem<Kw::GROUP>().getTrimmedString(0);
         const auto group_names = handlerContext.groupNames(groupNamePattern);
         if (group_names.empty()) {
             handlerContext.invalidNamePattern(groupNamePattern);
         }
 
-        const bool use_efficiency_in_network = DeckItem::to_bool(record.getItem("USE_GEFAC_IN_NETWORK").getTrimmedString(0));
-        const auto gefac = record.getItem("EFFICIENCY_FACTOR").get<double>(0);
+        const bool use_efficiency_in_network = DeckItem::to_bool(record.getItem<Kw::USE_GEFAC_IN_NETWORK>().getTrimmedString(0));
+        const auto gefac = record.getItem<Kw::EFFICIENCY_FACTOR>().get<double>(0);
 
         for (const auto& group_name : group_names) {
             auto new_group = handlerContext.state().groups.get(group_name);
@@ -562,14 +566,15 @@ void handleGEFAC(HandlerContext& handlerContext)
 
 void handleGPMAINT(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::GPMAINT;
     for (const auto& record : handlerContext.keyword) {
-        const std::string& groupNamePattern = record.getItem("GROUP").getTrimmedString(0);
+        const std::string& groupNamePattern = record.getItem<Kw::GROUP>().getTrimmedString(0);
         const auto group_names = handlerContext.groupNames(groupNamePattern);
         if (group_names.empty()) {
             handlerContext.invalidNamePattern(groupNamePattern);
         }
 
-        const auto& target_string = record.getItem<ParserKeywords::GPMAINT::FLOW_TARGET>().get<std::string>(0);
+        const auto& target_string = record.getItem<Kw::FLOW_TARGET>().get<std::string>(0);
 
         for (const auto& group_name : group_names) {
             auto new_group = handlerContext.state().groups.get(group_name);
@@ -586,13 +591,14 @@ void handleGPMAINT(HandlerContext& handlerContext)
 
 void handleGRUPTREE(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::GRUPTREE;
     for (const auto& record : handlerContext.keyword) {
         const std::string& childName = trim_wgname(handlerContext.keyword,
-                                                   record.getItem("CHILD_GROUP").get<std::string>(0),
+                                                   record.getItem<Kw::CHILD_GROUP>().get<std::string>(0),
                                                    handlerContext.parseContext,
                                                    handlerContext.errors);
         const std::string& parentName = trim_wgname(handlerContext.keyword,
-                                                    record.getItem("PARENT_GROUP").get<std::string>(0),
+                                                    record.getItem<Kw::PARENT_GROUP>().get<std::string>(0),
                                                     handlerContext.parseContext,
                                                     handlerContext.errors);
 

--- a/opm/input/eclipse/Schedule/Group/GuideRateKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRateKeywordHandlers.cpp
@@ -24,6 +24,7 @@
 
 #include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/L.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 
 #include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateModel.hpp>
@@ -77,18 +78,19 @@ void handleLINCOM(HandlerContext& handlerContext)
 
 void handleWGRUPCON(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WGRUPCON;
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern);
 
-        const bool availableForGroupControl = DeckItem::to_bool(record.getItem("GROUP_CONTROLLED").getTrimmedString(0));
-        const double guide_rate = record.getItem("GUIDE_RATE").get<double>(0);
-        const double scaling_factor = record.getItem("SCALING_FACTOR").get<double>(0);
+        const bool availableForGroupControl = DeckItem::to_bool(record.getItem<Kw::GROUP_CONTROLLED>().getTrimmedString(0));
+        const double guide_rate = record.getItem<Kw::GUIDE_RATE>().get<double>(0);
+        const double scaling_factor = record.getItem<Kw::SCALING_FACTOR>().get<double>(0);
 
         for (const auto& well_name : well_names) {
             auto phase = Well::GuideRateTarget::UNDEFINED;
-            if (!record.getItem("PHASE").defaultApplied(0)) {
-                std::string guideRatePhase = record.getItem("PHASE").getTrimmedString(0);
+            if (!record.getItem<Kw::PHASE>().defaultApplied(0)) {
+                std::string guideRatePhase = record.getItem<Kw::PHASE>().getTrimmedString(0);
                 phase = WellGuideRateTargetFromString(guideRatePhase);
             }
 

--- a/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -43,6 +43,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/F.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/N.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/P.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
 
 #include "GasLiftOptKeywordHandlers.hpp"
 #include "Group/GroupKeywordHandlers.hpp"
@@ -164,9 +165,9 @@ void handleNEXTSTEP(HandlerContext& handlerContext)
 
 void handleNUPCOL(HandlerContext& handlerContext)
 {
-    const int nupcol = handlerContext.keyword.getRecord(0).getItem("NUM_ITER").get<int>(0);
+    const int nupcol = handlerContext.keyword.getRecord(0).getItem<ParserKeywords::NUPCOL::NUM_ITER>().get<int>(0);
 
-    if (handlerContext.keyword.getRecord(0).getItem("NUM_ITER").defaultApplied(0)) {
+    if (handlerContext.keyword.getRecord(0).getItem<ParserKeywords::NUPCOL::NUM_ITER>().defaultApplied(0)) {
         std::string msg = "OPM Flow uses 12 as default NUPCOL value";
         OpmLog::note(msg);
     }
@@ -207,6 +208,8 @@ void handleSUMTHIN(HandlerContext& handlerContext)
 
 void handleTUNING(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::TUNING;
+
     const auto numrecords = handlerContext.keyword.size();
     auto tuning = handlerContext.state().tuning();
 
@@ -234,8 +237,8 @@ void handleTUNING(HandlerContext& handlerContext)
         const auto& record1 = handlerContext.keyword.getRecord(0);
 
         // \Note A value indicates TSINIT was set in this record
-        if (const auto& deck_item = record1.getItem("TSINIT"); !deck_item.defaultApplied(0))
-            tuning.TSINIT = std::optional<double>{ record1.getItem("TSINIT").getSIDouble(0) };
+        if (const auto& deck_item = record1.getItem<Kw::TSINIT>(); !deck_item.defaultApplied(0))
+            tuning.TSINIT = std::optional<double>{ record1.getItem<Kw::TSINIT>().getSIDouble(0) };
 
         tuning.TSMAXZ = nondefault_or_previous_sidouble(record1, "TSMAXZ", tuning.TSMAXZ);
         tuning.TSMINZ = nondefault_or_previous_sidouble(record1, "TSMINZ", tuning.TSMINZ);
@@ -246,7 +249,7 @@ void handleTUNING(HandlerContext& handlerContext)
         tuning.TFDIFF = nondefault_or_previous_double(record1, "TFDIFF", tuning.TFDIFF);
         tuning.THRUPT = nondefault_or_previous_double(record1, "THRUPT", tuning.THRUPT);
 
-        const auto& TMAXWCdeckItem = record1.getItem("TMAXWC");
+        const auto& TMAXWCdeckItem = record1.getItem<Kw::TMAXWC>();
         if (TMAXWCdeckItem.hasValue(0)) {
             tuning.TMAXWC_has_value = true;
             tuning.TMAXWC = nondefault_or_previous_sidouble(record1, "TMAXWC", tuning.TMAXWC);
@@ -267,7 +270,7 @@ void handleTUNING(HandlerContext& handlerContext)
         tuning.XXXWFL = nondefault_or_previous_double(record2, "XXXWFL", tuning.XXXWFL);
         tuning.TRGFIP = nondefault_or_previous_double(record2, "TRGFIP", tuning.TRGFIP);
 
-        const auto& TRGSFTdeckItem = record2.getItem("TRGSFT");
+        const auto& TRGSFTdeckItem = record2.getItem<Kw::TRGSFT>();
         if (TRGSFTdeckItem.hasValue(0)) {
             tuning.TRGSFT_has_value = true;
             tuning.TRGSFT = nondefault_or_previous_double(record2, "TRGSFT", tuning.TRGSFT);
@@ -284,14 +287,14 @@ void handleTUNING(HandlerContext& handlerContext)
         // record.getItem("").hasValue(0) does not differentiate between deck and default values.
         // An alternative is to remove the default values for the not supported items in TUNING
         // and use record.getItem("").hasValue(0).
-        tuning.TRGTTE_has_value = !record2.getItem("TRGTTE").defaultApplied(0);
-        tuning.TRGLCV_has_value = !record2.getItem("TRGLCV").defaultApplied(0);
-        tuning.XXXTTE_has_value = !record2.getItem("XXXTTE").defaultApplied(0);
-        tuning.XXXLCV_has_value = !record2.getItem("XXXLCV").defaultApplied(0);
-        tuning.XXXWFL_has_value = !record2.getItem("XXXWFL").defaultApplied(0);
-        tuning.TRGFIP_has_value = !record2.getItem("TRGFIP").defaultApplied(0);
-        tuning.THIONX_has_value = !record2.getItem("THIONX").defaultApplied(0);
-        tuning.TRWGHT_has_value = !record2.getItem("TRWGHT").defaultApplied(0);
+        tuning.TRGTTE_has_value = !record2.getItem<Kw::TRGTTE>().defaultApplied(0);
+        tuning.TRGLCV_has_value = !record2.getItem<Kw::TRGLCV>().defaultApplied(0);
+        tuning.XXXTTE_has_value = !record2.getItem<Kw::XXXTTE>().defaultApplied(0);
+        tuning.XXXLCV_has_value = !record2.getItem<Kw::XXXLCV>().defaultApplied(0);
+        tuning.XXXWFL_has_value = !record2.getItem<Kw::XXXWFL>().defaultApplied(0);
+        tuning.TRGFIP_has_value = !record2.getItem<Kw::TRGFIP>().defaultApplied(0);
+        tuning.THIONX_has_value = !record2.getItem<Kw::THIONX>().defaultApplied(0);
+        tuning.TRWGHT_has_value = !record2.getItem<Kw::TRWGHT>().defaultApplied(0);
     }
 
     if (numrecords > 2) {
@@ -307,7 +310,7 @@ void handleTUNING(HandlerContext& handlerContext)
         tuning.DDSLIM = nondefault_or_previous_double(record3, "DDSLIM", tuning.DDSLIM);
         tuning.TRGDPR = nondefault_or_previous_sidouble(record3, "TRGDPR", tuning.TRGDPR);
 
-        const auto& XXXDPRdeckItem = record3.getItem("XXXDPR");
+        const auto& XXXDPRdeckItem = record3.getItem<Kw::XXXDPR>();
         if (XXXDPRdeckItem.hasValue(0)) {
             tuning.XXXDPR_has_value = true;
             tuning.XXXDPR = nondefault_or_previous_sidouble(record3, "XXXDPR", tuning.XXXDPR);
@@ -319,14 +322,14 @@ void handleTUNING(HandlerContext& handlerContext)
         tuning.MNWRFP = nondefault_or_previous_int(record3, "MNWRFP", tuning.MNWRFP);
 
         // Check for no supported records from the deck to write as a warning.
-        tuning.LITMAX_has_value = !record3.getItem("LITMAX").defaultApplied(0);
-        tuning.LITMIN_has_value = !record3.getItem("LITMIN").defaultApplied(0);
-        tuning.MXWSIT_has_value = !record3.getItem("MXWSIT").defaultApplied(0);
-        tuning.MXWPIT_has_value = !record3.getItem("MXWPIT").defaultApplied(0);
-        tuning.DDPLIM_has_value = !record3.getItem("DDPLIM").defaultApplied(0);
-        tuning.DDSLIM_has_value = !record3.getItem("DDSLIM").defaultApplied(0);
-        tuning.TRGDPR_has_value = !record3.getItem("TRGDPR").defaultApplied(0);
-        tuning.MNWRFP_has_value = !record3.getItem("MNWRFP").defaultApplied(0);
+        tuning.LITMAX_has_value = !record3.getItem<Kw::LITMAX>().defaultApplied(0);
+        tuning.LITMIN_has_value = !record3.getItem<Kw::LITMIN>().defaultApplied(0);
+        tuning.MXWSIT_has_value = !record3.getItem<Kw::MXWSIT>().defaultApplied(0);
+        tuning.MXWPIT_has_value = !record3.getItem<Kw::MXWPIT>().defaultApplied(0);
+        tuning.DDPLIM_has_value = !record3.getItem<Kw::DDPLIM>().defaultApplied(0);
+        tuning.DDSLIM_has_value = !record3.getItem<Kw::DDSLIM>().defaultApplied(0);
+        tuning.TRGDPR_has_value = !record3.getItem<Kw::TRGDPR>().defaultApplied(0);
+        tuning.MNWRFP_has_value = !record3.getItem<Kw::MNWRFP>().defaultApplied(0);
     }
 
     handlerContext.state().update_tuning( std::move( tuning ));
@@ -365,8 +368,8 @@ void handleTUNINGDP(HandlerContext& handlerContext)
     tuning_dp.TRGDDRV = nondefault_or_previous_sidouble(record, "TRGDDRV", tuning_dp.TRGDDRV);
 
     // See handleTUNING for TRGLCV_has_value and XXXLCV_has_value
-    tuning_dp.TRGLCV_has_value = !record.getItem("TRGLCV").defaultApplied(0);
-    tuning_dp.XXXLCV_has_value = !record.getItem("XXXLCV").defaultApplied(0);
+    tuning_dp.TRGLCV_has_value = !record.getItem<ParserKeywords::TUNINGDP::TRGLCV>().defaultApplied(0);
+    tuning_dp.XXXLCV_has_value = !record.getItem<ParserKeywords::TUNINGDP::XXXLCV>().defaultApplied(0);
 
     // Update state and events
     handlerContext.state().update_tuning_dp( std::move(tuning_dp) );

--- a/opm/input/eclipse/Schedule/MSW/MSWKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/MSW/MSWKeywordHandlers.cpp
@@ -24,6 +24,7 @@
 
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 
 #include <opm/input/eclipse/Schedule/Action/WGNames.hpp>
@@ -46,7 +47,7 @@ namespace {
 void handleCOMPSEGS(HandlerContext& handlerContext)
 {
     const auto& record1 = handlerContext.keyword.getRecord(0);
-    const std::string& wname = record1.getItem("WELL").getTrimmedString(0);
+    const std::string& wname = record1.getItem<ParserKeywords::COMPSEGS::WELL>().getTrimmedString(0);
 
     if (!handlerContext.state().wells.has(wname)) {
         const auto& location = handlerContext.keyword.location();
@@ -86,7 +87,7 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
 void handleWELSEGS(HandlerContext& handlerContext)
 {
     const auto& record1 = handlerContext.keyword.getRecord(0);
-    const auto& wname = record1.getItem("WELL").getTrimmedString(0);
+    const auto& wname = record1.getItem<ParserKeywords::WELSEGS::WELL>().getTrimmedString(0);
     if (handlerContext.state().wells.has(wname)) {
         auto well = handlerContext.state().wells.get(wname);
         if (well.handleWELSEGS(handlerContext.keyword)) {

--- a/opm/input/eclipse/Schedule/MSW/Valve.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Valve.cpp
@@ -24,6 +24,8 @@
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
+
 #include "icd_convert.hpp"
 
 #include <cstddef>
@@ -101,44 +103,46 @@ namespace Opm {
     {}
 
     Valve::Valve(const DeckRecord& record, const double udq_default)
-        : m_con_flow_coeff(record.getItem("CV").get<double>(0))
-        , m_con_cross_area(record.getItem("AREA").get<UDAValue>(0))
+        : m_con_flow_coeff(record.getItem<ParserKeywords::WSEGVALV::CV>().get<double>(0))
+        , m_con_cross_area(record.getItem<ParserKeywords::WSEGVALV::AREA>().get<UDAValue>(0))
         , m_con_cross_area_value(m_con_cross_area.is<double>() ? m_con_cross_area.getSI() : -1.0)
         , m_udq_default(udq_default)
     {
+        using Kw = ParserKeywords::WSEGVALV;
+
         // We initialize negative values for the values are defaulted
         const double value_for_default = -1.0e100;
 
         // TODO: we assume that the value input for this keyword is always positive
-        if (record.getItem("EXTRA_LENGTH").defaultApplied(0)) {
+        if (record.getItem<Kw::EXTRA_LENGTH>().defaultApplied(0)) {
             m_pipe_additional_length = value_for_default;
         }
         else {
-            m_pipe_additional_length = record.getItem("EXTRA_LENGTH").getSIDouble(0);
+            m_pipe_additional_length = record.getItem<Kw::EXTRA_LENGTH>().getSIDouble(0);
         }
 
-        if (record.getItem("PIPE_D").defaultApplied(0)) {
+        if (record.getItem<Kw::PIPE_D>().defaultApplied(0)) {
             m_pipe_diameter = value_for_default;
         }
         else {
-            m_pipe_diameter = record.getItem("PIPE_D").getSIDouble(0);
+            m_pipe_diameter = record.getItem<Kw::PIPE_D>().getSIDouble(0);
         }
 
-        if (record.getItem("ROUGHNESS").defaultApplied(0)) {
+        if (record.getItem<Kw::ROUGHNESS>().defaultApplied(0)) {
             m_pipe_roughness = value_for_default;
         }
         else {
-            m_pipe_roughness = record.getItem("ROUGHNESS").getSIDouble(0);
+            m_pipe_roughness = record.getItem<Kw::ROUGHNESS>().getSIDouble(0);
         }
 
-        if (record.getItem("PIPE_A").defaultApplied(0)) {
+        if (record.getItem<Kw::PIPE_A>().defaultApplied(0)) {
             m_pipe_cross_area = value_for_default;
         }
         else {
-            m_pipe_cross_area = record.getItem("PIPE_A").getSIDouble(0);
+            m_pipe_cross_area = record.getItem<Kw::PIPE_A>().getSIDouble(0);
         }
 
-        if (record.getItem("STATUS").getTrimmedString(0) == "OPEN") {
+        if (record.getItem<Kw::STATUS>().getTrimmedString(0) == "OPEN") {
             m_status = ICDStatus::OPEN;
         }
         else {
@@ -146,11 +150,11 @@ namespace Opm {
             // TODO: should we check illegal input here
         }
 
-        if (record.getItem("MAX_A").defaultApplied(0)) {
+        if (record.getItem<Kw::MAX_A>().defaultApplied(0)) {
             m_con_max_cross_area = value_for_default;
         }
         else {
-            m_con_max_cross_area = record.getItem("MAX_A").getSIDouble(0);
+            m_con_max_cross_area = record.getItem<Kw::MAX_A>().getSIDouble(0);
         }
     }
 
@@ -173,12 +177,14 @@ namespace Opm {
     std::map<std::string, std::vector<std::pair<int, Valve>>>
     Valve::fromWSEGVALV(const DeckKeyword& keyword, const double udq_default)
     {
+        using Kw = ParserKeywords::WSEGVALV;
+
         auto res = std::map<std::string, std::vector<std::pair<int, Valve>>>{};
 
         for (const DeckRecord& record : keyword) {
-            const std::string well_name = record.getItem("WELL").getTrimmedString(0);
+            const std::string well_name = record.getItem<Kw::WELL>().getTrimmedString(0);
 
-            const int segment_number = record.getItem("SEGMENT_NUMBER").get<int>(0);
+            const int segment_number = record.getItem<Kw::SEGMENT_NUMBER>().get<int>(0);
 
             res[well_name].emplace_back(std::piecewise_construct,
                                         std::forward_as_tuple(segment_number),

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -35,6 +35,7 @@
 
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -249,6 +250,8 @@ namespace Opm {
 
     void WellSegments::loadWELSEGS(const DeckKeyword& welsegsKeyword, const UnitSystem& unit_system)
     {
+        using Kw = ParserKeywords::WELSEGS;
+
         // For the first record, which provides the information for the top
         // segment and information for the whole segment set.
         const auto& record1 = welsegsKeyword.getRecord(0);
@@ -256,15 +259,15 @@ namespace Opm {
         // Meaningless value to indicate unspecified values.
         const double invalid_value = Segment::invalidValue();
 
-        const auto& wname = record1.getItem("WELL").getTrimmedString(0);
-        const double depth_top = record1.getItem("TOP_DEPTH").getSIDouble(0);
-        const double length_top = record1.getItem("TOP_LENGTH").getSIDouble(0);
-        const double volume_top = record1.getItem("WELLBORE_VOLUME").getSIDouble(0);
-        const LengthDepth length_depth_type = LengthDepthFromString(record1.getItem("INFO_TYPE").getTrimmedString(0));
-        m_comp_pressure_drop = CompPressureDropFromString(record1.getItem("PRESSURE_COMPONENTS").getTrimmedString(0));
+        const auto& wname = record1.getItem<Kw::WELL>().getTrimmedString(0);
+        const double depth_top = record1.getItem<Kw::TOP_DEPTH>().getSIDouble(0);
+        const double length_top = record1.getItem<Kw::TOP_LENGTH>().getSIDouble(0);
+        const double volume_top = record1.getItem<Kw::WELLBORE_VOLUME>().getSIDouble(0);
+        const LengthDepth length_depth_type = LengthDepthFromString(record1.getItem<Kw::INFO_TYPE>().getTrimmedString(0));
+        m_comp_pressure_drop = CompPressureDropFromString(record1.getItem<Kw::PRESSURE_COMPONENTS>().getTrimmedString(0));
 
-        const auto nodeX_top = record1.getItem("TOP_X").getSIDouble(0);
-        const auto nodeY_top = record1.getItem("TOP_Y").getSIDouble(0);
+        const auto nodeX_top = record1.getItem<Kw::TOP_X>().getSIDouble(0);
+        const auto nodeY_top = record1.getItem<Kw::TOP_Y>().getSIDouble(0);
 
         // The main branch is 1 instead of 0.  The segment number for top
         // segment is also 1.
@@ -302,8 +305,8 @@ namespace Opm {
         // get all the requisite information.
         for (std::size_t recordIndex = 1; recordIndex < welsegsKeyword.size(); ++recordIndex) {
             const auto& record = welsegsKeyword.getRecord(recordIndex);
-            const int segment1 = record.getItem("SEGMENT1").get<int>(0);
-            const int segment2 = record.getItem("SEGMENT2").get<int>(0);
+            const int segment1 = record.getItem<Kw::SEGMENT1>().get<int>(0);
+            const int segment2 = record.getItem<Kw::SEGMENT2>().get<int>(0);
             if (segment1 < 2) {
                 throw std::logic_error {
                     fmt::format("Illegal segment 1 number in WELSEGS\n"
@@ -319,7 +322,7 @@ namespace Opm {
                 };
             }
 
-            const int branch = record.getItem("BRANCH").get<int>(0);
+            const int branch = record.getItem<Kw::BRANCH>().get<int>(0);
             if (branch < 1) {
                 throw std::logic_error {
                     fmt::format("Illegal branch number input "
@@ -327,10 +330,10 @@ namespace Opm {
                 };
             }
 
-            const double diameter = record.getItem("DIAMETER").getSIDouble(0);
+            const double diameter = record.getItem<Kw::DIAMETER>().getSIDouble(0);
             double area = std::numbers::pi * diameter * diameter / 4.0;
             {
-                const auto& itemArea = record.getItem("AREA");
+                const auto& itemArea = record.getItem<Kw::AREA>();
                 if (itemArea.hasValue(0)) {
                     area = itemArea.getSIDouble(0);
                 }
@@ -338,15 +341,15 @@ namespace Opm {
 
             // If the length_depth_type is INC, then the length is the length of the segment,
             // If the length_depth_type is ABS, then the length is the length of the last segment node in the range.
-            const double length = record.getItem("LENGTH").getSIDouble(0);
+            const double length = record.getItem<Kw::LENGTH>().getSIDouble(0);
 
             // If the length_depth_type is INC, then the depth is the depth change of the segment from the outlet segment.
             // If the length_depth_type is ABS, then the depth is the absolute depth of last the segment node in the range.
-            const double depth = record.getItem("DEPTH").getSIDouble(0);
+            const double depth = record.getItem<Kw::DEPTH>().getSIDouble(0);
 
             double volume = invalid_value;
             {
-                const auto& itemVolume = record.getItem("VOLUME");
+                const auto& itemVolume = record.getItem<Kw::VOLUME>();
                 if (itemVolume.hasValue(0)) {
                     volume = itemVolume.getSIDouble(0);
                 }
@@ -355,7 +358,7 @@ namespace Opm {
                 }
             }
 
-            const double input_roughness = record.getItem("ROUGHNESS").getSIDouble(0);
+            const double input_roughness = record.getItem<Kw::ROUGHNESS>().getSIDouble(0);
             const double safe_roughness = Segment::MAX_REL_ROUGHNESS * diameter;
             const bool too_high_roughness = input_roughness > safe_roughness;
             const double roughness = too_high_roughness ? safe_roughness : input_roughness;
@@ -366,8 +369,8 @@ namespace Opm {
                                             wname, segment1, segment2, input_roughness, location.lineno, location.filename, roughness));
             }
 
-            const auto node_X = record.getItem("LENGTH_X").getSIDouble(0);
-            const auto node_Y = record.getItem("LENGTH_Y").getSIDouble(0);
+            const auto node_X = record.getItem<Kw::LENGTH_X>().getSIDouble(0);
+            const auto node_Y = record.getItem<Kw::LENGTH_Y>().getSIDouble(0);
 
             for (int segment_number = segment1; segment_number <= segment2; ++segment_number) {
                 // For the first or the only segment in the range is the one
@@ -375,7 +378,7 @@ namespace Opm {
                 // range, the outlet segment is the previous segment in the
                 // range.
                 const int outlet_segment = (segment_number == segment1)
-                    ? record.getItem("JOIN_SEGMENT").get<int>(0)
+                    ? record.getItem<Kw::JOIN_SEGMENT>().get<int>(0)
                     : segment_number - 1;
 
                 const auto data_ready = (length_depth_type != LengthDepth::INC)

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -864,9 +864,10 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
                                                      ErrorGuard&         errors)
     {
         if (keyword.is<ParserKeywords::COMPDAT>()) {
+            using Kw = ParserKeywords::COMPDAT;
             for (const auto& record : keyword) {
-                const auto& itemI = record.getItem("I");
-                const auto& itemJ = record.getItem("J");
+                const auto& itemI = record.getItem<Kw::I>();
+                const auto& itemJ = record.getItem<Kw::J>();
 
                 const auto defaulted_I = itemI.defaultApplied(0) || (itemI.get<int>(0) == 0);
                 const auto defaulted_J = itemJ.defaultApplied(0) || (itemJ.get<int>(0) == 0);
@@ -884,10 +885,10 @@ Defaulted grid coordinates is not allowed for COMPDAT as part of ACTIONX)"
                 const auto I = itemI.get<int>(0) - 1;
                 const auto J = itemJ.get<int>(0) - 1;
 
-                const auto K1 = record.getItem("K1").get<int>(0) - 1;
-                const auto K2 = record.getItem("K2").get<int>(0) - 1;
+                const auto K1 = record.getItem<Kw::K1>().get<int>(0) - 1;
+                const auto K2 = record.getItem<Kw::K2>().get<int>(0) - 1;
 
-                const auto wellName = record.getItem("WELL").getTrimmedString(0);
+                const auto wellName = record.getItem<Kw::WELL>().getTrimmedString(0);
 
                 // Retrieve or create the set of future connections for the well
                 auto& currentSet = this->possibleFutureConnections[wellName];
@@ -916,6 +917,7 @@ Defaulted grid coordinates is not allowed for COMPDAT as part of ACTIONX)"
         }
 
         if (keyword.is<ParserKeywords::COMPSEGS>()) {
+            using Kw = ParserKeywords::COMPSEGS;
             bool first_record = true;
 
             for (const auto& record : keyword) {
@@ -924,9 +926,9 @@ Defaulted grid coordinates is not allowed for COMPDAT as part of ACTIONX)"
                     continue;
                 }
 
-                const int I = record.getItem("I").get<int>(0) - 1;
-                const int J = record.getItem("J").get<int>(0) - 1;
-                const int K = record.getItem("K").get<int>(0) - 1;
+                const int I = record.getItem<Kw::I>().get<int>(0) - 1;
+                const int J = record.getItem<Kw::J>().get<int>(0) - 1;
+                const int K = record.getItem<Kw::K>().get<int>(0) - 1;
 
                 try {
                     const auto& cell = grid.get_cell(I, J, K);
@@ -1127,11 +1129,11 @@ Defaulted grid coordinates is not allowed for COMPDAT as part of ACTIONX)"
                            Connection::Order wellConnectionOrder)
     {
         // We change from eclipse's 1 - n, to a 0 - n-1 solution
-        int headI = record.getItem("HEAD_I").get< int >(0) - 1;
-        int headJ = record.getItem("HEAD_J").get< int >(0) - 1;
+        int headI = record.getItem<ParserKeywords::WELSPECS::HEAD_I>().get< int >(0) - 1;
+        int headJ = record.getItem<ParserKeywords::WELSPECS::HEAD_J>().get< int >(0) - 1;
         Phase preferredPhase;
         {
-            const std::string phaseStr = record.getItem("PHASE").getTrimmedString(0);
+            const std::string phaseStr = record.getItem<ParserKeywords::WELSPECS::PHASE>().getTrimmedString(0);
             if (phaseStr == "LIQ") {
                 // We need a workaround in case the preferred phase is "LIQ",
                 // which is not proper phase and will cause the get_phase()
@@ -1143,12 +1145,12 @@ Defaulted grid coordinates is not allowed for COMPDAT as part of ACTIONX)"
                 preferredPhase = get_phase(phaseStr);
             }
         }
-        const auto& refDepthItem = record.getItem("REF_DEPTH");
+        const auto& refDepthItem = record.getItem<ParserKeywords::WELSPECS::REF_DEPTH>();
         std::optional<double> ref_depth;
         if (refDepthItem.hasValue( 0 ))
             ref_depth = refDepthItem.getSIDouble( 0 );
 
-        double drainageRadius = record.getItem( "D_RADIUS" ).getSIDouble(0);
+        double drainageRadius = record.getItem<ParserKeywords::WELSPECS::D_RADIUS>().getSIDouble(0);
 
         bool allowCrossFlow = true;
         const std::string& allowCrossFlowStr = record.getItem<ParserKeywords::WELSPECS::CROSSFLOW>().getTrimmedString(0);

--- a/opm/input/eclipse/Schedule/UDQ/UDQParams.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQParams.cpp
@@ -59,19 +59,21 @@ namespace Opm {
         UDQParams()
     {
         if (deck.hasKeyword("UDQDIMS")) {
+            using Kw = ParserKeywords::UDQDIMS;
             const auto& record = deck["UDQDIMS"].back().getRecord(0);
-            const auto& item = record.getItem("RESTART_NEW_SEED");
+            const auto& item = record.getItem<Kw::RESTART_NEW_SEED>();
             const auto& bool_string = item.get<std::string>(0);
 
             reseed_rng = (std::toupper(bool_string[0]) == 'Y');
         }
 
         if (deck.hasKeyword("UDQPARAM")) {
+            using Kw = ParserKeywords::UDQPARAM;
             const auto& record = deck["UDQPARAM"].back().getRecord(0);
-            random_seed = record.getItem("RANDOM_SEED").get<int>(0);
-            value_range = record.getItem("RANGE").get<double>(0);
-            undefined_value = record.getItem("UNDEFINED_VALUE").get<double>(0);
-            cmp_eps = record.getItem("CMP_EPSILON").get<double>(0);
+            random_seed = record.getItem<Kw::RANDOM_SEED>().get<int>(0);
+            value_range = record.getItem<Kw::RANGE>().get<double>(0);
+            undefined_value = record.getItem<Kw::UNDEFINED_VALUE>().get<double>(0);
+            cmp_eps = record.getItem<Kw::CMP_EPSILON>().get<double>(0);
         }
         this->m_sim_rng.seed( this->random_seed );
     }

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1626,6 +1626,8 @@ bool Well::handleCSKIN(const DeckRecord&      record,
 
 bool Well::handleCOMPLUMP(const DeckRecord& record)
 {
+    using Kw = ParserKeywords::COMPLUMP;
+
     auto match = [&record](const Connection &c) -> bool {
         if (!match_eq(c.getI(), record, "I" , -1)) { return false; }
         if (!match_eq(c.getJ(), record, "J" , -1)) { return false; }
@@ -1638,7 +1640,7 @@ bool Well::handleCOMPLUMP(const DeckRecord& record)
     auto new_connections = std::make_shared<WellConnections>
         (this->connections->ordering(), this->headI, this->headJ);
 
-    const int complnum = record.getItem("N").get<int>(0);
+    const int complnum = record.getItem<Kw::N>().get<int>(0);
     if (complnum <= 0) {
         throw std::invalid_argument {
             fmt::format("Completion number must be >= 1. COMPLNUM={} is invalid", complnum)
@@ -1662,6 +1664,8 @@ bool Well::handleCOMPLUMP(const DeckRecord& record)
 
 bool Well::handleWPIMULT(const DeckRecord& record)
 {
+    using Kw = ParserKeywords::WPIMULT;
+
     auto match = [&record](const Connection &c) -> bool {
         if (!match_ge(c.complnum(), record, "FIRST")) { return false; }
         if (!match_le(c.complnum(), record, "LAST"))  { return false; }
@@ -1675,7 +1679,7 @@ bool Well::handleWPIMULT(const DeckRecord& record)
     auto new_connections = std::make_shared<WellConnections>
         (this->connections->ordering(), this->headI, this->headJ);
 
-    const auto wellPi = record.getItem("WELLPI").get<double>(0);
+    const auto wellPi = record.getItem<Kw::WELLPI>().get<double>(0);
 
     for (const auto& connection : *this->connections) {
         if (! match(connection)) {

--- a/opm/input/eclipse/Schedule/Well/WellBrineProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellBrineProperties.cpp
@@ -33,7 +33,8 @@ Opm::WellBrineProperties Opm::WellBrineProperties::serializationTestObject()
 
 void Opm::WellBrineProperties::handleWSALT(const DeckRecord& rec)
 {
-    this->m_saltConcentration = rec.getItem<ParserKeywords::WSALT::CONCENTRATION>().get<UDAValue>(0).getSI();
+    using Kw = ParserKeywords::WSALT;
+    this->m_saltConcentration = rec.getItem<Kw::CONCENTRATION>().get<UDAValue>(0).getSI();
 }
 
 bool Opm::WellBrineProperties::operator!=(const WellBrineProperties& other) const

--- a/opm/input/eclipse/Schedule/Well/WellBrineProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellBrineProperties.cpp
@@ -21,6 +21,7 @@
 
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 
 Opm::WellBrineProperties Opm::WellBrineProperties::serializationTestObject()
 {
@@ -32,7 +33,7 @@ Opm::WellBrineProperties Opm::WellBrineProperties::serializationTestObject()
 
 void Opm::WellBrineProperties::handleWSALT(const DeckRecord& rec)
 {
-    this->m_saltConcentration = rec.getItem("CONCENTRATION").get<UDAValue>(0).getSI();
+    this->m_saltConcentration = rec.getItem<ParserKeywords::WSALT::CONCENTRATION>().get<UDAValue>(0).getSI();
 }
 
 bool Opm::WellBrineProperties::operator!=(const WellBrineProperties& other) const

--- a/opm/input/eclipse/Schedule/Well/WellCompletionKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellCompletionKeywordHandlers.cpp
@@ -48,11 +48,13 @@ template <typename CompdatKwHandler>
 void handleCOMPDATX(HandlerContext&    handlerContext,
                     CompdatKwHandler&& compdatKwHandler)
 {
+    using Kw = ParserKeywords::COMPDATX;
+
     auto pending_connections =
         std::unordered_map<std::string, std::shared_ptr<WellConnections>> {};
 
     for (const auto& record : handlerContext.keyword) {
-        const auto wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const auto wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto wellnames = handlerContext.wellNames(wellNamePattern);
 
         for (const auto& wname : wellnames) {
@@ -155,8 +157,10 @@ void handleCOMPDATL(HandlerContext& handlerContext)
 
 void handleCOMPLUMP(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::COMPLUMP;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern);
 
         for (const auto& wname : well_names) {

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -437,27 +437,32 @@ namespace Opm {
         requested_open_complnums.clear();
         requested_shut_complnums.clear();
 
-        const auto& itemI = record.getItem("I");
+        // Shared backend for COMPDAT/COMPDATL/COMPDATM.  COMPDATX is the
+        // superset keyword (same items plus the LGR item), so resolve all
+        // item names against it regardless of which variant 'record' holds.
+        using Kw = ParserKeywords::COMPDATX;
+
+        const auto& itemI = record.getItem<Kw::I>();
         const auto defaulted_I = itemI.defaultApplied(0) || (itemI.get<int>(0) == 0);
         const auto I = !defaulted_I ? itemI.get<int>(0) - 1 : this->headI;
 
-        const auto& itemJ = record.getItem("J");
+        const auto& itemJ = record.getItem<Kw::J>();
         const auto defaulted_J = itemJ.defaultApplied(0) || (itemJ.get<int>(0) == 0);
         const auto J = !defaulted_J ? itemJ.get<int>(0) - 1 : this->headJ;
 
-        const auto K1 = record.getItem("K1").get<int>(0) - 1;
-        const auto K2 = record.getItem("K2").get<int>(0) - 1;
-        const auto state = Connection::StateFromString(record.getItem("STATE").getTrimmedString(0));
+        const auto K1 = record.getItem<Kw::K1>().get<int>(0) - 1;
+        const auto K2 = record.getItem<Kw::K2>().get<int>(0) - 1;
+        const auto state = Connection::StateFromString(record.getItem<Kw::STATE>().getTrimmedString(0));
 
-        const auto& r0Item = record.getItem("PR");
-        const auto& CFItem = record.getItem("CONNECTION_TRANSMISSIBILITY_FACTOR");
-        const auto& diameterItem = record.getItem("DIAMETER");
-        const auto& KhItem = record.getItem("Kh");
-        const auto& satTableIdItem = record.getItem("SAT_TABLE");
-        const auto direction = Connection::DirectionFromString(record.getItem("DIR").getTrimmedString(0));
+        const auto& r0Item = record.getItem<Kw::PR>();
+        const auto& CFItem = record.getItem<Kw::CONNECTION_TRANSMISSIBILITY_FACTOR>();
+        const auto& diameterItem = record.getItem<Kw::DIAMETER>();
+        const auto& KhItem = record.getItem<Kw::Kh>();
+        const auto& satTableIdItem = record.getItem<Kw::SAT_TABLE>();
+        const auto direction = Connection::DirectionFromString(record.getItem<Kw::DIR>().getTrimmedString(0));
 
-        const auto skin_factor = record.getItem("SKIN").getSIDouble(0);
-        const auto d_factor = record.getItem("D_FACTOR").getSIDouble(0);
+        const auto skin_factor = record.getItem<Kw::SKIN>().getSIDouble(0);
+        const auto d_factor = record.getItem<Kw::D_FACTOR>().getSIDouble(0);
         const int lgr_grid_number = grid.get_lgr_grid_number(lgr_label);
 
         int satTableId = -1;
@@ -716,16 +721,18 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
     {
         if (this->coord[0].size() == 0) return;  // No path.
 
-        const auto& perf_top = record.getItem("PERF_TOP");
-        const auto& perf_bot = record.getItem("PERF_BOT");
+        using Kw = ParserKeywords::COMPTRAJ;
 
-        const auto& CFItem = record.getItem("CONNECTION_TRANSMISSIBILITY_FACTOR");
-        const auto& diameterItem = record.getItem("DIAMETER");
-        const auto& KhItem = record.getItem("Kh");
-        const auto skin_factor = record.getItem("SKIN").getSIDouble(0);
-        const auto d_factor = record.getItem("D_FACTOR").getSIDouble(0);
-        const auto& satTableIdItem = record.getItem("SAT_TABLE");
-        const auto state = Connection::StateFromString(record.getItem("STATE").getTrimmedString(0));
+        const auto& perf_top = record.getItem<Kw::PERF_TOP>();
+        const auto& perf_bot = record.getItem<Kw::PERF_BOT>();
+
+        const auto& CFItem = record.getItem<Kw::CONNECTION_TRANSMISSIBILITY_FACTOR>();
+        const auto& diameterItem = record.getItem<Kw::DIAMETER>();
+        const auto& KhItem = record.getItem<Kw::Kh>();
+        const auto skin_factor = record.getItem<Kw::SKIN>().getSIDouble(0);
+        const auto d_factor = record.getItem<Kw::D_FACTOR>().getSIDouble(0);
+        const auto& satTableIdItem = record.getItem<Kw::SAT_TABLE>();
+        const auto state = Connection::StateFromString(record.getItem<Kw::STATE>().getTrimmedString(0));
 
         int satTableId = -1;
         bool defaultSatTable = true;
@@ -932,8 +939,10 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                                       [[maybe_unused]] const ScheduleGrid&    grid,
                                       [[maybe_unused]] const KeywordLocation& location)
     {
-        double x = record.getItem("X").getSIDouble(0);
-        double y = record.getItem("Y").getSIDouble(0);
+        using Kw = ParserKeywords::WELTRAJ;
+
+        double x = record.getItem<Kw::X>().getSIDouble(0);
+        double y = record.getItem<Kw::Y>().getSIDouble(0);
 
         if (const auto& mapaxes = grid.get_grid()->getMapAxes();
             mapaxes.has_value())
@@ -943,9 +952,9 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
 
         this->coord[0].push_back(x);
         this->coord[1].push_back(y);
-        this->coord[2].push_back(record.getItem("TVD").getSIDouble(0));
+        this->coord[2].push_back(record.getItem<Kw::TVD>().getSIDouble(0));
 
-        this->md.push_back(record.getItem("MD").getSIDouble(0));
+        this->md.push_back(record.getItem<Kw::MD>().getSIDouble(0));
     }
 
     void WellConnections::applyDFactorCorrelation(const ScheduleGrid& grid,

--- a/opm/input/eclipse/Schedule/Well/WellEconProductionLimits.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellEconProductionLimits.cpp
@@ -25,6 +25,8 @@
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
+
 #include <cassert>
 #include <cmath>
 #include <stdexcept>
@@ -120,39 +122,41 @@ namespace Opm {
     }
 
     WellEconProductionLimits::WellEconProductionLimits(const DeckRecord& record)
-        : m_min_oil_rate(record.getItem("MIN_OIL_PRODUCTION").get<UDAValue>(0).SI_value_or(0.0))
-        , m_min_gas_rate(record.getItem("MIN_GAS_PRODUCTION").get<UDAValue>(0).SI_value_or(0.0))
-        , m_max_water_cut(record.getItem("MAX_WATER_CUT").get<UDAValue>(0).SI_value_or(0.0))
-        , m_max_gas_oil_ratio(record.getItem("MAX_GAS_OIL_RATIO").get<UDAValue>(0).SI_value_or(0.0))
-        , m_max_water_gas_ratio(record.getItem("MAX_WATER_GAS_RATIO").get<UDAValue>(0).SI_value_or(0.0))
-        , m_workover(EconWorkoverFromString(record.getItem("WORKOVER_RATIO_LIMIT").getTrimmedString(0)))
+        : m_min_oil_rate(record.getItem<ParserKeywords::WECON::MIN_OIL_PRODUCTION>().get<UDAValue>(0).SI_value_or(0.0))
+        , m_min_gas_rate(record.getItem<ParserKeywords::WECON::MIN_GAS_PRODUCTION>().get<UDAValue>(0).SI_value_or(0.0))
+        , m_max_water_cut(record.getItem<ParserKeywords::WECON::MAX_WATER_CUT>().get<UDAValue>(0).SI_value_or(0.0))
+        , m_max_gas_oil_ratio(record.getItem<ParserKeywords::WECON::MAX_GAS_OIL_RATIO>().get<UDAValue>(0).SI_value_or(0.0))
+        , m_max_water_gas_ratio(record.getItem<ParserKeywords::WECON::MAX_WATER_GAS_RATIO>().get<UDAValue>(0).SI_value_or(0.0))
+        , m_workover(EconWorkoverFromString(record.getItem<ParserKeywords::WECON::WORKOVER_RATIO_LIMIT>().getTrimmedString(0)))
         , m_end_run(false)
-        , m_followon_well(record.getItem("FOLLOW_ON_WELL").getTrimmedString(0))
-        , m_quantity_limit(QuantityLimitFromString(record.getItem("LIMITED_QUANTITY").getTrimmedString(0)))
-        , m_secondary_max_water_cut(record.getItem("SECOND_MAX_WATER_CUT").get<double>(0))
-        , m_max_gas_liquid_ratio(record.getItem("MAX_GAS_LIQUID_RATIO").get<double>(0))
-        , m_min_liquid_rate(record.getItem("MIN_LIQUID_PRODCUTION_RATE").getSIDouble(0))
-        , m_min_reservoir_fluid_rate(record.getItem("MIN_RES_FLUID_RATE").getSIDouble(0))
+        , m_followon_well(record.getItem<ParserKeywords::WECON::FOLLOW_ON_WELL>().getTrimmedString(0))
+        , m_quantity_limit(QuantityLimitFromString(record.getItem<ParserKeywords::WECON::LIMITED_QUANTITY>().getTrimmedString(0)))
+        , m_secondary_max_water_cut(record.getItem<ParserKeywords::WECON::SECOND_MAX_WATER_CUT>().get<double>(0))
+        , m_max_gas_liquid_ratio(record.getItem<ParserKeywords::WECON::MAX_GAS_LIQUID_RATIO>().get<double>(0))
+        , m_min_liquid_rate(record.getItem<ParserKeywords::WECON::MIN_LIQUID_PRODCUTION_RATE>().getSIDouble(0))
+        , m_min_reservoir_fluid_rate(record.getItem<ParserKeywords::WECON::MIN_RES_FLUID_RATE>().getSIDouble(0))
     {
         assert(m_workover != EconWorkover::LAST);
         assert(m_workover != EconWorkover::RED);
 
-        if (record.getItem("MAX_TEMP").hasValue(0)) {
-            m_max_temperature = record.getItem("MAX_TEMP").getSIDouble(0);
+        using Kw = ParserKeywords::WECON;
+
+        if (record.getItem<Kw::MAX_TEMP>().hasValue(0)) {
+            m_max_temperature = record.getItem<Kw::MAX_TEMP>().getSIDouble(0);
         } else {
             // defaulted with one really non-physical value.
             m_max_temperature = -1e8;
         }
 
-        if (record.getItem("WORKOVER_SECOND_WATER_CUT_LIMIT").hasValue(0)) {
-            const std::string string_workover = record.getItem("WORKOVER_SECOND_WATER_CUT_LIMIT").getTrimmedString(0);
+        if (record.getItem<Kw::WORKOVER_SECOND_WATER_CUT_LIMIT>().hasValue(0)) {
+            const std::string string_workover = record.getItem<Kw::WORKOVER_SECOND_WATER_CUT_LIMIT>().getTrimmedString(0);
             m_workover_secondary = EconWorkoverFromString(string_workover);
         } else {
             m_workover_secondary = m_workover;
         }
 
-        if (record.getItem("END_RUN_FLAG").hasValue(0)) {
-            std::string string_endrun = record.getItem("END_RUN_FLAG").getTrimmedString(0);
+        if (record.getItem<Kw::END_RUN_FLAG>().hasValue(0)) {
+            std::string string_endrun = record.getItem<Kw::END_RUN_FLAG>().getTrimmedString(0);
             if (string_endrun == "YES") {
                 m_end_run = true;
             } else if (string_endrun != "NO") {

--- a/opm/input/eclipse/Schedule/Well/WellFoamProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellFoamProperties.cpp
@@ -22,6 +22,8 @@
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
+
 Opm::WellFoamProperties Opm::WellFoamProperties::serializationTestObject()
 {
     Opm::WellFoamProperties result;
@@ -32,7 +34,9 @@ Opm::WellFoamProperties Opm::WellFoamProperties::serializationTestObject()
 
 void Opm::WellFoamProperties::handleWFOAM(const DeckRecord& rec)
 {
-    this->m_foamConcentration = rec.getItem("FOAM_CONCENTRATION").get<UDAValue>(0).getSI();
+    using Kw = ParserKeywords::WFOAM;
+
+    this->m_foamConcentration = rec.getItem<Kw::FOAM_CONCENTRATION>().get<UDAValue>(0).getSI();
 }
 
 bool Opm::WellFoamProperties::operator==(const WellFoamProperties& other) const

--- a/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
@@ -26,6 +26,7 @@
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>
@@ -94,26 +95,26 @@ namespace Opm {
                                                        const std::string& well_name,
                                                        const KeywordLocation& location)
     {
-        this->injectorType = InjectorTypeFromString( record.getItem("TYPE").getTrimmedString(0) );
+        this->injectorType = InjectorTypeFromString( record.getItem<ParserKeywords::WCONINJE::TYPE>().getTrimmedString(0) );
         this->predictionMode = true;
 
-        if (!record.getItem("RATE").defaultApplied(0)) {
-            this->surfaceInjectionRate = record.getItem("RATE").get<UDAValue>(0);
+        if (!record.getItem<ParserKeywords::WCONINJE::RATE>().defaultApplied(0)) {
+            this->surfaceInjectionRate = record.getItem<ParserKeywords::WCONINJE::RATE>().get<UDAValue>(0);
             this->addInjectionControl(InjectorCMode::RATE);
         } else
             this->dropInjectionControl(InjectorCMode::RATE);
 
 
-        if (!record.getItem("RESV").defaultApplied(0)) {
-            this->reservoirInjectionRate = record.getItem("RESV").get<UDAValue>(0);
+        if (!record.getItem<ParserKeywords::WCONINJE::RESV>().defaultApplied(0)) {
+            this->reservoirInjectionRate = record.getItem<ParserKeywords::WCONINJE::RESV>().get<UDAValue>(0);
             this->addInjectionControl(InjectorCMode::RESV);
         } else
             this->dropInjectionControl(InjectorCMode::RESV);
 
-        this->VFPTableNumber = record.getItem("VFP_TABLE").get< int >(0);
+        this->VFPTableNumber = record.getItem<ParserKeywords::WCONINJE::VFP_TABLE>().get< int >(0);
 
-        if (!record.getItem("THP").defaultApplied(0)) {
-            this->THPTarget = record.getItem("THP").get<UDAValue>(0);
+        if (!record.getItem<ParserKeywords::WCONINJE::THP>().defaultApplied(0)) {
+            this->THPTarget = record.getItem<ParserKeywords::WCONINJE::THP>().get<UDAValue>(0);
             this->addInjectionControl(InjectorCMode::THP);
             if (this->VFPTableNumber == 0) {
                 const auto msg = fmt::format("Well {} must have a VFP table to handle"
@@ -131,10 +132,10 @@ namespace Opm {
           current behavoir agrees with the behavior of Eclipse when BHPLimit is not
           specified while employed during group control.
         */
-        if (record.getItem("BHP").defaultApplied(0)) {
+        if (record.getItem<ParserKeywords::WCONINJE::BHP>().defaultApplied(0)) {
             this->BHPTarget.update(bhp_def);
         } else {
-            this->BHPTarget = record.getItem("BHP").get<UDAValue>(0);
+            this->BHPTarget = record.getItem<ParserKeywords::WCONINJE::BHP>().get<UDAValue>(0);
         }
         this->addInjectionControl(InjectorCMode::BHP);
 
@@ -143,7 +144,7 @@ namespace Opm {
         else
             this->dropInjectionControl(InjectorCMode::GRUP);
         {
-            const std::string& cmodeString = record.getItem("CMODE").getTrimmedString(0);
+            const std::string& cmodeString = record.getItem<ParserKeywords::WCONINJE::CMODE>().getTrimmedString(0);
             InjectorCMode controlModeArg = WellInjectorCModeFromString(cmodeString);
             if (this->hasInjectionControl( controlModeArg))
                 this->controlMode = controlModeArg;
@@ -151,11 +152,11 @@ namespace Opm {
                 throw std::invalid_argument("Tried to set invalid control: " + cmodeString + " for well: " + well_name);
             }
         }
-        this->rsRvInj = record.getItem("VAPOIL_C").getSIDouble(0);
+        this->rsRvInj = record.getItem<ParserKeywords::WCONINJE::VAPOIL_C>().getSIDouble(0);
         if (this->injectorType == InjectorType::OIL && this->rsRvInj > 0) {
-            double factor = record.getItem("VAPOIL_C").getSIDouble(0) / record.getItem("VAPOIL_C").get<double>(0);
+            double factor = record.getItem<ParserKeywords::WCONINJE::VAPOIL_C>().getSIDouble(0) / record.getItem<ParserKeywords::WCONINJE::VAPOIL_C>().get<double>(0);
             // for oil injectors the rsRvInj is Rs and the inverse of the si-conversion factor should be used
-            this->rsRvInj =  record.getItem("VAPOIL_C").get<double>(0) / factor;
+            this->rsRvInj =  record.getItem<ParserKeywords::WCONINJE::VAPOIL_C>().get<double>(0) / factor;
         }
     }
 
@@ -206,23 +207,23 @@ namespace Opm {
                                                   const KeywordLocation& loc)
     {
         // convert injection rates to SI
-        const auto& typeItem = record.getItem("TYPE");
+        const auto& typeItem = record.getItem<ParserKeywords::WCONINJH::TYPE>();
         if (typeItem.defaultApplied(0)) {
             const std::string msg = "Injection type can not be defaulted for keyword WCONINJH";
             throw std::invalid_argument(msg);
         }
         this->injectorType = InjectorTypeFromString( typeItem.getTrimmedString(0));
 
-        if (!record.getItem("RATE").defaultApplied(0)) {
-            double injectionRate = record.getItem("RATE").get<double>(0);
+        if (!record.getItem<ParserKeywords::WCONINJH::RATE>().defaultApplied(0)) {
+            double injectionRate = record.getItem<ParserKeywords::WCONINJH::RATE>().get<double>(0);
             this->surfaceInjectionRate.update(injectionRate);
         }
-        if ( record.getItem( "BHP" ).hasValue(0) )
-            this->BHPH = record.getItem("BHP").getSIDouble(0);
-        if ( record.getItem( "THP" ).hasValue(0) )
-            this->THPH = record.getItem("THP").getSIDouble(0);
+        if ( record.getItem<ParserKeywords::WCONINJH::BHP>().hasValue(0) )
+            this->BHPH = record.getItem<ParserKeywords::WCONINJH::BHP>().getSIDouble(0);
+        if ( record.getItem<ParserKeywords::WCONINJH::THP>().hasValue(0) )
+            this->THPH = record.getItem<ParserKeywords::WCONINJH::THP>().getSIDouble(0);
 
-        const std::string& cmodeString = record.getItem("CMODE").getTrimmedString(0);
+        const std::string& cmodeString = record.getItem<ParserKeywords::WCONINJH::CMODE>().getTrimmedString(0);
         InjectorCMode newControlMode = WellInjectorCModeFromString(cmodeString);
 
         if ( !(newControlMode == InjectorCMode::RATE || newControlMode == InjectorCMode::BHP) ) {
@@ -264,11 +265,11 @@ namespace Opm {
 
         this->VFPTableNumber = vfp_table_nr;
 
-        this->rsRvInj = record.getItem("VAPOIL_C").getSIDouble(0);
+        this->rsRvInj = record.getItem<ParserKeywords::WCONINJH::VAPOIL_C>().getSIDouble(0);
         if (this->injectorType == InjectorType::OIL && this->rsRvInj > 0) {
-            double factor = record.getItem("VAPOIL_C").getSIDouble(0) / record.getItem("VAPOIL_C").get<double>(0);
+            double factor = record.getItem<ParserKeywords::WCONINJH::VAPOIL_C>().getSIDouble(0) / record.getItem<ParserKeywords::WCONINJH::VAPOIL_C>().get<double>(0);
             // for oil injectors the rsRvInj is Rs and the inverse of the si-conversion factor should be used
-            this->rsRvInj =  record.getItem("VAPOIL_C").get<double>(0) / factor;
+            this->rsRvInj =  record.getItem<ParserKeywords::WCONINJH::VAPOIL_C>().get<double>(0) / factor;
         }
     }
 

--- a/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
@@ -95,26 +95,27 @@ namespace Opm {
                                                        const std::string& well_name,
                                                        const KeywordLocation& location)
     {
-        this->injectorType = InjectorTypeFromString( record.getItem<ParserKeywords::WCONINJE::TYPE>().getTrimmedString(0) );
+        using Kw = ParserKeywords::WCONINJE;
+        this->injectorType = InjectorTypeFromString( record.getItem<Kw::TYPE>().getTrimmedString(0) );
         this->predictionMode = true;
 
-        if (!record.getItem<ParserKeywords::WCONINJE::RATE>().defaultApplied(0)) {
-            this->surfaceInjectionRate = record.getItem<ParserKeywords::WCONINJE::RATE>().get<UDAValue>(0);
+        if (!record.getItem<Kw::RATE>().defaultApplied(0)) {
+            this->surfaceInjectionRate = record.getItem<Kw::RATE>().get<UDAValue>(0);
             this->addInjectionControl(InjectorCMode::RATE);
         } else
             this->dropInjectionControl(InjectorCMode::RATE);
 
 
-        if (!record.getItem<ParserKeywords::WCONINJE::RESV>().defaultApplied(0)) {
-            this->reservoirInjectionRate = record.getItem<ParserKeywords::WCONINJE::RESV>().get<UDAValue>(0);
+        if (!record.getItem<Kw::RESV>().defaultApplied(0)) {
+            this->reservoirInjectionRate = record.getItem<Kw::RESV>().get<UDAValue>(0);
             this->addInjectionControl(InjectorCMode::RESV);
         } else
             this->dropInjectionControl(InjectorCMode::RESV);
 
-        this->VFPTableNumber = record.getItem<ParserKeywords::WCONINJE::VFP_TABLE>().get< int >(0);
+        this->VFPTableNumber = record.getItem<Kw::VFP_TABLE>().get< int >(0);
 
-        if (!record.getItem<ParserKeywords::WCONINJE::THP>().defaultApplied(0)) {
-            this->THPTarget = record.getItem<ParserKeywords::WCONINJE::THP>().get<UDAValue>(0);
+        if (!record.getItem<Kw::THP>().defaultApplied(0)) {
+            this->THPTarget = record.getItem<Kw::THP>().get<UDAValue>(0);
             this->addInjectionControl(InjectorCMode::THP);
             if (this->VFPTableNumber == 0) {
                 const auto msg = fmt::format("Well {} must have a VFP table to handle"
@@ -132,10 +133,10 @@ namespace Opm {
           current behavoir agrees with the behavior of Eclipse when BHPLimit is not
           specified while employed during group control.
         */
-        if (record.getItem<ParserKeywords::WCONINJE::BHP>().defaultApplied(0)) {
+        if (record.getItem<Kw::BHP>().defaultApplied(0)) {
             this->BHPTarget.update(bhp_def);
         } else {
-            this->BHPTarget = record.getItem<ParserKeywords::WCONINJE::BHP>().get<UDAValue>(0);
+            this->BHPTarget = record.getItem<Kw::BHP>().get<UDAValue>(0);
         }
         this->addInjectionControl(InjectorCMode::BHP);
 
@@ -144,7 +145,7 @@ namespace Opm {
         else
             this->dropInjectionControl(InjectorCMode::GRUP);
         {
-            const std::string& cmodeString = record.getItem<ParserKeywords::WCONINJE::CMODE>().getTrimmedString(0);
+            const std::string& cmodeString = record.getItem<Kw::CMODE>().getTrimmedString(0);
             InjectorCMode controlModeArg = WellInjectorCModeFromString(cmodeString);
             if (this->hasInjectionControl( controlModeArg))
                 this->controlMode = controlModeArg;
@@ -152,11 +153,11 @@ namespace Opm {
                 throw std::invalid_argument("Tried to set invalid control: " + cmodeString + " for well: " + well_name);
             }
         }
-        this->rsRvInj = record.getItem<ParserKeywords::WCONINJE::VAPOIL_C>().getSIDouble(0);
+        this->rsRvInj = record.getItem<Kw::VAPOIL_C>().getSIDouble(0);
         if (this->injectorType == InjectorType::OIL && this->rsRvInj > 0) {
-            double factor = record.getItem<ParserKeywords::WCONINJE::VAPOIL_C>().getSIDouble(0) / record.getItem<ParserKeywords::WCONINJE::VAPOIL_C>().get<double>(0);
+            double factor = record.getItem<Kw::VAPOIL_C>().getSIDouble(0) / record.getItem<Kw::VAPOIL_C>().get<double>(0);
             // for oil injectors the rsRvInj is Rs and the inverse of the si-conversion factor should be used
-            this->rsRvInj =  record.getItem<ParserKeywords::WCONINJE::VAPOIL_C>().get<double>(0) / factor;
+            this->rsRvInj =  record.getItem<Kw::VAPOIL_C>().get<double>(0) / factor;
         }
     }
 
@@ -206,24 +207,25 @@ namespace Opm {
                                                   const std::string& well_name,
                                                   const KeywordLocation& loc)
     {
+        using Kw = ParserKeywords::WCONINJH;
         // convert injection rates to SI
-        const auto& typeItem = record.getItem<ParserKeywords::WCONINJH::TYPE>();
+        const auto& typeItem = record.getItem<Kw::TYPE>();
         if (typeItem.defaultApplied(0)) {
             const std::string msg = "Injection type can not be defaulted for keyword WCONINJH";
             throw std::invalid_argument(msg);
         }
         this->injectorType = InjectorTypeFromString( typeItem.getTrimmedString(0));
 
-        if (!record.getItem<ParserKeywords::WCONINJH::RATE>().defaultApplied(0)) {
-            double injectionRate = record.getItem<ParserKeywords::WCONINJH::RATE>().get<double>(0);
+        if (!record.getItem<Kw::RATE>().defaultApplied(0)) {
+            double injectionRate = record.getItem<Kw::RATE>().get<double>(0);
             this->surfaceInjectionRate.update(injectionRate);
         }
-        if ( record.getItem<ParserKeywords::WCONINJH::BHP>().hasValue(0) )
-            this->BHPH = record.getItem<ParserKeywords::WCONINJH::BHP>().getSIDouble(0);
-        if ( record.getItem<ParserKeywords::WCONINJH::THP>().hasValue(0) )
-            this->THPH = record.getItem<ParserKeywords::WCONINJH::THP>().getSIDouble(0);
+        if ( record.getItem<Kw::BHP>().hasValue(0) )
+            this->BHPH = record.getItem<Kw::BHP>().getSIDouble(0);
+        if ( record.getItem<Kw::THP>().hasValue(0) )
+            this->THPH = record.getItem<Kw::THP>().getSIDouble(0);
 
-        const std::string& cmodeString = record.getItem<ParserKeywords::WCONINJH::CMODE>().getTrimmedString(0);
+        const std::string& cmodeString = record.getItem<Kw::CMODE>().getTrimmedString(0);
         InjectorCMode newControlMode = WellInjectorCModeFromString(cmodeString);
 
         if ( !(newControlMode == InjectorCMode::RATE || newControlMode == InjectorCMode::BHP) ) {
@@ -265,11 +267,11 @@ namespace Opm {
 
         this->VFPTableNumber = vfp_table_nr;
 
-        this->rsRvInj = record.getItem<ParserKeywords::WCONINJH::VAPOIL_C>().getSIDouble(0);
+        this->rsRvInj = record.getItem<Kw::VAPOIL_C>().getSIDouble(0);
         if (this->injectorType == InjectorType::OIL && this->rsRvInj > 0) {
-            double factor = record.getItem<ParserKeywords::WCONINJH::VAPOIL_C>().getSIDouble(0) / record.getItem<ParserKeywords::WCONINJH::VAPOIL_C>().get<double>(0);
+            double factor = record.getItem<Kw::VAPOIL_C>().getSIDouble(0) / record.getItem<Kw::VAPOIL_C>().get<double>(0);
             // for oil injectors the rsRvInj is Rs and the inverse of the si-conversion factor should be used
-            this->rsRvInj =  record.getItem<ParserKeywords::WCONINJH::VAPOIL_C>().get<double>(0) / factor;
+            this->rsRvInj =  record.getItem<Kw::VAPOIL_C>().get<double>(0) / factor;
         }
     }
 

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -115,11 +115,13 @@ void updateOpenShutEvents(HandlerContext& handlerContext, const std::string& wel
 
 void handleWCONHIST(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WCONHIST;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, false);
 
-        const Well::Status status = WellStatusFromString(record.getItem("STATUS").getTrimmedString(0));
+        const Well::Status status = WellStatusFromString(record.getItem<Kw::STATUS>().getTrimmedString(0));
 
         for (const auto& well_name : well_names) {
             handlerContext.updateWellStatus(well_name, status,
@@ -131,8 +133,8 @@ void handleWCONHIST(HandlerContext& handlerContext)
             auto properties = std::make_shared<Well::WellProductionProperties>(well2.getProductionProperties());
             bool update_well = false;
 
-            auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
-            if (record.getItem("VFP_TABLE").defaultApplied(0)) { // Default 1* use the privious set vfp table
+            auto table_nr = record.getItem<Kw::VFP_TABLE>().get< int >(0);
+            if (record.getItem<Kw::VFP_TABLE>().defaultApplied(0)) { // Default 1* use the privious set vfp table
                 table_nr = properties->VFPTableNumber;
             }
 
@@ -203,11 +205,13 @@ void handleWCONHIST(HandlerContext& handlerContext)
 
 void handleWCONINJE(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WCONINJE;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern);
 
-        const Well::Status status = WellStatusFromString(record.getItem("STATUS").getTrimmedString(0));
+        const Well::Status status = WellStatusFromString(record.getItem<Kw::STATUS>().getTrimmedString(0));
 
         for (const auto& well_name : well_names) {
             handlerContext.updateWellStatus(well_name, status,
@@ -231,7 +235,7 @@ void handleWCONINJE(HandlerContext& handlerContext)
                                                  default_bhp_limit);
             }
 
-            auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
+            auto table_nr = record.getItem<Kw::VFP_TABLE>().get< int >(0);
 
             if (table_nr != 0) {
                 const auto& vfpinj = handlerContext.state().vfpinj;
@@ -282,10 +286,12 @@ void handleWCONINJE(HandlerContext& handlerContext)
 
 void handleWCONINJH(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WCONINJH;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, false);
-        const Well::Status status = WellStatusFromString( record.getItem("STATUS").getTrimmedString(0));
+        const Well::Status status = WellStatusFromString( record.getItem<Kw::STATUS>().getTrimmedString(0));
 
         for (const auto& well_name : well_names) {
             handlerContext.updateWellStatus(well_name, status,
@@ -303,8 +309,8 @@ void handleWCONINJH(HandlerContext& handlerContext)
                                                                   6891.2);
             }
 
-            auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
-            if (record.getItem("VFP_TABLE").defaultApplied(0)) { // Default 1* use the privious set vfp table
+            auto table_nr = record.getItem<Kw::VFP_TABLE>().get< int >(0);
+            if (record.getItem<Kw::VFP_TABLE>().defaultApplied(0)) { // Default 1* use the privious set vfp table
                 table_nr = injection->VFPTableNumber;
             }
             if (table_nr != 0) {
@@ -375,11 +381,13 @@ bool belongsToAutoChokeGroup(const Well& well, const ScheduleState& state) {
 
 void handleWCONPROD(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WCONPROD;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, false);
 
-        const Well::Status status = WellStatusFromString(record.getItem("STATUS").getTrimmedString(0));
+        const Well::Status status = WellStatusFromString(record.getItem<Kw::STATUS>().getTrimmedString(0));
 
         for (const auto& well_name : well_names) {
             bool update_well = handlerContext.updateWellStatus(well_name, status,
@@ -393,7 +401,7 @@ void handleWCONPROD(HandlerContext& handlerContext)
                 properties->addProductionControl(Well::ProducerCMode::GRUP);
             }
 
-            auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
+            auto table_nr = record.getItem<Kw::VFP_TABLE>().get< int >(0);
             if (table_nr != 0) {
                 const auto& vfpprod = handlerContext.state().vfpprod;
                 if (vfpprod.has(table_nr)) {
@@ -499,11 +507,13 @@ void handleWELOPEN(HandlerContext& handlerContext)
         return std::all_of( rec.begin() + 2, rec.end(), defaulted );
     };
 
+    using Kw = ParserKeywords::WELOPEN;
+
     constexpr auto open = Well::Status::OPEN;
 
     for (const auto& record : keyword) {
-        const auto& wellNamePattern = record.getItem( "WELL" ).getTrimmedString(0);
-        const auto& status_str = record.getItem( "STATUS" ).getTrimmedString( 0 );
+        const auto& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
+        const auto& status_str = record.getItem<Kw::STATUS>().getTrimmedString( 0 );
         const auto well_names = handlerContext.wellNames(wellNamePattern);
 
         /* if all records are defaulted or just the status is set, only
@@ -852,8 +862,10 @@ void handleWELTARG(HandlerContext& handlerContext)
 
 void handleWHISTCTL(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WHISTCTL;
+
     const auto& record = handlerContext.keyword.getRecord(0);
-    const std::string& cmodeString = record.getItem("CMODE").getTrimmedString(0);
+    const std::string& cmodeString = record.getItem<Kw::CMODE>().getTrimmedString(0);
     const auto controlMode = WellProducerCModeFromString(cmodeString);
 
     if (controlMode != Well::ProducerCMode::NONE && !Well::WellProductionProperties::effectiveHistoryProductionControl(controlMode) ) {
@@ -863,7 +875,7 @@ void handleWHISTCTL(HandlerContext& handlerContext)
     }
     handlerContext.state().update_whistctl( controlMode );
 
-    const std::string bhp_terminate = record.getItem("BPH_TERMINATE").getTrimmedString(0);
+    const std::string bhp_terminate = record.getItem<Kw::BPH_TERMINATE>().getTrimmedString(0);
     if (bhp_terminate == "YES") {
         std::string msg_fmt = "Problem with {keyword}\n"
                               "In {file} line {line}\n"
@@ -1368,18 +1380,20 @@ void handleWSEED(HandlerContext& handlerContext)
 
 void handleWTEST(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WTEST;
+
     auto new_config = handlerContext.state().wtest_config.get();
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern);
         if (well_names.empty()) {
             handlerContext.invalidNamePattern(wellNamePattern);
         }
 
-        const double test_interval = record.getItem("INTERVAL").getSIDouble(0);
-        const std::string& reasons = record.getItem("REASON").get<std::string>(0);
-        const int num_test = record.getItem("TEST_NUM").get<int>(0);
-        const double startup_time = record.getItem("START_TIME").getSIDouble(0);
+        const double test_interval = record.getItem<Kw::INTERVAL>().getSIDouble(0);
+        const std::string& reasons = record.getItem<Kw::REASON>().get<std::string>(0);
+        const int num_test = record.getItem<Kw::TEST_NUM>().get<int>(0);
+        const double startup_time = record.getItem<Kw::START_TIME>().getSIDouble(0);
 
         for (const auto& well_name : well_names) {
             if (reasons.empty())

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -134,7 +134,7 @@ void handleWCONHIST(HandlerContext& handlerContext)
             bool update_well = false;
 
             auto table_nr = record.getItem<Kw::VFP_TABLE>().get< int >(0);
-            if (record.getItem<Kw::VFP_TABLE>().defaultApplied(0)) { // Default 1* use the privious set vfp table
+            if (record.getItem<Kw::VFP_TABLE>().defaultApplied(0)) { // Default 1* use the previous set vfp table
                 table_nr = properties->VFPTableNumber;
             }
 
@@ -310,7 +310,7 @@ void handleWCONINJH(HandlerContext& handlerContext)
             }
 
             auto table_nr = record.getItem<Kw::VFP_TABLE>().get< int >(0);
-            if (record.getItem<Kw::VFP_TABLE>().defaultApplied(0)) { // Default 1* use the privious set vfp table
+            if (record.getItem<Kw::VFP_TABLE>().defaultApplied(0)) { // Default 1* use the previous set vfp table
                 table_nr = injection->VFPTableNumber;
             }
             if (table_nr != 0) {

--- a/opm/input/eclipse/Schedule/Well/WellPolymerProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPolymerProperties.cpp
@@ -19,6 +19,7 @@
 
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellPolymerProperties.hpp>
 
 #include <stdexcept>
@@ -52,8 +53,8 @@ namespace Opm {
 
 
     void WellPolymerProperties::handleWPOLYMER(const DeckRecord& record) {
-        const auto& group_polymer_item = record.getItem("GROUP_POLYMER_CONCENTRATION");
-        const auto& group_salt_item = record.getItem("GROUP_SALT_CONCENTRATION");
+        const auto& group_polymer_item = record.getItem<ParserKeywords::WPOLYMER::GROUP_POLYMER_CONCENTRATION>();
+        const auto& group_salt_item = record.getItem<ParserKeywords::WPOLYMER::GROUP_SALT_CONCENTRATION>();
 
         if (!group_polymer_item.defaultApplied(0))
             throw std::logic_error("Sorry explicit setting of \'GROUP_POLYMER_CONCENTRATION\' is not supported!");
@@ -61,17 +62,17 @@ namespace Opm {
         if (!group_salt_item.defaultApplied(0))
             throw std::logic_error("Sorry explicit setting of \'GROUP_SALT_CONCENTRATION\' is not supported!");
 
-        this->m_polymerConcentration = record.getItem("POLYMER_CONCENTRATION").get<UDAValue>(0).getSI();
-        this->m_saltConcentration = record.getItem("SALT_CONCENTRATION").get<UDAValue>(0).getSI();
+        this->m_polymerConcentration = record.getItem<ParserKeywords::WPOLYMER::POLYMER_CONCENTRATION>().get<UDAValue>(0).getSI();
+        this->m_saltConcentration = record.getItem<ParserKeywords::WPOLYMER::SALT_CONCENTRATION>().get<UDAValue>(0).getSI();
     }
 
     void WellPolymerProperties::handleWPMITAB(const DeckRecord& record) {
-        this->m_plymwinjtable = record.getItem("TABLE_NUMBER").get<int>(0);
+        this->m_plymwinjtable = record.getItem<ParserKeywords::WPMITAB::TABLE_NUMBER>().get<int>(0);
     }
 
     void WellPolymerProperties::handleWSKPTAB(const DeckRecord& record) {
-        this->m_skprwattable = record.getItem("TABLE_NUMBER_WATER").get<int>(0);
-        this->m_skprpolytable = record.getItem("TABLE_NUMBER_POLYMER").get<int>(0);
+        this->m_skprwattable = record.getItem<ParserKeywords::WSKPTAB::TABLE_NUMBER_WATER>().get<int>(0);
+        this->m_skprpolytable = record.getItem<ParserKeywords::WSKPTAB::TABLE_NUMBER_POLYMER>().get<int>(0);
     }
 
     bool WellPolymerProperties::operator!=(const WellPolymerProperties& other) const {

--- a/opm/input/eclipse/Schedule/Well/WellPolymerProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPolymerProperties.cpp
@@ -53,8 +53,9 @@ namespace Opm {
 
 
     void WellPolymerProperties::handleWPOLYMER(const DeckRecord& record) {
-        const auto& group_polymer_item = record.getItem<ParserKeywords::WPOLYMER::GROUP_POLYMER_CONCENTRATION>();
-        const auto& group_salt_item = record.getItem<ParserKeywords::WPOLYMER::GROUP_SALT_CONCENTRATION>();
+        using Kw = ParserKeywords::WPOLYMER;
+        const auto& group_polymer_item = record.getItem<Kw::GROUP_POLYMER_CONCENTRATION>();
+        const auto& group_salt_item = record.getItem<Kw::GROUP_SALT_CONCENTRATION>();
 
         if (!group_polymer_item.defaultApplied(0))
             throw std::logic_error("Sorry explicit setting of \'GROUP_POLYMER_CONCENTRATION\' is not supported!");
@@ -62,17 +63,19 @@ namespace Opm {
         if (!group_salt_item.defaultApplied(0))
             throw std::logic_error("Sorry explicit setting of \'GROUP_SALT_CONCENTRATION\' is not supported!");
 
-        this->m_polymerConcentration = record.getItem<ParserKeywords::WPOLYMER::POLYMER_CONCENTRATION>().get<UDAValue>(0).getSI();
-        this->m_saltConcentration = record.getItem<ParserKeywords::WPOLYMER::SALT_CONCENTRATION>().get<UDAValue>(0).getSI();
+        this->m_polymerConcentration = record.getItem<Kw::POLYMER_CONCENTRATION>().get<UDAValue>(0).getSI();
+        this->m_saltConcentration = record.getItem<Kw::SALT_CONCENTRATION>().get<UDAValue>(0).getSI();
     }
 
     void WellPolymerProperties::handleWPMITAB(const DeckRecord& record) {
-        this->m_plymwinjtable = record.getItem<ParserKeywords::WPMITAB::TABLE_NUMBER>().get<int>(0);
+        using Kw = ParserKeywords::WPMITAB;
+        this->m_plymwinjtable = record.getItem<Kw::TABLE_NUMBER>().get<int>(0);
     }
 
     void WellPolymerProperties::handleWSKPTAB(const DeckRecord& record) {
-        this->m_skprwattable = record.getItem<ParserKeywords::WSKPTAB::TABLE_NUMBER_WATER>().get<int>(0);
-        this->m_skprpolytable = record.getItem<ParserKeywords::WSKPTAB::TABLE_NUMBER_POLYMER>().get<int>(0);
+        using Kw = ParserKeywords::WSKPTAB;
+        this->m_skprwattable = record.getItem<Kw::TABLE_NUMBER_WATER>().get<int>(0);
+        this->m_skprpolytable = record.getItem<Kw::TABLE_NUMBER_POLYMER>().get<int>(0);
     }
 
     bool WellPolymerProperties::operator!=(const WellPolymerProperties& other) const {

--- a/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
@@ -31,6 +31,8 @@
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Units/Dimension.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
+
 #include "../eval_uda.hpp"
 
 #include <fmt/format.h>
@@ -91,9 +93,13 @@ namespace Opm {
     }
 
     void Well::WellProductionProperties::init_rates( const DeckRecord& record ) {
-        this->OilRate    = record.getItem("ORAT").get<UDAValue>(0);
-        this->WaterRate  = record.getItem("WRAT").get<UDAValue>(0);
-        this->GasRate    = record.getItem("GRAT").get<UDAValue>(0);
+        // Shared helper for WCONPROD and WCONHIST records.  The rate items
+        // ORAT/WRAT/GRAT have identical names in both keywords; WCONPROD is
+        // used here as it carries the full set of production rate targets.
+        using Kw = ParserKeywords::WCONPROD;
+        this->OilRate    = record.getItem<Kw::ORAT>().get<UDAValue>(0);
+        this->WaterRate  = record.getItem<Kw::WRAT>().get<UDAValue>(0);
+        this->GasRate    = record.getItem<Kw::GRAT>().get<UDAValue>(0);
     }
 
 
@@ -102,7 +108,9 @@ namespace Opm {
         // May have ALQ values used in UDQ calculations event without any table - use identity dimension in this case
         if (alq_type || vfp_table_nr==0) {
             Dimension alq_dim = alq_type ? VFPProdTable::ALQDimension(*alq_type, unit_system_arg) : Dimension(1.0);
-            const auto& alq_input = record.getItem("ALQ").get<UDAValue>(0);
+            // Shared helper for WCONPROD/WCONHIST; ALQ has the same name in both.
+            using Kw = ParserKeywords::WCONPROD;
+            const auto& alq_input = record.getItem<Kw::ALQ>().get<UDAValue>(0);
             if (alq_input.is<double>())
                 this->ALQValue = UDAValue(alq_input.get<double>(), alq_dim);
             else {
@@ -125,13 +133,16 @@ namespace Opm {
         // UDAValue is to ensure that the UDAValue has the correct dimension.
         this->LiquidRate = UDAValue(this->WaterRate.raw_value_or(0.0) + this->OilRate.raw_value_or(0.0), this->OilRate.get_dim());
 
-        if ( const auto& item = record.getItem( "BHP" ); item.hasValue(0) && !item.defaultApplied(0) )
-            this->BHPH = record.getItem("BHP").get<UDAValue>(0).getSI();
+        // init_history is only invoked for WCONHIST records.
+        using Kw = ParserKeywords::WCONHIST;
 
-        if ( const auto& item = record.getItem( "THP" ); item.hasValue(0) && !item.defaultApplied(0) )
-            this->THPH = record.getItem("THP").get<UDAValue>(0).getSI();
+        if ( const auto& item = record.getItem<Kw::BHP>(); item.hasValue(0) && !item.defaultApplied(0) )
+            this->BHPH = record.getItem<Kw::BHP>().get<UDAValue>(0).getSI();
 
-        const auto& cmodeItem = record.getItem("CMODE");
+        if ( const auto& item = record.getItem<Kw::THP>(); item.hasValue(0) && !item.defaultApplied(0) )
+            this->THPH = record.getItem<Kw::THP>().get<UDAValue>(0).getSI();
+
+        const auto& cmodeItem = record.getItem<Kw::CMODE>();
         if ( cmodeItem.defaultApplied(0) ) {
             const std::string msg = "control mode can not be defaulted for keyword WCONHIST";
             throw std::invalid_argument(msg);
@@ -181,15 +192,17 @@ namespace Opm {
         this->init_vfp(alq_type, vfp_table_nr, unit_system_arg, record);
         this->init_rates(record);
 
-        if (record.getItem("BHP").defaultApplied(0)) {
+        using Kw = ParserKeywords::WCONPROD;
+
+        if (record.getItem<Kw::BHP>().defaultApplied(0)) {
             this->BHPTarget.update(unit_system_arg.from_si(UnitSystem::measure::pressure,
                                                            bhp_def));
         } else {
-            this->BHPTarget      = record.getItem("BHP").get<UDAValue>(0);
+            this->BHPTarget      = record.getItem<Kw::BHP>().get<UDAValue>(0);
         }
-        this->THPTarget      = record.getItem("THP").get<UDAValue>(0);
-        this->LiquidRate     = record.getItem("LRAT").get<UDAValue>(0);
-        this->ResVRate       = record.getItem("RESV").get<UDAValue>(0);
+        this->THPTarget      = record.getItem<Kw::THP>().get<UDAValue>(0);
+        this->LiquidRate     = record.getItem<Kw::LRAT>().get<UDAValue>(0);
+        this->ResVRate       = record.getItem<Kw::RESV>().get<UDAValue>(0);
 
         using mode = std::pair< const std::string, ProducerCMode >;
         static const mode modes[] = {
@@ -260,7 +273,7 @@ Well {} specifies {} constraint, but {}. The constraint will be ignored.)",
         // There is always a BHP constraint, when not specified, will use the default value
         this->addProductionControl( ProducerCMode::BHP );
         {
-            const auto& cmodeItem = record.getItem("CMODE");
+            const auto& cmodeItem = record.getItem<Kw::CMODE>();
             if (cmodeItem.hasValue(0)) {
                 auto cmode = WellProducerCModeFromString(cmodeItem.getTrimmedString(0));
 

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -87,8 +87,10 @@ void handleWDFAC(HandlerContext& handlerContext)
 
 void handleWDFACCOR(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WDFACCOR;
+
     for (const auto& record : handlerContext.keyword) {
-        const auto wellNamePattern = record.getItem("WELLNAME").getTrimmedString(0);
+        const auto wellNamePattern = record.getItem<Kw::WELLNAME>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, true);
         if (well_names.empty()) {
             handlerContext.invalidNamePattern(wellNamePattern);
@@ -125,8 +127,10 @@ void handleWDFACCOR(HandlerContext& handlerContext)
 
 void handleWECON(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WECON;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, false);
 
         for (const auto& well_name : well_names) {
@@ -259,8 +263,10 @@ void handleWELPI(HandlerContext& handlerContext)
 
 void handleWFOAM(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WFOAM;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, false);
 
         for (const auto& well_name : well_names) {
@@ -318,8 +324,10 @@ void handleWINJFCNC(HandlerContext& handlerContext)
 
 void handleWINJMULT(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WINJMULT;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL_NAME").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL_NAME>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, true);
 
         for (const auto& well_name : well_names) {
@@ -340,11 +348,13 @@ void handleWINJTEMP(HandlerContext& handlerContext)
 {
     // we do not support the "enthalpy" field yet. how to do this is a more difficult
     // question.
+    using Kw = ParserKeywords::WINJTEMP;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         auto well_names = handlerContext.wellNames(wellNamePattern, false);
 
-        const double temp = record.getItem("TEMPERATURE").getSIDouble(0);
+        const double temp = record.getItem<Kw::TEMPERATURE>().getSIDouble(0);
 
         for (const auto& well_name : well_names) {
             const auto& well = handlerContext.state().wells.get(well_name);
@@ -360,8 +370,10 @@ void handleWINJTEMP(HandlerContext& handlerContext)
 
 void handleWMICP(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WMICP;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, false);
 
         for (const auto& well_name : well_names) {
@@ -377,6 +389,8 @@ void handleWMICP(HandlerContext& handlerContext)
 
 void handleWPIMULT(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WPIMULT;
+
     // from the third item to the seventh item in the WPIMULT record, they are numbers indicate
     // the I, J, K location and completion number range.
     // When defaulted, it assumes it is negative
@@ -391,7 +405,7 @@ void handleWPIMULT(HandlerContext& handlerContext)
     };
 
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto& well_names = handlerContext.wellNames(wellNamePattern);
 
         // for the record has defaulted connection and completion information, we do not apply it immediately
@@ -402,7 +416,7 @@ void handleWPIMULT(HandlerContext& handlerContext)
         const bool default_con_comp = defaultConCompRec(record);
         if (default_con_comp) {
             auto& wpimult_global_factor = handlerContext.wpimult_global_factor;
-            const auto scaling_factor = record.getItem("WELLPI").get<double>(0);
+            const auto scaling_factor = record.getItem<Kw::WELLPI>().get<double>(0);
             for (const auto& wname : well_names) {
                 wpimult_global_factor.insert_or_assign(wname, scaling_factor);
             }
@@ -420,8 +434,10 @@ void handleWPIMULT(HandlerContext& handlerContext)
 
 void handleWPMITAB(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WPMITAB;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, true);
 
         for (const auto& well_name : well_names) {
@@ -436,8 +452,10 @@ void handleWPMITAB(HandlerContext& handlerContext)
 
 void handleWPOLYMER(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WPOLYMER;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, false);
 
         for (const auto& well_name : well_names) {
@@ -452,8 +470,10 @@ void handleWPOLYMER(HandlerContext& handlerContext)
 
 void handleWSALT(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WSALT;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, true);
 
         for (const auto& well_name : well_names) {
@@ -468,8 +488,10 @@ void handleWSALT(HandlerContext& handlerContext)
 
 void handleWSKPTAB(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WSKPTAB;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, false);
 
         for (const auto& well_name : well_names) {
@@ -485,11 +507,13 @@ void handleWSKPTAB(HandlerContext& handlerContext)
 
 void handleWSOLVENT(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WSOLVENT;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, false);
 
-        const double fraction = record.getItem("SOLVENT_FRACTION").get<UDAValue>(0).getSI();
+        const double fraction = record.getItem<Kw::SOLVENT_FRACTION>().get<UDAValue>(0).getSI();
 
         for (const auto& well_name : well_names) {
             const auto& well = handlerContext.state().wells.get(well_name);
@@ -509,10 +533,12 @@ void handleWSOLVENT(HandlerContext& handlerContext)
 
 void handleWTEMP(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WTEMP;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, false);
-        double temp = record.getItem("TEMP").getSIDouble(0);
+        double temp = record.getItem<Kw::TEMP>().getSIDouble(0);
 
         for (const auto& well_name : well_names) {
             const auto& well = handlerContext.state().wells.get(well_name);
@@ -528,17 +554,19 @@ void handleWTEMP(HandlerContext& handlerContext)
 
 void handleWSPECIES(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WSPECIES;
+
     // NOTE: WSPECIES is equivalent to WTRACERS, and therefore well tracer facilities are used
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, false);
 
         if (well_names.empty()) {
             handlerContext.invalidNamePattern(wellNamePattern);
         }
 
-        const auto spConcentration = record.getItem<ParserKeywords::WSPECIES::CONCENTRATION>().get<UDAValue>(0);
-        const std::string& spName = record.getItem("SPECIES").getTrimmedString(0);
+        const auto spConcentration = record.getItem<Kw::CONCENTRATION>().get<UDAValue>(0);
+        const std::string& spName = record.getItem<Kw::SPECIES>().getTrimmedString(0);
 
         for (const auto& well_name : well_names) {
             auto well = handlerContext.state().wells.get( well_name );
@@ -651,16 +679,18 @@ void handleWTMULT(HandlerContext& handlerContext)
 
 void handleWTRACER(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WTRACER;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, false);
 
         if (well_names.empty()) {
             handlerContext.invalidNamePattern(wellNamePattern);
         }
 
-        const auto trConcentration = record.getItem<ParserKeywords::WTRACER::CONCENTRATION>().get<UDAValue>(0);
-        const std::string& trName = record.getItem("TRACER").getTrimmedString(0);
+        const auto trConcentration = record.getItem<Kw::CONCENTRATION>().get<UDAValue>(0);
+        const std::string& trName = record.getItem<Kw::TRACER>().getTrimmedString(0);
 
         for (const auto& well_name : well_names) {
             auto well = handlerContext.state().wells.get( well_name );
@@ -674,8 +704,10 @@ void handleWTRACER(HandlerContext& handlerContext)
 
 void handleWVFPDP(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WVFPDP;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, true);
         if (well_names.empty()) {
             handlerContext.invalidNamePattern(wellNamePattern);
@@ -694,8 +726,10 @@ void handleWVFPDP(HandlerContext& handlerContext)
 
 void handleWVFPEXP(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WVFPEXP;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, true);
         if (well_names.empty()) {
             handlerContext.invalidNamePattern(wellNamePattern);
@@ -713,8 +747,10 @@ void handleWVFPEXP(HandlerContext& handlerContext)
 
 void handleWWPAVE(HandlerContext& handlerContext)
 {
+    using Kw = ParserKeywords::WWPAVE;
+
     for (const auto& record : handlerContext.keyword) {
-        const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+        const std::string& wellNamePattern = record.getItem<Kw::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern, true);
 
         if (well_names.empty()) {

--- a/opm/output/eclipse/EclipseGridInspector.cpp
+++ b/opm/output/eclipse/EclipseGridInspector.cpp
@@ -40,6 +40,8 @@
 #include <opm/output/eclipse/EclipseGridInspector.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/D.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
@@ -70,17 +72,19 @@ void EclipseGridInspector::init_()
     }
 
     if (deck_.hasKeyword("SPECGRID")) {
+        using Kw = ParserKeywords::SPECGRID;
         const auto& specgridRecord =
             deck_["SPECGRID"].back().getRecord(0);
-        logical_gridsize_[0] = specgridRecord.getItem("NX").get< int >(0);
-        logical_gridsize_[1] = specgridRecord.getItem("NY").get< int >(0);
-        logical_gridsize_[2] = specgridRecord.getItem("NZ").get< int >(0);
+        logical_gridsize_[0] = specgridRecord.getItem<Kw::NX>().get< int >(0);
+        logical_gridsize_[1] = specgridRecord.getItem<Kw::NY>().get< int >(0);
+        logical_gridsize_[2] = specgridRecord.getItem<Kw::NZ>().get< int >(0);
     } else if (deck_.hasKeyword("DIMENS")) {
+        using Kw = ParserKeywords::DIMENS;
         const auto& dimensRecord =
             deck_["DIMENS"].back().getRecord(0);
-        logical_gridsize_[0] = dimensRecord.getItem("NX").get< int >(0);
-        logical_gridsize_[1] = dimensRecord.getItem("NY").get< int >(0);
-        logical_gridsize_[2] = dimensRecord.getItem("NZ").get< int >(0);
+        logical_gridsize_[0] = dimensRecord.getItem<Kw::NX>().get< int >(0);
+        logical_gridsize_[1] = dimensRecord.getItem<Kw::NY>().get< int >(0);
+        logical_gridsize_[2] = dimensRecord.getItem<Kw::NZ>().get< int >(0);
     } else {
         OPM_THROW(std::runtime_error, "Found neither SPECGRID nor DIMENS in file. At least one is needed.");
     }

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -43,6 +43,8 @@
 #include <opm/input/eclipse/Parser/InputErrorAction.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
+
 #include <opm/input/eclipse/Python/Python.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
@@ -330,8 +332,8 @@ WSEGSICD
     const Opm::DeckKeyword wsegsicd = deck["WSEGSICD"].back();
     BOOST_CHECK_EQUAL(1U, wsegsicd.size());
     const Opm::DeckRecord& record = wsegsicd.getRecord(0);
-    const int start_segment = record.getItem("SEGMENT1").get< int >(0);
-    const int end_segment = record.getItem("SEGMENT2").get< int >(0);
+    const int start_segment = record.getItem<Opm::ParserKeywords::WSEGSICD::SEGMENT1>().get< int >(0);
+    const int end_segment = record.getItem<Opm::ParserKeywords::WSEGSICD::SEGMENT2>().get< int >(0);
     BOOST_CHECK_EQUAL(8, start_segment);
     BOOST_CHECK_EQUAL(8, end_segment);
 
@@ -1092,11 +1094,11 @@ BOOST_AUTO_TEST_CASE(testwsegvalv)
     BOOST_CHECK_EQUAL(2U, wsegvalv.size());
 
     const Opm::DeckRecord& record1 = wsegvalv.getRecord(0);
-    const int seg1 = record1.getItem("SEGMENT_NUMBER").get< int >(0);
+    const int seg1 = record1.getItem<Opm::ParserKeywords::WSEGVALV::SEGMENT_NUMBER>().get< int >(0);
     BOOST_CHECK_EQUAL(8, seg1);
 
     const Opm::DeckRecord& record2 = wsegvalv.getRecord(1);
-    const int seg2 = record2.getItem("SEGMENT_NUMBER").get< int >(0);
+    const int seg2 = record2.getItem<Opm::ParserKeywords::WSEGVALV::SEGMENT_NUMBER>().get< int >(0);
     BOOST_CHECK_EQUAL(9, seg2);
 
     const auto segvalv_map = Opm::Valve::fromWSEGVALV(wsegvalv);

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -44,6 +44,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/U.hpp>
 #include <opm/input/eclipse/Parser/ParserRecord.hpp>
 
 #include "../../opm/input/eclipse/Parser/raw/RawKeyword.hpp"
@@ -1940,8 +1941,8 @@ BOOST_AUTO_TEST_CASE(ParseRAW_STRING) {
     const auto& udq = deck["UDQ"].back();
     const std::vector<std::string> expected0 = {"'P*X*'"};
     const std::vector<std::string> expected1 = {"'P*X*'", "5*(1", "+", "LOG(WBHP))"};
-    const auto& data0 = RawString::strings( udq.getRecord(0).getItem("DATA").getData<RawString>() );
-    const auto& data1 = RawString::strings( udq.getRecord(1).getItem("DATA").getData<RawString>() );
+    const auto& data0 = RawString::strings( udq.getRecord(0).getItem<ParserKeywords::UDQ::DATA>().getData<RawString>() );
+    const auto& data1 = RawString::strings( udq.getRecord(1).getItem<ParserKeywords::UDQ::DATA>().getData<RawString>() );
     BOOST_CHECK_EQUAL_COLLECTIONS( data0.begin(), data0.end(), expected0.begin(), expected0.end());
     BOOST_CHECK_EQUAL_COLLECTIONS( data1.begin(), data1.end(), expected1.begin(), expected1.end());
 

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -63,6 +63,7 @@
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
 #include <opm/input/eclipse/Parser/ParserKeywords/D.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/U.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -803,7 +804,7 @@ UDQ
     auto deck = parser.parseString(input);
     const auto& udq = deck["UDQ"].back();
     const auto& record = udq.getRecord(0);
-    const auto& data_item = record.getItem("DATA");
+    const auto& data_item = record.getItem<ParserKeywords::UDQ::DATA>();
     const auto& data = RawString::strings( data_item.getData<RawString>() );
     std::vector<std::string> exp = {"WWPR", "/", "(", "WWPR", "+", "WOPR", ")"};
     BOOST_CHECK_EQUAL_COLLECTIONS(data.begin(), data.end(),

--- a/tests/parser/WellSolventTests.cpp
+++ b/tests/parser/WellSolventTests.cpp
@@ -40,6 +40,8 @@
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
+
 using namespace Opm;
 
 namespace {
@@ -246,7 +248,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWSOLVENT)
     BOOST_CHECK_EQUAL(keyword.size(),1U);
 
     const auto& record = keyword.getRecord(0);
-    const std::string& well_name = record.getItem("WELL").getTrimmedString(0);
+    const std::string& well_name = record.getItem<ParserKeywords::WSOLVENT::WELL>().getTrimmedString(0);
     BOOST_CHECK_EQUAL(well_name, "W_1");
     BOOST_CHECK_EQUAL(schedule.getWell("W_1", 0).getSolventFraction(),0); //default 0
     BOOST_CHECK_EQUAL(schedule.getWell("W_1", 1).getSolventFraction(),1);

--- a/tests/parser/WellSpeciesTests.cpp
+++ b/tests/parser/WellSpeciesTests.cpp
@@ -49,6 +49,8 @@
 
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
+
 using namespace Opm;
 
 namespace {
@@ -198,7 +200,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWSPECIES)
     BOOST_CHECK_EQUAL(keyword.size(),1U);
 
     const auto& record = keyword.getRecord(0);
-    const std::string& well_name = record.getItem("WELL").getTrimmedString(0);
+    const std::string& well_name = record.getItem<ParserKeywords::WSPECIES::WELL>().getTrimmedString(0);
     const std::string ca_name{"CA"};
     const std::string k_name{"K"};
     const auto well = WellTracerProperties::Well{well_name};

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -50,6 +50,7 @@
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
 #include <opm/input/eclipse/Parser/ParserKeywords/F.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -605,7 +606,7 @@ namespace {
             Opm::UnitSystem unit_system(Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC);
             auto deck = parser.parseString(input);
             const auto& record = deck["WCONHIST"].back().getRecord(0);
-            auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
+            auto table_nr = record.getItem<Opm::ParserKeywords::WCONHIST::VFP_TABLE>().get< int >(0);
             Opm::Well::WellProductionProperties hist(unit_system, "W");
             hist.handleWCONHIST(alq_type, table_nr,
                                 Opm::ParserKeywords::FBHPDEF::TARGET_BHP::defaultValue * unit::barsa,
@@ -662,7 +663,7 @@ namespace {
             const auto& kwd     = deck["WCONPROD"].back();
             const auto&  record = kwd.getRecord(0);
             const Phases phases { true, true, true };
-            auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
+            auto table_nr = record.getItem<Opm::ParserKeywords::WCONPROD::VFP_TABLE>().get< int >(0);
             Opm::Well::WellProductionProperties pred(unit_system, "W");
             pred.handleWCONPROD(alq_type, table_nr,
                                 Opm::ParserKeywords::FBHPDEF::TARGET_BHP::defaultValue * unit::barsa,

--- a/tests/parser/WellTracerTests.cpp
+++ b/tests/parser/WellTracerTests.cpp
@@ -43,6 +43,8 @@
 
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
+
 using namespace Opm;
 
 namespace {
@@ -192,7 +194,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWTRACER)
     BOOST_CHECK_EQUAL(keyword.size(),1U);
 
     const auto& record = keyword.getRecord(0);
-    const std::string& well_name = record.getItem("WELL").getTrimmedString(0);
+    const std::string& well_name = record.getItem<ParserKeywords::WTRACER::WELL>().getTrimmedString(0);
     BOOST_CHECK_EQUAL(well_name, "W_1");
     BOOST_CHECK_EQUAL(schedule.getWell("W_1", 0).getTracerProperties().getConcentration(WellTracerProperties::Well{"W_1"}, WellTracerProperties::Tracer{"I1"}, st), 0); //default 0
     BOOST_CHECK_EQUAL(schedule.getWell("W_1", 0).getTracerProperties().getConcentration(WellTracerProperties::Well{"W_1"}, WellTracerProperties::Tracer{"I2"}, st), 0); //default 0

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -52,6 +52,13 @@
 #include <opm/input/eclipse/Parser/InputErrorAction.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/D.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/P.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/V.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -122,9 +129,9 @@ BOOST_AUTO_TEST_CASE( DENSITY ) {
     BOOST_CHECK_EQUAL( 2U , densityKw.size());
     const auto& rec1 = densityKw.getRecord(0);
 
-    const auto& oilDensity = rec1.getItem("OIL");
-    const auto& waterDensity = rec1.getItem("WATER");
-    const auto& gasDensity = rec1.getItem("GAS");
+    const auto& oilDensity = rec1.getItem<ParserKeywords::DENSITY::OIL>();
+    const auto& waterDensity = rec1.getItem<ParserKeywords::DENSITY::WATER>();
+    const auto& gasDensity = rec1.getItem<ParserKeywords::DENSITY::GAS>();
 
     const auto density = Field::Density;
     BOOST_CHECK_CLOSE(  500 * density, oilDensity.getSIDouble(0),   0.001 );
@@ -166,7 +173,7 @@ BOOST_AUTO_TEST_CASE( EQUIL_MISSING_DIMS ) {
     BOOST_CHECK_EQUAL( 1U , kw1.size() );
 
     const auto& rec1 = kw1.getRecord(0);
-    const auto& item1       = rec1.getItem("OWC");
+    const auto& item1       = rec1.getItem<ParserKeywords::EQUIL::OWC>();
     const auto& item1_index = rec1.getItem(2);
 
     BOOST_CHECK_EQUAL( &item1  , &item1_index );
@@ -184,13 +191,13 @@ BOOST_AUTO_TEST_CASE( EQUIL ) {
     const auto& rec1 = kw1.getRecord(0);
     const auto& rec3 = kw1.getRecord(2);
 
-    const auto& item1       = rec1.getItem("OWC");
+    const auto& item1       = rec1.getItem<ParserKeywords::EQUIL::OWC>();
     const auto& item1_index = rec1.getItem(2);
 
     BOOST_CHECK_EQUAL( &item1  , &item1_index );
     BOOST_CHECK( fabs(item1.getSIDouble(0) - 1705) < 0.001 );
 
-    const auto& item3       = rec3.getItem("OWC");
+    const auto& item3       = rec3.getItem<ParserKeywords::EQUIL::OWC>();
     const auto& item3_index = rec3.getItem(2);
 
     BOOST_CHECK_EQUAL( &item3  , &item3_index );
@@ -493,13 +500,13 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
     {
         const auto& rec1 = kw.getRecord(0); // top segment
 
-        const std::string well_name = rec1.getItem("WELL").getTrimmedString(0);
-        const double depth_top = rec1.getItem("TOP_DEPTH").get< double >(0);
-        const double length_top = rec1.getItem("TOP_LENGTH").get< double >(0);
-        const double volume_top = rec1.getItem("WELLBORE_VOLUME").get< double >(0);
-        const WellSegments::LengthDepth length_depth_type = WellSegments::LengthDepthFromString(rec1.getItem("INFO_TYPE").getTrimmedString(0));
-        const WellSegments::CompPressureDrop comp_pressure_drop = WellSegments::CompPressureDropFromString(rec1.getItem("PRESSURE_COMPONENTS").getTrimmedString(0));
-        const WellSegments::MultiPhaseModel multiphase_model = WellSegments::MultiPhaseModelFromString(rec1.getItem("FLOW_MODEL").getTrimmedString(0));
+        const std::string well_name = rec1.getItem<ParserKeywords::WELSEGS::WELL>().getTrimmedString(0);
+        const double depth_top = rec1.getItem<ParserKeywords::WELSEGS::TOP_DEPTH>().get< double >(0);
+        const double length_top = rec1.getItem<ParserKeywords::WELSEGS::TOP_LENGTH>().get< double >(0);
+        const double volume_top = rec1.getItem<ParserKeywords::WELSEGS::WELLBORE_VOLUME>().get< double >(0);
+        const WellSegments::LengthDepth length_depth_type = WellSegments::LengthDepthFromString(rec1.getItem<ParserKeywords::WELSEGS::INFO_TYPE>().getTrimmedString(0));
+        const WellSegments::CompPressureDrop comp_pressure_drop = WellSegments::CompPressureDropFromString(rec1.getItem<ParserKeywords::WELSEGS::PRESSURE_COMPONENTS>().getTrimmedString(0));
+        const WellSegments::MultiPhaseModel multiphase_model = WellSegments::MultiPhaseModelFromString(rec1.getItem<ParserKeywords::WELSEGS::FLOW_MODEL>().getTrimmedString(0));
 
         BOOST_CHECK_EQUAL( "PROD01", well_name );
         BOOST_CHECK_EQUAL( 2512.5, depth_top );
@@ -517,16 +524,16 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
     // Here, we check the information for the segment 2 and 6 as samples.
     {
         const auto& rec2 = kw.getRecord(1);
-        const int segment1 = rec2.getItem("SEGMENT2").get< int >(0);
-        const int segment2 = rec2.getItem("SEGMENT2").get< int >(0);
+        const int segment1 = rec2.getItem<ParserKeywords::WELSEGS::SEGMENT2>().get< int >(0);
+        const int segment2 = rec2.getItem<ParserKeywords::WELSEGS::SEGMENT2>().get< int >(0);
         BOOST_CHECK_EQUAL( 2, segment1 );
         BOOST_CHECK_EQUAL( 2, segment2 );
-        const int branch = rec2.getItem("BRANCH").get< int >(0);
-        const int outlet_segment = rec2.getItem("JOIN_SEGMENT").get< int >(0);
-        const double segment_length = rec2.getItem("LENGTH").get< double >(0);
-        const double depth_change = rec2.getItem("DEPTH").get< double >(0);
-        const double diameter = rec2.getItem("DIAMETER").get< double >(0);
-        const double roughness = rec2.getItem("ROUGHNESS").get< double >(0);
+        const int branch = rec2.getItem<ParserKeywords::WELSEGS::BRANCH>().get< int >(0);
+        const int outlet_segment = rec2.getItem<ParserKeywords::WELSEGS::JOIN_SEGMENT>().get< int >(0);
+        const double segment_length = rec2.getItem<ParserKeywords::WELSEGS::LENGTH>().get< double >(0);
+        const double depth_change = rec2.getItem<ParserKeywords::WELSEGS::DEPTH>().get< double >(0);
+        const double diameter = rec2.getItem<ParserKeywords::WELSEGS::DIAMETER>().get< double >(0);
+        const double roughness = rec2.getItem<ParserKeywords::WELSEGS::ROUGHNESS>().get< double >(0);
         BOOST_CHECK_EQUAL( 1, branch );
         BOOST_CHECK_EQUAL( 1, outlet_segment );
         BOOST_CHECK_EQUAL( 2537.5, segment_length );
@@ -537,16 +544,16 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
 
     {
         const auto& rec6 = kw.getRecord(4);
-        const int segment1 = rec6.getItem("SEGMENT2").get< int >(0);
-        const int segment2 = rec6.getItem("SEGMENT2").get< int >(0);
+        const int segment1 = rec6.getItem<ParserKeywords::WELSEGS::SEGMENT2>().get< int >(0);
+        const int segment2 = rec6.getItem<ParserKeywords::WELSEGS::SEGMENT2>().get< int >(0);
         BOOST_CHECK_EQUAL( 6, segment1 );
         BOOST_CHECK_EQUAL( 6, segment2 );
-        const int branch = rec6.getItem("BRANCH").get< int >(0);
-        const int outlet_segment = rec6.getItem("JOIN_SEGMENT").get< int >(0);
-        const double segment_length = rec6.getItem("LENGTH").get< double >(0);
-        const double depth_change = rec6.getItem("DEPTH").get< double >(0);
-        const double diameter = rec6.getItem("DIAMETER").get< double >(0);
-        const double roughness = rec6.getItem("ROUGHNESS").get< double >(0);
+        const int branch = rec6.getItem<ParserKeywords::WELSEGS::BRANCH>().get< int >(0);
+        const int outlet_segment = rec6.getItem<ParserKeywords::WELSEGS::JOIN_SEGMENT>().get< int >(0);
+        const double segment_length = rec6.getItem<ParserKeywords::WELSEGS::LENGTH>().get< double >(0);
+        const double depth_change = rec6.getItem<ParserKeywords::WELSEGS::DEPTH>().get< double >(0);
+        const double diameter = rec6.getItem<ParserKeywords::WELSEGS::DIAMETER>().get< double >(0);
+        const double roughness = rec6.getItem<ParserKeywords::WELSEGS::ROUGHNESS>().get< double >(0);
         BOOST_CHECK_EQUAL( 2, branch );
         BOOST_CHECK_EQUAL( 4, outlet_segment );
         BOOST_CHECK_EQUAL( 3037.5, segment_length );
@@ -557,16 +564,16 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
 
     {
         const auto& rec7 = kw.getRecord(6);
-        const int segment1 = rec7.getItem("SEGMENT2").get< int >(0);
-        const int segment2 = rec7.getItem("SEGMENT2").get< int >(0);
+        const int segment1 = rec7.getItem<ParserKeywords::WELSEGS::SEGMENT2>().get< int >(0);
+        const int segment2 = rec7.getItem<ParserKeywords::WELSEGS::SEGMENT2>().get< int >(0);
         BOOST_CHECK_EQUAL( 8, segment1 );
         BOOST_CHECK_EQUAL( 8, segment2 );
-        const int branch = rec7.getItem("BRANCH").get< int >(0);
-        const int outlet_segment = rec7.getItem("JOIN_SEGMENT").get< int >(0);
-        const double segment_length = rec7.getItem("LENGTH").get< double >(0);
-        const double depth_change = rec7.getItem("DEPTH").get< double >(0);
-        const double diameter = rec7.getItem("DIAMETER").get< double >(0);
-        const double roughness = rec7.getItem("ROUGHNESS").get< double >(0);
+        const int branch = rec7.getItem<ParserKeywords::WELSEGS::BRANCH>().get< int >(0);
+        const int outlet_segment = rec7.getItem<ParserKeywords::WELSEGS::JOIN_SEGMENT>().get< int >(0);
+        const double segment_length = rec7.getItem<ParserKeywords::WELSEGS::LENGTH>().get< double >(0);
+        const double depth_change = rec7.getItem<ParserKeywords::WELSEGS::DEPTH>().get< double >(0);
+        const double diameter = rec7.getItem<ParserKeywords::WELSEGS::DIAMETER>().get< double >(0);
+        const double roughness = rec7.getItem<ParserKeywords::WELSEGS::ROUGHNESS>().get< double >(0);
         BOOST_CHECK_EQUAL( 3, branch );
         BOOST_CHECK_EQUAL( 7, outlet_segment );
         BOOST_CHECK_EQUAL( 3337.6, segment_length );
@@ -582,19 +589,19 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
     // first record only contains the well name
     {
         const auto& rec1 = kw1.getRecord(0);
-        const std::string well_name = rec1.getItem("WELL").getTrimmedString(0);
+        const std::string well_name = rec1.getItem<ParserKeywords::COMPSEGS::WELL>().getTrimmedString(0);
         BOOST_CHECK_EQUAL( "PROD01", well_name );
     }
 
     // check the third record and the seventh record
     {
         const auto& rec3 = kw1.getRecord(2);
-        const int i = rec3.getItem("I").get< int >(0);
-        const int j = rec3.getItem("J").get< int >(0);
-        const int k = rec3.getItem("K").get< int >(0);
-        const int branch = rec3.getItem("BRANCH").get< int >(0);
-        const double distance_start = rec3.getItem("DISTANCE_START").get< double >(0);
-        const double distance_end = rec3.getItem("DISTANCE_END").get< double >(0);
+        const int i = rec3.getItem<ParserKeywords::COMPSEGS::I>().get< int >(0);
+        const int j = rec3.getItem<ParserKeywords::COMPSEGS::J>().get< int >(0);
+        const int k = rec3.getItem<ParserKeywords::COMPSEGS::K>().get< int >(0);
+        const int branch = rec3.getItem<ParserKeywords::COMPSEGS::BRANCH>().get< int >(0);
+        const double distance_start = rec3.getItem<ParserKeywords::COMPSEGS::DISTANCE_START>().get< double >(0);
+        const double distance_end = rec3.getItem<ParserKeywords::COMPSEGS::DISTANCE_END>().get< double >(0);
 
         BOOST_CHECK_EQUAL( 20, i );
         BOOST_CHECK_EQUAL(  1, j );
@@ -606,12 +613,12 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
 
     {
         const auto& rec7 = kw1.getRecord(6);
-        const int i = rec7.getItem("I").get< int >(0);
-        const int j = rec7.getItem("J").get< int >(0);
-        const int k = rec7.getItem("K").get< int >(0);
-        const int branch = rec7.getItem("BRANCH").get< int >(0);
-        const double distance_start = rec7.getItem("DISTANCE_START").get< double >(0);
-        const double distance_end = rec7.getItem("DISTANCE_END").get< double >(0);
+        const int i = rec7.getItem<ParserKeywords::COMPSEGS::I>().get< int >(0);
+        const int j = rec7.getItem<ParserKeywords::COMPSEGS::J>().get< int >(0);
+        const int k = rec7.getItem<ParserKeywords::COMPSEGS::K>().get< int >(0);
+        const int branch = rec7.getItem<ParserKeywords::COMPSEGS::BRANCH>().get< int >(0);
+        const double distance_start = rec7.getItem<ParserKeywords::COMPSEGS::DISTANCE_START>().get< double >(0);
+        const double distance_end = rec7.getItem<ParserKeywords::COMPSEGS::DISTANCE_END>().get< double >(0);
 
         BOOST_CHECK_EQUAL( 17, i );
         BOOST_CHECK_EQUAL(  1, j );
@@ -699,9 +706,9 @@ BOOST_AUTO_TEST_CASE( PLYSHLOG ) {
     const auto& kw = deck["PLYSHLOG"].back();
     const auto& rec1 = kw.getRecord(0); // reference conditions
 
-    const auto& itemRefPolyConc = rec1.getItem("REF_POLYMER_CONCENTRATION");
-    const auto& itemRefSali = rec1.getItem("REF_SALINITY");
-    const auto& itemRefTemp = rec1.getItem("REF_TEMPERATURE");
+    const auto& itemRefPolyConc = rec1.getItem<ParserKeywords::PLYSHLOG::REF_POLYMER_CONCENTRATION>();
+    const auto& itemRefSali = rec1.getItem<ParserKeywords::PLYSHLOG::REF_SALINITY>();
+    const auto& itemRefTemp = rec1.getItem<ParserKeywords::PLYSHLOG::REF_TEMPERATURE>();
 
     BOOST_CHECK_EQUAL( true, itemRefPolyConc.hasValue(0) );
     BOOST_CHECK_EQUAL( true, itemRefSali.hasValue(0) );
@@ -734,7 +741,7 @@ BOOST_AUTO_TEST_CASE( PLYSHLOG_MULTI_REGION ) {
 
     // Region 1
     const auto& rec1 = kw.getRecord(0);
-    BOOST_CHECK_EQUAL( 0.5, rec1.getItem("REF_POLYMER_CONCENTRATION").get<double>(0) );
+    BOOST_CHECK_EQUAL( 0.5, rec1.getItem<ParserKeywords::PLYSHLOG::REF_POLYMER_CONCENTRATION>().get<double>(0) );
     const auto& data1 = kw.getRecord(1).getItem(0);
     BOOST_CHECK_EQUAL( 1.0e-7, data1.get<double>(0) );
     BOOST_CHECK_EQUAL( 1.0,    data1.get<double>(1) );
@@ -743,7 +750,7 @@ BOOST_AUTO_TEST_CASE( PLYSHLOG_MULTI_REGION ) {
 
     // Region 2
     const auto& rec2 = kw.getRecord(2);
-    BOOST_CHECK_EQUAL( 0.6, rec2.getItem("REF_POLYMER_CONCENTRATION").get<double>(0) );
+    BOOST_CHECK_EQUAL( 0.6, rec2.getItem<ParserKeywords::PLYSHLOG::REF_POLYMER_CONCENTRATION>().get<double>(0) );
     const auto& data2 = kw.getRecord(3).getItem(0);
     BOOST_CHECK_EQUAL( 1.0e-7, data2.get<double>(0) );
     BOOST_CHECK_EQUAL( 1.0,    data2.get<double>(1) );
@@ -824,10 +831,10 @@ BOOST_AUTO_TEST_CASE( RSVD ) {
     const auto& rec1 = kw1.getRecord(0);
     const auto& rec3 = kw1.getRecord(2);
 
-    const auto& item1       = rec1.getItem("DATA");
+    const auto& item1       = rec1.getItem<ParserKeywords::RSVD::DATA>();
     BOOST_CHECK( fabs(item1.getSIDouble(0) - 2382) < 0.001);
 
-    const auto& item3       = rec3.getItem("DATA");
+    const auto& item3       = rec3.getItem<ParserKeywords::RSVD::DATA>();
     BOOST_CHECK( fabs(item3.getSIDouble(7) - 106.77) < 0.001);
 }
 
@@ -866,24 +873,24 @@ PVTG
     const auto& record3 = kw1.getRecord(3);
     const auto& record4 = kw1.getRecord(4);
 
-    const auto& item0_0 = record0.getItem("GAS_PRESSURE");
-    const auto& item0_1 = record0.getItem("DATA");
+    const auto& item0_0 = record0.getItem<ParserKeywords::PVTG::GAS_PRESSURE>();
+    const auto& item0_1 = record0.getItem<ParserKeywords::PVTG::DATA>();
     BOOST_CHECK(item0_0.hasValue(0));
     BOOST_CHECK_EQUAL(9U , item0_1.data_size());
 
-    const auto& item1_0 = record1.getItem("GAS_PRESSURE");
-    const auto& item1_1 = record1.getItem("DATA");
+    const auto& item1_0 = record1.getItem<ParserKeywords::PVTG::GAS_PRESSURE>();
+    const auto& item1_1 = record1.getItem<ParserKeywords::PVTG::DATA>();
     BOOST_CHECK(item1_0.hasValue(0));
     BOOST_CHECK_EQUAL(9U , item1_1.data_size());
 
-    const auto& item2_0 = record2.getItem("GAS_PRESSURE");
-    const auto& item2_1 = record2.getItem("DATA");
+    const auto& item2_0 = record2.getItem<ParserKeywords::PVTG::GAS_PRESSURE>();
+    const auto& item2_1 = record2.getItem<ParserKeywords::PVTG::DATA>();
     BOOST_CHECK( item2_0.defaultApplied(0));
     BOOST_CHECK_EQUAL(0U , item2_1.data_size());
 
 
-    const auto& item3_0 = record3.getItem("GAS_PRESSURE");
-    const auto& item3_1 = record3.getItem("DATA");
+    const auto& item3_0 = record3.getItem<ParserKeywords::PVTG::GAS_PRESSURE>();
+    const auto& item3_1 = record3.getItem<ParserKeywords::PVTG::DATA>();
     BOOST_CHECK( !item3_1.defaultApplied(0));
     BOOST_CHECK( item3_1.defaultApplied(1));
     BOOST_CHECK( !item3_1.defaultApplied(2));
@@ -894,8 +901,8 @@ PVTG
     BOOST_CHECK_EQUAL(9U , item3_1.data_size());
 
 
-    const auto& item4_0 = record4.getItem("GAS_PRESSURE");
-    const auto& item4_1 = record4.getItem("DATA");
+    const auto& item4_0 = record4.getItem<ParserKeywords::PVTG::GAS_PRESSURE>();
+    const auto& item4_1 = record4.getItem<ParserKeywords::PVTG::DATA>();
     BOOST_CHECK(item4_0.hasValue(0));
     BOOST_CHECK_EQUAL(9U , item4_1.data_size());
 
@@ -958,32 +965,32 @@ PVTO
     const auto& record3 = kw1.getRecord(3);
     const auto& record4 = kw1.getRecord(4);
 
-    const auto& item0_0 = record0.getItem("RS");
-    const auto& item0_1 = record0.getItem("DATA");
+    const auto& item0_0 = record0.getItem<ParserKeywords::PVTO::RS>();
+    const auto& item0_1 = record0.getItem<ParserKeywords::PVTO::DATA>();
     BOOST_CHECK(item0_0.hasValue(0));
     BOOST_CHECK_EQUAL(9U , item0_1.data_size());
     BOOST_CHECK_EQUAL(2U , record0.size());
 
-    const auto& item1_0 = record1.getItem("RS");
-    const auto& item1_1 = record1.getItem("DATA");
+    const auto& item1_0 = record1.getItem<ParserKeywords::PVTO::RS>();
+    const auto& item1_1 = record1.getItem<ParserKeywords::PVTO::DATA>();
     BOOST_CHECK(item1_0.hasValue(0));
     BOOST_CHECK_EQUAL(9U , item1_1.data_size());
     BOOST_CHECK_EQUAL(2U , record1.size());
 
-    const auto& item2_0 = record2.getItem("RS");
-    const auto& item2_1 = record2.getItem("DATA");
+    const auto& item2_0 = record2.getItem<ParserKeywords::PVTO::RS>();
+    const auto& item2_1 = record2.getItem<ParserKeywords::PVTO::DATA>();
     BOOST_CHECK(item2_0.defaultApplied(0));
     BOOST_CHECK_EQUAL(0U , item2_1.data_size());
     BOOST_CHECK_EQUAL(2U , record2.size());
 
-    const auto& item3_0 = record3.getItem("RS");
-    const auto& item3_1 = record3.getItem("DATA");
+    const auto& item3_0 = record3.getItem<ParserKeywords::PVTO::RS>();
+    const auto& item3_1 = record3.getItem<ParserKeywords::PVTO::DATA>();
     BOOST_CHECK(item3_0.hasValue(0));
     BOOST_CHECK_EQUAL(9U , item3_1.data_size());
     BOOST_CHECK_EQUAL(2U , record3.size());
 
-    const auto& item4_0 = record4.getItem("RS");
-    const auto& item4_1 = record4.getItem("DATA");
+    const auto& item4_0 = record4.getItem<ParserKeywords::PVTO::RS>();
+    const auto& item4_1 = record4.getItem<ParserKeywords::PVTO::DATA>();
     BOOST_CHECK(item4_0.hasValue(0));
     BOOST_CHECK_EQUAL(9U , item4_1.data_size());
     BOOST_CHECK_EQUAL(2U , record4.size());
@@ -1250,16 +1257,16 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
     {
         const auto& record = VFPPROD1.getRecord(0);
 
-        BOOST_CHECK_EQUAL( record.getItem("TABLE").get< int >(0) , 32 );
-        BOOST_CHECK_EQUAL( record.getItem("DATUM_DEPTH").getSIDouble(0) , 394);
-        BOOST_CHECK_EQUAL( record.getItem("RATE_TYPE").get< std::string >(0) , "LIQ");
-        BOOST_CHECK_EQUAL( record.getItem("WFR").get< std::string >(0) , "WCT");
-        BOOST_CHECK_EQUAL( record.getItem("GFR").get< std::string >(0) , "GOR");
+        BOOST_CHECK_EQUAL( record.getItem<ParserKeywords::VFPPROD::TABLE>().get< int >(0) , 32 );
+        BOOST_CHECK_EQUAL( record.getItem<ParserKeywords::VFPPROD::DATUM_DEPTH>().getSIDouble(0) , 394);
+        BOOST_CHECK_EQUAL( record.getItem<ParserKeywords::VFPPROD::RATE_TYPE>().get< std::string >(0) , "LIQ");
+        BOOST_CHECK_EQUAL( record.getItem<ParserKeywords::VFPPROD::WFR>().get< std::string >(0) , "WCT");
+        BOOST_CHECK_EQUAL( record.getItem<ParserKeywords::VFPPROD::GFR>().get< std::string >(0) , "GOR");
     }
 
     {
         const auto& record = VFPPROD1.getRecord(1);
-        const auto& item = record.getItem("FLOW_VALUES");
+        const auto& item = record.getItem<ParserKeywords::VFPPROD::FLOW_VALUES>();
 
         BOOST_CHECK_EQUAL( item.data_size() , 12 );
         BOOST_CHECK_EQUAL( item.get< double >(0)  ,   100 );
@@ -1268,7 +1275,7 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
 
     {
         const auto& record = VFPPROD1.getRecord(2);
-        const auto& item = record.getItem("THP_VALUES");
+        const auto& item = record.getItem<ParserKeywords::VFPPROD::THP_VALUES>();
 
         BOOST_CHECK_EQUAL( item.data_size() , 7 );
         BOOST_CHECK_CLOSE( item.get< double >(0)  , 16.01 , 0.0001 );
@@ -1277,7 +1284,7 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
 
     {
         const auto& record = VFPPROD1.getRecord(3);
-        const auto& item = record.getItem("WFR_VALUES");
+        const auto& item = record.getItem<ParserKeywords::VFPPROD::WFR_VALUES>();
 
         BOOST_CHECK_EQUAL( item.data_size() , 9 );
         BOOST_CHECK_CLOSE( item.get< double >(1)  , 0.1 , 0.0001 );
@@ -1286,7 +1293,7 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
 
     {
         const auto& record = VFPPROD1.getRecord(4);
-        const auto& item = record.getItem("GFR_VALUES");
+        const auto& item = record.getItem<ParserKeywords::VFPPROD::GFR_VALUES>();
 
         BOOST_CHECK_EQUAL( item.data_size() , 9 );
         BOOST_CHECK_EQUAL( item.get< double >(0)  ,   90 );
@@ -1295,7 +1302,7 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
 
     {
         const auto& record = VFPPROD1.getRecord(5);
-        const auto& item = record.getItem("ALQ_VALUES");
+        const auto& item = record.getItem<ParserKeywords::VFPPROD::ALQ_VALUES>();
 
         BOOST_CHECK_EQUAL( item.data_size() , 1 );
         BOOST_CHECK_EQUAL( item.get< double >(0)  ,   0 );
@@ -1305,28 +1312,28 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
         const auto& record = VFPPROD1.getRecord(6);
 
         {
-            const auto& item = record.getItem("THP_INDEX");
+            const auto& item = record.getItem<ParserKeywords::VFPPROD::THP_INDEX>();
             BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 1 );
         }
 
         {
-            const auto& item = record.getItem("WFR_INDEX");
+            const auto& item = record.getItem<ParserKeywords::VFPPROD::WFR_INDEX>();
             BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 1 );
         }
         {
-            const auto& item = record.getItem("GFR_INDEX");
+            const auto& item = record.getItem<ParserKeywords::VFPPROD::GFR_INDEX>();
             BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 1 );
         }
         {
-            const auto& item = record.getItem("ALQ_INDEX");
+            const auto& item = record.getItem<ParserKeywords::VFPPROD::ALQ_INDEX>();
             BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 1 );
         }
         {
-            const auto& item = record.getItem("VALUES");
+            const auto& item = record.getItem<ParserKeywords::VFPPROD::VALUES>();
             BOOST_CHECK_EQUAL( item.data_size() , 12 );
             BOOST_CHECK_EQUAL( item.get< double >(0) , 44.85 );
             BOOST_CHECK_EQUAL( item.get< double >(11) , 115.14 );
@@ -1336,27 +1343,27 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
     {
         const auto& record = VFPPROD1.getRecord(572);
         {
-            const auto& item = record.getItem("THP_INDEX");
+            const auto& item = record.getItem<ParserKeywords::VFPPROD::THP_INDEX>();
             BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 7 );
         }
         {
-            const auto& item = record.getItem("WFR_INDEX");
+            const auto& item = record.getItem<ParserKeywords::VFPPROD::WFR_INDEX>();
             BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 9 );
         }
         {
-            const auto& item = record.getItem("GFR_INDEX");
+            const auto& item = record.getItem<ParserKeywords::VFPPROD::GFR_INDEX>();
             BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 9 );
         }
         {
-            const auto& item = record.getItem("ALQ_INDEX");
+            const auto& item = record.getItem<ParserKeywords::VFPPROD::ALQ_INDEX>();
             BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 1 );
         }
         {
-            const auto& item = record.getItem("VALUES");
+            const auto& item = record.getItem<ParserKeywords::VFPPROD::VALUES>();
             BOOST_CHECK_EQUAL( item.data_size() , 12 );
             BOOST_CHECK_EQUAL( item.get< double >(0) , 100.80 );
             BOOST_CHECK_EQUAL( item.get< double >(11) , 147.79 );
@@ -1377,16 +1384,16 @@ BOOST_AUTO_TEST_CASE( WCHONHIST ) {
     const auto& rec3 = kw1.getRecord(2);
     BOOST_CHECK_EQUAL( 12U , rec3.size() );
 
-    const auto& item1       = rec1.getItem("WELL");
+    const auto& item1       = rec1.getItem<ParserKeywords::WCONHIST::WELL>();
     const auto& item1_index = rec1.getItem(0);
 
     BOOST_CHECK_EQUAL( &item1  , &item1_index );
     BOOST_CHECK_EQUAL( "OP_1" , item1.get< std::string >(0));
 
     const auto& kw2 = deck["WCONHIST"][1];
-    BOOST_CHECK_EQUAL( "OP_3" , rec3.getItem("WELL").get< std::string >(0));
+    BOOST_CHECK_EQUAL( "OP_3" , rec3.getItem<ParserKeywords::WCONHIST::WELL>().get< std::string >(0));
     BOOST_CHECK_EQUAL( 2U , deck.count("WCONHIST"));
-    BOOST_CHECK_EQUAL( "OP_3_B" , kw2.getRecord( 2 ).getItem("WELL").get< std::string >(0));
+    BOOST_CHECK_EQUAL( "OP_3_B" , kw2.getRecord( 2 ).getItem<ParserKeywords::WCONHIST::WELL>().get< std::string >(0));
     BOOST_CHECK( !deck.hasKeyword( "DIMENS" ) );
 }
 

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -544,7 +544,7 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
 
     {
         const auto& rec6 = kw.getRecord(4);
-        const int segment1 = rec6.getItem<ParserKeywords::WELSEGS::SEGMENT2>().get< int >(0);
+        const int segment1 = rec6.getItem<ParserKeywords::WELSEGS::SEGMENT1>().get< int >(0);
         const int segment2 = rec6.getItem<ParserKeywords::WELSEGS::SEGMENT2>().get< int >(0);
         BOOST_CHECK_EQUAL( 6, segment1 );
         BOOST_CHECK_EQUAL( 6, segment2 );
@@ -564,7 +564,7 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
 
     {
         const auto& rec7 = kw.getRecord(6);
-        const int segment1 = rec7.getItem<ParserKeywords::WELSEGS::SEGMENT2>().get< int >(0);
+        const int segment1 = rec7.getItem<ParserKeywords::WELSEGS::SEGMENT1>().get< int >(0);
         const int segment2 = rec7.getItem<ParserKeywords::WELSEGS::SEGMENT2>().get< int >(0);
         BOOST_CHECK_EQUAL( 8, segment1 );
         BOOST_CHECK_EQUAL( 8, segment2 );

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
     // Here, we check the information for the segment 2 and 6 as samples.
     {
         const auto& rec2 = kw.getRecord(1);
-        const int segment1 = rec2.getItem<ParserKeywords::WELSEGS::SEGMENT2>().get< int >(0);
+        const int segment1 = rec2.getItem<ParserKeywords::WELSEGS::SEGMENT1>().get< int >(0);
         const int segment2 = rec2.getItem<ParserKeywords::WELSEGS::SEGMENT2>().get< int >(0);
         BOOST_CHECK_EQUAL( 2, segment1 );
         BOOST_CHECK_EQUAL( 2, segment2 );


### PR DESCRIPTION
This PR convert most of the `getItem` function call with string the the templated version.

### Before ###
```C++
const auto& wname = record1.getItem("WELL").getTrimmedString(0);
```
### After ###
```C++
const auto& wname = record1.getItem<Kw::WELL>().getTrimmedString(0);
```
The motivation for this change is to get compiler errors instead of runtime errors when working with items. Another benefit is to make it easier to change the string representation to harmonize the naming of items between the code and the reference manual.

As you can see from the commits, most of this job is done using AI tools.

Related issue #5203