### PR TITLE
Generalise Restart File Quantity and Condition Types for Actions

### DIFF
--- a/opm/common/utility/TimeService.cpp
+++ b/opm/common/utility/TimeService.cpp
@@ -148,8 +148,9 @@ const std::unordered_map<int, std::string>& eclipseMonthNames() {
     return month_names;
 }
 
-bool valid_month(const std::string& month_name) {
-    return (month_indices.count(month_name) != 0);
+bool valid_month(const std::string& month_name)
+{
+    return month_indices.contains(month_name);
 }
 
 std::time_t mkdatetime(int in_year, int in_month, int in_day, int hour, int minute, int second) {

--- a/opm/input/eclipse/Schedule/Action/ActionX.cpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.cpp
@@ -190,12 +190,9 @@ ActionX ActionX::serializationTestObject()
     result.m_start_time = 3;
     result.keywords = {DeckKeyword::serializationTestObject()};
     result.condition = Action::AST::serializationTestObject();
-    Quantity quant;
-    quant.quantity = "test1";
-    quant.args = {"test2"};
     Condition cond;
-    cond.lhs = quant;
-    cond.rhs = quant;
+    cond.lhs = Quantity::serializationTestObject();
+    cond.rhs = Quantity::serializationTestObject();
     cond.logic = Logical::AND;
     cond.cmp = Comparator::GREATER_EQUAL;
     cond.cmp_string = "test3";

--- a/opm/input/eclipse/Schedule/Action/Condition.cpp
+++ b/opm/input/eclipse/Schedule/Action/Condition.cpp
@@ -17,214 +17,429 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <fmt/format.h>
-#include <string>
-
-
-#include <opm/output/eclipse/VectorItems/action.hpp>
-#include <opm/common/utility/String.hpp>
-#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/input/eclipse/Schedule/Action/ActionValue.hpp>
 #include <opm/input/eclipse/Schedule/Action/Condition.hpp>
-#include <opm/input/eclipse/Schedule/Action/Enums.hpp>
+
+#include <opm/common/utility/String.hpp>
+#include <opm/common/utility/TimeService.hpp>
+
 #include <opm/io/eclipse/rst/action.hpp>
 
-#include "ActionParser.hpp"
+#include <opm/output/eclipse/VectorItems/action.hpp>
 
+#include <opm/input/eclipse/Schedule/Action/ActionParser.hpp>
+#include <opm/input/eclipse/Schedule/Action/ActionValue.hpp>
+#include <opm/input/eclipse/Schedule/Action/Enums.hpp>
 
-namespace Opm {
-namespace Action {
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <charconv>
+#include <concepts>
+#include <cstddef>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
 
 namespace {
 
-Comparator comparator(TokenType tt) {
-    if (tt == TokenType::op_eq)
-        return Comparator::EQUAL;
+    template <typename T>
+    concept has_from_chars_fp = requires(const char* first, const char* last, T& value) {
+        { std::from_chars(first, last, value) } -> std::same_as<std::from_chars_result>;
+    };
 
-    if (tt == TokenType::op_ne)
-        return Comparator::NOT_EQUAL;
+    Opm::Action::Comparator comparator(Opm::Action::TokenType tt)
+    {
+        switch (tt) {
+        case Opm::Action::TokenType::op_eq:
+            return Opm::Action::Comparator::EQUAL;
 
-    if (tt == TokenType::op_gt)
-        return Comparator::GREATER;
+        case Opm::Action::TokenType::op_ne:
+            return Opm::Action::Comparator::NOT_EQUAL;
 
-    if (tt == TokenType::op_lt)
-        return Comparator::LESS;
+        case Opm::Action::TokenType::op_gt:
+            return Opm::Action::Comparator::GREATER;
 
-    if (tt == TokenType::op_le)
-        return Comparator::LESS_EQUAL;
+        case Opm::Action::TokenType::op_lt:
+            return Opm::Action::Comparator::LESS;
 
-    if (tt == TokenType::op_ge)
-        return Comparator::GREATER_EQUAL;
+        case Opm::Action::TokenType::op_le:
+            return Opm::Action::Comparator::LESS_EQUAL;
 
-    return Comparator::INVALID;
-}
+        case Opm::Action::TokenType::op_ge:
+            return Opm::Action::Comparator::GREATER_EQUAL;
 
+        default:
+            return Opm::Action::Comparator::INVALID;
+        }
+    }
 
+    std::string strip_quotes(const std::string& s)
+    {
+        if ((s.size() >= 2) && (s.front() == '\'') && (s.back() == '\'')) {
+            return s.substr(1, s.size() - 2);
+        }
 
-std::string strip_quotes(const std::string& s) {
-    if (s[0] == '\'')
-        return s.substr(1, s.size() - 2);
-    else
         return s;
-}
+    }
 
-}
+    std::pair<std::string, std::string>
+    decomposeRegionVectorName(const std::string& regQuant)
+    {
+        auto components = std::pair {
+            regQuant.substr(0, 5),
+            std::string { "NUM" }
+        };
 
-Quantity::Quantity(const std::string& arg) :
-    quantity(strip_quotes(arg))
+        if (regQuant.size() <= std::string::size_type{5}) {
+            return components;
+        }
+
+        components.first.erase(components.first.find_last_not_of('_') + 1);
+        components.second = regQuant.substr(5);
+
+        return components;
+    }
+
+} // Anonymous namespace
+
+namespace Opm::Action {
+
+// ===========================================================================
+// Class Action::Quantity
+// ===========================================================================
+
+Quantity::Quantity(const std::string& arg)
+    : quantity_ { trim_copy(strip_quotes(trim_copy(arg))) }
 {}
 
-
 Quantity::Quantity(const RestartIO::RstAction::Quantity& rst_quantity)
+    : quantity_ { rst_quantity.quantity() }
+    , args_     { rst_quantity.args() }
+{}
+
+Quantity Quantity::serializationTestObject()
 {
-    if (std::holds_alternative<std::string>(rst_quantity.quantity))
-        this->quantity = std::get<std::string>(rst_quantity.quantity);
-    else
-        this->quantity = format_double(std::get<double>(rst_quantity.quantity));
+    auto q = Quantity { "ROPR" };
 
-    if (rst_quantity.wgname.has_value())
-        this->add_arg(rst_quantity.wgname.value());
+    q.add_arg("42");
+    q.add_arg("ABC");
+    q.finalise();
+
+    return q;
 }
 
+int Quantity::int_type() const
+{
+    if (this->type_.has_value()) {
+        return *this->type_;
+    }
 
-void Quantity::add_arg(const std::string& arg) {
-    this->args.push_back(strip_quotes(arg));
+    return this->type();
 }
 
-bool Quantity::date() const {
-    if (this->quantity == "DAY")
-        return true;
+// ---------------------------------------------------------------------------
+// Private member functions for Action::Quantity below
+// ---------------------------------------------------------------------------
 
-    if (this->quantity == "MNTH")
-        return true;
+int Quantity::type() const
+{
+    if (this->quantity_.empty()) {
+        throw std::runtime_error {
+            "ACTIONX condition quantity does not "
+            "reference any appropriate variable or constant"
+        };
+    }
 
-    if (this->quantity == "MONTH")
-        return true;
+    using QType = Opm::RestartIO::Helpers::
+        VectorItems::IACN::Value::QuantityType;
 
-    if (this->quantity == "YEAR")
-        return true;
+    // Note: We check for (numeric) constants and dates first lest "FEB" be
+    // erroneously classified as a 'F'ield level summary vector or "SEP" be
+    // similarly erroneously classified as a 'S'egment level summary vector.
+    if (this->isNumeric() || this->isMonthName()) {
+        return QType::Const;
+    }
 
-    return false;
+    if (this->isDay())   { return QType::Day;   }
+    if (this->isMonth()) { return QType::Month; }
+    if (this->isYear())  { return QType::Year;  }
+
+    switch (this->quantity_.front()) {
+    case 'F': return QType::Field;
+    case 'W': return QType::Well;
+    case 'G': return QType::Group;
+    case 'R': return QType::Region;
+    case 'S': return QType::Segment;
+    case 'C': return QType::Connection;
+    case 'B': return QType::Block;
+    default:  return QType::Const;
+    }
 }
 
-int Quantity::int_type() const {
-    namespace QuantityType = Opm::RestartIO::Helpers::VectorItems::IACN::Value;
-    const auto& first_char = this->quantity[0];
-    if (first_char == 'W')
-        return QuantityType::Well;
+bool Quantity::isNumeric() const
+{
+    if (this->quantity_.empty()) {
+        return false;
+    }
 
-    if (first_char == 'F')
-        return QuantityType::Field;
+    auto qstr = std::string_view { this->quantity_ };
+    if (qstr.front() == '+') {
+        // From_chars() does not recognise leading positive signs so trim
+        // that.
+        qstr.remove_prefix(1);
 
-    if (first_char == 'G')
-        return QuantityType::Group;
+        if (qstr.empty()) {
+            // Quantity_ == '+'.  Not a number.
+            return false;
+        }
+    }
 
-    if (first_char == 'D')
-        return QuantityType::Day;
+    if constexpr (has_from_chars_fp<double>) {
+        // Quantity_ is a number if floating-point (i.e., double) overload of
+        // from_chars() can parse the full remaining quantity_ string.
+        auto x = 0.0;
+        const auto* first = qstr.data();
+        const auto* last  = qstr.data() + qstr.size();
+        auto [ptr, ec] = std::from_chars(first, last, x);
 
-    if (first_char == 'M')
-        return QuantityType::Month;
+        return (ec == std::errc{}) && (ptr == last);
+    }
+    else {
+        // Fallback for standard libraries without floating-point from_chars().
+        errno = 0;
+        char* end = nullptr;
+        const auto* first = qstr.data();
+        const auto* last  = qstr.data() + qstr.size();
+        [[maybe_unused]] const auto x = std::strtod(first, &end);
 
-    if (first_char == 'Y')
-        return QuantityType::Year;
-
-    return QuantityType::Const;
+        return (end == last) && (errno != ERANGE);
+    }
 }
 
+bool Quantity::isDay() const
+{
+    return this->quantity_ == "DAY";
+}
+
+bool Quantity::isMonth() const
+{
+    return (this->quantity_ == "MNTH")
+        || (this->quantity_ == "MONTH");
+}
+
+bool Quantity::isMonthName() const
+{
+    return TimeService::valid_month(this->quantity_);
+}
+
+bool Quantity::isYear() const
+{
+    return this->quantity_ == "YEAR";
+}
+
+void Quantity::add_arg(const std::string& arg)
+{
+    this->args_.push_back(trim_copy(strip_quotes(trim_copy(arg))));
+    this->type_.reset();
+}
+
+void Quantity::finalise()
+{
+    using QType = Opm::RestartIO::Helpers::
+        VectorItems::IACN::Value::QuantityType;
+
+    this->type_.emplace(this->type());
+
+    switch (*this->type_) {
+    case QType::Region:
+        this->finaliseRegion();
+        break;
+
+    case QType::Field:
+    case QType::Well:
+    case QType::Group:
+    case QType::Segment:
+    case QType::Connection:
+    case QType::Const:
+    case QType::Day:
+    case QType::Month:
+    case QType::Year:
+    case QType::Block:
+        // Nothing to do.
+        break;
+    }
+}
+
+void Quantity::finaliseRegion()
+{
+    // Request of the form
+    //
+    //   ROPR         -- All regions of built-in FIPNUM region set
+    //   ROPR 42      -- Region 42 of built-in FIPNUM region set
+    //   ROPR 42 ABC  -- Region 42 of user-defined FIPABC region set
+    //   ROPR_ABC     -- All regions of user-defined FIPABC region set
+    //   ROPR_ABC 42  -- Region 42 of user-defined FIPABC region set
+    //
+    // Create canonicalised lookup key (quantity_)
+    //
+    //    ROPR_set
+    //
+    // and ensure that args_ contains only the integer (42).  For the
+    // default/built-in FIPNUM region set, this will become
+    //
+    //    ROPR_NUM
+    //
+    // and that is intentional.  We write this canonical form to the ZACN
+    // restart file array.
+
+    auto [base, regset] = decomposeRegionVectorName(this->quantity_);
+
+    if (this->args_.size() == 2) {
+        regset = this->args_.back();
+        this->args_.erase(this->args_.begin() + 1, this->args_.end());
+    }
+
+    this->quantity_ = fmt::format("{:_<5}{}", base, regset);
+}
+
+// ===========================================================================
+// Class Action::Condition
+// ===========================================================================
 
 Condition::Condition(const RestartIO::RstAction::Condition& rst_condition)
-    : lhs(rst_condition.lhs)
-    , rhs(rst_condition.rhs)
-    , logic(rst_condition.logic)
-    , cmp(rst_condition.cmp_op)
-    , left_paren(rst_condition.left_paren)
-    , right_paren(rst_condition.right_paren)
+    : lhs         { rst_condition.lhs }
+    , rhs         { rst_condition.rhs }
+    , logic       { rst_condition.logic }
+    , cmp         { rst_condition.cmp_op }
+    , left_paren  { rst_condition.left_paren }
+    , right_paren { rst_condition.right_paren }
+    , cmp_string  { comparator_as_string(cmp) }
 {
+    this->lhs.finalise();
+    this->rhs.finalise();
 }
 
-
-Condition::Condition(const std::vector<std::string>& tokens, const KeywordLocation& location) {
+Condition::Condition(const std::vector<std::string>& tokens,
+                     const KeywordLocation&          location)
+{
     std::size_t token_index = 0;
-    if (tokens[0] == "(") {
+
+    if (tokens.front() == "(") {
         this->left_paren = true;
-        token_index += 1;
+        ++token_index;
     }
-    this->lhs = Quantity(tokens[token_index]);
-    token_index += 1;
+
+    this->lhs = Quantity { tokens[token_index] };
+    ++token_index;
 
     while (true) {
-        if (token_index >= tokens.size())
+        if (token_index >= tokens.size()) {
             break;
+        }
 
         const auto comp = comparator(Parser::tokenType(tokens[token_index]));
         if (comp == Comparator::INVALID) {
             this->lhs.add_arg(tokens[token_index]);
-            token_index += 1;
-        } else {
+            ++token_index;
+        }
+        else {
             this->cmp = comp;
             this->cmp_string = comparator_as_string(this->cmp);
-            token_index += 1;
+            ++token_index;
             break;
         }
     }
 
-    if (token_index >= tokens.size())
-        throw std::invalid_argument("Could not determine right hand side / comparator for ACTIONX keyword at " + location.filename + ":" + std::to_string(location.lineno));
+    if (token_index >= tokens.size()) {
+        throw std::invalid_argument {
+            fmt::format("Could not determine right hand side/comparator "
+                        "for ACTIONX keyword at {}:{}",
+                        location.filename, location.lineno)
+        };
+    }
 
-    this->rhs = Quantity(tokens[token_index]);
-    token_index++;
+    this->rhs = Quantity { tokens[token_index] };
+    ++token_index;
 
     while (true) {
-        if (token_index >= tokens.size())
+        if (token_index >= tokens.size()) {
+            break;
+        }
+
+        switch (Parser::tokenType(tokens[token_index])) {
+        case TokenType::op_and:
+            this->logic = Logical::AND;
             break;
 
-        const auto token_type = Parser::tokenType(tokens[token_index]);
-        if (token_type == TokenType::op_and)
-            this->logic = Logical::AND;
-        else if (token_type == TokenType::op_or)
+        case TokenType::op_or:
             this->logic = Logical::OR;
-        else if (token_type == TokenType::close_paren)
+            break;
+
+        case TokenType::close_paren:
             this->right_paren = true;
-        else
+            break;
+
+        default:
             this->rhs.add_arg(tokens[token_index]);
+            break;
+        }
 
-        token_index++;
+        ++token_index;
     }
+
+    this->lhs.finalise();
+    this->rhs.finalise();
 }
 
-
-bool Condition::operator==(const Condition& data) const {
-    return lhs == data.lhs &&
-           left_paren == data.left_paren &&
-           right_paren == data.right_paren &&
-           rhs == data.rhs &&
-           logic == data.logic &&
-           cmp == data.cmp &&
-           cmp_string == data.cmp_string;
+bool Condition::operator==(const Condition& data) const
+{
+    return (this->lhs == data.lhs)
+        && (this->rhs == data.rhs)
+        && (this->logic == data.logic)
+        && (this->cmp == data.cmp)
+        && (this->left_paren == data.left_paren)
+        && (this->right_paren == data.right_paren)
+        && (this->cmp_string == data.cmp_string)
+        ;
 }
 
-bool Condition::open_paren() const {
+bool Condition::open_paren() const
+{
     return this->left_paren && !this->right_paren;
 }
 
-bool Condition::close_paren() const {
+bool Condition::close_paren() const
+{
     return !this->left_paren && this->right_paren;
 }
 
-int Condition::paren_as_int() const {
-    namespace ParenType = Opm::RestartIO::Helpers::VectorItems::IACN::Value;
+int Condition::paren_as_int() const
+{
+    using ParenType = Opm::RestartIO::Helpers
+        ::VectorItems::IACN::Value::ParenType;
 
-    if (this->open_paren())
+    if (this->open_paren()) {
         return ParenType::Open;
-    else if (this->close_paren())
+    }
+    else if (this->close_paren()) {
         return ParenType::Close;
+    }
 
     return ParenType::None;
 }
 
-
-int Condition::logic_as_int() const {
+int Condition::logic_as_int() const
+{
     switch (this->logic) {
     case Logical::END:
         return 0;
@@ -237,8 +452,8 @@ int Condition::logic_as_int() const {
     }
 }
 
-
-int Condition::comparator_as_int() const {
+int Condition::comparator_as_int() const
+{
     switch (this->cmp) {
     case Comparator::GREATER:
         return 1;
@@ -257,5 +472,4 @@ int Condition::comparator_as_int() const {
     }
 }
 
-}
-}
+} // namespace Opm::Action

--- a/opm/input/eclipse/Schedule/Action/Condition.hpp
+++ b/opm/input/eclipse/Schedule/Action/Condition.hpp
@@ -20,71 +20,296 @@
 #ifndef ACTIONX_CONDITION_HPP
 #define ACTIONX_CONDITION_HPP
 
+#include <opm/common/OpmLog/KeywordLocation.hpp>
+
+#include <opm/io/eclipse/rst/action.hpp>
+
+#include <opm/input/eclipse/Schedule/Action/Enums.hpp>
+
+#include <optional>
 #include <string>
 #include <vector>
 
-#include <opm/common/OpmLog/KeywordLocation.hpp>
-#include <opm/input/eclipse/Schedule/Action/Enums.hpp>
-#include <opm/io/eclipse/rst/action.hpp>
+namespace Opm::Action {
 
-namespace Opm {
+class Condition;
 
-namespace Action {
+} // namespace Opm::Action
 
+namespace Opm::Action {
 
-class Quantity {
+/// Restart file representation of an action condition quantity.
+///
+/// This is typically a summary vector, e.g., a field level quantity
+/// such as FOPT, a group level quantity such as GOPR for a particular
+/// group, or a well level quantity such as WWCT for one or more wells.
+///
+/// Additional types include segment and region level quantities,
+/// as well as numerical constants or named months.
+class Quantity
+{
 public:
+    /// Construct a default quantity.
+    ///
+    /// Mostly to support deferred initialization, e.g., for serialization.
     Quantity() = default;
-    explicit Quantity(const RestartIO::RstAction::Quantity& rst_quantity);
+
+    /// Construct a quantity from a quantity name.
+    ///
+    /// This is typically a summary vector name.
+    ///
+    /// \param[in] arg The quantity name.
     explicit Quantity(const std::string& arg);
 
-    void add_arg(const std::string& arg);
-    std::string quantity;
-    std::vector<std::string> args;
-    bool date() const;
+    /// Construct a quantity from a restart action quantity.
+    ///
+    /// \param[in] rst_quantity The restart action quantity.  Expected
+    /// to include all requisite additional arguments such as group
+    /// names or segment numbers.
+    explicit Quantity(const RestartIO::RstAction::Quantity& rst_quantity);
+
+    /// Create a serialization test object.
+    static Quantity serializationTestObject();
+
+    /// Retrieve the quantity name.
+    ///
+    /// \return The quantity name or a string representation
+    /// of a numeric constant or named month.
+    const std::string& quantity() const { return this->quantity_; }
+
+    /// Retrieve the quantity arguments.
+    ///
+    /// \return The quantity arguments.  Empty if there are no additional
+    /// arguments such as for field level quantities, date keywords or
+    /// numeric constants.  Otherwise, contains e.g., well or group name,
+    /// segment numbers, region IDs, or cell IJK tuples.
+    const std::vector<std::string>& args() const { return this->args_; }
+
+    /// Integer type classification of the quantity.
+    ///
+    /// Expected to be one of the
+    ///
+    ///    RestartIO::Helpers::VectorItems::IACN::Value::QuantityType
+    ///
+    /// enumerators defined in VectorItems/action.hpp.
+    ///
+    /// Will throw an exception of type \code std::runtime_error \endcode if
+    /// this Condition does not reference any variables or constants.
+    ///
+    /// \return The integer type classification of the quantity.
     int int_type() const;
 
-
-    bool operator==(const Quantity& data) const {
-        return quantity == data.quantity &&
-               args == data.args;
+    /// Equality predicate.
+    ///
+    /// \param[in] that Object against which \code *this \endcode will
+    /// be tested for equality.
+    ///
+    /// \return Whether or not \code *this \endcode is the same as \p that.
+    bool operator==(const Quantity& that) const
+    {
+        return (this->quantity_ == that.quantity_)
+            && (this->args_     == that.args_)
+            && (this->type_     == that.type_)
+            ;
     }
 
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
-        serializer(quantity);
-        serializer(args);
+        serializer(this->quantity_);
+        serializer(this->args_);
+        serializer(this->type_);
     }
+
+    friend class Condition;
+
+private:
+    /// Action condition quantity name.
+    std::string quantity_{};
+
+    /// Action condition quantity arguments.
+    std::vector<std::string> args_{};
+
+    /// Action condition quantity type.
+    ///
+    /// Populated in finalise().
+    std::optional<int> type_{};
+
+    /// Determine the type of the quantity based on its name and arguments.
+    ///
+    /// \return The integer type classification of the quantity.
+    int type() const;
+
+    /// Check if the quantity is a numeric constant.
+    ///
+    /// \return True if the quantity is a numeric constant, false otherwise.
+    bool isNumeric() const;
+
+    /// Check if the quantity represents a day.
+    ///
+    /// \return True if quantity_ == "DAY", false otherwise.
+    bool isDay() const;
+
+    /// Check if the quantity represents a month.
+    ///
+    /// \return True if quantity_ == "MNTH" or quantity_ == "MONTH", false otherwise.
+    bool isMonth() const;
+
+    /// Check if the quantity represents a month name.
+    ///
+    /// \return True if quantity_ is one the canonical month name
+    /// abbreviations recognized by OPM, false otherwise.
+    bool isMonthName() const;
+
+    /// Check if the quantity represents a year.
+    ///
+    /// \return True if quantity_ == "YEAR", false otherwise.
+    bool isYear() const;
+
+    /// Add an argument to the quantity.
+    ///
+    /// Invoked by the Condition constructor as it parses the quantity
+    /// and its arguments.  The arguments are stored in the order they
+    /// are encountered, and the finalise() method is invoked after
+    /// all arguments have been added.
+    ///
+    /// \param[in] arg The argument to be added.
+    void add_arg(const std::string& arg);
+
+    /// Finalise the quantity.
+    ///
+    /// Invoked by the Condition constructor after the quantity has been
+    /// fully constructed and all arguments have been added.  Determines
+    /// the type of the quantity based on its name and arguments, and
+    /// performs any necessary validation or normalisation of the quantity
+    /// and its arguments.
+    void finalise();
+
+    /// Finalise a region quantity type.
+    ///
+    /// This is a helper function called by finalise().
+    ///
+    /// Ensures that the quantity keyword includes the region set name and
+    /// that the only argument is a region ID.
+    void finaliseRegion();
 };
 
-
-
-class Condition {
+/// Restart file representation of an action condition.
+///
+/// This is a single condition in an ACTIONX keyword.  It consists
+/// of a left hand side quantity, a comparison operator, and a right
+/// hand side quantity.  It may additionally include a logical operator
+/// by which to combine it with the next condition in a sequence
+/// of conditions.
+class Condition
+{
 public:
-
+    /// Default constructor.
+    ///
+    /// Mostly to support deferred initialization, e.g., for serialization.
     Condition() = default;
+
+    /// Construct a Condition from restart file information.
+    ///
+    /// \param[in] rst_condition The restart file condition to construct from.
     explicit Condition(const RestartIO::RstAction::Condition& rst_condition);
-    Condition(const std::vector<std::string>& tokens, const KeywordLocation& location);
 
+    /// Construct a Condition from SCHEDULE section information.
+    ///
+    /// \param[in] tokens The raw string tokens comprising the condition.
+    /// Each token is assumed to be free of leading and trailing whitespace,
+    /// and to have been split on whitespace.
+    ///
+    /// \param[in] location The location of the pertinent action
+    /// keyword in the input deck.  Needed for error reporting if
+    /// the condition cannot be parsed.
+    Condition(const std::vector<std::string>& tokens,
+              const KeywordLocation&          location);
 
-    Quantity lhs;
-    Quantity rhs;
-    Logical logic = Logical::END;
-    Comparator cmp = Comparator::INVALID;
-    bool left_paren = false;
-    bool right_paren = false;
+    /// Left hand side quantity of the condition.
+    ///
+    /// This is typically a summary vector, e.g., a field level quantity
+    /// such as FOPT, a group level quantity such as GOPR for a particular
+    /// group, or a well level quantity such as WWCT for one or more wells.
+    Quantity lhs{};
 
-    std::string cmp_string;
+    /// Right hand side quantity of the condition.
+    ///
+    /// This is typically a constant or a specific summary vector.
+    Quantity rhs{};
 
-    static Logical logic_from_int(int);
+    /// Logical operator of the condition.
+    ///
+    /// Operator by which to combine this condition with the next condition
+    /// in a sequence of conditions.  The default value is Logical::END,
+    /// which indicates that this is the last or only condition in a sequence
+    /// of conditions.  Other possibilities are Logical::AND and Logical::OR.
+    Logical logic { Logical::END };
+
+    /// Comparison operator of the condition.
+    ///
+    /// This is expected to be a regular boolean comparison operator
+    /// such as >, <, >=, <=, ==, or !=.
+    Comparator cmp { Comparator::INVALID };
+
+    /// Whether or not the condition starts with a left parenthesis.
+    bool left_paren { false };
+
+    /// Whether or not the condition includes a right parenthesis.
+    bool right_paren { false };
+
+    /// String representation of the comparison operator.
+    ///
+    /// Needed for restart file output.
+    std::string cmp_string{};
+
+    /// Compute restart file integer representation of the logical operator.
+    ///
+    /// \return Integer representation of the condition's logical operator.
     int logic_as_int() const;
+
+    /// Compute restart file integer representation of the comparison operator.
+    ///
+    /// \return Integer representation of the condition's comparison operator.
     int comparator_as_int() const;
+
+    /// Compute restart file integer representation of the parentheses.
+    ///
+    /// \return Integer representation of the condition's parentheses level.
     int paren_as_int() const;
+
+    /// Whether or not this condition increases the grouping level
+    /// of the condition sequence.
+    ///
+    /// \return True if the condition starts with a left parenthesis
+    /// and does *not* include a right parenthesis, false otherwise.
     bool open_paren() const;
+
+    /// Whether or not this condition decreases the grouping level
+    /// of the condition sequence.
+    ///
+    /// \return True if the condition does *not* start with a left
+    /// parenthesis but does include a right parenthesis, false otherwise.
     bool close_paren() const;
+
+    /// Equality predicate.
+    ///
+    /// \param[in] data Object against which \code *this \endcode will
+    /// be tested for equality.
+    ///
+    /// \return Whether or not \code *this \endcode is the same as \p data.
     bool operator==(const Condition& data) const;
 
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
@@ -98,8 +323,6 @@ public:
     }
 };
 
+} // namespace Opm::Action
 
-}
-}
-
-#endif
+#endif // ACTIONX_CONDITION_HPP

--- a/opm/input/eclipse/Schedule/Action/Enums.cpp
+++ b/opm/input/eclipse/Schedule/Action/Enums.cpp
@@ -17,10 +17,11 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <fmt/format.h>
+#include <opm/input/eclipse/Schedule/Action/Enums.hpp>
+
 #include <stdexcept>
 
-#include <opm/input/eclipse/Schedule/Action/Enums.hpp>
+#include <fmt/format.h>
 
 namespace Opm {
 namespace Action {

--- a/opm/io/eclipse/rst/action.cpp
+++ b/opm/io/eclipse/rst/action.cpp
@@ -15,138 +15,566 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <cmath>
 
 #include <opm/io/eclipse/rst/action.hpp>
-#include <opm/output/eclipse/VectorItems/action.hpp>
+
 #include <opm/common/utility/String.hpp>
 #include <opm/common/utility/TimeService.hpp>
 
-namespace Opm {
-namespace RestartIO {
+#include <opm/output/eclipse/VectorItems/action.hpp>
 
-namespace IACN = Helpers::VectorItems::IACN;
-namespace SACN = Helpers::VectorItems::SACN;
-namespace ZACN = Helpers::VectorItems::ZACN;
+#include <fmt/format.h>
 
+#include <array>
+#include <cmath>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
-RstAction::RstAction(const std::string& name_arg, int max_run_arg,
-                     int run_count_arg, double min_wait_arg,
-                     std::time_t start_time_arg, std::time_t last_run_arg,
-                     const std::vector<RstAction::Condition>& conditions_arg)
-    : name(name_arg)
-    , max_run(max_run_arg)
-    , run_count(run_count_arg)
-    , min_wait(min_wait_arg)
-    , start_time(start_time_arg)
-    , conditions(conditions_arg)
-{
-    if (this->run_count > 0)
-        this->last_run = last_run_arg;
-}
+namespace {
 
+    /// Export quantity name and arguments of the given restart
+    /// file action condition quantity into the given token vector.
+    ///
+    /// \param[in] quantity The quantity to capture.
+    ///
+    /// \param[in,out] tokens The vector into which to export the quantity's tokens.
+    void captureQuantityTokens(const Opm::RestartIO::RstAction::Quantity& quantity,
+                               std::vector<std::string>&                  tokens)
+    {
+        tokens.push_back(quantity.quantity());
 
-RstAction::Quantity::Quantity(const std::string * zacn, double sacn_value) {
-    auto str_quantity = trim_copy(zacn[ZACN::Quantity]);
-    if (str_quantity.empty()) {
-        this->quantity = sacn_value;
-        return;
+        if (const auto& args = quantity.args(); !args.empty()) {
+            tokens.insert(tokens.end(), args.begin(), args.end());
+        }
     }
 
-    this->quantity = str_quantity;
-    if (str_quantity[0] == 'W')
-        this->wgname = trim_copy(zacn[ZACN::Well]);
-    else if (str_quantity[0] == 'G')
-        this->wgname = trim_copy(zacn[ZACN::Group]);
-}
+    /// Whether or not a given double value is a numeric integer.
+    ///
+    /// A value is deemed to be an integer if it is finite and
+    /// has no fractional part.
+    ///
+    /// \param[in] value The double value to check.
+    ///
+    /// \return True if the value is a numeric integer, false otherwise.
+    bool isNumericInteger(const double value)
+    {
+        return std::isfinite(value) && (std::fmod(value, 1.0) == 0.0);
+    }
 
-RstAction::Quantity::Quantity(const std::string& q)
-    : quantity(q)
-{
-}
+    // --------------------------------------------------------------------------
 
-RstAction::Quantity::Quantity(double value)
-    : quantity(value)
-{
-}
+    /// Construct argument vector for a region level quantity from restart file information.
+    ///
+    /// \param[in] regionIDIndex The index of the region ID in the IACN vector.
+    /// Expected to be either LHSRegionID or RHSRegionID.
+    ///
+    /// \param[in] iacn Restart file integer items for a single action condition.
+    ///
+    /// \return A vector of strings representing the arguments for the region level
+    /// quantity.  Empty if the region ID is zero or negative, otherwise contains
+    /// the string representation of a single region ID.
+    std::vector<std::string>
+    regionArgs(const Opm::RestartIO::Helpers::VectorItems::IACN::index regionIDIndex,
+               std::span<const int>                                    iacn)
+    {
+        if (const auto regID = iacn[regionIDIndex]; regID > 0) {
+            return { fmt::format("{}", regID) };
+        }
 
+        return {};
+    }
 
+    /// Construct argument vector for a segment level quantity from restart file information.
+    ///
+    /// \param[in] segmentIDIndex The index of the segment ID in the IACN vector.
+    /// Expected to be either LHSSegmentID or RHSSegmentID.
+    ///
+    /// \param[in] wellNameIndex The index of the well name in the ZACN vector.
+    /// Expected to be either LHSWell or RHSWell.
+    ///
+    /// \param[in] iacn Restart file integer items for a single action condition.
+    ///
+    /// \param[in] zacn Restart file string items for a single action condition.
+    ///
+    /// \return A vector of strings representing the arguments for the segment level
+    /// quantity.  Contains the well name and, if the segment ID is positive,
+    /// the string representation of the segment ID.
+    std::vector<std::string>
+    segmentArgs(const Opm::RestartIO::Helpers::VectorItems::IACN::index segmentIDIndex,
+                const Opm::RestartIO::Helpers::VectorItems::ZACN::index wellNameIndex,
+                std::span<const int>                                    iacn,
+                std::span<const std::string>                            zacn)
+    {
+        auto args = std::vector { zacn[wellNameIndex] };
 
-RstAction::Condition::Condition(const std::string * zacn, const int * iacn, const double * sacn)
-    : logic(Action::logic_from_int(iacn[IACN::TerminalLogic]))
-    , cmp_op(Action::comparator_from_int(iacn[IACN::Comparator]))
+        if (const auto segID = iacn[segmentIDIndex]; segID > 0) {
+            args.push_back(fmt::format("{}", segID));
+        }
+
+        return args;
+    }
+
+    /// Derive string representation of an IJK location from restart file information.
+    ///
+    /// Common backend for block and connection level quantities.  The IJK location is
+    /// represented by its indices in the IACN vector.
+    ///
+    /// \param[in] ijk The indices of the IJK location in the IACN vector.
+    /// Expected to be either a block-level location like
+    ///
+    ///    { LHSBlockLocation_I, LHSBlockLocation_J, LHSBlockLocation_K },
+    ///    { RHSBlockLocation_I, RHSBlockLocation_J, RHSBlockLocation_K }
+    ///
+    /// or a connection-level location like
+    ///
+    ///    { LHSConnLocation_I, LHSConnLocation_J, LHSConnLocation_K },
+    ///    { RHSConnLocation_I, RHSConnLocation_J, RHSConnLocation_K }
+    ///
+    /// \param[in] iacn Restart file integer items for a single action condition.
+    ///
+    /// \return A vector of strings representing the IJK location.  Contains the string
+    /// representations of the IJK indices, with "0" for non-positive values.
+    std::vector<std::string>
+    ijkArgs(const std::array<Opm::RestartIO::Helpers::VectorItems::IACN::index, 3>& ijk,
+            std::span<const int>                                                    iacn)
+    {
+        auto args = std::vector<std::string> {};
+
+        for (const auto& ijkIndex : ijk) {
+            if (const auto loc = iacn[ijkIndex]; loc > 0) {
+                args.push_back(fmt::format("{}", loc));
+            }
+            else {
+                args.push_back("0");
+            }
+        }
+
+        return args;
+    }
+
+    /// @brief Construct argument vector for a connection level quantity from restart file information.
+    ///
+    /// \param[in] connIndices The indices of the connection location in the IACN vector.
+    /// Expected to be either { LHSConnLocation_I, LHSConnLocation_J, LHSConnLocation_K }
+    /// or { RHSConnLocation_I, RHSConnLocation_J, RHSConnLocation_K }.
+    ///
+    /// \param[in] wellNameIndex The index of the well name in the ZACN vector.
+    /// Expected to be either LHSWell or RHSWell.
+    ///
+    /// \param[in] iacn Restart file integer items for a single action condition.
+    ///
+    /// \param[in] zacn Restart file string items for a single action condition.
+    ///
+    /// \return A vector of strings representing the arguments for the connection level
+    /// quantity.  Contains the well name and the string representations of the
+    /// connection location indices.
+    std::vector<std::string>
+    connectionArgs(const std::array<Opm::RestartIO::Helpers::VectorItems::IACN::index, 3>& connIndices,
+                   const Opm::RestartIO::Helpers::VectorItems::ZACN::index                 wellNameIndex,
+                   std::span<const int>                                                    iacn,
+                   std::span<const std::string>                                            zacn)
+    {
+        auto args = ijkArgs(connIndices, iacn);
+        args.insert(args.begin(), zacn[wellNameIndex]);
+
+        return args;
+    }
+
+    // --------------------------------------------------------------------------
+
+    /// Construct argument vector for a left-hand side region from restart file information.
+    ///
+    /// \param[in] iacn Restart file integer items for a single action condition.
+    ///
+    /// \return A vector of strings representing the arguments for the left-hand side region.
+    std::vector<std::string>
+    lhsRegionArgs(std::span<const int> iacn)
+    {
+        return regionArgs(Opm::RestartIO::Helpers::VectorItems::IACN::index::LHSRegionID, iacn);
+    }
+
+    /// Construct argument vector for a left-hand side segment from restart file information.
+    ///
+    /// \param[in] iacn Restart file integer items for a single action condition.
+    ///
+    /// \param[in] zacn Restart file string items for a single action condition.
+    ///
+    /// \return A vector of strings representing the arguments for the left-hand side segment.
+    std::vector<std::string>
+    lhsSegmentArgs(std::span<const int>         iacn,
+                   std::span<const std::string> zacn)
+    {
+        return segmentArgs(Opm::RestartIO::Helpers::VectorItems::IACN::index::LHSSegmentID,
+                           Opm::RestartIO::Helpers::VectorItems::ZACN::index::LHSWell,
+                           iacn, zacn);
+    }
+
+    /// Construct argument vector for a left-hand side connection from restart file information.
+    ///
+    /// \param[in] iacn Restart file integer items for a single action condition.
+    ///
+    /// \param[in] zacn Restart file string items for a single action condition.
+    ///
+    /// \return A vector of strings representing the arguments for the left-hand side connection.
+    std::vector<std::string>
+    lhsConnectionArgs(std::span<const int>         iacn,
+                      std::span<const std::string> zacn)
+    {
+        using IIndex = Opm::RestartIO::Helpers::VectorItems::IACN::index;
+        using ZIndex = Opm::RestartIO::Helpers::VectorItems::ZACN::index;
+
+        return connectionArgs({ IIndex::LHSConnLocation_I,
+                                IIndex::LHSConnLocation_J,
+                                IIndex::LHSConnLocation_K },
+                              ZIndex::LHSWell, iacn, zacn);
+    }
+
+    /// Construct argument vector for a left-hand side block from restart file information.
+    ///
+    /// \param[in] iacn Restart file integer items for a single action condition.
+    ///
+    /// \return A vector of strings representing the arguments for the left-hand side block.
+    std::vector<std::string>
+    lhsBlockArgs(std::span<const int> iacn)
+    {
+        using IIndex = Opm::RestartIO::Helpers::VectorItems::IACN::index;
+
+        return ijkArgs({ IIndex::LHSBlockLocation_I,
+                         IIndex::LHSBlockLocation_J,
+                         IIndex::LHSBlockLocation_K },
+                       iacn);
+    }
+
+    // --------------------------------------------------------------------------
+
+    /// Construct argument vector for a right-hand side region from restart file information.
+    ///
+    /// \param[in] iacn Restart file integer items for a single action condition.
+    ///
+    /// \return A vector of strings representing the arguments for the right-hand side region.
+    std::vector<std::string>
+    rhsRegionArgs(std::span<const int> iacn)
+    {
+        return regionArgs(Opm::RestartIO::Helpers::VectorItems::IACN::index::RHSRegionID, iacn);
+    }
+
+    /// Construct argument vector for a right-hand side segment from restart file information.
+    ///
+    /// \param[in] iacn Restart file integer items for a single action condition.
+    ///
+    /// \param[in] zacn Restart file string items for a single action condition.
+    ///
+    /// \return A vector of strings representing the arguments for the right-hand side segment.
+    std::vector<std::string>
+    rhsSegmentArgs(std::span<const int>         iacn,
+                   std::span<const std::string> zacn)
+    {
+        return segmentArgs(Opm::RestartIO::Helpers::VectorItems::IACN::index::RHSSegmentID,
+                           Opm::RestartIO::Helpers::VectorItems::ZACN::index::RHSWell,
+                           iacn, zacn);
+    }
+
+    /// Construct argument vector for a right-hand side connection from restart file information.
+    ///
+    /// \param[in] iacn Restart file integer items for a single action condition.
+    ///
+    /// \param[in] zacn Restart file string items for a single action condition.
+    ///
+    /// \return A vector of strings representing the arguments for the right-hand side connection.
+    std::vector<std::string>
+    rhsConnectionArgs(std::span<const int>         iacn,
+                      std::span<const std::string> zacn)
+    {
+        using IIndex = Opm::RestartIO::Helpers::VectorItems::IACN::index;
+        using ZIndex = Opm::RestartIO::Helpers::VectorItems::ZACN::index;
+
+        return connectionArgs({ IIndex::RHSConnLocation_I,
+                                IIndex::RHSConnLocation_J,
+                                IIndex::RHSConnLocation_K },
+                              ZIndex::RHSWell, iacn, zacn);
+    }
+
+    /// Construct argument vector for a right-hand side block from restart file information.
+    ///
+    /// \param[in] iacn Restart file integer items for a single action condition.
+    ///
+    /// \return A vector of strings representing the arguments for the right-hand side block.
+    std::vector<std::string>
+    rhsBlockArgs(std::span<const int> iacn)
+    {
+        using IIndex = Opm::RestartIO::Helpers::VectorItems::IACN::index;
+
+        return ijkArgs({ IIndex::RHSBlockLocation_I,
+                         IIndex::RHSBlockLocation_J,
+                         IIndex::RHSBlockLocation_K },
+                       iacn);
+    }
+
+    /// Construct a right-hand side quantity for a constant value from restart file information.
+    ///
+    /// The constant is expected to be a numeric value or a named month.  If the
+    /// left hand side quantity is a Month and the numeric value is an integer,
+    /// the corresponding month name is returned.  Otherwise, the numeric value
+    /// is returned as a string.
+    ///
+    /// \param[in] iacn Restart file integer items for a single action condition.
+    ///
+    /// \param[in] sacn Restart file double items for a single action condition.
+    ///
+    /// \return A quantity representing the right-hand side constant value.
+    Opm::RestartIO::RstAction::Quantity
+    rhsConstant(std::span<const int>    iacn,
+                std::span<const double> sacn)
+    {
+        using IIndex = Opm::RestartIO::Helpers::VectorItems::IACN::index;
+        using QType = Opm::RestartIO::Helpers::VectorItems::IACN::Value::QuantityType;
+        using SIndex = Opm::RestartIO::Helpers::VectorItems::SACN::index;
+
+        if ((iacn[IIndex::LHSQuantityType] == QType::Month) &&
+            isNumericInteger(sacn[SIndex::RHSValue0]))
+        {
+            const auto& monthNames = Opm::TimeService::eclipseMonthNames();
+
+            auto monthPos = monthNames.find(static_cast<int>(sacn[SIndex::RHSValue0]));
+            if (monthPos != monthNames.end()) {
+                return Opm::RestartIO::RstAction::Quantity{monthPos->second};
+            }
+        }
+
+        return Opm::RestartIO::RstAction::
+            Quantity{fmt::format("{}", sacn[SIndex::RHSValue0])};
+    }
+
+} // Anonymous namespace
+
+namespace Opm::RestartIO {
+
+    namespace IACN = Helpers::VectorItems::IACN;
+    namespace SACN = Helpers::VectorItems::SACN;
+    namespace ZACN = Helpers::VectorItems::ZACN;
+
+    RstAction::Quantity::Quantity(const std::string& q)
+        : quantity_ { q }
+    {}
+
+    RstAction::Condition::Condition(std::span<const int>         iacn,
+                                    std::span<const double>      sacn,
+                                    std::span<const std::string> zacn)
+        : logic  { Action::logic_from_int(iacn[IACN::TerminalLogic]) }
+        , cmp_op { Action::comparator_from_int(iacn[IACN::Comparator]) }
+    {
+        if (iacn.size() != IACN::ConditionSize) {
+            throw std::invalid_argument {
+                fmt::format("Expected IACN vector "
+                            "of size {}, but got {}",
+                             IACN::ConditionSize, iacn.size())
+            };
+        }
+
+        if (sacn.size() != SACN::ConditionSize) {
+            throw std::invalid_argument {
+                fmt::format("Expected SACN vector "
+                            "of size {}, but got {}",
+                             SACN::ConditionSize, sacn.size())
+            };
+        }
+
+        if (zacn.size() != ZACN::ConditionSize) {
+            throw std::invalid_argument {
+                fmt::format("Expected ZACN vector "
+                            "of size {}, but got {}",
+                             ZACN::ConditionSize, zacn.size())
+            };
+        }
+
+        this->restoreLHSQuantity(iacn, zacn);
+        this->restoreRHSQuantity(iacn, sacn, zacn);
+
+        this->left_paren = iacn[IACN::Paren] == IACN::Value::Open;
+        this->right_paren = iacn[IACN::Paren] == IACN::Value::Close;
+    }
+
+bool
+RstAction::Condition::valid(std::span<const int>         iacn,
+                            std::span<const std::string> zacn)
 {
     auto type_index = IACN::LHSQuantityType;
-    auto rhs_value = sacn[SACN::RHSValue0];
     if (iacn[type_index] == IACN::Value::Day) {
-        this->lhs = RstAction::Quantity("DAY");
-        this->rhs = RstAction::Quantity(rhs_value);
-        return;
+        return true;
     }
 
     if (iacn[type_index] == IACN::Value::Month) {
-        this->lhs = RstAction::Quantity("MNTH");
-        this->rhs = RstAction::Quantity(TimeService::eclipseMonthNames().at(static_cast<int>(rhs_value)));
-        return;
+        return true;
     }
 
     if (iacn[type_index] == IACN::Value::Year) {
-        this->lhs = RstAction::Quantity("YEAR");
-        this->rhs = RstAction::Quantity(rhs_value);
-        return;
+        return true;
     }
-
-    this->lhs = RstAction::Quantity(zacn, sacn[SACN::LHSValue0]);
-    this->rhs = RstAction::Quantity(&zacn[ZACN::RHSOffset], sacn[SACN::RHSValue0]);
-    this->left_paren = (iacn[IACN::Paren] == IACN::Value::Open);
-    this->right_paren = (iacn[IACN::Paren] == IACN::Value::Close);
-}
-
-bool RstAction::Condition::valid(const std::string * zacn, const int * iacn) {
-    auto type_index = IACN::LHSQuantityType;
-    if (iacn[type_index] == IACN::Value::Day)
-        return true;
-
-    if (iacn[type_index] == IACN::Value::Month)
-        return true;
-
-    if (iacn[type_index] == IACN::Value::Year)
-        return true;
 
     auto str_quantity = trim_copy(zacn[ZACN::LHSQuantity]);
     return !str_quantity.empty();
 }
 
-std::vector<std::string> RstAction::Condition::tokens() const {
-    std::vector<std::string> tokens;
-    if (this->left_paren)
+void
+RstAction::Condition::restoreLHSQuantity(std::span<const int>         iacn,
+                                         std::span<const std::string> zacn)
+{
+    using IIndex = IACN::index;
+    using ZIndex = ZACN::index;
+    using QType = IACN::Value::QuantityType;
+
+    switch (iacn[IIndex::LHSQuantityType]) {
+    case QType::Field:
+        this->lhs = RstAction::Quantity{zacn[ZIndex::LHSQuantity]};
+        break;
+
+    case QType::Well:
+        this->lhs = RstAction::Quantity{zacn[ZIndex::LHSQuantity]};
+        this->lhs.args_ = { zacn[ZIndex::LHSWell] };
+        break;
+
+    case QType::Group:
+        this->lhs = RstAction::Quantity{zacn[ZIndex::LHSQuantity]};
+        this->lhs.args_ = { zacn[ZIndex::LHSGroup] };
+        break;
+
+    case QType::Region:
+        this->lhs = RstAction::Quantity{zacn[ZIndex::LHSQuantity]};
+        this->lhs.args_ = lhsRegionArgs(iacn);
+        break;
+
+    case QType::Segment:
+        this->lhs = RstAction::Quantity{zacn[ZIndex::LHSQuantity]};
+        this->lhs.args_ = lhsSegmentArgs(iacn, zacn);
+        break;
+
+    case QType::Connection:
+        this->lhs = RstAction::Quantity{zacn[ZIndex::LHSQuantity]};
+        this->lhs.args_ = lhsConnectionArgs(iacn, zacn);
+        break;
+
+    case QType::Day:
+        this->lhs = RstAction::Quantity{"DAY"};
+        break;
+
+    case QType::Month:
+        this->lhs = RstAction::Quantity{"MNTH"};
+        break;
+
+    case QType::Year:
+        this->lhs = RstAction::Quantity{"YEAR"};
+        break;
+
+    case QType::Block:
+        this->lhs = RstAction::Quantity {zacn[ZIndex::LHSQuantity]};
+        this->lhs.args_ = lhsBlockArgs(iacn);
+        break;
+    }
+}
+
+void
+RstAction::Condition::restoreRHSQuantity(std::span<const int>         iacn,
+                                         std::span<const double>      sacn,
+                                         std::span<const std::string> zacn)
+{
+    using IIndex = IACN::index;
+    using ZIndex = ZACN::index;
+    using QType = IACN::Value::QuantityType;
+
+    switch (iacn[IIndex::RHSQuantityType]) {
+    case QType::Field:
+        this->rhs = RstAction::Quantity{zacn[ZIndex::RHSQuantity]};
+        break;
+
+    case QType::Well:
+        this->rhs = RstAction::Quantity{zacn[ZIndex::RHSQuantity]};
+        this->rhs.args_ = { zacn[ZIndex::RHSWell] };
+        break;
+
+    case QType::Group:
+        this->rhs = RstAction::Quantity{zacn[ZIndex::RHSQuantity]};
+        this->rhs.args_ = { zacn[ZIndex::RHSGroup] };
+        break;
+
+    case QType::Region:
+        this->rhs = RstAction::Quantity{zacn[ZIndex::RHSQuantity]};
+        this->rhs.args_ = rhsRegionArgs(iacn);
+        break;
+
+    case QType::Segment:
+        this->rhs = RstAction::Quantity{zacn[ZIndex::RHSQuantity]};
+        this->rhs.args_ = rhsSegmentArgs(iacn, zacn);
+        break;
+
+    case QType::Connection:
+        this->rhs = RstAction::Quantity{zacn[ZIndex::RHSQuantity]};
+        this->rhs.args_ = rhsConnectionArgs(iacn, zacn);
+        break;
+
+    case QType::Const:
+        this->rhs = rhsConstant(iacn, sacn);
+        break;
+
+    case QType::Block:
+        this->rhs = RstAction::Quantity {zacn[ZIndex::RHSQuantity]};
+        this->rhs.args_ = rhsBlockArgs(iacn);
+        break;
+    }
+}
+
+// --------------------------------------------------------------------------
+
+RstAction::RstAction(const std::string& name_arg,
+                     const int max_run_arg,
+                     const int run_count_arg,
+                     const double min_wait_arg,
+                     const std::time_t start_time_arg,
+                     const std::time_t last_run_arg,
+                     std::vector<RstAction::Condition>&& conditions_arg)
+    : name       { name_arg }
+    , max_run    { max_run_arg }
+    , run_count  { run_count_arg }
+    , min_wait   { min_wait_arg }
+    , start_time { start_time_arg }
+    , last_run   { run_count_arg > 0 ? std::optional{last_run_arg} : std::nullopt }
+    , conditions { std::move(conditions_arg) }
+{}
+
+std::vector<std::string>
+RstAction::Condition::tokens() const
+{
+    auto tokens = std::vector<std::string> {};
+    if (this->left_paren) {
         tokens.push_back("(");
+    }
 
-    tokens.push_back(std::get<std::string>(this->lhs.quantity));
-    if (this->lhs.wgname.has_value())
-        tokens.push_back(this->lhs.wgname.value());
-
+    captureQuantityTokens(this->lhs, tokens);
     tokens.push_back(Action::comparator_as_string(this->cmp_op));
+    captureQuantityTokens(this->rhs, tokens);
 
-    if (std::holds_alternative<std::string>(this->rhs.quantity))
-        tokens.push_back(std::get<std::string>(this->rhs.quantity));
-    else
-        tokens.push_back(format_double(std::get<double>(this->rhs.quantity)));
-
-    if (this->rhs.wgname.has_value())
-        tokens.push_back(this->rhs.wgname.value());
-
-    if (this->right_paren)
+    if (this->right_paren) {
         tokens.push_back(")");
+    }
 
-    if (this->logic == Action::Logical::AND)
+    switch (this->logic) {
+    case Action::Logical::AND:
         tokens.push_back("AND");
+        break;
 
-    if (this->logic == Action::Logical::OR)
+    case Action::Logical::OR:
         tokens.push_back("OR");
+        break;
+
+    case Action::Logical::END:
+        break;
+    }
 
     return tokens;
 }
 
-}
-}
+} // namespace Opm::RestartIO

--- a/opm/io/eclipse/rst/action.hpp
+++ b/opm/io/eclipse/rst/action.hpp
@@ -19,62 +19,219 @@
 #ifndef RST_ACTIONX
 #define RST_ACTIONX
 
-#include <ctime>
-#include <optional>
-#include <string>
-#include <variant>
-#include <vector>
+#include <opm/output/eclipse/VectorItems/action.hpp>
 
 #include <opm/input/eclipse/Schedule/Action/Enums.hpp>
+
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 
-namespace Opm {
+#include <ctime>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
 
-namespace RestartIO {
+namespace Opm::RestartIO {
 
-struct RstAction {
-    struct Quantity {
-        std::variant<std::string, double> quantity;
-        std::optional<std::string> wgname;
+/// ACTIONX keyword constructed from restart file information.
+struct RstAction
+{
+    class Condition;
 
+    /// Restart file representation of an action condition quantity.
+    ///
+    /// This is typically a summary vector, e.g., a field level quantity
+    /// such as FOPT, a group level quantity such as GOPR for a particular
+    /// group, or a well level quantity such as WWCT for one or more wells.
+    class Quantity
+    {
+    public:
+        /// Default constructor.
+        ///
+        /// Mostly to support deferred initialization, e.g., for serialization.
         Quantity() = default;
-        Quantity(const std::string * zacn, double sacn_value);
+
+        /// Construct a Quantity with the given string.
+        ///
+        /// \param[in] quantity Quantity name or string representation
+        /// of a numeric constant or named month.
         explicit Quantity(const std::string& quantity);
-        explicit Quantity(double value);
+
+        /// Retrieve the quantity name.
+        ///
+        /// \return The quantity name or a string representation
+        /// of a numeric constant or named month.
+        const std::string& quantity() const { return this->quantity_; }
+
+        /// Retrieve the quantity arguments.
+        ///
+        /// \return The quantity arguments.  Empty if there are no additional
+        /// arguments such as for field level quantities, date keywords or
+        /// numeric constants.  Otherwise, contains e.g., well or group name,
+        /// segment numbers, region IDs, or cell IJK tuples.
+        const std::vector<std::string>& args() const { return this->args_; }
+
+        friend class Condition;
+
+    private:
+        /// Action condition quantity name.
+        std::string quantity_ {};
+
+        /// Action condition quantity arguments.
+        ///
+        /// Populated by Condition.
+        std::vector<std::string> args_ {};
     };
 
+    /// Restart file representation of an action condition.
+    ///
+    /// This is a single condition in an ACTIONX keyword.  It consists
+    /// of a left hand side quantity, a comparison operator, and a right
+    /// hand side quantity.  It may additionally include a logical operator
+    /// by which to combine it with the next condition in a sequence
+    /// of conditions.
+    class Condition
+    {
+    public:
+        /// Check if the given restart file information represents a valid
+        /// action condition.
+        ///
+        /// \param[in] iacn Integer condition items, notably including
+        /// the quantity types and comparison operator.
+        ///
+        /// \param[in] zacn String condition items, notably including
+        /// the left and right hand side quantity names.
+        ///
+        /// \return True if the given restart file information represents
+        /// a valid action condition, false otherwise.
+        static bool
+        valid(std::span<const int>         iacn,
+              std::span<const std::string> zacn);
 
-    struct Condition {
-        static bool valid(const std::string * zacn, const int * iacn);
-        Condition(const std::string * zacn, const int * iacn, const double * sacn);
+        /// Construct a Condition from restart file information.
+        ///
+        /// \param[in] iacn Integer condition items, notably including
+        /// the quantity types and comparison operator. Must have size
+        /// IACN::ConditionSize.
+        ///
+        /// \param[in] sacn Double condition items, notably including
+        /// the right hand side numeric values. Must have size
+        /// SACN::ConditionSize.
+        ///
+        /// \param[in] zacn String condition items, notably including
+        /// the left and right hand side quantity names. Must have size
+        /// ZACN::ConditionSize.
+        Condition(std::span<const int>         iacn,
+                  std::span<const double>      sacn,
+                  std::span<const std::string> zacn);
+
+        /// Logical operator of the condition.
         Action::Logical logic;
-        Action::Comparator cmp_op;
-        Quantity lhs;
-        Quantity rhs;
-        bool left_paren{false};
-        bool right_paren{false};
 
+        /// Comparison operator of the condition.
+        Action::Comparator cmp_op;
+
+        /// Left hand side quantity of the condition.
+        ///
+        /// This is typically a summary vector, e.g., a field level quantity
+        /// such as FOPT, a group level quantity such as GOPR for a particular
+        /// group, or a well level quantity such as WWCT for one or more wells.
+        Quantity lhs;
+
+        /// Right hand side quantity of the condition.
+        ///
+        /// This is typically a constant or a specific summary vector.
+        Quantity rhs;
+
+        /// Whether or not the condition starts with a left parenthesis.
+        bool left_paren {false};
+
+        /// Whether or not the condition includes a right parenthesis.
+        bool right_paren {false};
+
+        /// Canonicalised string tokens comprising the condition.
+        ///
+        /// No leading or trailing whitespace for any token.
+        ///
+        /// \return Vector of string tokens.
         std::vector<std::string> tokens() const;
+
+    private:
+        /// Restore the left hand side quantity from restart file information.
+        ///
+        /// \param[in] iacn Integer condition items, notably including the
+        /// quantity types and comparison operator.
+        ///
+        /// \param[in] zacn String condition items, notably including the
+        /// left and right hand side quantity names.
+        void restoreLHSQuantity(std::span<const int>         iacn,
+                                std::span<const std::string> zacn);
+
+        /// Restore the right hand side quantity from restart file information.
+        ///
+        /// \param[in] iacn Integer condition items, notably including the
+        /// quantity types and comparison operator.
+        ///
+        /// \param[in] sacn Double condition items, notably including
+        /// constant values.
+        ///
+        /// \param[in] zacn String condition items, notably including
+        /// the left and right hand side quantity names.
+        void restoreRHSQuantity(std::span<const int>         iacn,
+                                std::span<const double>      sacn,
+                                std::span<const std::string> zacn);
     };
 
+    /// Construct a new RstAction object from restart file information.
+    ///
+    /// \param[in] name_arg Action name.
+    ///
+    /// \param[in] max_run_arg Maximum number of times the action can be run.
+    ///
+    /// \param[in] run_count_arg Number of times the action has been run.
+    ///
+    /// \param[in] min_wait_arg Minimum wait time between action runs.
+    ///
+    /// \param[in] start_time Start time of the action.
+    ///
+    /// \param[in] last_run Last run time of the action.
+    ///
+    /// \param[in] conditions_arg Conditions associated with the action.
+    RstAction(const std::string& name_arg,
+              int max_run_arg,
+              int run_count_arg,
+              double min_wait_arg,
+              std::time_t start_time,
+              std::time_t last_run,
+              std::vector<Condition>&& conditions_arg);
 
-    RstAction(const std::string& name_arg, int max_run_arg, int run_count_arg,
-              double min_wait_arg, std::time_t start_time, std::time_t last_run,
-              const std::vector<Condition>& conditions_arg);
-
+    /// Action name.
     std::string name;
+
+    /// Maximum number of times the action can be run.
     int max_run;
+
+    /// Number of times the action has been run.
     int run_count;
+
+    /// Minimum wait time between action runs.
     double min_wait;
+
+    /// Start time of the action.
     std::time_t start_time;
+
+    /// Last run time of the action.
+    ///
+    /// Nullopt if the action has not yet run.
     std::optional<std::time_t> last_run;
+
+    /// Conditions associated with the action.
     std::vector<Condition> conditions;
+
+    /// Action block keywords associated with the action.
     std::vector<DeckKeyword> keywords;
 };
 
-}
-}
+} // namespace Opm::RestartIO
 
-
-
-#endif
+#endif // RST_ACTIONX

--- a/opm/io/eclipse/rst/state.cpp
+++ b/opm/io/eclipse/rst/state.cpp
@@ -36,6 +36,7 @@
 
 #include <opm/output/eclipse/UDQDims.hpp>
 
+#include <opm/output/eclipse/VectorItems/action.hpp>
 #include <opm/output/eclipse/VectorItems/connection.hpp>
 #include <opm/output/eclipse/VectorItems/doubhead.hpp>
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
@@ -64,6 +65,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <span>
 #include <utility>
 #include <vector>
 
@@ -362,7 +364,7 @@ namespace {
                           doubhead[VI::doubhead::OilVapPropensity],
                           doubhead[VI::doubhead::OilVapDensPropensity]);
     }
-}
+} // Anonymous namespace
 
 namespace Opm::RestartIO {
 
@@ -382,6 +384,111 @@ RstState::RstState(std::shared_ptr<EclIO::RestartFileView> rstView,
                                 rstView->logihead(),
                                 rstView->doubhead());
 }
+
+const RstWell&
+RstState::get_well(const std::string& wname) const
+{
+    const auto well_iter = std::ranges::find_if(this->wells,
+                                                [&wname] (const auto& well)
+                                                { return well.name == wname; });
+
+    if (well_iter == this->wells.end()) {
+        throw std::out_of_range("No such well: " + wname);
+    }
+
+    return *well_iter;
+}
+
+RstState RstState::load(std::shared_ptr<EclIO::RestartFileView> rstView,
+                        const Runspec&                          runspec,
+                        const Parser&                           parser,
+                        const ::Opm::EclipseGrid*               grid)
+{
+    if (rstView->isGraphicsOnly()) {
+        throw std::runtime_error {
+            fmt::format("Cannot restart from restart file "
+                        "report step {}): the file appears to be graphics-only "
+                        "or is missing well arrays required for simulation restart. "
+                        "Please use a standard restart file instead.",
+                        rstView->reportStep())
+        };
+    }
+
+    RstState state(rstView, runspec, grid);
+
+    // At minimum we need any applicable constraint data for FIELD.  Load
+    // groups unconditionally.
+    {
+        const auto& zgrp = rstView->getKeyword<std::string>("ZGRP");
+        const auto& igrp = rstView->getKeyword<int>("IGRP");
+        const auto& sgrp = rstView->getKeyword<float>("SGRP");
+        const auto& xgrp = rstView->getKeyword<double>("XGRP");
+
+        state.add_groups(zgrp, igrp, sgrp, xgrp);
+    }
+
+    if (state.header.num_wells > 0) {
+        const auto& zwel = rstView->getKeyword<std::string>("ZWEL");
+        const auto& iwel = rstView->getKeyword<int>("IWEL");
+        const auto& swel = rstView->getKeyword<float>("SWEL");
+        const auto& xwel = rstView->getKeyword<double>("XWEL");
+
+        const auto& icon = rstView->getKeyword<int>("ICON");
+        const auto& scon = rstView->getKeyword<float>("SCON");
+        const auto& xcon = rstView->getKeyword<double>("XCON");
+
+        if (rstView->hasKeyword<int>("ISEG")) {
+            // Multi-segmented wells in restart file.
+            const auto& iseg = rstView->getKeyword<int>("ISEG");
+            const auto& rseg = rstView->getKeyword<double>("RSEG");
+
+            state.add_msw(zwel, iwel, swel, xwel,
+                          icon, scon, xcon,
+                          iseg, rseg);
+        }
+        else {
+            // Standard wells only.
+            state.add_wells(zwel, iwel, swel, xwel,
+                            icon, scon, xcon);
+        }
+
+        if (rstView->hasKeyword<int>("IWLS")) {
+            const auto& iwls = rstView->getKeyword<int>("IWLS");
+            const auto& zwls = rstView->getKeyword<std::string>("ZWLS");
+
+            state.add_wlist(zwls, iwls);
+        }
+    }
+
+    if (state.header.num_udq() > 0) {
+        state.add_udqs(rstView);
+    }
+
+    if (state.header.num_action > 0) {
+        const auto actionArrays = ActionData<float> {
+            .i = rstView->getKeyword<int>("IACT"),
+            .s = rstView->getKeyword<float>("SACT"),
+            .z = rstView->getKeyword<std::string>("ZACT")
+        };
+
+        const auto conditions = ActionData<double> {
+            .i = rstView->getKeyword<int>("IACN"),
+            .s = rstView->getKeyword<double>("SACN"),
+            .z = rstView->getKeyword<std::string>("ZACN")
+        };
+
+        state.add_actions(parser, runspec,
+                          state.header.sim_time(),
+                          actionArrays, conditions,
+                          rstView->getKeyword<std::string>("ZLACT"));
+    }
+
+    return state;
+}
+
+// -----------------------------------------------------------------------------
+// Private member functions
+// -----------------------------------------------------------------------------
 
 void RstState::load_oil_vaporization(const std::vector<int>&    intehead,
                                      const std::vector<bool>&   logihead,
@@ -491,7 +598,9 @@ void RstState::add_wells(const std::vector<std::string>& zwel,
                          const std::vector<float>& scon,
                          const std::vector<double>& xcon)
 {
-    for (int iw = 0; iw < this->header.num_wells; ++iw) {
+    const auto num_wells = static_cast<std::size_t>(this->header.num_wells);
+
+    for (std::size_t iw = 0; iw < num_wells; ++iw) {
         const std::size_t zwel_offset = iw * this->header.nzwelz;
         const std::size_t iwel_offset = iw * this->header.niwelz;
         const std::size_t swel_offset = iw * this->header.nswelz;
@@ -541,7 +650,9 @@ void RstState::add_msw(const std::vector<std::string>& zwel,
                        const std::vector<int>& iseg,
                        const std::vector<double>& rseg)
 {
-    for (int iw = 0; iw < this->header.num_wells; ++iw) {
+    const auto num_wells = static_cast<std::size_t>(this->header.num_wells);
+
+    for (std::size_t iw = 0; iw < num_wells; ++iw) {
         const std::size_t zwel_offset = iw * this->header.nzwelz;
         const std::size_t iwel_offset = iw * this->header.niwelz;
         const std::size_t swel_offset = iw * this->header.nswelz;
@@ -590,9 +701,9 @@ void RstState::add_udqs(std::shared_ptr<EclIO::RestartFileView> rstView)
 
     auto udqValues = UDQVectors { std::move(rstView) };
 
-    for (auto udq_index = 0*this->header.num_udq();
-         udq_index < this->header.num_udq(); ++udq_index)
-    {
+    const auto num_udq = static_cast<std::size_t>(this->header.num_udq());
+
+    for (auto udq_index = 0*num_udq; udq_index < num_udq; ++udq_index) {
         const auto& name = zudn[udq_index*UDQDims::entriesPerZUDN() + 0];
         const auto& unit = zudn[udq_index*UDQDims::entriesPerZUDN() + 1];
 
@@ -606,89 +717,39 @@ void RstState::add_udqs(std::shared_ptr<EclIO::RestartFileView> rstView)
     }
 }
 
-void RstState::add_actions(const Parser& parser,
-                           const Runspec& runspec,
-                           std::time_t sim_time,
-                           const std::vector<std::string>& zact,
-                           const std::vector<int>& iact,
-                           const std::vector<float>& sact,
-                           const std::vector<std::string>& zacn,
-                           const std::vector<int>& iacn,
-                           const std::vector<double>& sacn,
-                           const std::vector<std::string>& zlact)
+void RstState::add_actions(const Parser&                parser,
+                           const Runspec&               runspec,
+                           const std::time_t            sim_time,
+                           ActionData<float>            actionArrays,
+                           ActionData<double>           conditions,
+                           std::span<const std::string> zlact)
 {
+    const auto num_actions = static_cast<std::size_t>(this->header.num_action);
+
     const auto& actdims = runspec.actdims();
-    auto zact_action_size  = RestartIO::Helpers::entriesPerZACT();
-    auto iact_action_size  = RestartIO::Helpers::entriesPerIACT();
-    auto sact_action_size  = RestartIO::Helpers::entriesPerSACT();
-    auto zacn_action_size  = RestartIO::Helpers::entriesPerZACN(actdims);
-    auto iacn_action_size  = RestartIO::Helpers::entriesPerIACN(actdims);
-    auto sacn_action_size  = RestartIO::Helpers::entriesPerSACN(actdims);
-    auto zlact_action_size = zlact.size() / this->header.num_action;
+    const auto zlact_action_size = zlact.size() / num_actions;
 
-    auto zacn_cond_size = 13;
-    auto iacn_cond_size = 26;
-    auto sacn_cond_size = 16;
+    for (std::size_t index = 0; index < num_actions; ++index) {
+        auto actionConditions = this->restore_conditions(actdims, conditions, index);
+        this->create_action(runspec, sim_time, actionArrays, index, std::move(actionConditions));
 
-    for (std::size_t index=0; index < static_cast<std::size_t>(this->header.num_action); index++) {
-        std::vector<RstAction::Condition> conditions;
-        for (std::size_t icond = 0; icond < actdims.max_conditions(); icond++) {
-            const auto zacn_offset = index * zacn_action_size + icond * zacn_cond_size;
-            const auto iacn_offset = index * iacn_action_size + icond * iacn_cond_size;
-
-            if (RstAction::Condition::valid(&zacn[zacn_offset], &iacn[iacn_offset])) {
-                const auto sacn_offset = index * sacn_action_size + icond * sacn_cond_size;
-                conditions.emplace_back(&zacn[zacn_offset], &iacn[iacn_offset], &sacn[sacn_offset]);
-            }
-        }
-
-        const auto& name = zact[index * zact_action_size + 0];
-        const auto& max_run = iact[index * iact_action_size + 5];
-        const auto& run_count = iact[index * iact_action_size + 2] - 1;
-        const auto& min_wait = this->unit_system.to_si(UnitSystem::measure::time, sact[index * sact_action_size + 3]);
-        const auto& last_run_elapsed = this->unit_system.to_si(UnitSystem::measure::time, sact[index * sact_action_size + 4]);
-
-        auto last_run_time = TimeService::advance( runspec.start_time(), last_run_elapsed );
-        this->actions.emplace_back(name, max_run, run_count, min_wait, sim_time, last_run_time, conditions );
-
-
-        std::string action_deck;
-        auto zlact_offset = index * zlact_action_size;
-        while (true) {
-            std::string line;
-            for (std::size_t item_index = 0; item_index < actdims.line_size(); item_index++) {
-                const auto padded = EclIO::PaddedOutputString<8> { zlact[zlact_offset + item_index] };
-                line += padded.c_str();
-            }
-
-            line = trim_copy(line);
-            if (line.empty())
-                continue;
-
-            if (line == "ENDACTIO")
-                break;
-
-            action_deck += line + "\n";
-            zlact_offset += actdims.line_size();
-        }
-        // Ignore invalid keyword combinaions in actions, since these decks are typically incomplete
-        ParseContext parseContext;
-        parseContext.update(ParseContext::PARSE_INVALID_KEYWORD_COMBINATION, InputErrorAction::IGNORE);
-        const auto& deck = parser.parseString( action_deck, parseContext );
-        for (auto keyword : deck)
-            this->actions.back().keywords.push_back(std::move(keyword));
+        this->restore_action_keywords(parser, actdims,
+                                      zlact.subspan(index * zlact_action_size, zlact_action_size));
     }
 }
 
 void RstState::add_wlist(const std::vector<std::string>& zwls,
                          const std::vector<int>& iwls)
 {
-    for (auto well_index = 0*this->header.num_wells; well_index < this->header.num_wells; well_index++) {
-        const auto zwls_offset = this->header.max_wlist * well_index;
-        const auto iwls_offset = this->header.max_wlist * well_index;
+    const auto num_wells = static_cast<std::size_t>(this->header.num_wells);
+    const auto max_wlist = static_cast<std::size_t>(this->header.max_wlist);
+
+    for (auto well_index = 0*num_wells; well_index < num_wells; ++well_index) {
+        const auto zwls_offset = max_wlist * well_index;
+        const auto iwls_offset = max_wlist * well_index;
         const auto& well_name = this->wells[well_index].name;
 
-        for (auto wlist_index = 0*this->header.max_wlist; wlist_index < this->header.max_wlist; wlist_index++) {
+        for (auto wlist_index = 0*max_wlist; wlist_index < max_wlist; ++wlist_index) {
             const auto well_order = iwls[iwls_offset + wlist_index];
             if (well_order < 1) {
                 continue;
@@ -704,94 +765,112 @@ void RstState::add_wlist(const std::vector<std::string>& zwls,
     }
 }
 
-const RstWell& RstState::get_well(const std::string& wname) const
+std::vector<RstAction::Condition>
+RstState::restore_conditions(const Actdims&     actdims,
+                             ActionData<double> conditions,
+                             const std::size_t  index) const
 {
-    const auto well_iter = std::ranges::find_if(this->wells,
-                                                [&wname] (const auto& well)
-                                                { return well.name == wname; });
-    if (well_iter == this->wells.end())
-        throw std::out_of_range("No such well: " + wname);
+    auto actConditions = std::vector<RstAction::Condition> {};
 
-    return *well_iter;
+    const auto iacn_action_size = RestartIO::Helpers::entriesPerIACN(actdims);
+    const auto sacn_action_size = RestartIO::Helpers::entriesPerSACN(actdims);
+    const auto zacn_action_size = RestartIO::Helpers::entriesPerZACN(actdims);
+
+    constexpr auto iacn_cond_size = RestartIO::Helpers::VectorItems::IACN::ConditionSize;
+    constexpr auto sacn_cond_size = RestartIO::Helpers::VectorItems::SACN::ConditionSize;
+    constexpr auto zacn_cond_size = RestartIO::Helpers::VectorItems::ZACN::ConditionSize;
+
+    const auto act_iacn = conditions.i.subspan(index * iacn_action_size, iacn_action_size);
+    const auto act_sacn = conditions.s.subspan(index * sacn_action_size, sacn_action_size);
+    const auto act_zacn = conditions.z.subspan(index * zacn_action_size, zacn_action_size);
+
+    for (std::size_t icond = 0; icond < actdims.max_conditions(); ++icond) {
+        const auto iacn = act_iacn.subspan(icond * iacn_cond_size, iacn_cond_size);
+        const auto sacn = act_sacn.subspan(icond * sacn_cond_size, sacn_cond_size);
+        const auto zacn = act_zacn.subspan(icond * zacn_cond_size, zacn_cond_size);
+
+        if (RstAction::Condition::valid(iacn, zacn)) {
+            actConditions.emplace_back(iacn, sacn, zacn);
+        }
+    }
+
+    return actConditions;
 }
 
-RstState RstState::load(std::shared_ptr<EclIO::RestartFileView> rstView,
-                        const Runspec&                          runspec,
-                        const Parser&                           parser,
-                        const ::Opm::EclipseGrid*               grid)
+void
+RstState::create_action(const Runspec&                      runspec,
+                        const std::time_t                   sim_time,
+                        ActionData<float>                   actionArrays,
+                        const std::size_t                   index,
+                        std::vector<RstAction::Condition>&& conditions)
 {
-    if (rstView->isGraphicsOnly()) {
-        throw std::runtime_error {
-            fmt::format("Cannot restart from restart file "
-                        "report step {}): the file appears to be graphics-only "
-                        "or is missing well arrays required for simulation restart. "
-                        "Please use a standard restart file instead.",
-                        rstView->reportStep())
-        };
-    }
+    constexpr auto iact_action_size = RestartIO::Helpers::entriesPerIACT();
+    constexpr auto sact_action_size = RestartIO::Helpers::entriesPerSACT();
+    constexpr auto zact_action_size = RestartIO::Helpers::entriesPerZACT();
 
-    RstState state(rstView, runspec, grid);
+    const auto iact = actionArrays.i.subspan(index * iact_action_size, iact_action_size);
+    const auto sact = actionArrays.s.subspan(index * sact_action_size, sact_action_size);
+    const auto zact = actionArrays.z.subspan(index * zact_action_size, zact_action_size);
 
-    // At minimum we need any applicable constraint data for FIELD.  Load
-    // groups unconditionally.
-    {
-        const auto& zgrp = rstView->getKeyword<std::string>("ZGRP");
-        const auto& igrp = rstView->getKeyword<int>("IGRP");
-        const auto& sgrp = rstView->getKeyword<float>("SGRP");
-        const auto& xgrp = rstView->getKeyword<double>("XGRP");
+    const auto& name = zact[0];
+    const auto max_run = iact[5];
+    const auto run_count = iact[2] - 1;
 
-        state.add_groups(zgrp, igrp, sgrp, xgrp);
-    }
+    const auto min_wait = this->unit_system.to_si(UnitSystem::measure::time, sact[3]);
+    const auto last_run_elapsed = this->unit_system.to_si(UnitSystem::measure::time, sact[4]);
 
-    if (state.header.num_wells > 0) {
-        const auto& zwel = rstView->getKeyword<std::string>("ZWEL");
-        const auto& iwel = rstView->getKeyword<int>("IWEL");
-        const auto& swel = rstView->getKeyword<float>("SWEL");
-        const auto& xwel = rstView->getKeyword<double>("XWEL");
+    const auto last_run_time = TimeService::advance(runspec.start_time(), last_run_elapsed);
 
-        const auto& icon = rstView->getKeyword<int>("ICON");
-        const auto& scon = rstView->getKeyword<float>("SCON");
-        const auto& xcon = rstView->getKeyword<double>("XCON");
+    this->actions.emplace_back(name, max_run, run_count,
+                               min_wait, sim_time, last_run_time,
+                               std::move(conditions));
+}
 
-        if (rstView->hasKeyword<int>("ISEG")) {
-            // Multi-segmented wells in restart file.
-            const auto& iseg = rstView->getKeyword<int>("ISEG");
-            const auto& rseg = rstView->getKeyword<double>("RSEG");
+void
+RstState::restore_action_keywords(const Parser& parser,
+                                  const Actdims& actdims,
+                                  std::span<const std::string> zlact)
+{
+    auto action_deck = std::string{};
 
-            state.add_msw(zwel, iwel, swel, xwel,
-                          icon, scon, xcon,
-                          iseg, rseg);
-        }
-        else {
-            // Standard wells only.
-            state.add_wells(zwel, iwel, swel, xwel,
-                            icon, scon, xcon);
+    auto lineIdx = 0 * actdims.line_size();
+    while (true) {
+        const auto offset = lineIdx++ * actdims.line_size();
+        if (offset + actdims.line_size() > zlact.size()) {
+            throw std::runtime_error {
+                "Malformed ZLACT: missing ENDACTIO terminator"
+            };
         }
 
-        if (rstView->hasKeyword<int>("IWLS")) {
-            const auto& iwls = rstView->getKeyword<int>("IWLS");
-            const auto& zwls = rstView->getKeyword<std::string>("ZWLS");
+        auto zlact_line = zlact.subspan(offset, actdims.line_size());
 
-            state.add_wlist(zwls, iwls);
+        auto line = std::string{};
+        for (const auto& line_item : zlact_line) {
+            const auto padded = EclIO::PaddedOutputString<8> {line_item};
+            line += padded.c_str();
         }
+
+        line = trim_copy(line);
+        if (line.empty()) {
+            continue;
+        }
+
+        if (line == "ENDACTIO") {
+            break;
+        }
+
+        action_deck += line + "\n";
     }
 
-    if (state.header.num_udq() > 0) {
-        state.add_udqs(rstView);
-    }
+    // Ignore invalid keyword combinations in actions,
+    // since these decks are typically incomplete.
+    auto parseContext = ParseContext {};
+    parseContext.update(ParseContext::PARSE_INVALID_KEYWORD_COMBINATION,
+                        InputErrorAction::IGNORE);
 
-    if (state.header.num_action > 0) {
-        const auto& zact = rstView->getKeyword<std::string>("ZACT");
-        const auto& iact = rstView->getKeyword<int>("IACT");
-        const auto& sact = rstView->getKeyword<float>("SACT");
-        const auto& zacn = rstView->getKeyword<std::string>("ZACN");
-        const auto& iacn = rstView->getKeyword<int>("IACN");
-        const auto& sacn = rstView->getKeyword<double>("SACN");
-        const auto& zlact= rstView->getKeyword<std::string>("ZLACT");
-        state.add_actions(parser, runspec, state.header.sim_time(), zact, iact, sact, zacn, iacn, sacn, zlact);
+    for (auto&& keyword : parser.parseString(action_deck, parseContext)) {
+        this->actions.back().keywords.push_back(std::move(keyword));
     }
-
-    return state;
 }
 
 } // namespace Opm::RestartIO

--- a/opm/io/eclipse/rst/state.hpp
+++ b/opm/io/eclipse/rst/state.hpp
@@ -37,6 +37,7 @@
 #include <ctime>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -81,6 +82,29 @@ struct RstState
     std::unordered_map<std::string, std::vector<std::string>> wlists;
 
 private:
+    /// Encapsulation of restart file information pertaining to actions or conditions.
+    ///
+    /// \tparam FloatType The floating point type used for the action data.
+    /// Typically \c float or \c double.
+    template <typename FloatType>
+    struct ActionData
+    {
+        /// Integer restart file information pertaining to all actions or conditions.
+        ///
+        /// Typically wraps IACT for actions and IACN for conditions.
+        std::span<const int> i;
+
+        /// Floating point restart file information pertaining to all actions or conditions.
+        ///
+        /// Typically wraps SACT (\c float) for actions and SACN (\c double) for conditions.
+        std::span<const FloatType> s;
+
+        /// String restart file information pertaining to all actions or conditions.
+        ///
+        /// Typically wraps ZACT for actions and ZACN for conditions.
+        std::span<const std::string> z;
+    };
+
     void load_oil_vaporization(const std::vector<int>&    intehead,
                                const std::vector<bool>&   logihead,
                                const std::vector<double>& doubhead);
@@ -113,19 +137,80 @@ private:
 
     void add_udqs(std::shared_ptr<EclIO::RestartFileView> rstView);
 
-    void add_actions(const Parser& parser,
-                     const Runspec& runspec,
-                     std::time_t sim_time,
-                     const std::vector<std::string>& zact,
-                     const std::vector<int>& iact,
-                     const std::vector<float>& sact,
-                     const std::vector<std::string>& zacn,
-                     const std::vector<int>& iacn,
-                     const std::vector<double>& sacn,
-                     const std::vector<std::string>& zlact);
+    /// Restore all applicable dynamic actions from the restart file.
+    ///
+    /// Populates the \c actions vector of this \c RstState object with all applicable actions.
+    ///
+    /// \param[in] parser The parser used to interpret action block keywords.
+    ///
+    /// \param[in] runspec Run's specification including dimensions and active phases.
+    ///
+    /// \param[in] sim_time Simulated time (i.e., time point) at simulation restart.
+    ///
+    /// \param[in] actions The action data (i.e., the [ISZ]ACT arrays).
+    ///
+    /// \param[in] conditions The condition data (i.e., the [ISZ]ACN arrays).
+    ///
+    /// \param[in] zlact The action block keywords.
+    void add_actions(const Parser&                parser,
+                     const Runspec&               runspec,
+                     std::time_t                  sim_time,
+                     ActionData<float>            actions,
+                     ActionData<double>           conditions,
+                     std::span<const std::string> zlact);
 
     void add_wlist(const std::vector<std::string>& zwls,
                    const std::vector<int>& iwls);
+
+    /// Restore conditions for single action from restart file information.
+    ///
+    /// \param[in] actdims The action dimensions, e.g., maximum number of
+    /// conditions and sizes of condition arrays per condition.
+    ///
+    /// \param[in] conditions The condition data (i.e., the [ISZ]ACN arrays).
+    ///
+    /// \param[in] index The action index.
+    ///
+    /// \return The restored conditions for the \p index-th action.
+    std::vector<RstAction::Condition>
+    restore_conditions(const Actdims&     actdims,
+                       ActionData<double> conditions,
+                       std::size_t        index) const;
+
+    /// Restore a single action from restart file information.
+    ///
+    /// Appends an action object to the \c actions vector of this \c RstState object.
+    ///
+    /// \param[in] runspec The run's specification including dimensions and active phases.
+    ///
+    /// \param[in] sim_time Simulated time (i.e., time point) at simulation restart.
+    ///
+    /// \param[in] actionArrays The action data (i.e., the [ISZ]ACT arrays).
+    ///
+    /// \param[in] index The action index.
+    ///
+    /// \param[in] conditions The restored conditions for the \p index-th action.
+    void create_action(const Runspec&                      runspec,
+                       const std::time_t                   sim_time,
+                       ActionData<float>                   actionArrays,
+                       std::size_t                         index,
+                       std::vector<RstAction::Condition>&& conditions);
+
+    /// Restore action keywords from restart file information.
+    ///
+    /// Populates the \c keywords container of \code actions.back() \endcode
+    /// with the pertinent action block keywords.
+    ///
+    /// \param[in] parser The parser used to interpret action block keywords.
+    ///
+    /// \param[in] actdims The action dimensions, e.g., maximum number of
+    /// conditions and sizes of condition arrays per condition.
+    ///
+    /// \param[in] zlact Linearised collection of action block keyword strings.
+    /// Assumed to encompass only those strings that pertain to \code actions.back() \endcode.
+    void restore_action_keywords(const Parser&                parser,
+                                 const Actdims&               actdims,
+                                 std::span<const std::string> zlact);
 
 };
 

--- a/opm/output/eclipse/AggregateActionxData.cpp
+++ b/opm/output/eclipse/AggregateActionxData.cpp
@@ -33,16 +33,21 @@
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/common/utility/String.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <algorithm>
+#include <charconv>
 #include <cstddef>
 #include <cstring>
 #include <ctime>
 #include <functional>
 #include <map>
+#include <optional>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <vector>
 
 #include <fmt/format.h>
@@ -67,7 +72,9 @@ namespace {
         }
 
         template <class IACTArray>
-        void staticContrib(const Opm::Action::ActionX& actx, IACTArray& iAct, const Opm::Action::State& action_state)
+        void staticContrib(const Opm::Action::ActionX& actx,
+                           const Opm::Action::State&   action_state,
+                           IACTArray&                  iAct)
         {
             //item [0]: is unknown, (=0)
             iAct[0] = 0;
@@ -150,22 +157,27 @@ namespace {
 
     namespace zLACT {
 
-         Opm::RestartIO::Helpers::WindowedArray<
+        Opm::RestartIO::Helpers::WindowedArray<
             Opm::EclIO::PaddedOutputString<8>
         >
-         allocate(std::size_t num_actions, std::size_t max_input_lines, const Opm::Actdims& actdims)
+        allocate(const std::size_t   num_actions,
+                 const std::size_t   max_input_lines,
+                 const Opm::Actdims& actdims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<
                 Opm::EclIO::PaddedOutputString<8>
             >;
+
             return WV {
                 WV::NumWindows{ num_actions },
                 WV::WindowSize{ actdims.line_size() * max_input_lines }
             };
         }
 
-    template <class ZLACTArray>
-    void staticContrib(const Opm::Action::ActionX& actx, const Opm::Actdims& actdims, ZLACTArray& zLact)
+        template <class ZLACTArray>
+        void staticContrib(const Opm::Action::ActionX& actx,
+                           const Opm::Actdims&         actdims,
+                           ZLACTArray&                 zLact)
         {
             std::size_t offset = 0;
             int l_sstr = 8;
@@ -188,219 +200,568 @@ namespace {
         }
     } // zLact
 
-    namespace zACN {
+    namespace ConditionHelpers {
 
-         Opm::RestartIO::Helpers::WindowedArray<
-            Opm::EclIO::PaddedOutputString<8>
-        >
-        allocate(std::size_t num_actions, const Opm::Actdims& actdims)
-        {
-            using WV = Opm::RestartIO::Helpers::WindowedArray<
-                Opm::EclIO::PaddedOutputString<8>
-            >;
-
-            return WV {
-                WV::NumWindows{ num_actions },
-                WV::WindowSize{ actdims.max_conditions() * Opm::RestartIO::Helpers::VectorItems::ZACN::ConditionSize }
-            };
-        }
-
-    template <class ZACNArray>
-    void staticContrib(const Opm::Action::ActionX& actx, ZACNArray& zAcn)
-        {
-            using Ix = Opm::RestartIO::Helpers::VectorItems::ZACN::index;
-            std::size_t offset = 0;
-            // write out the schedule Actionx conditions
-            const auto& actx_cond = actx.conditions();
-            for (const auto& z_data : actx_cond) {
-                // left hand quantity
-                if (!z_data.lhs.date())
-                    zAcn[offset + Ix::LHSQuantity] = z_data.lhs.quantity;
-
-                // right hand quantity
-                if ((z_data.rhs.quantity.substr(0,1) == "W") ||
-                    (z_data.rhs.quantity.substr(0,1) == "G") ||
-                    (z_data.rhs.quantity.substr(0,1) == "F"))
-                    zAcn[offset + Ix::RHSQuantity] = z_data.rhs.quantity;
-                // operator (comparator)
-                zAcn[offset + Ix::Comparator] = z_data.cmp_string;
-                // well-name if left hand quantity is a well quantity
-                if (z_data.lhs.quantity.substr(0,1) == "W") {
-                    zAcn[offset + Ix::LHSWell] = z_data.lhs.args[0];
-                }
-                // well-name if right hand quantity is a well quantity
-                if (z_data.rhs.quantity.substr(0,1) == "W") {
-                    zAcn[offset + Ix::RHSWell] = z_data.rhs.args[0];
-                }
-
-                // group-name if left hand quantity is a group quantity
-                if (z_data.lhs.quantity.substr(0,1) == "G") {
-                    zAcn[offset + Ix::LHSGroup] = z_data.lhs.args[0];
-                }
-                // group-name if right hand quantity is a group quantity
-                if (z_data.rhs.quantity.substr(0,1) == "G") {
-                    zAcn[offset + Ix::RHSGroup] = z_data.rhs.args[0];
-                }
-
-                //increment offsetex according to no of items pr condition
-                offset += Opm::RestartIO::Helpers::VectorItems::ZACN::ConditionSize;
-            }
-        }
-    } // zAcn
-
-    namespace iACN {
-
-        Opm::RestartIO::Helpers::WindowedArray<int>
-        allocate(std::size_t num_actions, const Opm::Actdims& actdims)
-        {
-            using WV = Opm::RestartIO::Helpers::WindowedArray<int>;
-            return WV {
-                WV::NumWindows{ num_actions },
-                WV::WindowSize{ actdims.max_conditions() * Opm::RestartIO::Helpers::VectorItems::IACN::ConditionSize }
-            };
-        }
-
-
-
-        template <class IACNArray>
-        void staticContrib(const Opm::Action::ActionX& actx, IACNArray& iAcn)
-        {
-            using Ix = Opm::RestartIO::Helpers::VectorItems::IACN::index;
-            std::size_t offset = 0;
-            const auto& actx_cond = actx.conditions();
-            int first_greater = 0;
-            if( !actx_cond.empty() &&
-                actx_cond[0].cmp == Opm::Action::Comparator::LESS)
-            {
-                first_greater = 1;
-            }
-
-            for (const auto& cond : actx_cond) {
-                iAcn[offset + Ix::LHSQuantityType] = cond.lhs.int_type();
-                iAcn[offset + Ix::RHSQuantityType] = cond.rhs.int_type();
-                iAcn[offset + Ix::FirstGreater] = first_greater;
-                iAcn[offset + Ix::TerminalLogic] = cond.logic_as_int();
-                iAcn[offset + Ix::Paren] = cond.paren_as_int();
-                iAcn[offset + Ix::Comparator] = cond.comparator_as_int();
-
-                offset += Opm::RestartIO::Helpers::VectorItems::IACN::ConditionSize;
-            }
-
-            /*item [17] - is an item that is non-zero for actions with several conditions combined using logical operators (AND / OR)
-                * First condition => [17] =  0
-                * Second+ conditions
-                *Case - no parentheses
-                    *If all conditions before current condition has AND => [17] = 1
-                    *If one condition before current condition has OR   => [17] = 0
-                *Case - parenthesis before first condition
-                    *If inside first parenthesis
-                        *If all conditions before current condition has AND [17] => 1
-                        *If one condition before current condition has OR  [17] => 0
-                    *If after first parenthesis end and outside parenthesis
-                        *If all conditions outside parentheses and before current condition has AND => [17] = 1
-                        *If one condition outside parentheses and before current condition has OR [17] => 0
-                    *If after first parenthesis end and inside a susequent parenthesis
-                        * [17] = 0
-                *Case - parenthesis after first condition
-                    *If inside parentesis => [17] = 0
-                    *If outside parenthesis:
-                        *If all conditions outside parentheses and before current condition has AND => [17] = 1
-                        *If one condition outside parentheses and before current condition has OR [17] => 0
-            */
-
-            offset = 0;
-            bool insideParen = false;
-            bool parenFirstCond = false;
-            bool allPrevLogicOp_AND = false;
-            for (auto cond_it = actx_cond.begin(); cond_it < actx_cond.end(); cond_it++) {
-                if (cond_it == actx_cond.begin()) {
-                    if (cond_it->open_paren()) {
-                        parenFirstCond = true;
-                        insideParen = true;
-                    }
-                    if (cond_it->logic == Opm::Action::Logical::AND) {
-                        allPrevLogicOp_AND = true;
-                    }
-                } else {
-                    // update inside parenthesis or not plus whether in first parenthesis or not
-                    if (cond_it->open_paren()) {
-                        insideParen = true;
-                        parenFirstCond = false;
-                    } else if (cond_it->close_paren()) {
-                        insideParen = false;
-                        parenFirstCond = false;
-                    }
-
-                    // Assign [17] based on logic (see above)
-                    if (parenFirstCond && allPrevLogicOp_AND) {
-                        iAcn[offset + Ix::BoolLink] = 1;
-                    }
-                    else if (!parenFirstCond && !insideParen && allPrevLogicOp_AND) {
-                        iAcn[offset + Ix::BoolLink] = 1;
-                    } else {
-                        iAcn[offset + Ix::BoolLink] = 0;
-                    }
-
-                    // update the previous logic-sequence
-                    if (parenFirstCond && cond_it->logic == Opm::Action::Logical::OR) {
-                        allPrevLogicOp_AND = false;
-                    } else if (!insideParen && cond_it->logic == Opm::Action::Logical::OR) {
-                        allPrevLogicOp_AND = false;
-                    }
-                }
-                //increment index according to no of items pr condition
-                offset += Opm::RestartIO::Helpers::VectorItems::IACN::ConditionSize;
-            }
-        }
-    } // iAcn
-
-    namespace sACN {
-
+        template <typename T>
         class Array
         {
         public:
-            using Matrix = Opm::RestartIO::Helpers::WindowedMatrix<double>;
+            using Matrix = Opm::RestartIO::Helpers::WindowedMatrix<T>;
 
-            explicit Array(Matrix&           sacn,
-                           const Matrix::Idx actionID)
-                : sacn_   { std::ref(sacn) }
+            explicit Array(Matrix& cond, const Matrix::Idx actionID)
+                : cond_   { std::ref(cond) }
                 , action_ { actionID }
             {}
 
             decltype(auto) operator[](const Matrix::Idx condition)
             {
-                return this->sacn_.get()(this->action_, condition);
+                return this->cond_.get()(this->action_, condition);
             }
 
         private:
-            std::reference_wrapper<Matrix> sacn_;
+            std::reference_wrapper<Matrix> cond_;
             Matrix::Idx action_;
         };
 
-        int rhsQuantityIndex(const char quantity)
-        {
-            const auto index = std::map<std::string, int> {
-                {"F", 1},
-                {"W", 2},
-                {"G", 3},
-            };
+    } // namespace ConditionHelpers
 
-            auto pos = index.find(std::string{quantity});
-            return (pos == index.end())
-                ? -1
-                : pos->second;
+    namespace iACN {
+
+        std::optional<int> asInteger(std::string_view s)
+        {
+            auto i = -1;
+            auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), i);
+
+            if ((ec == std::errc{}) && (ptr == s.data() + s.size())) {
+                return { i };
+            }
+
+            return std::nullopt;
         }
 
-        Opm::RestartIO::Helpers::WindowedMatrix<double>
-        allocate(std::size_t num_actions, const Opm::Actdims& actdims)
+        // -------------------------------------------------------------
+
+        template <typename IACNArray>
+        void captureIJKLocation(const std::array<Opm::RestartIO::Helpers::VectorItems::IACN::index, 3>& ijk,
+                                const std::size_t                                                       offset,
+                                const Opm::Action::Quantity&                                            quant,
+                                IACNArray&                                                              iacn)
         {
-            using WV = Opm::RestartIO::Helpers::WindowedMatrix<double>;
+            const auto& args = quant.args();
+
+            for (auto ix = 0*ijk.size(); ix != ijk.size(); ++ix) {
+                if (const auto ijkValue = asInteger(args[offset + ix]);
+                    ijkValue.has_value())
+                {
+                    iacn[ijk[ix]] = *ijkValue;
+                }
+            }
+        }
+
+        template <typename IACNArray>
+        void captureRegionQuantity(const Opm::RestartIO::Helpers::VectorItems::IACN::index regID,
+                                   const Opm::Action::Quantity&                            quant,
+                                   IACNArray&                                              iacn)
+        {
+            // Condition references vector of the form
+            //
+            //    ROPT_ABC 42
+            //
+            // This function assumes that quant.args holds the string "42"
+            // and parses it as an integer in that case.
+
+            if (quant.args().size() != 1) {
+                return;
+            }
+
+            if (const auto regIDValue = asInteger(quant.args().front());
+                regIDValue.has_value())
+            {
+                iacn[regID] = *regIDValue;
+            }
+        }
+
+        template <typename IACNArray>
+        void captureSegmentQuantity(const Opm::RestartIO::Helpers::VectorItems::IACN::index segmentID,
+                                    const Opm::Action::Quantity&                            quant,
+                                    IACNArray&                                              iacn)
+        {
+            // Condition references vector of the form
+            //
+            //    SOFR 'P-52' 11
+            //
+            // This function assumes that quant.args holds both of the
+            // strings "P-52" and "11" and parses the segment number (i.e.,
+            // "11") as an integer in that case.
+
+            if (quant.args().size() != 2) {
+                return;
+            }
+
+            if (const auto segmentIDValue = asInteger(quant.args()[1]);
+                segmentIDValue.has_value())
+            {
+                iacn[segmentID] = *segmentIDValue;
+            }
+        }
+
+        template <typename IACNArray>
+        void captureConnectionQuantity(const std::array<Opm::RestartIO::Helpers::VectorItems::IACN::index, 3>& ijk,
+                                       const Opm::Action::Quantity&                                            quant,
+                                       IACNArray&                                                              iacn)
+        {
+            // Condition references vector of the form
+            //
+            //    COPR 'P-52' 11 22 33
+            //
+            // This function assumes that quant.args holds all of the
+            // strings "P-52", "11", "22", and "33" and parses the IJK
+            // indices (i.e., "11", "22", "33") as an integers in that case.
+
+            if (quant.args().size() != 4) {
+                return;
+            }
+
+            captureIJKLocation(ijk, /* args.quant.begin() + */ 1, quant, iacn);
+        }
+
+        template <typename IACNArray>
+        void captureBlockQuantity(const std::array<Opm::RestartIO::Helpers::VectorItems::IACN::index, 3>& ijk,
+                                  const Opm::Action::Quantity&                                            quant,
+                                  IACNArray&                                                              iacn)
+        {
+            // Condition references vector of the form
+            //
+            //    BPR 11 22 33
+            //
+            // This function assumes that quant.args holds all of the
+            // strings "11", "22", and "33" and parses the IJK indices as an
+            // integers in that case.
+
+            if (quant.args().size() != 3) {
+                return;
+            }
+
+            captureIJKLocation(ijk, /* args.quant.begin() + */ 0, quant, iacn);
+        }
+
+        // -------------------------------------------------------------
+
+        template <typename IACNArray>
+        void captureLHSQuantity(const Opm::Action::Quantity& quant,
+                                IACNArray&                   iacn)
+        {
+            using Ix = Opm::RestartIO::Helpers::VectorItems::IACN::index;
+            using QType = Opm::RestartIO::Helpers::VectorItems::IACN::Value::QuantityType;
+
+            switch ((iacn[Ix::LHSQuantityType] = quant.int_type())) {
+            case QType::Region:
+                captureRegionQuantity(Ix::LHSRegionID, quant, iacn);
+                break;
+
+            case QType::Segment:
+                captureSegmentQuantity(Ix::LHSSegmentID, quant, iacn);
+                break;
+
+            case QType::Connection:
+                captureConnectionQuantity({
+                        Ix::LHSConnLocation_I,
+                        Ix::LHSConnLocation_J,
+                        Ix::LHSConnLocation_K,
+                    }, quant, iacn);
+                break;
+
+            case QType::Block:
+                captureBlockQuantity({
+                        Ix::LHSBlockLocation_I,
+                        Ix::LHSBlockLocation_J,
+                        Ix::LHSBlockLocation_K,
+                    }, quant, iacn);
+                break;
+
+            case QType::Field: case QType::Well : case QType::Group:
+            case QType::Day  : case QType::Month: case QType::Year:
+            case QType::Const:
+                // No special integer handling needed.
+                break;
+            }
+        }
+
+        template <typename IACNArray>
+        void captureRHSQuantity(const Opm::Action::Quantity& quant,
+                                IACNArray&                   iacn)
+        {
+            using Ix = Opm::RestartIO::Helpers::VectorItems::IACN::index;
+            using QType = Opm::RestartIO::Helpers::VectorItems::IACN::Value::QuantityType;
+
+            switch ((iacn[Ix::RHSQuantityType] = quant.int_type())) {
+            case QType::Region:
+                captureRegionQuantity(Ix::RHSRegionID, quant, iacn);
+                break;
+
+            case QType::Segment:
+                captureSegmentQuantity(Ix::RHSSegmentID, quant, iacn);
+                break;
+
+            case QType::Connection:
+                captureConnectionQuantity({
+                        Ix::RHSConnLocation_I,
+                        Ix::RHSConnLocation_J,
+                        Ix::RHSConnLocation_K,
+                    }, quant, iacn);
+                break;
+
+            case QType::Block:
+                captureBlockQuantity({
+                        Ix::RHSBlockLocation_I,
+                        Ix::RHSBlockLocation_J,
+                        Ix::RHSBlockLocation_K,
+                    }, quant, iacn);
+                break;
+
+            case QType::Field: case QType::Well : case QType::Group:
+            case QType::Day  : case QType::Month: case QType::Year:
+            case QType::Const:
+                // No special integer handling needed.
+                break;
+            }
+        }
+
+        // item [17] - is an item that is non-zero for actions with
+        // several conditions combined using logical operators (AND/OR)
+        //
+        //   * First condition => [17] =  0
+        //   * Second+ conditions
+        //
+        //   *Case - no parentheses
+        //       *If all conditions before current condition has AND => [17] = 1
+        //       *If one condition before current condition has OR   => [17] = 0
+        //
+        //   *Case - parenthesis before first condition
+        //       *If inside first parenthesis
+        //           *If all conditions before current condition has AND [17] => 1
+        //           *If one condition before current condition has OR  [17] => 0
+        //       *If after first parenthesis end and outside parenthesis
+        //           *If all conditions outside parentheses and before current condition has AND => [17] = 1
+        //           *If one condition outside parentheses and before current condition has OR [17] => 0
+        //       *If after first parenthesis end and inside a susequent parenthesis
+        //           * [17] = 0
+        //
+        //   *Case - parenthesis after first condition
+        //       *If inside parentesis => [17] = 0
+        //       *If outside parenthesis:
+        //           *If all conditions outside parentheses and before current condition has AND => [17] = 1
+        //           *If one condition outside parentheses and before current condition has OR [17] => 0
+
+        void inferConditionLink(const Opm::Action::ActionX&   actx,
+                                ConditionHelpers::Array<int>& iAcn)
+        {
+            using Ix = Opm::RestartIO::Helpers::VectorItems::IACN::index;
+
+            bool insideParen = false;
+            bool parenFirstCond = false;
+            bool allPrevLogicOp_AND = false;
+
+            auto condIdx = ConditionHelpers::Array<int>::Matrix::Idx{};
+
+            for (const auto& condition : actx.conditions()) {
+                if (condIdx == 0) {
+                    if (condition.open_paren()) {
+                        parenFirstCond = true;
+                        insideParen = true;
+                    }
+
+                    if (condition.logic == Opm::Action::Logical::AND) {
+                        allPrevLogicOp_AND = true;
+                    }
+                }
+                else {
+                    // update inside parenthesis or not plus whether in
+                    // first parenthesis or not
+                    if (condition.open_paren()) {
+                        insideParen = true;
+                        parenFirstCond = false;
+                    }
+                    else if (condition.close_paren()) {
+                        insideParen = false;
+                        parenFirstCond = false;
+                    }
+
+                    // Assign [17] based on logic (see above)
+                    if (allPrevLogicOp_AND &&
+                        (parenFirstCond || (!parenFirstCond && !insideParen)))
+                    {
+                        iAcn[condIdx][Ix::BoolLink] = 1;
+                    }
+                    else {
+                        iAcn[condIdx][Ix::BoolLink] = 0;
+                    }
+
+                    // update the previous logic-sequence
+                    if (parenFirstCond && condition.logic == Opm::Action::Logical::OR) {
+                        allPrevLogicOp_AND = false;
+                    }
+                    else if (!insideParen && condition.logic == Opm::Action::Logical::OR) {
+                        allPrevLogicOp_AND = false;
+                    }
+                }
+
+                ++condIdx;
+            }
+        }
+
+        // -------------------------------------------------------------
+
+        Opm::RestartIO::Helpers::WindowedMatrix<int>
+        allocate(const std::size_t num_actions, const Opm::Actdims& actdims)
+        {
+            using WV = Opm::RestartIO::Helpers::WindowedMatrix<int>;
 
             return WV {
                 WV::NumRows    { num_actions },
                 WV::NumCols    { actdims.max_conditions() },
-                WV::WindowSize { Opm::RestartIO::Helpers::VectorItems::SACN::ConditionSize }
+                WV::WindowSize { Opm::RestartIO::Helpers::VectorItems::IACN::ConditionSize }
             };
+        }
+
+        void staticContrib(const Opm::Action::ActionX&   actx,
+                           ConditionHelpers::Array<int>& iAcn)
+        {
+            using Ix = Opm::RestartIO::Helpers::VectorItems::IACN::index;
+
+            if (actx.conditions().empty()) {
+                // Unconditional action.  Triggers at every time step.  Unusual.
+                return;
+            }
+
+            const auto first_greater = static_cast<int>
+                (actx.conditions().front().cmp == Opm::Action::Comparator::LESS);
+
+            for (auto condIdx = ConditionHelpers::Array<int>::Matrix::Idx{};
+                 const auto& condition : actx.conditions())
+            {
+                auto iacn = iAcn[condIdx++];
+
+                iacn[Ix::FirstGreater]  = first_greater;
+                iacn[Ix::TerminalLogic] = condition.logic_as_int();
+                iacn[Ix::Paren]         = condition.paren_as_int();
+                iacn[Ix::Comparator]    = condition.comparator_as_int();
+
+                captureLHSQuantity(condition.lhs, iacn);
+                captureRHSQuantity(condition.rhs, iacn);
+            }
+
+            inferConditionLink(actx, iAcn);
+        }
+
+    } // namespace iAcn
+
+    namespace sACN {
+
+        using Ix = Opm::RestartIO::Helpers::VectorItems::SACN::index;
+        using QType = Opm::RestartIO::Helpers::VectorItems::IACN::Value::QuantityType;
+
+        // -------------------------------------------------------------
+
+        template <typename SACNArray>
+        void captureLHSDateQuantity(const double undef, SACNArray& sacn)
+        {
+            // Note: This function *also* overwrites 'RHS'!
+            sacn[Ix::LHSValue1] = sacn[Ix::RHSValue1] = undef;
+            sacn[Ix::LHSValue2] = sacn[Ix::RHSValue2] = undef;
+            sacn[Ix::LHSValue3] = sacn[Ix::RHSValue3] = undef;
+        }
+
+        template <typename SACNArray>
+        void captureLHSFieldQuantity(const Opm::Action::Quantity& quant,
+                                     const Opm::SummaryState&     st,
+                                     SACNArray&                   sacn)
+        {
+            const auto& lhsQuant = quant.quantity();
+
+            if (st.has(lhsQuant)) {
+                sacn[Ix::LHSValue1] = sacn[Ix::LHSValue2] = sacn[Ix::LHSValue3]
+                    = st.get(lhsQuant);
+            }
+        }
+
+        template <typename SACNArray>
+        void captureLHSWellQuantity(const Opm::Action::Quantity& quant,
+                                    std::span<const std::string> wells,
+                                    const Opm::Action::Result&   ar,
+                                    const Opm::SummaryState&     st,
+                                    SACNArray&                   sacn)
+        {
+            if (! ar.conditionSatisfied()) {
+                return;
+            }
+
+            // Find the well that violates action if relevant
+            auto well_iter = std::ranges::find_if
+                (wells,
+                 [&matchSet = ar.matches()](const std::string& well)
+                 { return matchSet.hasWell(well); });
+
+            if (well_iter == wells.end()) {
+                return;
+            }
+
+            const auto& lhsQuant = quant.quantity();
+            const auto& wname    = *well_iter;
+
+            if (st.has_well_var(wname, lhsQuant)) {
+                sacn[Ix::LHSValue1] = sacn[Ix::LHSValue2] = sacn[Ix::LHSValue3]
+                    = st.get_well_var(wname, lhsQuant);
+            }
+        }
+
+        template <typename SACNArray>
+        void captureLHSGroupQuantity(const Opm::Action::Quantity& quant,
+                                     const Opm::SummaryState&     st,
+                                     SACNArray&                   sacn)
+        {
+            const auto& lhsQuant = quant.quantity();
+            const auto& gnames   = quant.args();
+
+            if (! gnames.empty() && st.has_group_var(gnames.front(), lhsQuant)) {
+                sacn[Ix::LHSValue1] = sacn[Ix::LHSValue2] = sacn[Ix::LHSValue3]
+                    = st.get_group_var(gnames.front(), lhsQuant);
+            }
+        }
+
+        // -------------------------------------------------------------
+
+        template <typename SACNArray>
+        void captureRHSConstantQuantity(const Opm::Action::Quantity& quant,
+                                        SACNArray&                   sacn)
+        {
+            const auto& monthIx   = Opm::TimeService::eclipseMonthIndices();
+            const auto& rhsQuant  = quant.quantity();
+            const auto monthIxPos = monthIx.find(rhsQuant);
+
+            const auto t_val = (monthIxPos == monthIx.end())
+                ? std::stod(rhsQuant) // Numeric day, month (!), or year.
+                : static_cast<double>(monthIxPos->second); // Named month.
+
+            sacn[Ix::RHSValue0]
+                = sacn[Ix::RHSValue1]
+                = sacn[Ix::RHSValue2]
+                = sacn[Ix::RHSValue3]
+                = t_val;
+        }
+
+        template <typename SACNArray>
+        void captureRHSFieldQuantity(const Opm::Action::Quantity& quant,
+                                     const Opm::SummaryState&     st,
+                                     SACNArray&                   sacn)
+        {
+            const auto& rhsQuant = quant.quantity();
+
+            if (st.has(rhsQuant)) {
+                sacn[Ix::RHSValue1] = sacn[Ix::RHSValue2] = sacn[Ix::RHSValue3]
+                    = st.get(rhsQuant);
+            }
+        }
+
+        template <typename SACNArray>
+        void captureRHSWellQuantity(const Opm::Action::Quantity& quant,
+                                    const Opm::SummaryState&     st,
+                                    SACNArray&                   sacn)
+        {
+            const auto& rhsQuant = quant.quantity();
+            const auto& wnames   = quant.args();
+
+            if (! wnames.empty() && st.has_well_var(wnames.front(), rhsQuant)) {
+                sacn[Ix::RHSValue1] = sacn[Ix::RHSValue2] = sacn[Ix::RHSValue3]
+                    = st.get_well_var(wnames.front(), rhsQuant);
+            }
+        }
+
+        template <typename SACNArray>
+        void captureRHSGroupQuantity(const Opm::Action::Quantity& quant,
+                                     const Opm::SummaryState&     st,
+                                     SACNArray&                   sacn)
+        {
+            const auto& rhsQuant = quant.quantity();
+            const auto& gnames   = quant.args();
+
+            if (! gnames.empty() && st.has_group_var(gnames.front(), rhsQuant)) {
+                sacn[Ix::RHSValue1] = sacn[Ix::RHSValue2] = sacn[Ix::RHSValue3]
+                    = st.get_group_var(gnames.front(), rhsQuant);
+            }
+        }
+
+        // -------------------------------------------------------------
+
+        template <typename SACNArray>
+        void captureLHSQuantity(const Opm::Action::Quantity& quant,
+                                std::span<const std::string> wells,
+                                const Opm::Action::Result&   ar,
+                                const Opm::SummaryState&     st,
+                                const double                 undef,
+                                SACNArray&                   sacn)
+        {
+            switch (quant.int_type()) {
+            case QType::Field:
+                captureLHSFieldQuantity(quant, st, sacn);
+                break;
+
+            case QType::Well:
+                captureLHSWellQuantity(quant, wells, ar, st, sacn);
+                break;
+
+            case QType::Group:
+                captureLHSGroupQuantity(quant, st, sacn);
+                break;
+
+            case QType::Day:
+            case QType::Month:
+            case QType::Year:
+                captureLHSDateQuantity(undef, sacn);
+                break;
+
+            case QType::Region:
+            case QType::Segment:
+            case QType::Connection:
+            case QType::Const:
+            case QType::Block:
+                // Unhandled.
+                break;
+            }
+        }
+
+        template <typename SACNArray>
+        void captureRHSQuantity(const Opm::Action::Quantity& quant,
+                                const Opm::SummaryState&     st,
+                                SACNArray&                   sacn)
+        {
+            switch (quant.int_type()) {
+            case QType::Field:
+                captureRHSFieldQuantity(quant, st, sacn);
+                break;
+
+            case QType::Well:
+                captureRHSWellQuantity(quant, st, sacn);
+                break;
+
+            case QType::Group:
+                captureRHSGroupQuantity(quant, st, sacn);
+                break;
+
+            case QType::Const:
+            case QType::Day:
+            case QType::Month:
+            case QType::Year:
+                captureRHSConstantQuantity(quant, sacn);
+                break;
+
+            case QType::Region:
+            case QType::Segment:
+            case QType::Connection:
+            case QType::Block:
+                // Unhandled.
+                break;
+            }
         }
 
         Opm::Action::Result
@@ -421,14 +782,24 @@ namespace {
             return action.eval(context);
         }
 
+        Opm::RestartIO::Helpers::WindowedMatrix<double>
+        allocate(std::size_t num_actions, const Opm::Actdims& actdims)
+        {
+            using WV = Opm::RestartIO::Helpers::WindowedMatrix<double>;
+
+            return WV {
+                WV::NumRows    { num_actions },
+                WV::NumCols    { actdims.max_conditions() },
+                WV::WindowSize { Opm::RestartIO::Helpers::VectorItems::SACN::ConditionSize }
+            };
+        }
+
         void staticContrib(const Opm::Action::ActionX& action,
                            const Opm::Action::State&   action_state,
                            const Opm::SummaryState&    st,
                            const Opm::RestartIO::Helpers::AggregateActionxRuntimeContext& runtime,
-                           Array&                      sAcn)
+                           ConditionHelpers::Array<double>& sAcn)
         {
-            using Ix = Opm::RestartIO::Helpers::VectorItems::SACN::index;
-
             const auto undef_high_val = 1.0E+20;
             const auto& wells = runtime.wellNames;
             const auto ar = act_res(action,
@@ -442,91 +813,166 @@ namespace {
             for (const auto& condition : action.conditions()) {
                 auto sacn = sAcn[condIx++];
 
-                const auto lhsQtype = condition.lhs.quantity.front();
-                const auto rhsQtype = condition.rhs.quantity.front();
+                // Note ordering peculiarity here: We *must* capture the RHS
+                // quantity *before* the LHS quantity.  Certain RHS entries
+                // in SACN will be overwritten/cleared if the LHS is a date
+                // quantity (i.e., DAY, MNTH/MONTH, or YEAR).
+                captureRHSQuantity(condition.rhs, st, sacn);
 
-                // Note: date() && Qtype == 'M' is a special case for the
-                // month string "FEB" which would otherwise mistakenly be
-                // identified as a 'F'ield-level condition.
-                const auto is_constant_rhs_condition = (rhsQuantityIndex(rhsQtype) < 0)
-                    || (condition.lhs.date() && (lhsQtype == 'M'));
-
-                if (is_constant_rhs_condition)  {
-                    // Come here if constant value condition
-                    const auto t_val = (lhsQtype != 'M')
-                        ? std::stod(condition.rhs.quantity)
-                        : Opm::TimeService::eclipseMonth(condition.rhs.quantity);
-
-                    sacn[Ix::RHSValue0]
-                        = sacn[Ix::RHSValue1]
-                        = sacn[Ix::RHSValue2]
-                        = sacn[Ix::RHSValue3]
-                        = t_val;
-                }
-
-                // Treat well, group and field right hand side conditions
-                if (! is_constant_rhs_condition) {
-                    // Well variable
-                    if ((rhsQtype == 'W') && st.has_well_var(condition.rhs.args[0], condition.rhs.quantity)) {
-                        sacn[Ix::RHSValue1] = sacn[Ix::RHSValue2] = sacn[Ix::RHSValue3]
-                            = st.get_well_var(condition.rhs.args[0], condition.rhs.quantity);
-                    }
-
-                    // group variable
-                    if ((rhsQtype == 'G') && st.has_group_var(condition.rhs.args[0], condition.rhs.quantity)) {
-                        sacn[Ix::RHSValue1] = sacn[Ix::RHSValue2] = sacn[Ix::RHSValue3] =
-                            st.get_group_var(condition.rhs.args[0], condition.rhs.quantity);
-                    }
-
-                    // Field variable
-                    if ((rhsQtype == 'F') && st.has(condition.rhs.quantity)) {
-                        sacn[Ix::RHSValue1] = sacn[Ix::RHSValue2] = sacn[Ix::RHSValue3] =
-                            st.get(condition.rhs.quantity);
-                    }
-                }
-
-                if (condition.lhs.date()) {
-                    sacn[Ix::LHSValue1] = sacn[Ix::RHSValue1] = undef_high_val;
-                    sacn[Ix::LHSValue2] = sacn[Ix::RHSValue2] = undef_high_val;
-                    sacn[Ix::LHSValue3] = sacn[Ix::RHSValue3] = undef_high_val;
-                }
-                else {
-                    // Treat well, group and field left hand side conditions
-                    //
-                    // Well variable
-                    if ((lhsQtype == 'W') && ar.conditionSatisfied()) {
-                        // Find the well that violates action if relevant
-                        auto well_iter =
-                            std::ranges::find_if(wells,
-                                                 [&matchSet = ar.matches()](const std::string& well)
-                                                 { return matchSet.hasWell(well); });
-
-                        if (well_iter != wells.end()) {
-                            const auto& wn = *well_iter;
-
-                            if (st.has_well_var(wn, condition.lhs.quantity)) {
-                                sacn[Ix::LHSValue1] = sacn[Ix::LHSValue2] = sacn[Ix::LHSValue3] =
-                                    st.get_well_var(wn, condition.lhs.quantity);
-                            }
-                        }
-                    }
-
-                    // Group variable
-                    if ((lhsQtype == 'G') && st.has_group_var(condition.lhs.args[0], condition.lhs.quantity)) {
-                        sacn[Ix::LHSValue1] = sacn[Ix::LHSValue2] = sacn[Ix::LHSValue3] =
-                            st.get_group_var(condition.lhs.args[0], condition.lhs.quantity);
-                    }
-
-                    // Field variable
-                    if ((lhsQtype == 'F') && st.has(condition.lhs.quantity)) {
-                        sacn[Ix::LHSValue1] = sacn[Ix::LHSValue2] = sacn[Ix::LHSValue3] =
-                            st.get(condition.lhs.quantity);
-                    }
-                }
+                captureLHSQuantity(condition.lhs,
+                                   wells, ar, st,
+                                   undef_high_val,
+                                   sacn);
             }
         }
 
-    } // sAcn
+    } // namespace sAcn
+
+    namespace zACN {
+
+        template <typename ZACNArray>
+        void captureUnnamedQuantity(const Opm::RestartIO::Helpers::VectorItems::ZACN::index quantityIx,
+                                    const Opm::Action::Quantity&                            quant,
+                                    ZACNArray&                                              zacn)
+        {
+            zacn[quantityIx] = quant.quantity();
+        }
+
+        template <typename ZACNArray>
+        void captureNamedQuantity(const Opm::RestartIO::Helpers::VectorItems::ZACN::index quantityIx,
+                                  const Opm::RestartIO::Helpers::VectorItems::ZACN::index nameIx,
+                                  const Opm::Action::Quantity&                            quant,
+                                  ZACNArray&                                              zacn)
+        {
+            captureUnnamedQuantity(quantityIx, quant, zacn);
+
+            if (! quant.args().empty()) {
+                zacn[nameIx] = quant.args().front();
+            }
+        }
+
+        template <typename ZACNArray>
+        void captureRegionQuantity(const Opm::RestartIO::Helpers::VectorItems::ZACN::index quantityIx,
+                                   const Opm::RestartIO::Helpers::VectorItems::ZACN::index regsetIx,
+                                   const Opm::Action::Quantity&                            quant,
+                                   ZACNArray&                                              zacn)
+        {
+            // This code *depends* on quant.quantity() having the canonical form
+            //
+            //    ROPR_SET
+            //
+            // even when 'SET' is the built-in FIPNUM region set--i.e., ROPR_NUM.
+            zacn[quantityIx] = quant.quantity();
+            zacn[regsetIx]   = quant.quantity().substr(5);
+        }
+
+        template <typename ZACNArray>
+        void captureLHSQuantity(const Opm::Action::Quantity& quant,
+                                ZACNArray&                   zacn)
+        {
+            using Ix = Opm::RestartIO::Helpers::VectorItems::ZACN::index;
+            using QType = Opm::RestartIO::Helpers::VectorItems::IACN::Value::QuantityType;
+
+            switch (quant.int_type()) {
+            case QType::Field:
+            case QType::Block:
+                captureUnnamedQuantity(Ix::LHSQuantity, quant, zacn);
+                break;
+
+            case QType::Well:
+            case QType::Segment:
+            case QType::Connection:
+                captureNamedQuantity(Ix::LHSQuantity, Ix::LHSWell, quant, zacn);
+                break;
+
+            case QType::Group:
+                captureNamedQuantity(Ix::LHSQuantity, Ix::LHSGroup, quant, zacn);
+                break;
+
+            case QType::Region:
+                captureRegionQuantity(Ix::LHSQuantity, Ix::LHSRegionSet, quant, zacn);
+                break;
+
+            case QType::Const:
+            case QType::Day  : case QType::Month: case QType::Year:
+                // No special string/name handling needed.
+                break;
+            }
+        }
+
+        template <typename ZACNArray>
+        void captureRHSQuantity(const Opm::Action::Quantity& quant,
+                                ZACNArray&                   zacn)
+        {
+            using Ix = Opm::RestartIO::Helpers::VectorItems::ZACN::index;
+            using QType = Opm::RestartIO::Helpers::VectorItems::IACN::Value::QuantityType;
+
+            switch (quant.int_type()) {
+            case QType::Field:
+            case QType::Block:
+                captureUnnamedQuantity(Ix::RHSQuantity, quant, zacn);
+                break;
+
+            case QType::Well:
+            case QType::Segment:
+            case QType::Connection:
+                captureNamedQuantity(Ix::RHSQuantity, Ix::RHSWell, quant, zacn);
+                break;
+
+            case QType::Group:
+                captureNamedQuantity(Ix::RHSQuantity, Ix::RHSGroup, quant, zacn);
+                break;
+
+            case QType::Region:
+                captureRegionQuantity(Ix::RHSQuantity, Ix::RHSRegionSet, quant, zacn);
+                break;
+
+            case QType::Const:
+            case QType::Day  : case QType::Month: case QType::Year:
+                // No special string/name handling needed.
+                break;
+            }
+        }
+
+        Opm::RestartIO::Helpers::WindowedMatrix<
+            Opm::EclIO::PaddedOutputString<8>
+        >
+        allocate(const std::size_t num_actions, const Opm::Actdims& actdims)
+        {
+            using WV = Opm::RestartIO::Helpers::WindowedMatrix<
+                Opm::EclIO::PaddedOutputString<8>
+            >;
+
+            return WV {
+                WV::NumRows    { num_actions },
+                WV::NumCols    { actdims.max_conditions() },
+                WV::WindowSize { Opm::RestartIO::Helpers::VectorItems::ZACN::ConditionSize }
+            };
+        }
+
+        void staticContrib(const Opm::Action::ActionX&                                 actx,
+                           ConditionHelpers::Array<Opm::EclIO::PaddedOutputString<8>>& zAcn)
+        {
+            using Ix = Opm::RestartIO::Helpers::VectorItems::ZACN::index;
+
+            if (actx.conditions().empty()) {
+                // Unconditional action.  Triggers at every time step.  Unusual.
+                return;
+            }
+
+            for (auto condIdx = ConditionHelpers::Array<int>::Matrix::Idx{};
+                 const auto& condition : actx.conditions())
+            {
+                auto zacn = zAcn[condIdx++];
+
+                // Comparison operator.
+                zacn[Ix::Comparator] = condition.cmp_string;
+
+                captureLHSQuantity(condition.lhs, zacn);
+                captureRHSQuantity(condition.rhs, zacn);
+            }
+        }
+    } // namespace zAcn
 
     std::span<const Opm::Action::ActionX>
     actionSpan(const Opm::Action::Actions& actions)
@@ -564,20 +1010,23 @@ AggregateActionxData(std::span<const Action::ActionX>      actions,
     , sACT_ (sACT::allocate(actions.size()))
     , zACT_ (zACT::allocate(actions.size()))
     , zLACT_(zLACT::allocate(actions.size(), maxInputLines(actions), actdims))
-    , zACN_ (zACN::allocate(actions.size(), actdims))
     , iACN_ (iACN::allocate(actions.size(), actdims))
     , sACN_ (sACN::allocate(actions.size(), actdims))
+    , zACN_ (zACN::allocate(actions.size(), actdims))
 {
     std::size_t act_ind = 0;
     for (const auto& action : actions) {
         {
             auto i_act = this->iACT_[act_ind];
-            iACT::staticContrib(action, i_act, action_state);
+            iACT::staticContrib(action, action_state, i_act);
         }
 
         {
             auto s_act = this->sACT_[act_ind];
-            sACT::staticContrib(action, action_state, runtime.startTime, runtime.units, s_act);
+            sACT::staticContrib(action, action_state,
+                                runtime.startTime,
+                                runtime.units,
+                                s_act);
         }
 
         {
@@ -591,21 +1040,24 @@ AggregateActionxData(std::span<const Action::ActionX>      actions,
         }
 
         {
-            auto z_acn = this->zACN_[act_ind];
-            zACN::staticContrib(action, z_acn);
-        }
-
-        {
-            auto i_acn = this->iACN_[act_ind];
+            auto i_acn = ConditionHelpers::Array<int> { this->iACN_, act_ind };
             iACN::staticContrib(action, i_acn);
         }
 
         {
-            auto s_acn = sACN::Array { this->sACN_, act_ind };
+            auto s_acn = ConditionHelpers::Array<double> { this->sACN_, act_ind };
             sACN::staticContrib(action, action_state, st, runtime, s_acn);
         }
 
-        act_ind +=1;
+        {
+            auto z_acn = ConditionHelpers::Array<EclIO::PaddedOutputString<8>> {
+                this->zACN_, act_ind
+            };
+
+            zACN::staticContrib(action, z_acn);
+        }
+
+        ++act_ind;
     }
 }
 

--- a/opm/output/eclipse/AggregateActionxData.hpp
+++ b/opm/output/eclipse/AggregateActionxData.hpp
@@ -109,27 +109,51 @@ public:
     }
 
 private:
-    /// Aggregate 'IACT' array (Integer) for all ACTIONX data  (9 integers pr UDQ)
+    /// Integer descriptors for ACTIONX.
+    ///
+    /// Nine (9) integers per ACTIONX keyword.
     WindowedArray<int> iACT_;
 
-    /// Aggregate 'SACT' array (Integer) for all ACTIONX data  (5 integers pr ACTIONX - currently all zero - meaning unknown)
+    /// Floating-point descriptors for ACTIONX.
+    ///
+    /// Five (5) floats per ACTIONX keyword.
     WindowedArray<float> sACT_;
 
-    /// Aggregate 'ZACT' array (Character) for all ACTIONX data. (4 * 8 chars pr ACIONX keyword - name of Action)
+    /// Character descriptors for ACTIONX.
+    ///
+    /// One (1) string of 8 characters, the action name, per ACTIONX keyword.
     WindowedArray<EclIO::PaddedOutputString<8>> zACT_;
 
-    /// Aggregate 'ZLACT' array (Character) for all Actionx data.  (max 16 * 8 characters pr line (default 80 chars pr line)
+    /// Linearised action block keywords for all ACTIONX keywords.
+    ///
+    /// At most 16 eight-character strings per ACTIONX keyword line, with
+    /// a (common) runtime-configured number of lines per ACTIONX keyword.
     WindowedArray<EclIO::PaddedOutputString<8>> zLACT_;
 
-    /// Aggregate 'ZACN' array (Character) for all Actionx data  (length equal to max no of conditions pr Actionx * the number of Actiox kwords)
-    WindowedArray<EclIO::PaddedOutputString<8>> zACN_;
+    /// Integer descriptors for all ACTIONX conditions.
+    ///
+    /// 26 integers per ACTIONX condition, with a (common) runtime-configured
+    /// number of conditions per ACTIONX keyword.  Not all integer descriptors
+    /// are used for all conditions, but the restart file format is fixed.
+    WindowedMatrix<int> iACN_;
 
-    /// Aggregate 'IACN' array (Integer) for all Actionx data  (length 26* the max number of conditoins pr Actionx * the number of Actionx kwords)
-    WindowedArray<int> iACN_;
-
-    /// Aggregate 'SACN' array (double precision floating-point) for all Actionx data  (16 * max number of Actionx conditions)
+    /// Floating-point descriptors for all ACTIONX conditions.
+    ///
+    /// 16 items per ACTIONX condition, with a (common) runtime-configured
+    /// number of conditions per ACTIONX keyword.  Not all floating-point
+    /// descriptors are used for all conditions, but the restart file format
+    /// is fixed.
+    ///
+    /// Note: Type 'double' despite the S* name.
     WindowedMatrix<double> sACN_;
 
+    /// String descriptors for all ACTIONX conditions.
+    ///
+    /// 13 eight-character strings per ACTIONX condition, with a (common)
+    /// runtime-configured number of conditions per ACTIONX keyword.  Not all
+    /// string descriptors are used for all conditions, but the restart file
+    /// format is fixed.
+    WindowedMatrix<EclIO::PaddedOutputString<8>> zACN_;
 };
 
 AggregateActionxData

--- a/opm/output/eclipse/VectorItems/action.hpp
+++ b/opm/output/eclipse/VectorItems/action.hpp
@@ -22,86 +22,178 @@
 
 #include <vector>
 
-namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems {
+namespace Opm::RestartIO::Helpers::VectorItems {
 
     namespace IACN {
         enum index : std::vector<int>::size_type {
+            /// Region ID of LHS region quantity.
+            LHSRegionID = 0,
+
+            /// Region ID of RHS region quantity.
+            RHSRegionID = 1,
+
+            /// Segment ID of LHS segment quantity.
+            LHSSegmentID = 2,
+
+            /// Segment ID of RHS segment quantity.
+            RHSSegmentID = 3,
+
+            /// I location of LHS connection quantity
+            LHSConnLocation_I = 4,
+
+            /// J location of LHS connection quantity
+            LHSConnLocation_J = 5,
+
+            /// K location of LHS connection quantity
+            LHSConnLocation_K = 6,
+
+            /// I location of RHS connection quantity
+            RHSConnLocation_I = 7,
+
+            /// J location of RHS connection quantity
+            RHSConnLocation_J = 8,
+
+            /// K location of RHS connection quantity
+            RHSConnLocation_K = 9,
+
+            /// Quantity type (level) of LHS quantity.
             LHSQuantityType = 10,
+
+            /// Quantity type (level) of RHS quantity.
             RHSQuantityType = 11,
+
             FirstGreater    = 12,
             TerminalLogic   = 13,
             Paren           = 15,
             Comparator      = 16,
-            BoolLink        = 17
+            BoolLink        = 17,
+
+            /// I location of LHS block/cell quantity
+            LHSBlockLocation_I = 20,
+
+            /// J location of LHS block/cell quantity
+            LHSBlockLocation_J = 21,
+
+            /// K location of LHS block/cell quantity
+            LHSBlockLocation_K = 22,
+
+            /// I location of RHS block/cell quantity
+            RHSBlockLocation_I = 23,
+
+            /// J location of RHS block/cell quantity
+            RHSBlockLocation_J = 24,
+
+            /// K location of RHS block/cell quantity
+            RHSBlockLocation_K = 25,
         };
 
-        // The same enum is used for both lefthand side and righthand side quantities;
-        // although not all values can be used on both sides.
+        // The same enum is used for both left-hand side and right-hand side
+        // quantities.  Note that not all values are eligible for both
+        // sides.
         namespace Value {
-        enum QuantityType {
-            Field     = 1,
-            Well      = 2,
-            Group     = 3,
-            Const     = 8,
-            Day       = 10,
-            Month     = 11,
-            Year      = 12
-        };
+            enum QuantityType {
+                /// Quantity is defined at the field level (F* vector).
+                Field = 1,
 
-        enum ParenType {
-            None = 0,
-            Open = 1,
-            Close = 2
-        };
+                /// Quantity is defined at the well level (W* vector).
+                Well = 2,
 
-        }
+                /// Quantity is defined at the group level (G* vector).
+                Group = 3,
+
+                /// Quantity is defined at the region level (R* vector).
+                Region = 4,
+
+                /// Quantity is defined at the segment level (S* vector).
+                Segment = 5,
+
+                /// Quantity is defined at the connection level (C* vector).
+                Connection = 6,
+
+                /// Quantity is a constant--i.e., a number.
+                Const = 8,
+
+                /// Quantity is a day (in a month).
+                Day = 10,
+
+                /// Quantity is a month.
+                Month = 11,
+
+                /// Quantity is a year.
+                Year = 12,
+
+                /// Quantity is defined at the block/cell level (B* vector).
+                Block = 15,
+            };
+
+            enum ParenType {
+                None = 0,
+                Open = 1,
+                Close = 2,
+            };
+        } // namespace Value
 
         constexpr std::size_t ConditionSize = 26;
-    }
-
+    } // namespace IACN
 
     namespace SACN {
+        enum index : std::vector<int>::size_type {
+            LHSValue0 = 0,
+            RHSValue0 = 2,
+            LHSValue1 = 4,
+            RHSValue1 = 5,
+            LHSValue2 = 6,
+            RHSValue2 = 7,
+            LHSValue3 = 8,
+            RHSValue3 = 9,
+        };
 
-    enum index : std::vector<int>::size_type {
-        LHSValue0 = 0,
-        RHSValue0 = 2,
-        LHSValue1 = 4,
-        RHSValue1 = 5,
-        LHSValue2 = 6,
-        RHSValue2 = 7,
-        LHSValue3 = 8,
-        RHSValue3 = 9
-    };
-
-    constexpr std::size_t ConditionSize = 16;
-    }
-
+        constexpr std::size_t ConditionSize = 16;
+    } // namespace SACN
 
     namespace ZACN {
-    enum index : std::vector<int>::size_type {
-        Quantity = 0,
-        LHSQuantity = 0,
-        RHSQuantity = 1,
-        Comparator = 2,
-        Well = 3,
-        LHSWell = 3,
-        RHSWell = 4,
-        Group = 5,
-        LHSGroup = 5,
-        RHSGroup = 6
-    };
+        enum index : std::vector<int>::size_type {
+            Quantity = 0,
 
-    constexpr std::size_t RHSOffset = 1;
-    constexpr std::size_t ConditionSize = 13;
-    }
+            /// Summary vector keyword of LHS quantity.
+            LHSQuantity = 0,
+
+            /// Summary vector keyword of RHS quantity.
+            RHSQuantity = 1,
+
+            Comparator = 2,
+
+            Well = 3,
+
+            /// Well name of LHS quantity (Well, Connection, Segment).
+            LHSWell = 3,
+
+            /// Well name of RHS quantity (Well, Connection, Segment).
+            RHSWell = 4,
+
+            Group = 5,
+
+            /// Group name of LHS quantity (Group).
+            LHSGroup = 5,
+
+            /// Group name of RHS quantity (Group).
+            RHSGroup = 6,
+
+            /// Region set name for LHS region quantity.  "NUM" for default FIPNUM set.
+            LHSRegionSet = 7,
+
+            /// Region set name for RHS region quantity.  "NUM" for default FIPNUM set.
+            RHSRegionSet = 8,
+        };
+
+        constexpr std::size_t RHSOffset = 1;
+        constexpr std::size_t ConditionSize = 13;
+    } // namespace ZACN
 
     namespace ZLACT {
+        constexpr std::size_t max_line_length = 128;
+    } // namespace ZLACT
 
-    constexpr std::size_t max_line_length = 128;
-    }
-
-
-
-}}}} // Opm::RestartIO::Helpers::VectorItems
+} // namespace Opm::RestartIO::Helpers::VectorItems
 
 #endif

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -870,27 +870,27 @@ BOOST_AUTO_TEST_CASE(Conditions)
     Action::Condition cond({"WWCT", "OPX", ">", "0.75",  "AND"}, location);
     BOOST_CHECK(cond.cmp == Action::Comparator::GREATER);
     BOOST_CHECK(cond.cmp_string == ">" );
-    BOOST_CHECK_EQUAL(cond.lhs.quantity, "WWCT");
-    BOOST_CHECK_EQUAL(cond.lhs.args.size(), 1U);
-    BOOST_CHECK_EQUAL(cond.lhs.args[0], "OPX");
+    BOOST_CHECK_EQUAL(cond.lhs.quantity(), "WWCT");
+    BOOST_CHECK_EQUAL(cond.lhs.args().size(), 1U);
+    BOOST_CHECK_EQUAL(cond.lhs.args()[0], "OPX");
     BOOST_CHECK( !cond.open_paren() );
     BOOST_CHECK( !cond.close_paren() );
 
-    BOOST_CHECK_EQUAL(cond.rhs.quantity, "0.75");
-    BOOST_CHECK_EQUAL(cond.rhs.args.size(), 0U);
+    BOOST_CHECK_EQUAL(cond.rhs.quantity(), "0.75");
+    BOOST_CHECK_EQUAL(cond.rhs.args().size(), 0U);
     BOOST_CHECK(cond.logic == Action::Logical::AND);
 
     Action::Condition cond2({"WWCT", "OPX", "<=", "WSOPR", "OPX", "235"}, location);
     BOOST_CHECK(cond2.cmp == Action::Comparator::LESS_EQUAL);
     BOOST_CHECK(cond2.cmp_string == "<=" );
-    BOOST_CHECK_EQUAL(cond2.lhs.quantity, "WWCT");
-    BOOST_CHECK_EQUAL(cond2.lhs.args.size(), 1U);
-    BOOST_CHECK_EQUAL(cond2.lhs.args[0], "OPX");
+    BOOST_CHECK_EQUAL(cond2.lhs.quantity(), "WWCT");
+    BOOST_CHECK_EQUAL(cond2.lhs.args().size(), 1U);
+    BOOST_CHECK_EQUAL(cond2.lhs.args()[0], "OPX");
 
-    BOOST_CHECK_EQUAL(cond2.rhs.quantity, "WSOPR");
-    BOOST_CHECK_EQUAL(cond2.rhs.args.size(), 2U);
-    BOOST_CHECK_EQUAL(cond2.rhs.args[0], "OPX");
-    BOOST_CHECK_EQUAL(cond2.rhs.args[1], "235");
+    BOOST_CHECK_EQUAL(cond2.rhs.quantity(), "WSOPR");
+    BOOST_CHECK_EQUAL(cond2.rhs.args().size(), 2U);
+    BOOST_CHECK_EQUAL(cond2.rhs.args()[0], "OPX");
+    BOOST_CHECK_EQUAL(cond2.rhs.args()[1], "235");
     BOOST_CHECK(cond2.logic == Action::Logical::END);
 }
 
@@ -973,16 +973,16 @@ TSTEP
     BOOST_CHECK_EQUAL(conditions.size() , 2U);
 
     const auto& cond0 = conditions[0];
-    BOOST_CHECK_EQUAL(cond0.lhs.quantity, "WWCT");
+    BOOST_CHECK_EQUAL(cond0.lhs.quantity(), "WWCT");
     BOOST_CHECK(cond0.cmp == Action::Comparator::GREATER);
     BOOST_CHECK(cond0.logic == Action::Logical::AND);
-    BOOST_CHECK_EQUAL(cond0.lhs.args.size(), 1U);
-    BOOST_CHECK_EQUAL(cond0.lhs.args[0], "OPX");
-    BOOST_CHECK_EQUAL(cond0.rhs.args.size(), 0U);
-    BOOST_CHECK_EQUAL(cond0.rhs.quantity, "0.75");
+    BOOST_CHECK_EQUAL(cond0.lhs.args().size(), 1U);
+    BOOST_CHECK_EQUAL(cond0.lhs.args()[0], "OPX");
+    BOOST_CHECK_EQUAL(cond0.rhs.args().size(), 0U);
+    BOOST_CHECK_EQUAL(cond0.rhs.quantity(), "0.75");
 
     const auto& cond1 = conditions[1];
-    BOOST_CHECK_EQUAL(cond1.lhs.quantity, "FPR");
+    BOOST_CHECK_EQUAL(cond1.lhs.quantity(), "FPR");
     BOOST_CHECK(cond1.cmp == Action::Comparator::LESS);
     BOOST_CHECK(cond1.logic == Action::Logical::END);
 
@@ -994,7 +994,7 @@ TSTEP
     const auto& actB = actions2["B"];
     const auto& condB = actB.conditions();
     BOOST_CHECK_EQUAL(condB.size() , 1U);
-    BOOST_CHECK_EQUAL(condB[0].lhs.quantity, "FWCT");
+    BOOST_CHECK_EQUAL(condB[0].lhs.quantity(), "FWCT");
     BOOST_CHECK(condB[0].cmp == Action::Comparator::LESS_EQUAL);
     BOOST_CHECK(condB[0].logic == Action::Logical::END);
     BOOST_CHECK_EQUAL(condB[0].cmp_string, "<=");
@@ -1002,7 +1002,7 @@ TSTEP
     const auto& actA = actions2["A"];
     const auto& condA = actA.conditions();
     BOOST_CHECK_EQUAL(condA.size() , 1U);
-    BOOST_CHECK_EQUAL(condA[0].lhs.quantity, "WOPR");
+    BOOST_CHECK_EQUAL(condA[0].lhs.quantity(), "WOPR");
     BOOST_CHECK(condA[0].cmp == Action::Comparator::EQUAL);
     BOOST_CHECK(condA[0].logic == Action::Logical::END);
     BOOST_CHECK_EQUAL(condA[0].cmp_string , "=");
@@ -1681,8 +1681,8 @@ END
     {
         const auto cond0 = conditions[0];
 
-        BOOST_CHECK_EQUAL(cond0.lhs.quantity, "FU1");
-        BOOST_CHECK(cond0.lhs.args.empty());
+        BOOST_CHECK_EQUAL(cond0.lhs.quantity(), "FU1");
+        BOOST_CHECK(cond0.lhs.args().empty());
         BOOST_CHECK(!cond0.left_paren);
         BOOST_CHECK(!cond0.right_paren);
         BOOST_CHECK(!cond0.open_paren());
@@ -1692,8 +1692,8 @@ END
     {
         const auto cond1 = conditions[1];
 
-        BOOST_CHECK_EQUAL(cond1.lhs.quantity, "FU2");
-        BOOST_CHECK(cond1.lhs.args.empty());
+        BOOST_CHECK_EQUAL(cond1.lhs.quantity(), "FU2");
+        BOOST_CHECK(cond1.lhs.args().empty());
         BOOST_CHECK(cond1.left_paren);
         BOOST_CHECK(cond1.right_paren);
         BOOST_CHECK(!cond1.open_paren());
@@ -1703,8 +1703,8 @@ END
     {
         const auto cond2 = conditions[2];
 
-        BOOST_CHECK_EQUAL(cond2.lhs.quantity, "FU2");
-        BOOST_CHECK(cond2.lhs.args.empty());
+        BOOST_CHECK_EQUAL(cond2.lhs.quantity(), "FU2");
+        BOOST_CHECK(cond2.lhs.args().empty());
         BOOST_CHECK(cond2.left_paren);
         BOOST_CHECK(!cond2.right_paren);
         BOOST_CHECK(cond2.open_paren());
@@ -1714,14 +1714,14 @@ END
     {
         const auto cond3 = conditions[3];
 
-        BOOST_CHECK_EQUAL(cond3.lhs.quantity, "FU2");
-        BOOST_CHECK(cond3.lhs.args.empty());
+        BOOST_CHECK_EQUAL(cond3.lhs.quantity(), "FU2");
+        BOOST_CHECK(cond3.lhs.args().empty());
         BOOST_CHECK(!cond3.left_paren);
         BOOST_CHECK(cond3.right_paren);
         BOOST_CHECK(!cond3.open_paren());
         BOOST_CHECK(cond3.close_paren());
 
-        BOOST_CHECK(cond3.rhs.args.empty());
+        BOOST_CHECK(cond3.rhs.args().empty());
     }
 }
 

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -561,6 +561,25 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
 
                 const auto& iAcn = actionxData.getIACN();
 
+                // First ACTIONX keyword
+                //
+                //   ACTIONX
+                //   ACT01 10  0.543 /
+                //   FMWPR > 45 AND /
+                //   WUPR3 'OP*' > 46 OR /
+                //   MNTH < MAY  /
+                //   /
+                //   WELOPEN
+                //   '?' SHUT 0 0 0 2* /
+                //   /
+                //   WELOPEN
+                //    'OPU02' 'OPEN' 5* /
+                //   /
+                //   WELOPEN
+                //    'OPL02' 'OPEN' 5* /
+                //   /
+                //   ENDACTIO
+
                 auto start_a = 0 * iAcnStride;
                 auto start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 0], 0);
@@ -662,6 +681,24 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 16], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
+
+                // ===========================================================
+
+                // Second ACTIONX keyword
+                //
+                //    ACTIONX
+                //    ACT02 11 0.567 /
+                //    FMWPR > 25 AND /
+                //    WGPR 'OPL02' > GGPR 'LOWER' AND /
+                //    MNTH > NOV /
+                //    /
+                //    WELOPEN
+                //    '?' 'SHUT' 0 0 0 2* /
+                //    /
+                //    WELOPEN
+                //     'OPL01' 'OPEN' 5* /
+                //    /
+                //    ENDACTIO
 
                 start_a = 3 * iAcnStride;
                 start = start_a + 0 * condSize;
@@ -1108,7 +1145,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK(compare_tokens(action.conditions[2].tokens(), {"WOPR", "OP*", ">", "32", "AND"}));
                 BOOST_CHECK(compare_tokens(action.conditions[3].tokens(), {"(", "WLPR", "OP*", ">", "43", "AND"}));
                 BOOST_CHECK(
-                    compare_tokens(action.conditions[4].tokens(), {"WWCT", "OP*", ">", "0.310000", ")", "AND"}));
+                    compare_tokens(action.conditions[4].tokens(), {"WWCT", "OP*", ">", "0.31", ")", "AND"}));
                 BOOST_CHECK(compare_tokens(action.conditions[5].tokens(), {"WWPR", "OP*", ">", "23", "AND"}));
                 BOOST_CHECK(compare_tokens(action.conditions[6].tokens(), {"MNTH", ">", "OCT"}));
             }


### PR DESCRIPTION
This commit generalises the `Action::Quantity` and `RstAction::Quantity` types to permit a larger set of quantity kinds in the restart file output.  In particular, we no longer associate a `Quantity` exclusively to a well- or group name, but permit IJK locations, region IDs, or segment numbers too.  To this end, we store additional "arguments" as a vector of strings and convert these to appropriate integer or floating point values as needed.

We also expand the set of `IACN::Value::QuantityType` enumerators, but do not yet fully support all of these kinds.  As an example, we do not support well name matching for segment level quantities, nor region ID matching for region level quantities.  In other words, we mostly support the simplest case of fully specified vectors for these new quantity kinds.

The size of this patch is large because we completely switch the low level representation of quantities and this impacts a considerable number of different locations throughout the restart file code.

While here though, we switch to using span<> instead of vector<> where possible since the [`subspan()`](https://cppreference.com/cpp/container/span/subspan) member function removes a lot of the manual indexing from the current master sources.

Collectively, these changes enable restarting a simulation run containing `ACTIONX` conditions of the form
> ```eclipse
> SWFR 'W314' 17 > 29 /
> ```
Previously, we would not be able to restore either the well name or the segment number and the restarted simulation would generate a nebulous diagnostic message along the lines of
> ```
> Summary vector SWFR is unknown
> ```
the first time we tried to evaluate the condition.  This would be especially confusing for users since the base run would complete without issue in this case.