### PR TITLE
Add thermal multi-segment well parsing support

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -251,6 +251,7 @@ list(APPEND MAIN_SOURCE_FILES
   opm/input/eclipse/Schedule/MSW/icd.cpp
   opm/input/eclipse/Schedule/MSW/MSWKeywordHandlers.cpp
   opm/input/eclipse/Schedule/MSW/Segment.cpp
+  opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
   opm/input/eclipse/Schedule/MSW/SegmentMatcher.cpp
   opm/input/eclipse/Schedule/MSW/SICD.cpp
   opm/input/eclipse/Schedule/MSW/Valve.cpp
@@ -1144,6 +1145,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/input/eclipse/Schedule/MSW/AICD.hpp
   opm/input/eclipse/Schedule/MSW/SICD.hpp
   opm/input/eclipse/Schedule/MSW/Segment.hpp
+  opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp
   opm/input/eclipse/Schedule/MSW/SegmentMatcher.hpp
   opm/input/eclipse/Schedule/MSW/Valve.hpp
   opm/input/eclipse/Schedule/MSW/WellSegments.hpp

--- a/opm/input/eclipse/Parser/ParseContext.cpp
+++ b/opm/input/eclipse/Parser/ParseContext.cpp
@@ -131,6 +131,7 @@ namespace Opm {
         this->addKey(SCHEDULE_NO_CONNECTION_MATCH, InputErrorAction::WARN);
 
         this->addKey(SCHEDULE_MISSING_SEGMENT, InputErrorAction::WARN);
+        this->addKey(SCHEDULE_MSW_KEYWORD_ON_NON_MSW_WELL, InputErrorAction::THROW_EXCEPTION);
         this->addKey(SCHEDULE_ICD_INCOMPATIBLE_PDROP_MODEL, InputErrorAction::THROW_EXCEPTION);
 
         addKey(SCHEDULE_INVALID_NAME, InputErrorAction::THROW_EXCEPTION);
@@ -418,6 +419,7 @@ namespace Opm {
     const std::string ParseContext::SCHEDULE_NO_CONNECTION_MATCH = "SCHEDULE_NO_CONNECTION_MATCH";
 
     const std::string ParseContext::SCHEDULE_MISSING_SEGMENT = "SCHEDULE_MISSING_SEGMENT";
+    const std::string ParseContext::SCHEDULE_MSW_KEYWORD_ON_NON_MSW_WELL = "SCHEDULE_MSW_KEYWORD_ON_NON_MSW_WELL";
     const std::string ParseContext::SCHEDULE_ICD_INCOMPATIBLE_PDROP_MODEL = "SCHEDULE_ICD_INCOMPATIBLE_PDROP_MODEL";
 
 }

--- a/opm/input/eclipse/Parser/ParseContext.cpp
+++ b/opm/input/eclipse/Parser/ParseContext.cpp
@@ -130,7 +130,7 @@ namespace Opm {
         this->addKey(SCHEDULE_COMPDAT_ZERO_PERM, InputErrorAction::WARN);
         this->addKey(SCHEDULE_NO_CONNECTION_MATCH, InputErrorAction::WARN);
 
-        this->addKey(SCHEDULE_ICD_MISSING_SEGMENT, InputErrorAction::WARN);
+        this->addKey(SCHEDULE_MISSING_SEGMENT, InputErrorAction::WARN);
         this->addKey(SCHEDULE_ICD_INCOMPATIBLE_PDROP_MODEL, InputErrorAction::THROW_EXCEPTION);
 
         addKey(SCHEDULE_INVALID_NAME, InputErrorAction::THROW_EXCEPTION);
@@ -417,7 +417,7 @@ namespace Opm {
     const std::string ParseContext::SCHEDULE_COMPDAT_ZERO_PERM = "SCHEDULE_COMPDAT_ZERO_PERM";
     const std::string ParseContext::SCHEDULE_NO_CONNECTION_MATCH = "SCHEDULE_NO_CONNECTION_MATCH";
 
-    const std::string ParseContext::SCHEDULE_ICD_MISSING_SEGMENT = "SCHEDULE_ICD_MISSING_SEGMENT";
+    const std::string ParseContext::SCHEDULE_MISSING_SEGMENT = "SCHEDULE_MISSING_SEGMENT";
     const std::string ParseContext::SCHEDULE_ICD_INCOMPATIBLE_PDROP_MODEL = "SCHEDULE_ICD_INCOMPATIBLE_PDROP_MODEL";
 
 }

--- a/opm/input/eclipse/Parser/ParseContext.cpp
+++ b/opm/input/eclipse/Parser/ParseContext.cpp
@@ -31,6 +31,32 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <map>
+#include <string>
+
+namespace {
+
+    // Original names of renamed context categories, mapped to the
+    // categories' current names.  Enables existing user configurations to
+    // keep working across a rename for a transition period of at least one
+    // or two release cycles, after which the corresponding entry should be
+    // removed.
+    const std::map<std::string, std::string>& renamedKeys()
+    {
+        static const auto renamed = std::map<std::string, std::string> {
+            // Renamed after release 2026.04.
+            { "SCHEDULE_ICD_MISSING_SEGMENT", "SCHEDULE_MISSING_SEGMENT" },
+        };
+
+        return renamed;
+    }
+
+    bool isRenamedKey(const std::string& key)
+    {
+        return renamedKeys().find(key) != renamedKeys().end();
+    }
+
+} // Anonymous namespace
 
 namespace Opm {
 
@@ -259,9 +285,23 @@ namespace Opm {
         const auto actionPos = this->m_errorContexts.find(key);
 
         if (actionPos == this->m_errorContexts.end()) {
-            throw std::invalid_argument {
-                "The errormode key: " + key + " has not been registered"
-            };
+            const auto renamePos = renamedKeys().find(key);
+
+            if (renamePos == renamedKeys().end()) {
+                throw std::invalid_argument {
+                    "The errormode key: " + key + " has not been registered"
+                };
+            }
+
+            // 'key' is the original name of a renamed category.  Apply the
+            // action to the category's current name, but remind the user to
+            // update their configuration.
+            OpmLog::warning("The error handling category '" + key
+                            + "' has been renamed to '" + renamePos->second
+                            + "'.  Support for the original name will be "
+                            "removed in a future release.");
+
+            this->updateKey(renamePos->second, action);
         }
         else {
             actionPos->second = action;
@@ -305,7 +345,7 @@ namespace Opm {
             const auto wildcard_pos = input_key.find("*");
 
             if (wildcard_pos == std::string::npos) {
-                if (hasKey(input_key)) {
+                if (hasKey(input_key) || isRenamedKey(input_key)) {
                     updateKey(input_key, action);
                 }
             }

--- a/opm/input/eclipse/Parser/ParseContext.hpp
+++ b/opm/input/eclipse/Parser/ParseContext.hpp
@@ -584,13 +584,13 @@ namespace Opm {
         /// connection in the targeted well.
         const static std::string SCHEDULE_NO_CONNECTION_MATCH;
 
-        /// ICD keyword (WSEGAICD, WSEGSICD, WSEGVALV) references a missing
-        /// well segment.
+        /// A multisegment-well keyword (e.g. WSEGAICD, WSEGSICD, WSEGVALV,
+        /// WSEGHEAT) references a missing well segment.
         ///
         /// Typically generates a warning and drops the device.  Note,
         /// however, that there are likely to be other issues in the input
         /// deck when this situation occurs.
-        const static std::string SCHEDULE_ICD_MISSING_SEGMENT;
+        const static std::string SCHEDULE_MISSING_SEGMENT;
 
         /// ICD keyword (WSEGAICD, WSEGSICD, WSEGVALV) is not compatible
         /// with the pressure drop model chosen for a particular MSW.

--- a/opm/input/eclipse/Parser/ParseContext.hpp
+++ b/opm/input/eclipse/Parser/ParseContext.hpp
@@ -592,6 +592,13 @@ namespace Opm {
         /// deck when this situation occurs.
         const static std::string SCHEDULE_MISSING_SEGMENT;
 
+        /// A multisegment-well keyword (e.g. WSEGHEAT) is applied to a well
+        /// that is not a multisegment well.
+        ///
+        /// This is an unambiguous input error, so by default it throws and
+        /// terminates the run.
+        const static std::string SCHEDULE_MSW_KEYWORD_ON_NON_MSW_WELL;
+
         /// ICD keyword (WSEGAICD, WSEGSICD, WSEGVALV) is not compatible
         /// with the pressure drop model chosen for a particular MSW.
         const static std::string SCHEDULE_ICD_INCOMPATIBLE_PDROP_MODEL;

--- a/opm/input/eclipse/Parser/ParseContext.hpp
+++ b/opm/input/eclipse/Parser/ParseContext.hpp
@@ -196,7 +196,9 @@ namespace Opm {
         /// Reset action for particular context category.
         ///
         /// Throws an exception of type \code std::invalid_argument \endcode
-        /// if the context category is unknown.
+        /// if the context category is unknown.  If \p key is the original
+        /// name of a renamed category, the action is applied to the
+        /// category's current name and a deprecation warning is issued.
         ///
         /// \param[in] key Context category.
         ///
@@ -590,6 +592,11 @@ namespace Opm {
         /// Typically generates a warning and drops the device.  Note,
         /// however, that there are likely to be other issues in the input
         /// deck when this situation occurs.
+        ///
+        /// \note This category was named SCHEDULE_ICD_MISSING_SEGMENT up to
+        /// and including release 2026.04.  The original name is still
+        /// accepted by the update functions for a transition period, but
+        /// will be removed in a future release.
         const static std::string SCHEDULE_MISSING_SEGMENT;
 
         /// A multisegment-well keyword (e.g. WSEGHEAT) is applied to a well

--- a/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
@@ -38,6 +38,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <optional>
@@ -78,9 +79,10 @@ namespace {
 
         double center_depth;
 
-        // Effective length of the connection in the wellbore segment used in
-        // the thermal conductivity calculation (COMPSEGS item 10).  Empty when
-        // not specified.
+        // Effective connection length used in the thermal conductivity
+        // calculation (COMPSEGS item 10).  Nullopt when defaulted, in which case
+        // the grid-block thickness in the connection's penetration direction is
+        // substituted once the direction is known.
         std::optional<double> m_thermal_length;
 
         int segment_number;
@@ -95,7 +97,7 @@ namespace {
                    const double distance_end_in,
                    const Opm::Connection::Direction dir_in,
                    const double center_depth_in,
-                   const std::optional<double> thermal_length_in,
+                   std::optional<double> thermal_length_in,
                    const int segment_number_in,
                    const std::size_t seqIndex_in)
         : m_i              { i_in }
@@ -239,6 +241,20 @@ namespace {
 
     // ---------------------------------------------------------------------------
 
+    // Default thermal length used when COMPSEGS item 10 is defaulted: grid-block
+    // thickness in the connection's penetration direction (COMPDAT item 13).
+    double penetrationThickness(const std::array<double, 3>&     cellDims,
+                                const Opm::Connection::Direction direction)
+    {
+        switch (direction) {
+        case Opm::Connection::Direction::X: return cellDims[0];
+        case Opm::Connection::Direction::Y: return cellDims[1];
+        case Opm::Connection::Direction::Z: return cellDims[2];
+        }
+
+        return cellDims[2];
+    }
+
     std::vector<Record>
     compsegsFromCOMPSEGSKeyword(std::string_view         well_name,
                                 const Opm::DeckKeyword&  compsegsKeyword,
@@ -359,14 +375,6 @@ The direction must be specified when END_IJK is specified. Well: {})", well_name
                 ? record.getItem<Kw::CENTER_DEPTH>().getSIDouble(0)
                 : 0.0;
 
-            // Effective length of the connection in the wellbore segment, used
-            // in the thermal conductivity calculation (thermal option).  Left
-            // empty when defaulted: a downstream thermal consumer is expected
-            // to use the grid-block thickness in the direction of penetration.
-            const auto thermal_length = record.getItem<Kw::THERMAL_LENGTH>().hasValue(0)
-                ? std::optional<double>{ record.getItem<Kw::THERMAL_LENGTH>().getSIDouble(0) }
-                : std::nullopt;
-
             if (center_depth < 0.0) {
                 // TODO: get the depth from COMPDAT data.
                 const auto msg_fmt = fmt::format(R"(Problems with {{keyword}}
@@ -385,7 +393,14 @@ The use of negative center depth in item 9 is not supported. Well: {})", well_na
                 : Opm::Connection::Direction::X;
 
             if (! record.getItem<Kw::END_IJK>().hasValue(0)) { // only one compsegs
-                if (grid.get_cell(I, J, K).is_active()) {
+                const auto& cell = grid.get_cell(I, J, K);
+                if (cell.is_active()) {
+                    // Thermal length (COMPSEGS item 10); left unset when
+                    // defaulted, then filled in process_compsegs_records().
+                    const auto thermal_length = record.getItem<Kw::THERMAL_LENGTH>().hasValue(0)
+                        ? std::optional<double>{ record.getItem<Kw::THERMAL_LENGTH>().getSIDouble(0) }
+                        : std::nullopt;
+
                     const std::size_t seqIndex = compsegs.size();
                     compsegs.emplace_back(I, J, K,
                                           branch,
@@ -428,7 +443,9 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
             // Defaulted values:
             const auto direction = Opm::Connection::Direction::X;
             const auto center_depth = 0.0;
-            const std::optional<double> thermal_length = std::nullopt;
+            // Thermal length (COMPSEGS item 10); left unset here, then filled
+            // in process_compsegs_records().
+            const auto thermal_length = std::optional<double>{};
             const auto segment_number = 0;
             const auto branch = 1;
 
@@ -507,13 +524,19 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
                     ? compseg.center_depth
                     : cell.depth;
 
-                new_connection_set.getFromIJK(i, j, k)
-                    .updateSegment(compseg.segment_number,
-                                   cdepth,
-                                   compseg.m_thermal_length,
-                                   compseg.m_seqIndex,
-                                   std::make_pair(compseg.m_distance_start,
-                                                  compseg.m_distance_end));
+                auto& connection = new_connection_set.getFromIJK(i, j, k);
+
+                // Fall back to the grid-block thickness when COMPSEGS item 10
+                // was defaulted (see penetrationThickness).
+                const double thermal_length = compseg.m_thermal_length
+                    .value_or(penetrationThickness(cell.dimensions, connection.dir()));
+
+                connection.updateSegment(compseg.segment_number,
+                                         cdepth,
+                                         thermal_length,
+                                         compseg.m_seqIndex,
+                                         std::make_pair(compseg.m_distance_start,
+                                                        compseg.m_distance_end));
             }
         }
 

--- a/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -59,7 +60,7 @@ namespace {
                double distance_end_in,
                Opm::Connection::Direction dir_in,
                double center_depth_in,
-               double thermal_length_in,
+               std::optional<double> thermal_length_in,
                int segment_number_in,
                std::size_t seqIndex_in);
 
@@ -78,9 +79,9 @@ namespace {
         double center_depth;
 
         // Effective length of the connection in the wellbore segment used in
-        // the thermal conductivity calculation (COMPSEGS item 10).  Zero when
+        // the thermal conductivity calculation (COMPSEGS item 10).  Empty when
         // not specified.
-        double m_thermal_length;
+        std::optional<double> m_thermal_length;
 
         int segment_number;
         std::size_t m_seqIndex;
@@ -94,7 +95,7 @@ namespace {
                    const double distance_end_in,
                    const Opm::Connection::Direction dir_in,
                    const double center_depth_in,
-                   const double thermal_length_in,
+                   const std::optional<double> thermal_length_in,
                    const int segment_number_in,
                    const std::size_t seqIndex_in)
         : m_i              { i_in }
@@ -360,12 +361,11 @@ The direction must be specified when END_IJK is specified. Well: {})", well_name
 
             // Effective length of the connection in the wellbore segment, used
             // in the thermal conductivity calculation (thermal option).  Left
-            // at zero when defaulted, signalling that the consumer should apply
-            // the ECLIPSE default: the thickness of the grid block in the
-            // direction of penetration.
+            // empty when defaulted: a downstream thermal consumer is expected
+            // to use the grid-block thickness in the direction of penetration.
             const auto thermal_length = record.getItem<Kw::THERMAL_LENGTH>().hasValue(0)
-                ? record.getItem<Kw::THERMAL_LENGTH>().getSIDouble(0)
-                : 0.0;
+                ? std::optional<double>{ record.getItem<Kw::THERMAL_LENGTH>().getSIDouble(0) }
+                : std::nullopt;
 
             if (center_depth < 0.0) {
                 // TODO: get the depth from COMPDAT data.
@@ -428,7 +428,7 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
             // Defaulted values:
             const auto direction = Opm::Connection::Direction::X;
             const auto center_depth = 0.0;
-            const auto thermal_length = 0.0;
+            const std::optional<double> thermal_length = std::nullopt;
             const auto segment_number = 0;
             const auto branch = 1;
 

--- a/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
@@ -358,8 +358,11 @@ The direction must be specified when END_IJK is specified. Well: {})", well_name
                 ? record.getItem<Kw::CENTER_DEPTH>().getSIDouble(0)
                 : 0.0;
 
-            // Effective length of the connection used in thermal conductivity
-            // calculations (thermal option).  Zero when not specified.
+            // Effective length of the connection in the wellbore segment, used
+            // in the thermal conductivity calculation (thermal option).  Left
+            // at zero when defaulted, signalling that the consumer should apply
+            // the ECLIPSE default: the thickness of the grid block in the
+            // direction of penetration.
             const auto thermal_length = record.getItem<Kw::THERMAL_LENGTH>().hasValue(0)
                 ? record.getItem<Kw::THERMAL_LENGTH>().getSIDouble(0)
                 : 0.0;
@@ -507,10 +510,10 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
                 new_connection_set.getFromIJK(i, j, k)
                     .updateSegment(compseg.segment_number,
                                    cdepth,
+                                   compseg.m_thermal_length,
                                    compseg.m_seqIndex,
                                    std::make_pair(compseg.m_distance_start,
-                                                  compseg.m_distance_end),
-                                   compseg.m_thermal_length);
+                                                  compseg.m_distance_end));
             }
         }
 

--- a/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
@@ -59,6 +59,7 @@ namespace {
                double distance_end_in,
                Opm::Connection::Direction dir_in,
                double center_depth_in,
+               double thermal_length_in,
                int segment_number_in,
                std::size_t seqIndex_in);
 
@@ -75,8 +76,12 @@ namespace {
         Opm::Connection::Direction m_dir;
 
         double center_depth;
-        // we do not handle thermal length for the moment
-        // double m_thermal_length;
+
+        // Effective length of the connection in the wellbore segment used in
+        // the thermal conductivity calculation (COMPSEGS item 10).  Zero when
+        // not specified.
+        double m_thermal_length;
+
         int segment_number;
         std::size_t m_seqIndex;
 
@@ -89,6 +94,7 @@ namespace {
                    const double distance_end_in,
                    const Opm::Connection::Direction dir_in,
                    const double center_depth_in,
+                   const double thermal_length_in,
                    const int segment_number_in,
                    const std::size_t seqIndex_in)
         : m_i              { i_in }
@@ -99,6 +105,7 @@ namespace {
         , m_distance_end   { distance_end_in }
         , m_dir            { dir_in }
         , center_depth     { center_depth_in }
+        , m_thermal_length { thermal_length_in }
         , segment_number   { segment_number_in }
         , m_seqIndex       { seqIndex_in }
     {}
@@ -351,6 +358,12 @@ The direction must be specified when END_IJK is specified. Well: {})", well_name
                 ? record.getItem<Kw::CENTER_DEPTH>().getSIDouble(0)
                 : 0.0;
 
+            // Effective length of the connection used in thermal conductivity
+            // calculations (thermal option).  Zero when not specified.
+            const auto thermal_length = record.getItem<Kw::THERMAL_LENGTH>().hasValue(0)
+                ? record.getItem<Kw::THERMAL_LENGTH>().getSIDouble(0)
+                : 0.0;
+
             if (center_depth < 0.0) {
                 // TODO: get the depth from COMPDAT data.
                 const auto msg_fmt = fmt::format(R"(Problems with {{keyword}}
@@ -376,6 +389,7 @@ The use of negative center depth in item 9 is not supported. Well: {})", well_na
                                           distance_start, distance_end,
                                           direction,
                                           center_depth,
+                                          thermal_length,
                                           segment_number,
                                           seqIndex);
                 }
@@ -411,6 +425,7 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
             // Defaulted values:
             const auto direction = Opm::Connection::Direction::X;
             const auto center_depth = 0.0;
+            const auto thermal_length = 0.0;
             const auto segment_number = 0;
             const auto branch = 1;
 
@@ -423,6 +438,7 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
                                   trajectory_point.startMD, trajectory_point.endMD,
                                   direction,
                                   center_depth,
+                                  thermal_length,
                                   segment_number, seqIndex);
         }
 
@@ -493,7 +509,8 @@ Well: {}, connection: ({},{},{}))", well_name, I+1, J+1 , K+1);
                                    cdepth,
                                    compseg.m_seqIndex,
                                    std::make_pair(compseg.m_distance_start,
-                                                  compseg.m_distance_end));
+                                                  compseg.m_distance_end),
+                                   compseg.m_thermal_length);
             }
         }
 

--- a/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
@@ -393,8 +393,7 @@ The use of negative center depth in item 9 is not supported. Well: {})", well_na
                 : Opm::Connection::Direction::X;
 
             if (! record.getItem<Kw::END_IJK>().hasValue(0)) { // only one compsegs
-                const auto& cell = grid.get_cell(I, J, K);
-                if (cell.is_active()) {
+                if (grid.get_cell(I, J, K).is_active()) {
                     // Thermal length (COMPSEGS item 10); left unset when
                     // defaulted, then filled in process_compsegs_records().
                     const auto thermal_length = record.getItem<Kw::THERMAL_LENGTH>().hasValue(0)

--- a/opm/input/eclipse/Schedule/MSW/MSWKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/MSW/MSWKeywordHandlers.cpp
@@ -40,6 +40,11 @@
 
 #include <fmt/format.h>
 
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace Opm {
 
 namespace {
@@ -133,19 +138,29 @@ void handleWSEGHEAT(HandlerContext& handlerContext)
     const auto heat_transfers =
         segmentHeatTransferFromWSEGHEAT(handlerContext.keyword);
 
-    for (const auto& [well_name_pattern, records] : heat_transfers) {
-        const auto well_names = handlerContext.wellNames(well_name_pattern);
+    // Expand the well-name patterns and regroup the records by concrete well,
+    // preserving their order of appearance in the deck.  Different wells are
+    // independent, but the records of a single well are order-dependent
+    // (WSEGHEAT replace/'+'/'-'/NONE operations), so deck order must be honoured
+    // even when several overlapping patterns name the same well.
+    auto records_by_well =
+        std::map<std::string, std::vector<SegmentHeatTransferRecord>>{};
 
-        for (const auto& well_name : well_names) {
-            auto well = handlerContext.state().wells(well_name);
+    for (const auto& [well_name_pattern, record] : heat_transfers) {
+        for (const auto& well_name : handlerContext.wellNames(well_name_pattern)) {
+            records_by_well[well_name].push_back(record);
+        }
+    }
 
-            const auto did_update = well.updateWSEGHEAT
-                (records, handlerContext.keyword.location(),
-                 handlerContext.parseContext, handlerContext.errors);
+    for (const auto& [well_name, records] : records_by_well) {
+        auto well = handlerContext.state().wells(well_name);
 
-            if (did_update) {
-                handlerContext.state().wells.update(std::move(well));
-            }
+        const auto did_update = well.updateWSEGHEAT
+            (records, handlerContext.keyword.location(),
+             handlerContext.parseContext, handlerContext.errors);
+
+        if (did_update) {
+            handlerContext.state().wells.update(std::move(well));
         }
     }
 }

--- a/opm/input/eclipse/Schedule/MSW/MSWKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/MSW/MSWKeywordHandlers.cpp
@@ -28,6 +28,7 @@
 
 #include <opm/input/eclipse/Schedule/Action/WGNames.hpp>
 #include <opm/input/eclipse/Schedule/MSW/AICD.hpp>
+#include <opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp>
 #include <opm/input/eclipse/Schedule/MSW/SICD.hpp>
 #include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
@@ -127,6 +128,28 @@ void handleWSEGAICD(HandlerContext& handlerContext)
     }
 }
 
+void handleWSEGHEAT(HandlerContext& handlerContext)
+{
+    const auto heat_transfers =
+        segmentHeatTransferFromWSEGHEAT(handlerContext.keyword);
+
+    for (const auto& [well_name_pattern, records] : heat_transfers) {
+        const auto well_names = handlerContext.wellNames(well_name_pattern);
+
+        for (const auto& well_name : well_names) {
+            auto well = handlerContext.state().wells(well_name);
+
+            const auto did_update = well.updateWSEGHEAT
+                (records, handlerContext.keyword.location(),
+                 handlerContext.parseContext, handlerContext.errors);
+
+            if (did_update) {
+                handlerContext.state().wells.update(std::move(well));
+            }
+        }
+    }
+}
+
 void handleWSEGITER(HandlerContext& handlerContext)
 {
     const auto& record = handlerContext.keyword.getRecord(0);
@@ -195,6 +218,7 @@ getMSWHandlers()
         { "COMPSEGS", &handleCOMPSEGS },
         { "WELSEGS" , &handleWELSEGS  },
         { "WSEGAICD", &handleWSEGAICD },
+        { "WSEGHEAT", &handleWSEGHEAT },
         { "WSEGITER", &handleWSEGITER },
         { "WSEGSICD", &handleWSEGSICD },
         { "WSEGVALV", &handleWSEGVALV },

--- a/opm/input/eclipse/Schedule/MSW/Segment.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Segment.cpp
@@ -230,6 +230,7 @@ namespace Opm {
         result.m_wall_area = 14.0;
         result.m_wall_volumetric_heat_capacity = 15.0;
         result.m_wall_thermal_conductivity = 16.0;
+        result.m_heat_transfer = {SegmentHeatTransfer::serializationTestObject()};
         result.m_icd = SICD::serializationTestObject();
         return result;
     }
@@ -333,6 +334,73 @@ namespace Opm {
         }
     }
 
+    const std::vector<SegmentHeatTransfer>& Segment::heatTransfer() const
+    {
+        return this->m_heat_transfer;
+    }
+
+    void Segment::updateHeatTransfer(const SegmentHeatTransferRecord& record)
+    {
+        using Type = SegmentHeatTransfer::Type;
+        using Operation = SegmentHeatTransfer::Operation;
+
+        // Maximum number of segment-to-segment heat transfer coefficients that
+        // may be associated with a single segment (ECLIPSE limit).
+        constexpr std::size_t max_seg_coefficients = 5;
+
+        const auto& coeff = record.coefficient;
+
+        // Whether an existing coefficient describes the same heat transfer
+        // destination as the incoming one.  COMP and TEMP are unique per
+        // segment; SEG coefficients are distinguished by their target segment.
+        const auto sameDestination = [&coeff](const SegmentHeatTransfer& existing)
+        {
+            if (existing.type() != coeff.type()) {
+                return false;
+            }
+
+            return (coeff.type() != Type::SEG)
+                || (existing.targetSegment() == coeff.targetSegment());
+        };
+
+        switch (record.operation) {
+        case Operation::CLEAR:
+            this->m_heat_transfer.clear();
+            break;
+
+        case Operation::REPLACE_ALL:
+            this->m_heat_transfer.clear();
+            this->m_heat_transfer.push_back(coeff);
+            break;
+
+        case Operation::ADD: {
+            auto pos = std::ranges::find_if(this->m_heat_transfer, sameDestination);
+            if (pos != this->m_heat_transfer.end()) {
+                *pos = coeff;
+            }
+            else if (coeff.type() != Type::SEG) {
+                this->m_heat_transfer.push_back(coeff);
+            }
+            else {
+                // SEG coefficients are capped; ignore additions beyond the
+                // limit, matching the documented ECLIPSE behaviour.
+                const auto seg_count = std::ranges::count_if
+                    (this->m_heat_transfer, [](const SegmentHeatTransfer& e)
+                     { return e.type() == Type::SEG; });
+
+                if (static_cast<std::size_t>(seg_count) < max_seg_coefficients) {
+                    this->m_heat_transfer.push_back(coeff);
+                }
+            }
+            break;
+        }
+
+        case Operation::REMOVE:
+            std::erase_if(this->m_heat_transfer, sameDestination);
+            break;
+        }
+    }
+
     double Segment::invalidValue()
     {
         return invalid_value;
@@ -356,6 +424,7 @@ namespace Opm {
             && (this->m_wall_area        == rhs.m_wall_area)
             && (this->m_wall_volumetric_heat_capacity == rhs.m_wall_volumetric_heat_capacity)
             && (this->m_wall_thermal_conductivity     == rhs.m_wall_thermal_conductivity)
+            && (this->m_heat_transfer    == rhs.m_heat_transfer)
             ;
     }
 

--- a/opm/input/eclipse/Schedule/MSW/Segment.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Segment.cpp
@@ -142,7 +142,10 @@ namespace Opm {
                      const double volume_in,
                      const bool   data_ready_in,
                      const double x_in,
-                     const double y_in)
+                     const double y_in,
+                     const double wall_area_in,
+                     const double wall_volumetric_heat_capacity_in,
+                     const double wall_thermal_conductivity_in)
         : m_segment_number   (segment_number_in)
         , m_branch           (branch_in)
         , m_outlet_segment   (outlet_segment_in)
@@ -155,6 +158,9 @@ namespace Opm {
         , m_data_ready       (data_ready_in)
         , m_x                (x_in)
         , m_y                (y_in)
+        , m_wall_area                    (wall_area_in)
+        , m_wall_volumetric_heat_capacity(wall_volumetric_heat_capacity_in)
+        , m_wall_thermal_conductivity    (wall_thermal_conductivity_in)
     {}
 
     Segment::Segment(const Segment& src,
@@ -221,6 +227,9 @@ namespace Opm {
         result.m_data_ready = true;
         result.m_x = 12.0;
         result.m_y = 13.0;
+        result.m_wall_area = 14.0;
+        result.m_wall_volumetric_heat_capacity = 15.0;
+        result.m_wall_thermal_conductivity = 16.0;
         result.m_icd = SICD::serializationTestObject();
         return result;
     }
@@ -278,6 +287,21 @@ namespace Opm {
         return m_data_ready;
     }
 
+    double Segment::wallArea() const
+    {
+        return m_wall_area;
+    }
+
+    double Segment::wallVolumetricHeatCapacity() const
+    {
+        return m_wall_volumetric_heat_capacity;
+    }
+
+    double Segment::wallThermalConductivity() const
+    {
+        return m_wall_thermal_conductivity;
+    }
+
     Segment::SegmentType Segment::segmentType() const
     {
         if (this->isRegular())
@@ -329,6 +353,9 @@ namespace Opm {
             && this->m_data_ready        == rhs.m_data_ready
             && (this->m_x                == rhs.m_x)
             && (this->m_y                == rhs.m_y)
+            && (this->m_wall_area        == rhs.m_wall_area)
+            && (this->m_wall_volumetric_heat_capacity == rhs.m_wall_volumetric_heat_capacity)
+            && (this->m_wall_thermal_conductivity     == rhs.m_wall_thermal_conductivity)
             ;
     }
 

--- a/opm/input/eclipse/Schedule/MSW/Segment.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Segment.cpp
@@ -129,6 +129,11 @@ namespace Opm {
         // If none of the above type-specific conditions trigger, then this
         // is a RegularSegment and 'm_icd' is fully formed by the variant's
         // default constructor.
+
+        // The thermal members (wall properties and m_heat_transfer) keep their
+        // in-class defaults: RstSegment does not carry WSEGHEAT/pipe-wall data,
+        // so a thermal MSW run restarted here begins with zero wall properties
+        // and no heat transfer coefficients.  TODO: persist and restore these.
     }
 
     Segment::Segment(const int    segment_number_in,
@@ -345,7 +350,7 @@ namespace Opm {
         using Operation = SegmentHeatTransfer::Operation;
 
         // Maximum number of segment-to-segment heat transfer coefficients that
-        // may be associated with a single segment (ECLIPSE limit).
+        // may be associated with a single segment.
         constexpr std::size_t max_seg_coefficients = 5;
 
         const auto& coeff = record.coefficient;
@@ -383,7 +388,7 @@ namespace Opm {
             }
             else {
                 // SEG coefficients are capped; ignore additions beyond the
-                // limit, matching the documented ECLIPSE behaviour.
+                // limit, matching the documented behaviour.
                 const auto seg_count = std::ranges::count_if
                     (this->m_heat_transfer, [](const SegmentHeatTransfer& e)
                      { return e.type() == Type::SEG; });

--- a/opm/input/eclipse/Schedule/MSW/Segment.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Segment.cpp
@@ -235,7 +235,7 @@ namespace Opm {
         result.m_wall_area = 14.0;
         result.m_wall_volumetric_heat_capacity = 15.0;
         result.m_wall_thermal_conductivity = 16.0;
-        result.m_heat_transfer = {SegmentHeatTransfer::serializationTestObject()};
+        result.m_heat_transfer = {SegmentHeatTransferCoeff::serializationTestObject()};
         result.m_icd = SICD::serializationTestObject();
         return result;
     }
@@ -339,15 +339,15 @@ namespace Opm {
         }
     }
 
-    const std::vector<SegmentHeatTransfer>& Segment::heatTransfer() const
+    const std::vector<SegmentHeatTransferCoeff>& Segment::heatTransfer() const
     {
         return this->m_heat_transfer;
     }
 
     void Segment::updateHeatTransfer(const SegmentHeatTransferRecord& record)
     {
-        using Type = SegmentHeatTransfer::Type;
-        using Operation = SegmentHeatTransfer::Operation;
+        using Type = SegmentHeatTransferCoeff::Type;
+        using Operation = SegmentHeatTransferCoeff::Operation;
 
         // Maximum number of segment-to-segment heat transfer coefficients that
         // may be associated with a single segment.
@@ -358,7 +358,7 @@ namespace Opm {
         // Whether an existing coefficient describes the same heat transfer
         // destination as the incoming one.  COMP and TEMP are unique per
         // segment; SEG coefficients are distinguished by their target segment.
-        const auto sameDestination = [&coeff](const SegmentHeatTransfer& existing)
+        const auto sameDestination = [&coeff](const SegmentHeatTransferCoeff& existing)
         {
             if (existing.type() != coeff.type()) {
                 return false;
@@ -390,7 +390,7 @@ namespace Opm {
                 // SEG coefficients are capped; ignore additions beyond the
                 // limit, matching the documented behaviour.
                 const auto seg_count = std::ranges::count_if
-                    (this->m_heat_transfer, [](const SegmentHeatTransfer& e)
+                    (this->m_heat_transfer, [](const SegmentHeatTransferCoeff& e)
                      { return e.type() == Type::SEG; });
 
                 if (static_cast<std::size_t>(seg_count) < max_seg_coefficients) {

--- a/opm/input/eclipse/Schedule/MSW/Segment.hpp
+++ b/opm/input/eclipse/Schedule/MSW/Segment.hpp
@@ -124,7 +124,7 @@ namespace Opm {
         void addInletSegment(const int segment_number);
 
         // Heat transfer coefficients associated with this segment (WSEGHEAT).
-        const std::vector<SegmentHeatTransfer>& heatTransfer() const;
+        const std::vector<SegmentHeatTransferCoeff>& heatTransfer() const;
 
         // Apply one WSEGHEAT record to this segment's coefficients; the record's
         // operation replaces, extends, reduces or clears the existing set.
@@ -261,7 +261,7 @@ namespace Opm {
 
         // Heat transfer coefficients (WSEGHEAT): at most one COMP, one TEMP and
         // five SEG per segment.
-        std::vector<SegmentHeatTransfer> m_heat_transfer{};
+        std::vector<SegmentHeatTransferCoeff> m_heat_transfer{};
 
         void updateValve__(Valve& valve, const double segment_length);
     };

--- a/opm/input/eclipse/Schedule/MSW/Segment.hpp
+++ b/opm/input/eclipse/Schedule/MSW/Segment.hpp
@@ -21,6 +21,7 @@
 #define SEGMENT_HPP_HEADER_INCLUDED
 
 #include <opm/input/eclipse/Schedule/MSW/AICD.hpp>
+#include <opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp>
 #include <opm/input/eclipse/Schedule/MSW/SICD.hpp>
 #include <opm/input/eclipse/Schedule/MSW/Valve.hpp>
 
@@ -122,6 +123,14 @@ namespace Opm {
         bool updateICDScalingFactor(const double outlet_segment_length, const double completion_length);
         void addInletSegment(const int segment_number);
 
+        // Heat transfer coefficients associated with this segment (WSEGHEAT).
+        const std::vector<SegmentHeatTransfer>& heatTransfer() const;
+
+        // Apply one WSEGHEAT record to this segment's set of heat transfer
+        // coefficients.  The operation carried by the record determines whether
+        // the existing set is replaced, extended, reduced or cleared.
+        void updateHeatTransfer(const SegmentHeatTransferRecord& record);
+
         bool isRegular() const
         {
             return std::holds_alternative<RegularSegment>(this->m_icd);
@@ -161,6 +170,7 @@ namespace Opm {
             serializer(m_wall_area);
             serializer(m_wall_volumetric_heat_capacity);
             serializer(m_wall_thermal_conductivity);
+            serializer(m_heat_transfer);
             serializer(m_icd);
         }
 
@@ -257,6 +267,11 @@ namespace Opm {
 
         // Thermal conductivity of the pipe wall.
         double m_wall_thermal_conductivity{0.0};
+
+        // Heat transfer coefficients to completions, other segments or fixed
+        // external temperatures, as defined by the WSEGHEAT keyword.  At most
+        // one COMP, one TEMP and five SEG coefficients may be present.
+        std::vector<SegmentHeatTransfer> m_heat_transfer{};
 
         void updateValve__(Valve& valve, const double segment_length);
     };

--- a/opm/input/eclipse/Schedule/MSW/Segment.hpp
+++ b/opm/input/eclipse/Schedule/MSW/Segment.hpp
@@ -126,9 +126,8 @@ namespace Opm {
         // Heat transfer coefficients associated with this segment (WSEGHEAT).
         const std::vector<SegmentHeatTransfer>& heatTransfer() const;
 
-        // Apply one WSEGHEAT record to this segment's set of heat transfer
-        // coefficients.  The operation carried by the record determines whether
-        // the existing set is replaced, extended, reduced or cleared.
+        // Apply one WSEGHEAT record to this segment's coefficients; the record's
+        // operation replaces, extends, reduces or clears the existing set.
         void updateHeatTransfer(const SegmentHeatTransferRecord& record);
 
         bool isRegular() const
@@ -254,23 +253,14 @@ namespace Opm {
 
         std::variant<RegularSegment, SICD, AutoICD, Valve> m_icd;
 
-        // Three properties for the segment pertaining to thermal conduction
-        // through the pipe wall, used by the thermal option.  They default to
-        // zero when not specified in WELSEGS.
-
-        // Cross-sectional area of the pipe wall used in the thermal
-        // conductivity calculation.
+        // Pipe-wall thermal conduction properties (thermal option), default
+        // zero when WELSEGS omits them.  See the accessors above.
         double m_wall_area{0.0};
-
-        // Volumetric heat capacity of the pipe wall.
         double m_wall_volumetric_heat_capacity{0.0};
-
-        // Thermal conductivity of the pipe wall.
         double m_wall_thermal_conductivity{0.0};
 
-        // Heat transfer coefficients to completions, other segments or fixed
-        // external temperatures, as defined by the WSEGHEAT keyword.  At most
-        // one COMP, one TEMP and five SEG coefficients may be present.
+        // Heat transfer coefficients (WSEGHEAT): at most one COMP, one TEMP and
+        // five SEG per segment.
         std::vector<SegmentHeatTransfer> m_heat_transfer{};
 
         void updateValve__(Valve& valve, const double segment_length);

--- a/opm/input/eclipse/Schedule/MSW/Segment.hpp
+++ b/opm/input/eclipse/Schedule/MSW/Segment.hpp
@@ -69,7 +69,10 @@ namespace Opm {
                 const double volume_in,
                 const bool data_ready_in,
                 const double x_in,
-                const double y_in);
+                const double y_in,
+                const double wall_area_in = 0.0,
+                const double wall_volumetric_heat_capacity_in = 0.0,
+                const double wall_thermal_conductivity_in = 0.0);
 
         explicit Segment(const RestartIO::RstSegment& rst_segment, const std::string& wname);
 
@@ -87,6 +90,16 @@ namespace Opm {
         double crossArea() const;
         double volume() const;
         bool dataReady() const;
+
+        // Cross-sectional area of the pipe wall used in the thermal
+        // conductivity calculation (WELSEGS item 10/13).
+        double wallArea() const;
+
+        // Volumetric heat capacity of the pipe wall (WELSEGS item 11/14).
+        double wallVolumetricHeatCapacity() const;
+
+        // Thermal conductivity of the pipe wall (WELSEGS item 12/15).
+        double wallThermalConductivity() const;
 
         SegmentType segmentType() const;
         int ecl_type_id() const;
@@ -145,6 +158,9 @@ namespace Opm {
             serializer(m_data_ready);
             serializer(m_x);
             serializer(m_y);
+            serializer(m_wall_area);
+            serializer(m_wall_volumetric_heat_capacity);
+            serializer(m_wall_thermal_conductivity);
             serializer(m_icd);
         }
 
@@ -228,8 +244,19 @@ namespace Opm {
 
         std::variant<RegularSegment, SICD, AutoICD, Valve> m_icd;
 
-        // There are three other properties for the segment pertaining to
-        // thermal conduction.  These are not currently supported.
+        // Three properties for the segment pertaining to thermal conduction
+        // through the pipe wall, used by the thermal option.  They default to
+        // zero when not specified in WELSEGS.
+
+        // Cross-sectional area of the pipe wall used in the thermal
+        // conductivity calculation.
+        double m_wall_area{0.0};
+
+        // Volumetric heat capacity of the pipe wall.
+        double m_wall_volumetric_heat_capacity{0.0};
+
+        // Thermal conductivity of the pipe wall.
+        double m_wall_thermal_conductivity{0.0};
 
         void updateValve__(Valve& valve, const double segment_length);
     };

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2024 Equinor.
+  Copyright 2026 Equinor.
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
@@ -19,6 +19,8 @@
 
 #include <opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp>
 
+#include <opm/common/utility/OpmInputError.hpp>
+
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
@@ -49,8 +51,8 @@ namespace Opm {
         this->m_interpolation_constant =
             record.getItem<Kw::INTERPOLATION_CONSTANT>().get<double>(0);
 
-        // A negative contact length flags that item 9 was defaulted; the
-        // mean length of the adjacent segments should be used instead.
+        // Contact length (item 9) is left unset when defaulted, in which case
+        // the mean length of the adjacent segments should be used instead.
         if (record.getItem<Kw::CONTACT_LENGTH>().hasValue(0)) {
             this->m_contact_length = record.getItem<Kw::CONTACT_LENGTH>().getSIDouble(0);
         }
@@ -132,22 +134,38 @@ namespace Opm {
             // record carries a coefficient to set/add/remove.
             if (operation != SegmentHeatTransfer::Operation::CLEAR) {
                 rec.coefficient = SegmentHeatTransfer{type, record};
+
+                // The destination-specific items are mandatory for the
+                // corresponding coefficient type.
+                if ((type == SegmentHeatTransfer::Type::TEMP) &&
+                    !rec.coefficient.temperature().has_value())
+                {
+                    throw OpmInputError {
+                        fmt::format("A TEMP heat transfer coefficient for well {} "
+                                    "segments {} to {} requires an external "
+                                    "temperature in item 7.",
+                                    well_name, rec.segment1, rec.segment2),
+                        keyword.location()
+                    };
+                }
+
+                if ((type == SegmentHeatTransfer::Type::SEG) &&
+                    (rec.coefficient.targetSegment() < 1))
+                {
+                    throw OpmInputError {
+                        fmt::format("A SEG heat transfer coefficient for well {} "
+                                    "segments {} to {} requires a target segment "
+                                    "in item 6.",
+                                    well_name, rec.segment1, rec.segment2),
+                        keyword.location()
+                    };
+                }
             }
 
             res[well_name].push_back(rec);
         }
 
         return res;
-    }
-
-    bool SegmentHeatTransfer::operator==(const SegmentHeatTransfer& rhs) const
-    {
-        return (this->m_type == rhs.m_type)
-            && (this->m_thermal_resistance == rhs.m_thermal_resistance)
-            && (this->m_target_segment == rhs.m_target_segment)
-            && (this->m_temperature == rhs.m_temperature)
-            && (this->m_interpolation_constant == rhs.m_interpolation_constant)
-            && (this->m_contact_length == rhs.m_contact_length);
     }
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
@@ -51,12 +51,16 @@ namespace Opm {
                 record.getItem<Kw::TARGET_SEGMENT>().get<int>(0);
         }
 
-        if (record.getItem<Kw::TEMPERATURE>().hasValue(0)) {
+        // Item 7 is only meaningful for TEMP; leaving it unset otherwise keeps
+        // the temperature()-is-nullopt-unless-TEMP invariant and equality clean.
+        if ((type == Type::TEMP) &&
+            record.getItem<Kw::TEMPERATURE>().hasValue(0))
+        {
             this->m_temperature = record.getItem<Kw::TEMPERATURE>().getSIDouble(0);
         }
 
         this->m_interpolation_constant =
-            record.getItem<Kw::INTERPOLATION_CONSTANT>().get<double>(0);
+            record.getItem<Kw::INTERPOLATION_CONSTANT>().getSIDouble(0);
 
         // Contact length (item 9) is left unset when defaulted, in which case
         // the mean length of the adjacent segments should be used instead.
@@ -137,10 +141,8 @@ namespace Opm {
             rec.segment2 = record.getItem<Kw::SEGMENT2>().get<int>(0);
             rec.operation = operation;
 
-            // The record applies to the inclusive segment range [segment1,
-            // segment2].  A non-positive first segment or an inverted range is
-            // self-inconsistent and can never match any well, so reject it here
-            // rather than let it be silently ignored downstream.
+            // Reject a self-inconsistent range [segment1, segment2] (non-positive
+            // start or inverted) up front; it can never match any well.
             if ((rec.segment1 < 1) || (rec.segment2 < rec.segment1)) {
                 throw OpmInputError {
                     fmt::format("An invalid WSEGHEAT segment range {} to {} was "
@@ -156,10 +158,8 @@ namespace Opm {
             if (operation != SegmentHeatTransfer::Operation::CLEAR) {
                 rec.coefficient = SegmentHeatTransfer{type, record};
 
-                // Whether this record sets or adds a coefficient (a bare type
-                // or one suffixed with '+').  A removal record ('-') only needs
-                // to identify an existing coefficient and therefore need not
-                // repeat the values that define it.
+                // Set/add records (bare type or '+') must carry the defining
+                // values; a removal ('-') need only identify the coefficient.
                 const bool is_set =
                     (operation == SegmentHeatTransfer::Operation::REPLACE_ALL) ||
                     (operation == SegmentHeatTransfer::Operation::ADD);

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
@@ -33,7 +33,7 @@
 
 namespace Opm {
 
-    SegmentHeatTransfer::SegmentHeatTransfer(const Type type, const DeckRecord& record)
+    SegmentHeatTransferCoeff::SegmentHeatTransferCoeff(const Type type, const DeckRecord& record)
         : m_type(type)
     {
         using Kw = ParserKeywords::WSEGHEAT;
@@ -69,9 +69,9 @@ namespace Opm {
         }
     }
 
-    SegmentHeatTransfer SegmentHeatTransfer::serializationTestObject()
+    SegmentHeatTransferCoeff SegmentHeatTransferCoeff::serializationTestObject()
     {
-        SegmentHeatTransfer result;
+        SegmentHeatTransferCoeff result;
         result.m_type = Type::SEG;
         result.m_thermal_resistance = 0.02;
         result.m_target_segment = 24;
@@ -81,8 +81,8 @@ namespace Opm {
         return result;
     }
 
-    std::pair<SegmentHeatTransfer::Type, SegmentHeatTransfer::Operation>
-    SegmentHeatTransfer::typeFromString(const std::string& s)
+    std::pair<SegmentHeatTransferCoeff::Type, SegmentHeatTransferCoeff::Operation>
+    SegmentHeatTransferCoeff::typeFromString(const std::string& s)
     {
         if (s == "NONE") {
             return { Type::NONE, Operation::CLEAR };
@@ -111,7 +111,7 @@ namespace Opm {
         };
     }
 
-    std::string SegmentHeatTransfer::typeToString(const Type type)
+    std::string SegmentHeatTransferCoeff::typeToString(const Type type)
     {
         switch (type) {
         case Type::COMP: return "COMP";
@@ -120,7 +120,7 @@ namespace Opm {
         case Type::NONE: return "NONE";
         }
 
-        throw std::invalid_argument("Unhandled SegmentHeatTransfer::Type value");
+        throw std::invalid_argument("Unhandled SegmentHeatTransferCoeff::Type value");
     }
 
     std::vector<std::pair<std::string, SegmentHeatTransferRecord>>
@@ -133,7 +133,7 @@ namespace Opm {
         for (const auto& record : keyword) {
             const auto well_name = record.getItem<Kw::WELL>().getTrimmedString(0);
 
-            const auto [type, operation] = SegmentHeatTransfer::typeFromString
+            const auto [type, operation] = SegmentHeatTransferCoeff::typeFromString
                 (record.getItem<Kw::TYPE>().getTrimmedString(0));
 
             auto rec = SegmentHeatTransferRecord{};
@@ -155,14 +155,14 @@ namespace Opm {
 
             // For CLEAR (type NONE) only the operation matters; otherwise the
             // record carries a coefficient to set/add/remove.
-            if (operation != SegmentHeatTransfer::Operation::CLEAR) {
-                rec.coefficient = SegmentHeatTransfer{type, record};
+            if (operation != SegmentHeatTransferCoeff::Operation::CLEAR) {
+                rec.coefficient = SegmentHeatTransferCoeff{type, record};
 
                 // Set/add records (bare type or '+') must carry the defining
                 // values; a removal ('-') need only identify the coefficient.
                 const bool is_set =
-                    (operation == SegmentHeatTransfer::Operation::REPLACE_ALL) ||
-                    (operation == SegmentHeatTransfer::Operation::ADD);
+                    (operation == SegmentHeatTransferCoeff::Operation::REPLACE_ALL) ||
+                    (operation == SegmentHeatTransferCoeff::Operation::ADD);
 
                 // The specific thermal resistance (item 5) is mandatory whenever
                 // a coefficient is set or added.
@@ -171,7 +171,7 @@ namespace Opm {
                         fmt::format("A {} heat transfer coefficient for well {} "
                                     "segments {} to {} requires a specific thermal "
                                     "resistance in item 5.",
-                                    SegmentHeatTransfer::typeToString(type),
+                                    SegmentHeatTransferCoeff::typeToString(type),
                                     well_name, rec.segment1, rec.segment2),
                         keyword.location()
                     };
@@ -179,7 +179,7 @@ namespace Opm {
 
                 // A fixed external temperature (item 7) is mandatory when a TEMP
                 // coefficient is set or added.
-                if (is_set && (type == SegmentHeatTransfer::Type::TEMP) &&
+                if (is_set && (type == SegmentHeatTransferCoeff::Type::TEMP) &&
                     !rec.coefficient.temperature().has_value())
                 {
                     throw OpmInputError {
@@ -193,7 +193,7 @@ namespace Opm {
 
                 // The target segment (item 6) identifies a SEG coefficient and
                 // is therefore required for every SEG record, removal included.
-                if ((type == SegmentHeatTransfer::Type::SEG) &&
+                if ((type == SegmentHeatTransferCoeff::Type::SEG) &&
                     (rec.coefficient.targetSegment() < 1))
                 {
                     throw OpmInputError {

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
@@ -38,11 +38,18 @@ namespace Opm {
     {
         using Kw = ParserKeywords::WSEGHEAT;
 
-        this->m_thermal_resistance =
-            record.getItem<Kw::THERMAL_RESISTANCE>().getSIDouble(0);
+        // Items 5 and 6 have no default and are left at their member defaults
+        // when not specified (e.g. for removal records).  Whether either item
+        // is required is enforced in segmentHeatTransferFromWSEGHEAT().
+        if (record.getItem<Kw::THERMAL_RESISTANCE>().hasValue(0)) {
+            this->m_thermal_resistance =
+                record.getItem<Kw::THERMAL_RESISTANCE>().getSIDouble(0);
+        }
 
-        this->m_target_segment =
-            record.getItem<Kw::TARGET_SEGMENT>().get<int>(0);
+        if (record.getItem<Kw::TARGET_SEGMENT>().hasValue(0)) {
+            this->m_target_segment =
+                record.getItem<Kw::TARGET_SEGMENT>().get<int>(0);
+        }
 
         if (record.getItem<Kw::TEMPERATURE>().hasValue(0)) {
             this->m_temperature = record.getItem<Kw::TEMPERATURE>().getSIDouble(0);
@@ -135,9 +142,30 @@ namespace Opm {
             if (operation != SegmentHeatTransfer::Operation::CLEAR) {
                 rec.coefficient = SegmentHeatTransfer{type, record};
 
-                // The destination-specific items are mandatory for the
-                // corresponding coefficient type.
-                if ((type == SegmentHeatTransfer::Type::TEMP) &&
+                // Whether this record sets or adds a coefficient (a bare type
+                // or one suffixed with '+').  A removal record ('-') only needs
+                // to identify an existing coefficient and therefore need not
+                // repeat the values that define it.
+                const bool is_set =
+                    (operation == SegmentHeatTransfer::Operation::REPLACE_ALL) ||
+                    (operation == SegmentHeatTransfer::Operation::ADD);
+
+                // The specific thermal resistance (item 5) is mandatory whenever
+                // a coefficient is set or added.
+                if (is_set && !record.getItem<Kw::THERMAL_RESISTANCE>().hasValue(0)) {
+                    throw OpmInputError {
+                        fmt::format("A {} heat transfer coefficient for well {} "
+                                    "segments {} to {} requires a specific thermal "
+                                    "resistance in item 5.",
+                                    SegmentHeatTransfer::typeToString(type),
+                                    well_name, rec.segment1, rec.segment2),
+                        keyword.location()
+                    };
+                }
+
+                // A fixed external temperature (item 7) is mandatory when a TEMP
+                // coefficient is set or added.
+                if (is_set && (type == SegmentHeatTransfer::Type::TEMP) &&
                     !rec.coefficient.temperature().has_value())
                 {
                     throw OpmInputError {
@@ -149,6 +177,8 @@ namespace Opm {
                     };
                 }
 
+                // The target segment (item 6) identifies a SEG coefficient and
+                // is therefore required for every SEG record, removal included.
                 if ((type == SegmentHeatTransfer::Type::SEG) &&
                     (rec.coefficient.targetSegment() < 1))
                 {

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
@@ -137,6 +137,20 @@ namespace Opm {
             rec.segment2 = record.getItem<Kw::SEGMENT2>().get<int>(0);
             rec.operation = operation;
 
+            // The record applies to the inclusive segment range [segment1,
+            // segment2].  A non-positive first segment or an inverted range is
+            // self-inconsistent and can never match any well, so reject it here
+            // rather than let it be silently ignored downstream.
+            if ((rec.segment1 < 1) || (rec.segment2 < rec.segment1)) {
+                throw OpmInputError {
+                    fmt::format("An invalid WSEGHEAT segment range {} to {} was "
+                                "specified for well {}; a valid range satisfies "
+                                "1 <= item 2 (SEGMENT1) <= item 3 (SEGMENT2).",
+                                rec.segment1, rec.segment2, well_name),
+                    keyword.location()
+                };
+            }
+
             // For CLEAR (type NONE) only the operation matters; otherwise the
             // record carries a coefficient to set/add/remove.
             if (operation != SegmentHeatTransfer::Operation::CLEAR) {

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
@@ -119,12 +119,12 @@ namespace Opm {
         throw std::invalid_argument("Unhandled SegmentHeatTransfer::Type value");
     }
 
-    std::map<std::string, std::vector<SegmentHeatTransferRecord>>
+    std::vector<std::pair<std::string, SegmentHeatTransferRecord>>
     segmentHeatTransferFromWSEGHEAT(const DeckKeyword& keyword)
     {
         using Kw = ParserKeywords::WSEGHEAT;
 
-        auto res = std::map<std::string, std::vector<SegmentHeatTransferRecord>>{};
+        auto res = std::vector<std::pair<std::string, SegmentHeatTransferRecord>>{};
 
         for (const auto& record : keyword) {
             const auto well_name = record.getItem<Kw::WELL>().getTrimmedString(0);
@@ -192,7 +192,7 @@ namespace Opm {
                 }
             }
 
-            res[well_name].push_back(rec);
+            res.emplace_back(well_name, rec);
         }
 
         return res;

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.cpp
@@ -1,0 +1,153 @@
+/*
+  Copyright 2024 Equinor.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp>
+
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/input/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
+
+#include <stdexcept>
+#include <string>
+
+#include <fmt/format.h>
+
+namespace Opm {
+
+    SegmentHeatTransfer::SegmentHeatTransfer(const Type type, const DeckRecord& record)
+        : m_type(type)
+    {
+        using Kw = ParserKeywords::WSEGHEAT;
+
+        this->m_thermal_resistance =
+            record.getItem<Kw::THERMAL_RESISTANCE>().getSIDouble(0);
+
+        this->m_target_segment =
+            record.getItem<Kw::TARGET_SEGMENT>().get<int>(0);
+
+        if (record.getItem<Kw::TEMPERATURE>().hasValue(0)) {
+            this->m_temperature = record.getItem<Kw::TEMPERATURE>().getSIDouble(0);
+        }
+
+        this->m_interpolation_constant =
+            record.getItem<Kw::INTERPOLATION_CONSTANT>().get<double>(0);
+
+        // A negative contact length flags that item 9 was defaulted; the
+        // mean length of the adjacent segments should be used instead.
+        if (record.getItem<Kw::CONTACT_LENGTH>().hasValue(0)) {
+            this->m_contact_length = record.getItem<Kw::CONTACT_LENGTH>().getSIDouble(0);
+        }
+    }
+
+    SegmentHeatTransfer SegmentHeatTransfer::serializationTestObject()
+    {
+        SegmentHeatTransfer result;
+        result.m_type = Type::SEG;
+        result.m_thermal_resistance = 0.02;
+        result.m_target_segment = 24;
+        result.m_temperature = 350.0;
+        result.m_interpolation_constant = 0.5;
+        result.m_contact_length = 12.5;
+        return result;
+    }
+
+    std::pair<SegmentHeatTransfer::Type, SegmentHeatTransfer::Operation>
+    SegmentHeatTransfer::typeFromString(const std::string& s)
+    {
+        if (s == "NONE") {
+            return { Type::NONE, Operation::CLEAR };
+        }
+
+        // The base type may be followed by '+' (add) or '-' (remove).
+        auto operation = Operation::REPLACE_ALL;
+        std::string base = s;
+        if (!base.empty()) {
+            if (base.back() == '+') {
+                operation = Operation::ADD;
+                base.pop_back();
+            }
+            else if (base.back() == '-') {
+                operation = Operation::REMOVE;
+                base.pop_back();
+            }
+        }
+
+        if (base == "COMP") { return { Type::COMP, operation }; }
+        if (base == "SEG")  { return { Type::SEG,  operation }; }
+        if (base == "TEMP") { return { Type::TEMP, operation }; }
+
+        throw std::invalid_argument {
+            fmt::format("Unknown WSEGHEAT heat transfer coefficient type '{}'", s)
+        };
+    }
+
+    std::string SegmentHeatTransfer::typeToString(const Type type)
+    {
+        switch (type) {
+        case Type::COMP: return "COMP";
+        case Type::SEG:  return "SEG";
+        case Type::TEMP: return "TEMP";
+        case Type::NONE: return "NONE";
+        }
+
+        throw std::invalid_argument("Unhandled SegmentHeatTransfer::Type value");
+    }
+
+    std::map<std::string, std::vector<SegmentHeatTransferRecord>>
+    segmentHeatTransferFromWSEGHEAT(const DeckKeyword& keyword)
+    {
+        using Kw = ParserKeywords::WSEGHEAT;
+
+        auto res = std::map<std::string, std::vector<SegmentHeatTransferRecord>>{};
+
+        for (const auto& record : keyword) {
+            const auto well_name = record.getItem<Kw::WELL>().getTrimmedString(0);
+
+            const auto [type, operation] = SegmentHeatTransfer::typeFromString
+                (record.getItem<Kw::TYPE>().getTrimmedString(0));
+
+            auto rec = SegmentHeatTransferRecord{};
+            rec.segment1 = record.getItem<Kw::SEGMENT1>().get<int>(0);
+            rec.segment2 = record.getItem<Kw::SEGMENT2>().get<int>(0);
+            rec.operation = operation;
+
+            // For CLEAR (type NONE) only the operation matters; otherwise the
+            // record carries a coefficient to set/add/remove.
+            if (operation != SegmentHeatTransfer::Operation::CLEAR) {
+                rec.coefficient = SegmentHeatTransfer{type, record};
+            }
+
+            res[well_name].push_back(rec);
+        }
+
+        return res;
+    }
+
+    bool SegmentHeatTransfer::operator==(const SegmentHeatTransfer& rhs) const
+    {
+        return (this->m_type == rhs.m_type)
+            && (this->m_thermal_resistance == rhs.m_thermal_resistance)
+            && (this->m_target_segment == rhs.m_target_segment)
+            && (this->m_temperature == rhs.m_temperature)
+            && (this->m_interpolation_constant == rhs.m_interpolation_constant)
+            && (this->m_contact_length == rhs.m_contact_length);
+    }
+
+} // namespace Opm

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2024 Equinor.
+  Copyright 2026 Equinor.
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp
@@ -104,14 +104,13 @@ namespace Opm {
         // Target segment number (item 6), only meaningful for Type::SEG.
         int m_target_segment{0};
 
-        // External fixed temperature (item 7), only meaningful for Type::TEMP.
-        // Nullopt when not specified.
+        // External fixed temperature (item 7); see temperature().
         std::optional<double> m_temperature{};
 
         // Interpolation constant (item 8), only meaningful for Type::SEG.
         double m_interpolation_constant{0.5};
 
-        // Contact length (item 9).  Nullopt when the item was defaulted.
+        // Contact length (item 9); see contactLength().
         std::optional<double> m_contact_length{};
     };
 
@@ -138,12 +137,10 @@ namespace Opm {
     };
 
     // Parse a WSEGHEAT keyword into a deck-ordered list of (well-name pattern,
-    // record) pairs.  The order of the records is preserved deliberately:
-    // WSEGHEAT supports incremental operations (replace, '+' add, '-' remove,
-    // NONE clear), so the records of any given well must be applied in the
-    // order they appear in the deck.  Grouping by well name up front would lose
-    // that order whenever two overlapping well-name patterns refer to the same
-    // well, so the regrouping is left to the consumer, which can expand the
+    // record) pairs.  Deck order is preserved deliberately: WSEGHEAT records are
+    // incremental (replace, '+' add, '-' remove, NONE clear) and must be applied
+    // in deck order per well.  Grouping by well name here would lose that order
+    // when patterns overlap, so it is left to the consumer, which can expand the
     // patterns to concrete well names first.
     std::vector<std::pair<std::string, SegmentHeatTransferRecord>>
     segmentHeatTransferFromWSEGHEAT(const DeckKeyword& keyword);

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp
@@ -36,7 +36,7 @@ namespace Opm {
 
     // A single heat transfer coefficient associated with a segment of a
     // multisegment well, as specified by the WSEGHEAT keyword.
-    class SegmentHeatTransfer
+    class SegmentHeatTransferCoeff
     {
     public:
         // The destination of the heat transfer.  NONE is not a coefficient in
@@ -57,10 +57,10 @@ namespace Opm {
             CLEAR,       // remove all coefficients (type NONE)
         };
 
-        SegmentHeatTransfer() = default;
-        SegmentHeatTransfer(Type type, const DeckRecord& record);
+        SegmentHeatTransferCoeff() = default;
+        SegmentHeatTransferCoeff(Type type, const DeckRecord& record);
 
-        static SegmentHeatTransfer serializationTestObject();
+        static SegmentHeatTransferCoeff serializationTestObject();
 
         // Decode the WSEGHEAT type string (item 4), e.g. "SEG", "COMP+" or
         // "TEMP-", into a base type and the operation it implies.
@@ -82,7 +82,7 @@ namespace Opm {
         // adjacent segments.
         const std::optional<double>& contactLength() const { return m_contact_length; }
 
-        bool operator==(const SegmentHeatTransfer&) const = default;
+        bool operator==(const SegmentHeatTransferCoeff&) const = default;
 
         template <class Serializer>
         void serializeOp(Serializer& serializer)
@@ -121,8 +121,8 @@ namespace Opm {
     {
         int segment1{};
         int segment2{};
-        SegmentHeatTransfer::Operation operation{SegmentHeatTransfer::Operation::CLEAR};
-        SegmentHeatTransfer coefficient{};
+        SegmentHeatTransferCoeff::Operation operation{SegmentHeatTransferCoeff::Operation::CLEAR};
+        SegmentHeatTransferCoeff coefficient{};
 
         bool operator==(const SegmentHeatTransferRecord&) const = default;
 

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp
@@ -1,0 +1,144 @@
+/*
+  Copyright 2024 Equinor.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SEGMENT_HEAT_TRANSFER_HPP_HEADER_INCLUDED
+#define SEGMENT_HEAT_TRANSFER_HPP_HEADER_INCLUDED
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Opm {
+
+    class DeckKeyword;
+    class DeckRecord;
+
+} // namespace Opm
+
+namespace Opm {
+
+    // A single heat transfer coefficient associated with a segment of a
+    // multisegment well, as specified by the WSEGHEAT keyword.
+    class SegmentHeatTransfer
+    {
+    public:
+        // The destination of the heat transfer.  NONE is not a coefficient in
+        // its own right; it is only used to clear all coefficients.
+        enum class Type {
+            COMP,   // heat transfer to a previously defined completion
+            SEG,    // heat transfer to another segment
+            TEMP,   // heat transfer to a fixed external temperature
+            NONE,   // remove the segment from the list of source/sinks
+        };
+
+        // How a WSEGHEAT record modifies the set of coefficients already
+        // associated with a segment.
+        enum class Operation {
+            REPLACE_ALL, // replace all existing coefficients with this one
+            ADD,         // add to (or update within) the existing set ('+')
+            REMOVE,      // remove the matching coefficient ('-')
+            CLEAR,       // remove all coefficients (type NONE)
+        };
+
+        SegmentHeatTransfer() = default;
+        SegmentHeatTransfer(Type type, const DeckRecord& record);
+
+        static SegmentHeatTransfer serializationTestObject();
+
+        // Decode the WSEGHEAT type string (item 4), e.g. "SEG", "COMP+" or
+        // "TEMP-", into a base type and the operation it implies.
+        static std::pair<Type, Operation> typeFromString(const std::string& s);
+
+        static std::string typeToString(Type type);
+
+        Type type() const { return m_type; }
+        double thermalResistance() const { return m_thermal_resistance; }
+        int targetSegment() const { return m_target_segment; }
+        double temperature() const { return m_temperature; }
+        double interpolationConstant() const { return m_interpolation_constant; }
+        double contactLength() const { return m_contact_length; }
+
+        // True when the contact length (item 9) was defaulted, in which case
+        // the value should be taken as the mean length of the adjacent
+        // segments.
+        bool defaultedContactLength() const { return m_contact_length < 0.0; }
+
+        bool operator==(const SegmentHeatTransfer&) const;
+
+        template <class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(m_type);
+            serializer(m_thermal_resistance);
+            serializer(m_target_segment);
+            serializer(m_temperature);
+            serializer(m_interpolation_constant);
+            serializer(m_contact_length);
+        }
+
+    private:
+        Type m_type{Type::COMP};
+
+        // Specific thermal resistance (item 5).
+        double m_thermal_resistance{0.0};
+
+        // Target segment number (item 6), only meaningful for Type::SEG.
+        int m_target_segment{0};
+
+        // External fixed temperature (item 7), only meaningful for Type::TEMP.
+        double m_temperature{0.0};
+
+        // Interpolation constant (item 8), only meaningful for Type::SEG.
+        double m_interpolation_constant{0.5};
+
+        // Contact length (item 9).  A negative value indicates the item was
+        // defaulted.
+        double m_contact_length{-1.0};
+    };
+
+    // One parsed WSEGHEAT record: the segment range it applies to, the
+    // operation it performs on those segments' coefficient sets, and the
+    // coefficient itself (unused when the operation is CLEAR).
+    struct SegmentHeatTransferRecord
+    {
+        int segment1{};
+        int segment2{};
+        SegmentHeatTransfer::Operation operation{SegmentHeatTransfer::Operation::CLEAR};
+        SegmentHeatTransfer coefficient{};
+
+        bool operator==(const SegmentHeatTransferRecord&) const = default;
+
+        template <class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(segment1);
+            serializer(segment2);
+            serializer(operation);
+            serializer(coefficient);
+        }
+    };
+
+    // Parse a WSEGHEAT keyword into per-well lists of records.
+    std::map<std::string, std::vector<SegmentHeatTransferRecord>>
+    segmentHeatTransferFromWSEGHEAT(const DeckKeyword& keyword);
+
+} // namespace Opm
+
+#endif // SEGMENT_HEAT_TRANSFER_HPP_HEADER_INCLUDED

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp
@@ -21,6 +21,7 @@
 #define SEGMENT_HEAT_TRANSFER_HPP_HEADER_INCLUDED
 
 #include <map>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -71,16 +72,18 @@ namespace Opm {
         Type type() const { return m_type; }
         double thermalResistance() const { return m_thermal_resistance; }
         int targetSegment() const { return m_target_segment; }
-        double temperature() const { return m_temperature; }
         double interpolationConstant() const { return m_interpolation_constant; }
-        double contactLength() const { return m_contact_length; }
 
-        // True when the contact length (item 9) was defaulted, in which case
-        // the value should be taken as the mean length of the adjacent
-        // segments.
-        bool defaultedContactLength() const { return m_contact_length < 0.0; }
+        // External fixed temperature (item 7).  Only set for Type::TEMP;
+        // nullopt otherwise.
+        const std::optional<double>& temperature() const { return m_temperature; }
 
-        bool operator==(const SegmentHeatTransfer&) const;
+        // Contact length (item 9).  Nullopt when the item was defaulted, in
+        // which case the value should be taken as the mean length of the
+        // adjacent segments.
+        const std::optional<double>& contactLength() const { return m_contact_length; }
+
+        bool operator==(const SegmentHeatTransfer&) const = default;
 
         template <class Serializer>
         void serializeOp(Serializer& serializer)
@@ -103,14 +106,14 @@ namespace Opm {
         int m_target_segment{0};
 
         // External fixed temperature (item 7), only meaningful for Type::TEMP.
-        double m_temperature{0.0};
+        // Nullopt when not specified.
+        std::optional<double> m_temperature{};
 
         // Interpolation constant (item 8), only meaningful for Type::SEG.
         double m_interpolation_constant{0.5};
 
-        // Contact length (item 9).  A negative value indicates the item was
-        // defaulted.
-        double m_contact_length{-1.0};
+        // Contact length (item 9).  Nullopt when the item was defaulted.
+        std::optional<double> m_contact_length{};
     };
 
     // One parsed WSEGHEAT record: the segment range it applies to, the

--- a/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp
+++ b/opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp
@@ -20,7 +20,6 @@
 #ifndef SEGMENT_HEAT_TRANSFER_HPP_HEADER_INCLUDED
 #define SEGMENT_HEAT_TRANSFER_HPP_HEADER_INCLUDED
 
-#include <map>
 #include <optional>
 #include <string>
 #include <utility>
@@ -138,8 +137,15 @@ namespace Opm {
         }
     };
 
-    // Parse a WSEGHEAT keyword into per-well lists of records.
-    std::map<std::string, std::vector<SegmentHeatTransferRecord>>
+    // Parse a WSEGHEAT keyword into a deck-ordered list of (well-name pattern,
+    // record) pairs.  The order of the records is preserved deliberately:
+    // WSEGHEAT supports incremental operations (replace, '+' add, '-' remove,
+    // NONE clear), so the records of any given well must be applied in the
+    // order they appear in the deck.  Grouping by well name up front would lose
+    // that order whenever two overlapping well-name patterns refer to the same
+    // well, so the regrouping is left to the consumer, which can expand the
+    // patterns to concrete well names first.
+    std::vector<std::pair<std::string, SegmentHeatTransferRecord>>
     segmentHeatTransferFromWSEGHEAT(const DeckKeyword& keyword);
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -893,33 +893,50 @@ namespace Opm {
 
         bool update = false;
         for (const auto& record : records) {
-            for (int segment_number = record.segment1;
-                 segment_number <= record.segment2; ++segment_number)
-            {
-                const auto seg_idx = this->segmentNumberToIndex(segment_number);
+            const auto& coeff = record.coefficient;
 
-                if (seg_idx < 0) {
-                    handleMissingMSWSegment(well_name, segment_number,
-                                            location, parseContext, errors);
+            // A SEG coefficient's target segment must itself be defined in the
+            // well -- a genuine missing-segment condition.
+            if ((coeff.type() == SegmentHeatTransfer::Type::SEG) &&
+                (this->segmentNumberToIndex(coeff.targetSegment()) < 0))
+            {
+                handleMissingMSWSegment(well_name, coeff.targetSegment(),
+                                        location, parseContext, errors);
+                continue;
+            }
+
+            // Apply to every defined segment in the inclusive range [segment1,
+            // segment2].  Iterate the defined segments (numbering may be
+            // non-contiguous) rather than every integer, so gaps aren't flagged
+            // as missing.
+            bool matched = false;
+            for (auto& segment : this->m_segments) {
+                const int segment_number = segment.segmentNumber();
+                if ((segment_number < record.segment1) ||
+                    (segment_number > record.segment2))
+                {
                     continue;
                 }
 
-                const auto& coeff = record.coefficient;
+                matched = true;
+
+                // A segment cannot exchange heat with itself; skip the target
+                // when a SEG range includes it (normal usage, not an error).
                 if ((coeff.type() == SegmentHeatTransfer::Type::SEG) &&
                     (coeff.targetSegment() == segment_number))
                 {
-                    const auto msg_fmt = fmt::format(R"(Problem with keyword {{keyword}}
-In {{file}} line {{line}}
-A SEG heat transfer coefficient for well {} segment {} targets the segment itself; the segment is skipped.)",
-                                                     well_name, segment_number);
-
-                    parseContext.handleError(Opm::ParseContext::SCHEDULE_MISSING_SEGMENT,
-                                             msg_fmt, location, errors);
                     continue;
                 }
 
-                this->m_segments[seg_idx].updateHeatTransfer(record);
+                segment.updateHeatTransfer(record);
                 update = true;
+            }
+
+            // The range names no defined segment at all -- most likely a typo
+            // in item 2/3 -- so surface it as a missing-segment condition.
+            if (! matched) {
+                handleMissingMSWSegment(well_name, record.segment1,
+                                        location, parseContext, errors);
             }
         }
 

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -199,13 +199,17 @@ namespace Opm {
                                   const double volume,
                                   const bool data_ready,
                                   const double node_x,
-                                  const double node_y)
+                                  const double node_y,
+                                  const double wall_area,
+                                  const double wall_volumetric_heat_capacity,
+                                  const double wall_thermal_conductivity)
     {
         const auto segment = Segment {
             segment_number, branch, outlet_segment,
             depth, length, internal_diameter, roughness,
             cross_area, volume,
-            data_ready, node_x, node_y
+            data_ready, node_x, node_y,
+            wall_area, wall_volumetric_heat_capacity, wall_thermal_conductivity
         };
 
         this->addSegment(segment);
@@ -266,6 +270,14 @@ namespace Opm {
         const auto nodeX_top = record1.getItem("TOP_X").getSIDouble(0);
         const auto nodeY_top = record1.getItem("TOP_Y").getSIDouble(0);
 
+        // Pipe-wall thermal properties for the whole segment set.  Individual
+        // segments may override these in their own records.
+        const auto wall_area_top = record1.getItem("TOP_PIPE_WALL_AREA").getSIDouble(0);
+        const auto wall_volumetric_heat_capacity_top =
+            record1.getItem("TOP_PIPE_WALL_VOLUMETRIC_HEAT_CAPACITY").getSIDouble(0);
+        const auto wall_thermal_conductivity_top =
+            record1.getItem("TOP_PIPE_WALL_THERMAL_CONDUCTIVITY").getSIDouble(0);
+
         // The main branch is 1 instead of 0.  The segment number for top
         // segment is also 1.
         if (length_depth_type == LengthDepth::INC) {
@@ -281,7 +293,9 @@ namespace Opm {
 
             this->addSegment(segmentID, branchID, outletSegment, depth, length,
                              internal_diameter, roughness, cross_area,
-                             volume_top, data_ready, nodeX_top, nodeY_top);
+                             volume_top, data_ready, nodeX_top, nodeY_top,
+                             wall_area_top, wall_volumetric_heat_capacity_top,
+                             wall_thermal_conductivity_top);
         }
         else if (length_depth_type == LengthDepth::ABS) {
             const auto segmentID = 1;
@@ -295,7 +309,9 @@ namespace Opm {
             this->addSegment(segmentID, branchID, outletSegment,
                              depth_top, length_top,
                              internal_diameter, roughness, cross_area,
-                             volume_top, data_ready, nodeX_top, nodeY_top);
+                             volume_top, data_ready, nodeX_top, nodeY_top,
+                             wall_area_top, wall_volumetric_heat_capacity_top,
+                             wall_thermal_conductivity_top);
         }
 
         // Read all the information out from the DECK first then process to
@@ -369,6 +385,20 @@ namespace Opm {
             const auto node_X = record.getItem("LENGTH_X").getSIDouble(0);
             const auto node_Y = record.getItem("LENGTH_Y").getSIDouble(0);
 
+            // Pipe-wall thermal properties default to the values given in
+            // record 1 (items 10-12) when not specified for the segment.
+            const auto wall_area = record.getItem("PIPE_WALL_AREA").hasValue(0)
+                ? record.getItem("PIPE_WALL_AREA").getSIDouble(0)
+                : wall_area_top;
+            const auto wall_volumetric_heat_capacity =
+                record.getItem("PIPE_WALL_VOLUMETRIC_HEAT_CAPACITY").hasValue(0)
+                ? record.getItem("PIPE_WALL_VOLUMETRIC_HEAT_CAPACITY").getSIDouble(0)
+                : wall_volumetric_heat_capacity_top;
+            const auto wall_thermal_conductivity =
+                record.getItem("PIPE_WALL_THERMAL_CONDUCTIVITY").hasValue(0)
+                ? record.getItem("PIPE_WALL_THERMAL_CONDUCTIVITY").getSIDouble(0)
+                : wall_thermal_conductivity_top;
+
             for (int segment_number = segment1; segment_number <= segment2; ++segment_number) {
                 // For the first or the only segment in the range is the one
                 // specified in WELSEGS.  From the second segment in the
@@ -384,7 +414,9 @@ namespace Opm {
                 this->addSegment(segment_number, branch, outlet_segment,
                                  depth, length, diameter,
                                  roughness, area, volume, data_ready,
-                                 node_X, node_Y);
+                                 node_X, node_Y,
+                                 wall_area, wall_volumetric_heat_capacity,
+                                 wall_thermal_conductivity);
             }
         }
 

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -20,7 +20,6 @@
 #include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
-#include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/Schedule/MSW/AICD.hpp>
 #include <opm/input/eclipse/Schedule/MSW/SICD.hpp>
@@ -913,7 +912,7 @@ namespace Opm {
 
             // A SEG coefficient's target segment must itself be defined in the
             // well -- a genuine missing-segment condition.
-            if ((coeff.type() == SegmentHeatTransfer::Type::SEG) &&
+            if ((coeff.type() == SegmentHeatTransferCoeff::Type::SEG) &&
                 (this->segmentNumberToIndex(coeff.targetSegment()) < 0))
             {
                 handleMissingMSWSegment(well_name, coeff.targetSegment(),
@@ -938,7 +937,7 @@ namespace Opm {
 
                 // A segment cannot exchange heat with itself; skip the target
                 // when a SEG range includes it (normal usage, not an error).
-                if ((coeff.type() == SegmentHeatTransfer::Type::SEG) &&
+                if ((coeff.type() == SegmentHeatTransferCoeff::Type::SEG) &&
                     (coeff.targetSegment() == segment_number))
                 {
                     continue;

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -908,12 +908,14 @@ namespace Opm {
                 if ((coeff.type() == SegmentHeatTransfer::Type::SEG) &&
                     (coeff.targetSegment() == segment_number))
                 {
-                    throw OpmInputError {
-                        fmt::format("A SEG heat transfer coefficient for well {} "
-                                    "segment {} targets the segment itself.",
-                                    well_name, segment_number),
-                        location
-                    };
+                    const auto msg_fmt = fmt::format(R"(Problem with keyword {{keyword}}
+In {{file}} line {{line}}
+A SEG heat transfer coefficient for well {} segment {} targets the segment itself; the segment is skipped.)",
+                                                     well_name, segment_number);
+
+                    parseContext.handleError(Opm::ParseContext::SCHEDULE_MISSING_SEGMENT,
+                                             msg_fmt, location, errors);
+                    continue;
                 }
 
                 this->m_segments[seg_idx].updateHeatTransfer(record);

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -880,6 +880,37 @@ namespace Opm {
         return true;
     }
 
+    bool WellSegments::updateWSEGHEAT(std::string_view                                well_name,
+                                      const std::vector<SegmentHeatTransferRecord>&   records,
+                                      const KeywordLocation&                          location,
+                                      const ParseContext&                             parseContext,
+                                      ErrorGuard&                                     errors)
+    {
+        if (records.empty()) {
+            return false;
+        }
+
+        bool update = false;
+        for (const auto& record : records) {
+            for (int segment_number = record.segment1;
+                 segment_number <= record.segment2; ++segment_number)
+            {
+                const auto seg_idx = this->segmentNumberToIndex(segment_number);
+
+                if (seg_idx < 0) {
+                    handleMissingICDSegment(well_name, segment_number,
+                                            location, parseContext, errors);
+                    continue;
+                }
+
+                this->m_segments[seg_idx].updateHeatTransfer(record);
+                update = true;
+            }
+        }
+
+        return update;
+    }
+
     bool WellSegments::operator!=(const WellSegments& rhs) const
     {
         return ! (*this == rhs);

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -20,6 +20,7 @@
 #include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/Schedule/MSW/AICD.hpp>
 #include <opm/input/eclipse/Schedule/MSW/SICD.hpp>
@@ -55,7 +56,7 @@
 #include <fmt/format.h>
 
 namespace {
-    void handleMissingICDSegment(std::string_view            well_name,
+    void handleMissingMSWSegment(std::string_view            well_name,
                                  const int                   segment_number,
                                  const Opm::KeywordLocation& location,
                                  const Opm::ParseContext&    parseContext,
@@ -802,7 +803,7 @@ namespace Opm {
             const auto seg_idx = this->segmentNumberToIndex(segment_number);
 
             if (seg_idx < 0) {
-                handleMissingICDSegment(well_name, segment_number,
+                handleMissingMSWSegment(well_name, segment_number,
                                         location, parseContext, errors);
                 continue;
             }
@@ -834,7 +835,7 @@ namespace Opm {
             const auto seg_idx = this->segmentNumberToIndex(segment_number);
 
             if (seg_idx < 0) {
-                handleMissingICDSegment(well_name, segment_number,
+                handleMissingMSWSegment(well_name, segment_number,
                                         location, parseContext, errors);
                 continue;
             }
@@ -866,7 +867,7 @@ namespace Opm {
             const auto seg_idx = this->segmentNumberToIndex(segment_number);
 
             if (seg_idx < 0) {
-                handleMissingICDSegment(well_name, segment_number,
+                handleMissingMSWSegment(well_name, segment_number,
                                         location, parseContext, errors);
                 continue;
             }
@@ -898,9 +899,21 @@ namespace Opm {
                 const auto seg_idx = this->segmentNumberToIndex(segment_number);
 
                 if (seg_idx < 0) {
-                    handleMissingICDSegment(well_name, segment_number,
+                    handleMissingMSWSegment(well_name, segment_number,
                                             location, parseContext, errors);
                     continue;
+                }
+
+                const auto& coeff = record.coefficient;
+                if ((coeff.type() == SegmentHeatTransfer::Type::SEG) &&
+                    (coeff.targetSegment() == segment_number))
+                {
+                    throw OpmInputError {
+                        fmt::format("A SEG heat transfer coefficient for well {} "
+                                    "segment {} targets the segment itself.",
+                                    well_name, segment_number),
+                        location
+                    };
                 }
 
                 this->m_segments[seg_idx].updateHeatTransfer(record);

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -57,17 +57,33 @@
 
 namespace {
     void handleMissingMSWSegment(std::string_view            well_name,
+                                 const int                   first_segment,
+                                 const int                   last_segment,
+                                 const Opm::KeywordLocation& location,
+                                 const Opm::ParseContext&    parseContext,
+                                 Opm::ErrorGuard&            errors)
+    {
+        const auto detail = (first_segment == last_segment)
+            ? fmt::format("Segment {} is not defined", first_segment)
+            : fmt::format("Segment range {} to {} matches no segment defined",
+                          first_segment, last_segment);
+
+        const auto msg_fmt = fmt::format(R"(Problem with keyword {{keyword}}
+In {{file}} line {{line}}
+{} in WELSEGS for well {}.)", detail, well_name);
+
+        parseContext.handleError(Opm::ParseContext::SCHEDULE_MISSING_SEGMENT,
+                                 msg_fmt, location, errors);
+    }
+
+    void handleMissingMSWSegment(std::string_view            well_name,
                                  const int                   segment_number,
                                  const Opm::KeywordLocation& location,
                                  const Opm::ParseContext&    parseContext,
                                  Opm::ErrorGuard&            errors)
     {
-        const auto msg_fmt = fmt::format(R"(Problem with keyword {{keyword}}
-In {{file}} line {{line}}
-Segment {} is not defined in WELSEGS for well {}.)", segment_number, well_name);
-
-        parseContext.handleError(Opm::ParseContext::SCHEDULE_MISSING_SEGMENT,
-                                 msg_fmt, location, errors);
+        handleMissingMSWSegment(well_name, segment_number, segment_number,
+                                location, parseContext, errors);
     }
 
     void handleIncompatiblePDropModel(std::string_view                       well_name,
@@ -935,7 +951,7 @@ namespace Opm {
             // The range names no defined segment at all -- most likely a typo
             // in item 2/3 -- so surface it as a missing-segment condition.
             if (! matched) {
-                handleMissingMSWSegment(well_name, record.segment1,
+                handleMissingMSWSegment(well_name, record.segment1, record.segment2,
                                         location, parseContext, errors);
             }
         }

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -66,7 +66,7 @@ namespace {
 In {{file}} line {{line}}
 Segment {} is not defined in WELSEGS for well {}.)", segment_number, well_name);
 
-        parseContext.handleError(Opm::ParseContext::SCHEDULE_ICD_MISSING_SEGMENT,
+        parseContext.handleError(Opm::ParseContext::SCHEDULE_MISSING_SEGMENT,
                                  msg_fmt, location, errors);
     }
 

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -176,9 +176,7 @@ namespace Opm {
 
         // components of the pressure drop to be included
         CompPressureDrop m_comp_pressure_drop{CompPressureDrop::HFA};
-        // The three pipe-wall properties related to thermal conduction
-        // (cross-sectional area, volumetric heat capacity and thermal
-        // conductivity) are stored on the individual segments.
+        // Pipe-wall thermal conduction properties are stored per segment.
 
         std::vector< Segment > m_segments{};
         // the mapping from the segment number to the

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -162,13 +162,17 @@ namespace Opm {
                         const double volume,
                         const bool data_ready,
                         const double node_x,
-                        const double node_y);
+                        const double node_y,
+                        const double wall_area = 0.0,
+                        const double wall_volumetric_heat_capacity = 0.0,
+                        const double wall_thermal_conductivity = 0.0);
         const Segment& topSegment() const;
 
         // components of the pressure drop to be included
         CompPressureDrop m_comp_pressure_drop{CompPressureDrop::HFA};
-        // There are other three properties for segment related to thermal conduction,
-        // while they are not supported by the keyword at the moment.
+        // The three pipe-wall properties related to thermal conduction
+        // (cross-sectional area, volumetric heat capacity and thermal
+        // conductivity) are stored on the individual segments.
 
         std::vector< Segment > m_segments{};
         // the mapping from the segment number to the

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -130,6 +130,12 @@ namespace Opm {
                             const ParseContext&                       parseContext,
                             ErrorGuard&                               errors);
 
+        bool updateWSEGHEAT(std::string_view                                well_name,
+                            const std::vector<SegmentHeatTransferRecord>&   records,
+                            const KeywordLocation&                          location,
+                            const ParseContext&                             parseContext,
+                            ErrorGuard&                                     errors);
+
         auto begin() const { return this->m_segments.begin(); }
         auto end() const { return this->m_segments.end(); }
 

--- a/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -191,6 +191,7 @@ namespace Opm
         result.m_sort_value = 14;
         result.m_defaultSatTabId = true;
         result.segment_number = 16;
+        result.m_thermal_length = 17.0;
         result.m_wpimult = 0.123;
         result.m_subject_to_welpi = true;
         result.m_filter_cake = FilterCake::serializationTestObject();
@@ -366,12 +367,14 @@ namespace Opm
     void Connection::updateSegment(const int segment_number_arg,
                                    const double center_depth_arg,
                                    const std::size_t compseg_insert_index,
-                                   const std::optional<std::pair<double, double>>& perf_range)
+                                   const std::optional<std::pair<double, double>>& perf_range,
+                                   const double thermal_length_arg)
     {
         this->segment_number = segment_number_arg;
         this->center_depth = center_depth_arg;
         this->m_sort_value = compseg_insert_index;
         this->m_perf_range = perf_range;
+        this->m_thermal_length = thermal_length_arg;
     }
 
     void Connection::updateSegmentRST(int segment_number_arg,
@@ -384,6 +387,11 @@ namespace Opm
     int Connection::segment() const
     {
         return this->segment_number;
+    }
+
+    double Connection::thermalLength() const
+    {
+        return this->m_thermal_length;
     }
 
     void Connection::scaleWellPi(double wellPi)
@@ -462,6 +470,7 @@ namespace Opm
             && (this->m_sort_value == that.m_sort_value)
             && (this->m_defaultSatTabId == that.m_defaultSatTabId)
             && (this->segment_number == that.segment_number)
+            && (this->m_thermal_length == that.m_thermal_length)
             && (this->m_subject_to_welpi == that.m_subject_to_welpi)
             && (this->ijk == that.ijk)
             && (this->lgr_grid == that.lgr_grid)

--- a/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -166,6 +166,10 @@ namespace Opm
                                                 rst_connection.segdist_end);
         }
 
+        // m_thermal_length (COMPSEGS item 10) keeps its default: RstConnection
+        // does not carry it, so a thermal MSW run restarted here begins with a
+        // zero thermal length.  TODO: persist and restore it.
+
         // TODO: recompute re from the grid
     }
 
@@ -366,7 +370,7 @@ namespace Opm
 
     void Connection::updateSegment(const int segment_number_arg,
                                    const double center_depth_arg,
-                                   const std::optional<double> thermal_length_arg,
+                                   const double thermal_length_arg,
                                    const std::size_t compseg_insert_index,
                                    const std::optional<std::pair<double, double>>& perf_range)
     {
@@ -389,7 +393,7 @@ namespace Opm
         return this->segment_number;
     }
 
-    std::optional<double> Connection::thermalLength() const
+    double Connection::thermalLength() const
     {
         return this->m_thermal_length;
     }

--- a/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -366,7 +366,7 @@ namespace Opm
 
     void Connection::updateSegment(const int segment_number_arg,
                                    const double center_depth_arg,
-                                   const double thermal_length_arg,
+                                   const std::optional<double> thermal_length_arg,
                                    const std::size_t compseg_insert_index,
                                    const std::optional<std::pair<double, double>>& perf_range)
     {
@@ -389,7 +389,7 @@ namespace Opm
         return this->segment_number;
     }
 
-    double Connection::thermalLength() const
+    std::optional<double> Connection::thermalLength() const
     {
         return this->m_thermal_length;
     }

--- a/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -366,15 +366,15 @@ namespace Opm
 
     void Connection::updateSegment(const int segment_number_arg,
                                    const double center_depth_arg,
+                                   const double thermal_length_arg,
                                    const std::size_t compseg_insert_index,
-                                   const std::optional<std::pair<double, double>>& perf_range,
-                                   const double thermal_length_arg)
+                                   const std::optional<std::pair<double, double>>& perf_range)
     {
         this->segment_number = segment_number_arg;
         this->center_depth = center_depth_arg;
+        this->m_thermal_length = thermal_length_arg;
         this->m_sort_value = compseg_insert_index;
         this->m_perf_range = perf_range;
-        this->m_thermal_length = thermal_length_arg;
     }
 
     void Connection::updateSegmentRST(int segment_number_arg,

--- a/opm/input/eclipse/Schedule/Well/Connection.hpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.hpp
@@ -200,7 +200,7 @@ namespace Opm {
         State state() const;
         Direction dir() const;
         double depth() const;
-        double thermalLength() const;
+        std::optional<double> thermalLength() const;
         int satTableId() const;
         int complnum() const;
         int segment() const;
@@ -266,7 +266,7 @@ namespace Opm {
                               double center_depth_arg);
         void updateSegment(int segment_number_arg,
                            double center_depth_arg,
-                           double thermal_length_arg,
+                           std::optional<double> thermal_length_arg,
                            std::size_t compseg_insert_index,
                            const std::optional<std::pair<double,double>>& perf_range);
 
@@ -374,11 +374,10 @@ namespace Opm {
         int segment_number { 0 };
 
         // Effective length of the connection in the wellbore segment used in
-        // the thermal conductivity calculation (COMPSEGS item 10).  Zero when
-        // defaulted, signalling that the consumer should apply the ECLIPSE
-        // default: the thickness of the grid block in the direction of
-        // penetration.
-        double m_thermal_length { 0.0 };
+        // the thermal conductivity calculation (COMPSEGS item 10).  Empty when
+        // defaulted: a downstream thermal consumer is expected to use the
+        // grid-block thickness in the direction of penetration.
+        std::optional<double> m_thermal_length {};
 
         double m_wpimult { 1.0 };
 

--- a/opm/input/eclipse/Schedule/Well/Connection.hpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.hpp
@@ -200,7 +200,7 @@ namespace Opm {
         State state() const;
         Direction dir() const;
         double depth() const;
-        std::optional<double> thermalLength() const;
+        double thermalLength() const;
         int satTableId() const;
         int complnum() const;
         int segment() const;
@@ -266,7 +266,7 @@ namespace Opm {
                               double center_depth_arg);
         void updateSegment(int segment_number_arg,
                            double center_depth_arg,
-                           std::optional<double> thermal_length_arg,
+                           double thermal_length_arg,
                            std::size_t compseg_insert_index,
                            const std::optional<std::pair<double,double>>& perf_range);
 
@@ -374,10 +374,10 @@ namespace Opm {
         int segment_number { 0 };
 
         // Effective length of the connection in the wellbore segment used in
-        // the thermal conductivity calculation (COMPSEGS item 10).  Empty when
-        // defaulted: a downstream thermal consumer is expected to use the
-        // grid-block thickness in the direction of penetration.
-        std::optional<double> m_thermal_length {};
+        // the thermal conductivity calculation (COMPSEGS item 10).  Populated
+        // with the grid-block thickness in the direction of penetration when
+        // the item is defaulted.
+        double m_thermal_length { 0.0 };
 
         double m_wpimult { 1.0 };
 

--- a/opm/input/eclipse/Schedule/Well/Connection.hpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.hpp
@@ -266,9 +266,9 @@ namespace Opm {
                               double center_depth_arg);
         void updateSegment(int segment_number_arg,
                            double center_depth_arg,
+                           double thermal_length_arg,
                            std::size_t compseg_insert_index,
-                           const std::optional<std::pair<double,double>>& perf_range,
-                           double thermal_length_arg = 0.0);
+                           const std::optional<std::pair<double,double>>& perf_range);
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -375,7 +375,9 @@ namespace Opm {
 
         // Effective length of the connection in the wellbore segment used in
         // the thermal conductivity calculation (COMPSEGS item 10).  Zero when
-        // not specified.
+        // defaulted, signalling that the consumer should apply the ECLIPSE
+        // default: the thickness of the grid block in the direction of
+        // penetration.
         double m_thermal_length { 0.0 };
 
         double m_wpimult { 1.0 };

--- a/opm/input/eclipse/Schedule/Well/Connection.hpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.hpp
@@ -200,6 +200,7 @@ namespace Opm {
         State state() const;
         Direction dir() const;
         double depth() const;
+        double thermalLength() const;
         int satTableId() const;
         int complnum() const;
         int segment() const;
@@ -266,7 +267,8 @@ namespace Opm {
         void updateSegment(int segment_number_arg,
                            double center_depth_arg,
                            std::size_t compseg_insert_index,
-                           const std::optional<std::pair<double,double>>& perf_range);
+                           const std::optional<std::pair<double,double>>& perf_range,
+                           double thermal_length_arg = 0.0);
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -286,6 +288,7 @@ namespace Opm {
             serializer(this->m_perf_range);
             serializer(this->m_defaultSatTabId);
             serializer(this->segment_number);
+            serializer(this->m_thermal_length);
             serializer(this->m_wpimult);
             serializer(this->m_subject_to_welpi);
             serializer(this->m_filter_cake);
@@ -369,6 +372,11 @@ namespace Opm {
         //
         // 0 means the connection is not associated to a segment.
         int segment_number { 0 };
+
+        // Effective length of the connection in the wellbore segment used in
+        // the thermal conductivity calculation (COMPSEGS item 10).  Zero when
+        // not specified.
+        double m_thermal_length { 0.0 };
 
         double m_wpimult { 1.0 };
 

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -28,6 +28,7 @@
 #include <opm/input/eclipse/EclipseState/Phase.hpp>
 #include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
 
+#include <opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp>
 #include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleGrid.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -2010,6 +2010,16 @@ bool Well::updateWSEGHEAT(const std::vector<SegmentHeatTransferRecord>& records,
                           const ParseContext&                           parseContext,
                           ErrorGuard&                                   errors)
 {
+    if (! this->isMultiSegment()) {
+        const auto msg_fmt = fmt::format(R"(Problem with keyword {{keyword}}
+In {{file}} line {{line}}
+WSEGHEAT applied to well {} which is not a multisegment well.)", this->name());
+
+        parseContext.handleError(ParseContext::SCHEDULE_MISSING_SEGMENT,
+                                 msg_fmt, location, errors);
+        return false;
+    }
+
     auto new_segments = std::make_shared<WellSegments>(*this->segments);
 
     if (new_segments->updateWSEGHEAT(this->name(), records, location, parseContext, errors)) {

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -2016,7 +2016,7 @@ bool Well::updateWSEGHEAT(const std::vector<SegmentHeatTransferRecord>& records,
 In {{file}} line {{line}}
 WSEGHEAT applied to well {} which is not a multisegment well.)", this->name());
 
-        parseContext.handleError(ParseContext::SCHEDULE_MISSING_SEGMENT,
+        parseContext.handleError(ParseContext::SCHEDULE_MSW_KEYWORD_ON_NON_MSW_WELL,
                                  msg_fmt, location, errors);
         return false;
     }

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -2005,6 +2005,21 @@ bool Well::updateWSEGVALV(const std::vector<std::pair<int, Valve>>& valve_pairs,
     return false;
 }
 
+bool Well::updateWSEGHEAT(const std::vector<SegmentHeatTransferRecord>& records,
+                          const KeywordLocation&                        location,
+                          const ParseContext&                           parseContext,
+                          ErrorGuard&                                   errors)
+{
+    auto new_segments = std::make_shared<WellSegments>(*this->segments);
+
+    if (new_segments->updateWSEGHEAT(this->name(), records, location, parseContext, errors)) {
+        this->segments = std::move(new_segments);
+        return true;
+    }
+
+    return false;
+}
+
 bool Well::updateICDFlowScalingFactors()
 {
     auto new_segments = std::make_shared<WellSegments>(*this->segments);

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -22,6 +22,7 @@
 
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 #include <opm/input/eclipse/EclipseState/Phase.hpp>
+#include <opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
@@ -565,6 +566,11 @@ public:
                         const KeywordLocation&                    location,
                         const ParseContext&                       parseContext,
                         ErrorGuard&                               errors);
+
+    bool updateWSEGHEAT(const std::vector<SegmentHeatTransferRecord>& records,
+                        const KeywordLocation&                        location,
+                        const ParseContext&                           parseContext,
+                        ErrorGuard&                                   errors);
 
     bool updateICDFlowScalingFactors();
     bool updateWPAVE(const PAvg& pavg);

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -22,7 +22,6 @@
 
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 #include <opm/input/eclipse/EclipseState/Phase.hpp>
-#include <opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
@@ -54,6 +53,7 @@ class KeywordLocation;
 class ParseContext;
 class Phases;
 class ScheduleGrid;
+struct SegmentHeatTransferRecord;
 class SICD;
 class SummaryState;
 class UDQActive;

--- a/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -637,6 +637,7 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
                 const auto css_ind = prev->sort_value();
                 const auto conSegNo = prev->segment();
                 const auto perf_range = prev->perf_range();
+                const auto thermal_length = prev->thermalLength();
 
                 if (state == Connection::State::OPEN) {
                     // Report existing connections this record opens, so the
@@ -662,7 +663,8 @@ The cell ({},{},{}) in well {} is not active and the connection will be ignored)
                     css_ind, defaultSatTable, lgr_grid_number
                 };
 
-                prev->updateSegment(conSegNo, cell.depth, css_ind, perf_range);
+                prev->updateSegment(conSegNo, cell.depth, thermal_length,
+                                    css_ind, perf_range);
             }
         }
     }
@@ -912,6 +914,7 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                 const auto css_ind = prev->sort_value();
                 const auto conSegNo = prev->segment();
                 const auto perf_range = prev->perf_range();
+                const auto thermal_length = prev->thermalLength();
 
                 *prev = Connection {
                     ijk[0], ijk[1], ijk[2],
@@ -921,7 +924,8 @@ CF and Kh items for well {} must both be specified or both defaulted/negative)",
                     css_ind, defaultSatTable
                 };
 
-                prev->updateSegment(conSegNo, cell.depth, css_ind, *perf_range);
+                prev->updateSegment(conSegNo, cell.depth, thermal_length,
+                                    css_ind, *perf_range);
             }
         }
     }

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/W/WELSEGS
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/W/WELSEGS
@@ -51,6 +51,24 @@
         "value_type": "DOUBLE",
         "dimension": "Length",
         "default": 0
+      },
+      {
+        "name": "TOP_PIPE_WALL_AREA",
+        "value_type": "DOUBLE",
+        "dimension": "Length*Length",
+        "default": 0
+      },
+      {
+        "name": "TOP_PIPE_WALL_VOLUMETRIC_HEAT_CAPACITY",
+        "value_type": "DOUBLE",
+        "dimension": "Energy/Length*Length*Length*AbsoluteTemperature",
+        "default": 0
+      },
+      {
+        "name": "TOP_PIPE_WALL_THERMAL_CONDUCTIVITY",
+        "value_type": "DOUBLE",
+        "dimension": "ThermalConductivity",
+        "default": 0
       }
     ],
     [
@@ -111,6 +129,21 @@
         "value_type": "DOUBLE",
         "dimension": "Length",
         "default": 0
+      },
+      {
+        "name": "PIPE_WALL_AREA",
+        "value_type": "DOUBLE",
+        "dimension": "Length*Length"
+      },
+      {
+        "name": "PIPE_WALL_VOLUMETRIC_HEAT_CAPACITY",
+        "value_type": "DOUBLE",
+        "dimension": "Energy/Length*Length*Length*AbsoluteTemperature"
+      },
+      {
+        "name": "PIPE_WALL_THERMAL_CONDUCTIVITY",
+        "value_type": "DOUBLE",
+        "dimension": "ThermalConductivity"
       }
     ]
   ]

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/W/WSEGHEAT
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/W/WSEGHEAT
@@ -1,0 +1,60 @@
+{
+  "name": "WSEGHEAT",
+  "sections": [
+    "SCHEDULE"
+  ],
+  "items": [
+    {
+      "item": 1,
+      "name": "WELL",
+      "value_type": "STRING"
+    },
+    {
+      "item": 2,
+      "name": "SEGMENT1",
+      "value_type": "INT"
+    },
+    {
+      "item": 3,
+      "name": "SEGMENT2",
+      "value_type": "INT"
+    },
+    {
+      "item": 4,
+      "name": "TYPE",
+      "value_type": "STRING",
+      "default": "NONE"
+    },
+    {
+      "item": 5,
+      "name": "THERMAL_RESISTANCE",
+      "value_type": "DOUBLE",
+      "dimension": "1/ThermalConductivity",
+      "default": 0
+    },
+    {
+      "item": 6,
+      "name": "TARGET_SEGMENT",
+      "value_type": "INT",
+      "default": 0
+    },
+    {
+      "item": 7,
+      "name": "TEMPERATURE",
+      "value_type": "DOUBLE",
+      "dimension": "Temperature"
+    },
+    {
+      "item": 8,
+      "name": "INTERPOLATION_CONSTANT",
+      "value_type": "DOUBLE",
+      "default": 0.5
+    },
+    {
+      "item": 9,
+      "name": "CONTACT_LENGTH",
+      "value_type": "DOUBLE",
+      "dimension": "Length"
+    }
+  ]
+}

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/W/WSEGHEAT
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/W/WSEGHEAT
@@ -29,14 +29,12 @@
       "item": 5,
       "name": "THERMAL_RESISTANCE",
       "value_type": "DOUBLE",
-      "dimension": "1/ThermalConductivity",
-      "default": 0
+      "dimension": "1/ThermalConductivity"
     },
     {
       "item": 6,
       "name": "TARGET_SEGMENT",
-      "value_type": "INT",
-      "default": 0
+      "value_type": "INT"
     },
     {
       "item": 7,

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/W/WSEGHEAT
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/W/WSEGHEAT
@@ -46,6 +46,7 @@
       "item": 8,
       "name": "INTERPOLATION_CONSTANT",
       "value_type": "DOUBLE",
+      "dimension": "1",
       "default": 0.5
     },
     {

--- a/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1129,6 +1129,7 @@ set( keywords
      001_Eclipse300/W/WINJGAS
      001_Eclipse300/W/WINJTEMP
      001_Eclipse300/W/WATDENT
+     001_Eclipse300/W/WSEGHEAT
      001_Eclipse300/W/WSF
      001_Eclipse300/X/XMF
      001_Eclipse300/Y/YMF

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -1311,7 +1311,7 @@ COMPSEGS
     }
 }
 
-BOOST_AUTO_TEST_CASE(PipeWallThermalProperties)
+BOOST_AUTO_TEST_CASE(ThermalMSW_ScheduleIntegration)
 {
     // WELSEGS items 10-12 (record 1) and 13-15 (subsequent records) provide
     // the pipe-wall properties used by the thermal option.  Segment 2 sets its
@@ -1436,41 +1436,117 @@ WSEGHEAT
 
     // The top segment was never named in WSEGHEAT and has no coefficients.
     BOOST_CHECK(segments.getFromSegmentNumber(1).heatTransfer().empty());
+
+    // Overlapping well-name patterns are applied in deck order.  Here 'PROD01'
+    // replaces all coefficients on segment 2 with a COMP of resistance 0.01,
+    // then the wildcard 'PROD*' updates that COMP to 0.02.  Applied in deck
+    // order the final resistance is 0.02; if the records were instead grouped
+    // and applied by sorted pattern ('PROD*' sorts before 'PROD01') the
+    // replace-all would run last and leave 0.01.
+    {
+        const auto order_deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
+DIMENS
+  20 20 20 /
+GRID
+DXV
+  20*100 /
+DYV
+  20*100 /
+DZV
+  20*10 /
+DEPTHZ
+  441*2000.0 /
+PORO
+    8000*0.1 /
+PERMX
+    8000*1 /
+PERMY
+    8000*0.1 /
+PERMZ
+    8000*0.01 /
+SCHEDULE
+WELSPECS
+ 'PROD01' 'P' 20 20 1* OIL /
+/
+COMPDAT
+ 'PROD01' 20 20 1 3 'OPEN' /
+/
+WELSEGS
+'PROD01' 2512.5 2512.5 1.0e-5 'ABS' /
+2  2  1  1  2537.5 2525.5  0.3  0.00010 /
+3  3  1  2  2562.5 2562.5  0.2  0.00010 /
+/
+COMPSEGS
+  'PROD01' /
+  20    20     1     1   2512.5   2525.0 /
+  20    20     2     1   2525.0   2550.0 /
+  20    20     3     1   2550.0   2575.0 /
+/
+WSEGHEAT
+   'PROD01' 2 2 COMP  0.01 /
+   'PROD*'  2 2 COMP+ 0.02 /
+/
+)");
+
+        const auto order_es    = ::Opm::EclipseState { order_deck };
+        const auto order_sched = ::Opm::Schedule {
+            order_deck, order_es, std::make_shared<const ::Opm::Python>()
+        };
+
+        const auto& order_ht = order_sched[0].wells("PROD01").getSegments()
+            .getFromSegmentNumber(2).heatTransfer();
+
+        BOOST_REQUIRE_EQUAL(order_ht.size(), 1);
+        BOOST_CHECK(order_ht[0].type() == HT::Type::COMP);
+        BOOST_CHECK_CLOSE(order_ht[0].thermalResistance(), 0.02 * day / kJ, 1.0e-8);
+    }
 }
 
-BOOST_AUTO_TEST_CASE(WSEGHEAT_TypeFromString)
+namespace {
+    // Extract, in deck order, the WSEGHEAT records that apply to a single well
+    // name from the (pattern, record) list returned by
+    // segmentHeatTransferFromWSEGHEAT().
+    std::vector<::Opm::SegmentHeatTransferRecord>
+    recordsForWell(const std::vector<std::pair<std::string,
+                                               ::Opm::SegmentHeatTransferRecord>>& parsed,
+                   const std::string& well_name)
+    {
+        std::vector<::Opm::SegmentHeatTransferRecord> records;
+        for (const auto& [pattern, record] : parsed) {
+            if (pattern == well_name) {
+                records.push_back(record);
+            }
+        }
+        return records;
+    }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(WSEGHEAT_CoefficientOperations)
 {
     using HT   = ::Opm::SegmentHeatTransfer;
     using Type = HT::Type;
     using Op   = HT::Operation;
 
-    // Bare types replace the existing set.
+    // --- Type/operation parsing (WSEGHEAT item 4) --------------------------
+    // A bare type replaces the existing coefficient set, a '+' suffix adds to
+    // it, a '-' suffix removes from it, and NONE clears it.
     BOOST_CHECK(HT::typeFromString("COMP") == std::make_pair(Type::COMP, Op::REPLACE_ALL));
     BOOST_CHECK(HT::typeFromString("SEG")  == std::make_pair(Type::SEG,  Op::REPLACE_ALL));
     BOOST_CHECK(HT::typeFromString("TEMP") == std::make_pair(Type::TEMP, Op::REPLACE_ALL));
-
-    // A '+' suffix adds to the set, a '-' suffix removes from it.
     BOOST_CHECK(HT::typeFromString("COMP+") == std::make_pair(Type::COMP, Op::ADD));
     BOOST_CHECK(HT::typeFromString("SEG+")  == std::make_pair(Type::SEG,  Op::ADD));
     BOOST_CHECK(HT::typeFromString("TEMP+") == std::make_pair(Type::TEMP, Op::ADD));
     BOOST_CHECK(HT::typeFromString("COMP-") == std::make_pair(Type::COMP, Op::REMOVE));
     BOOST_CHECK(HT::typeFromString("SEG-")  == std::make_pair(Type::SEG,  Op::REMOVE));
     BOOST_CHECK(HT::typeFromString("TEMP-") == std::make_pair(Type::TEMP, Op::REMOVE));
-
-    // NONE clears the set.
-    BOOST_CHECK(HT::typeFromString("NONE") == std::make_pair(Type::NONE, Op::CLEAR));
+    BOOST_CHECK(HT::typeFromString("NONE")  == std::make_pair(Type::NONE, Op::CLEAR));
 
     // Anything else is an error.
     BOOST_CHECK_THROW(HT::typeFromString("FOO"),   std::invalid_argument);
     BOOST_CHECK_THROW(HT::typeFromString("NONE+"), std::invalid_argument);
     BOOST_CHECK_THROW(HT::typeFromString(""),      std::invalid_argument);
-}
 
-BOOST_AUTO_TEST_CASE(WSEGHEAT_UpdateHeatTransfer)
-{
-    using HT   = ::Opm::SegmentHeatTransfer;
-    using Type = HT::Type;
-
+    // --- Applying a sequence of records to a segment -----------------------
     // A sequence of records exercising replace / add / update / remove / clear.
     const auto deck = ::Opm::Parser{}.parseString(R"(SCHEDULE
 WSEGHEAT
@@ -1486,8 +1562,8 @@ WSEGHEAT
 /
 )");
 
-    const auto records =
-        ::Opm::segmentHeatTransferFromWSEGHEAT(deck["WSEGHEAT"].back()).at("W");
+    const auto records = recordsForWell
+        (::Opm::segmentHeatTransferFromWSEGHEAT(deck["WSEGHEAT"].back()), "W");
     BOOST_REQUIRE_EQUAL(records.size(), 9);
 
     const double kJ  = 1.0e3;
@@ -1553,16 +1629,13 @@ WSEGHEAT
     // NONE clears everything.
     seg.updateHeatTransfer(records[8]);
     BOOST_CHECK(ht.empty());
-}
 
-BOOST_AUTO_TEST_CASE(WSEGHEAT_SegmentCoefficientCap)
-{
-    using HT   = ::Opm::SegmentHeatTransfer;
-    using Type = HT::Type;
-
-    // Six SEG coefficients to distinct targets, but a segment may carry at
-    // most five; the sixth (target 7) must be silently ignored.
-    const auto deck = ::Opm::Parser{}.parseString(R"(SCHEDULE
+    // A segment may carry at most five SEG coefficients.  Feeding six SEG+
+    // records to distinct targets keeps the first five and silently ignores
+    // the sixth (target 7).  This reuses the same updateHeatTransfer machinery
+    // on a fresh segment.
+    {
+        const auto cap_deck = ::Opm::Parser{}.parseString(R"(SCHEDULE
 WSEGHEAT
    'W' 2 2 SEG+ 0.01 1 /
    'W' 2 2 SEG+ 0.02 3 /
@@ -1573,26 +1646,27 @@ WSEGHEAT
 /
 )");
 
-    const auto records =
-        ::Opm::segmentHeatTransferFromWSEGHEAT(deck["WSEGHEAT"].back()).at("W");
-    BOOST_REQUIRE_EQUAL(records.size(), 6);
+        const auto cap_records = recordsForWell
+            (::Opm::segmentHeatTransferFromWSEGHEAT(cap_deck["WSEGHEAT"].back()), "W");
+        BOOST_REQUIRE_EQUAL(cap_records.size(), 6);
 
-    ::Opm::Segment seg{};
-    for (const auto& record : records) {
-        seg.updateHeatTransfer(record);
+        ::Opm::Segment cap_seg{};
+        for (const auto& record : cap_records) {
+            cap_seg.updateHeatTransfer(record);
+        }
+
+        const auto& cap_ht = cap_seg.heatTransfer();
+        BOOST_CHECK_EQUAL(cap_ht.size(), 5);
+
+        int n_target1 = 0, n_target7 = 0;
+        for (const auto& c : cap_ht) {
+            BOOST_CHECK(c.type() == Type::SEG);
+            if (c.targetSegment() == 1) { ++n_target1; }
+            if (c.targetSegment() == 7) { ++n_target7; }
+        }
+        BOOST_CHECK_EQUAL(n_target1, 1); // first one kept
+        BOOST_CHECK_EQUAL(n_target7, 0); // sixth one dropped
     }
-
-    const auto& ht = seg.heatTransfer();
-    BOOST_CHECK_EQUAL(ht.size(), 5);
-
-    int n_target1 = 0, n_target7 = 0;
-    for (const auto& c : ht) {
-        BOOST_CHECK(c.type() == Type::SEG);
-        if (c.targetSegment() == 1) { ++n_target1; }
-        if (c.targetSegment() == 7) { ++n_target7; }
-    }
-    BOOST_CHECK_EQUAL(n_target1, 1); // first one kept
-    BOOST_CHECK_EQUAL(n_target7, 0); // sixth one dropped
 }
 
 BOOST_AUTO_TEST_CASE(WSEGHEAT_Validation)

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -1166,6 +1166,32 @@ namespace {
         Opm::EclipseState st(deck);
         return Opm::Schedule(deck, st);
     }
+
+    // Shared RUNSPEC/GRID preamble (a 20x20x20 box grid, DX = DY = 100 m,
+    // DZ = 10 m) used by the thermal MSW tests below.  Each test appends its
+    // own SCHEDULE section to this string.
+    const std::string thermalMSWGridPreamble = R"(RUNSPEC
+DIMENS
+  20 20 20 /
+GRID
+DXV
+  20*100 /
+DYV
+  20*100 /
+DZV
+  20*10 /
+DEPTHZ
+  441*2000.0 /
+PORO
+    8000*0.1 /
+PERMX
+    8000*1 /
+PERMY
+    8000*0.1 /
+PERMZ
+    8000*0.01 /
+SCHEDULE
+)";
 } // Anonymous namespace
 
 BOOST_AUTO_TEST_CASE(MSW_SEGMENT_LENGTH) {
@@ -1319,37 +1345,9 @@ BOOST_AUTO_TEST_CASE(ThermalMSW_ScheduleIntegration)
     //
     // COMPSEGS item 10 (THERMAL_LENGTH) provides the effective connection
     // length used by the same thermal option; connections that leave it
-    // defaulted have an unset (nullopt) thermal length.  A downstream thermal
-    // consumer is expected to use the grid-block thickness.
-    const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
-DIMENS
-  20 20 20 /
-
-GRID
-
-DXV
-  20*100 /
-
-DYV
-  20*100 /
-
-DZV
-  20*10 /
-
-DEPTHZ
-  441*2000.0 /
-
-PORO
-    8000*0.1 /
-PERMX
-    8000*1 /
-PERMY
-    8000*0.1 /
-PERMZ
-    8000*0.01 /
-
-SCHEDULE
-
+    // defaulted are populated with the grid-block thickness in the penetration
+    // direction.
+    const auto deck = ::Opm::Parser{}.parseString(thermalMSWGridPreamble + R"(
 WELSPECS
  'PROD01' 'P' 20 20 1* OIL /
 /
@@ -1405,13 +1403,14 @@ WSEGHEAT
 
     // COMPSEGS thermal length: explicitly specified on the first two
     // connections (metric length is in metres, so the SI value equals the
-    // input value) and defaulted (empty) on the third.
+    // input value).  The third connection defaults item 10, so the grid-block
+    // thickness in the connection's penetration direction (COMPDAT item 13) is
+    // substituted.  Here the COMPDAT direction defaults to Z, giving the
+    // vertical thickness DZ = 10 m.
     const auto& connections = sched[0].wells("PROD01").getConnections();
-    BOOST_REQUIRE(connections.getFromIJK(19, 19, 0).thermalLength().has_value());
-    BOOST_CHECK_CLOSE(*connections.getFromIJK(19, 19, 0).thermalLength(), 10.0, 1.0e-8);
-    BOOST_REQUIRE(connections.getFromIJK(19, 19, 1).thermalLength().has_value());
-    BOOST_CHECK_CLOSE(*connections.getFromIJK(19, 19, 1).thermalLength(), 20.0, 1.0e-8);
-    BOOST_CHECK(! connections.getFromIJK(19, 19, 2).thermalLength().has_value());
+    BOOST_CHECK_CLOSE(connections.getFromIJK(19, 19, 0).thermalLength(), 10.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(connections.getFromIJK(19, 19, 1).thermalLength(), 20.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(connections.getFromIJK(19, 19, 2).thermalLength(), 10.0, 1.0e-8);
 
     // WSEGHEAT: segment 2 gets a single fixed-temperature (TEMP) coefficient,
     // segment 3 a single segment-to-segment (SEG) coefficient.  The specific
@@ -1447,27 +1446,7 @@ WSEGHEAT
     // and applied by sorted pattern ('PROD*' sorts before 'PROD01') the
     // replace-all would run last and leave 0.01.
     {
-        const auto order_deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
-DIMENS
-  20 20 20 /
-GRID
-DXV
-  20*100 /
-DYV
-  20*100 /
-DZV
-  20*10 /
-DEPTHZ
-  441*2000.0 /
-PORO
-    8000*0.1 /
-PERMX
-    8000*1 /
-PERMY
-    8000*0.1 /
-PERMZ
-    8000*0.01 /
-SCHEDULE
+        const auto order_deck = ::Opm::Parser{}.parseString(thermalMSWGridPreamble + R"(
 WELSPECS
  'PROD01' 'P' 20 20 1* OIL /
 /
@@ -1677,27 +1656,7 @@ BOOST_AUTO_TEST_CASE(WSEGHEAT_Validation)
     // A three-segment well 'PROD01' to attach WSEGHEAT records to, plus a
     // regular (non-multisegment) well 'PROD02' used to check that WSEGHEAT
     // applied to a well without a segment structure is handled gracefully.
-    const std::string base = R"(RUNSPEC
-DIMENS
-  20 20 20 /
-GRID
-DXV
-  20*100 /
-DYV
-  20*100 /
-DZV
-  20*10 /
-DEPTHZ
-  441*2000.0 /
-PORO
-    8000*0.1 /
-PERMX
-    8000*1 /
-PERMY
-    8000*0.1 /
-PERMZ
-    8000*0.01 /
-SCHEDULE
+    const std::string base = thermalMSWGridPreamble + R"(
 WELSPECS
  'PROD01' 'P' 20 20 1* OIL /
  'PROD02' 'P' 10 10 1* OIL /
@@ -1736,16 +1695,92 @@ COMPSEGS
     BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 3 3 SEG 0.04 /\n/\n"),
                       ::Opm::OpmInputError);
 
-    // A SEG coefficient that targets its own segment is skipped with a warning
-    // (routed through ParseContext::SCHEDULE_MISSING_SEGMENT) rather than
-    // aborting the parse, so an otherwise-usable deck still loads.
+    // A SEG coefficient whose range includes its own target segment simply
+    // skips that one segment (a segment cannot exchange heat with itself); this
+    // is normal usage, not a missing-segment condition, so it must never abort
+    // the parse -- not even when SCHEDULE_MISSING_SEGMENT is promoted to a hard
+    // error.
     BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 3 3 SEG 0.04 3 /\n/\n"));
+    {
+        const auto deck = ::Opm::Parser{}.parseString
+            (base + "WSEGHEAT\n 'PROD01' 3 3 SEG 0.04 3 /\n/\n");
+        const auto es     = ::Opm::EclipseState { deck };
+        const auto python = std::make_shared<const ::Opm::Python>();
+
+        ::Opm::ParseContext parseContext;
+        parseContext.update(::Opm::ParseContext::SCHEDULE_MISSING_SEGMENT,
+                            ::Opm::InputErrorAction::THROW_EXCEPTION);
+        ::Opm::ErrorGuard errors;
+        BOOST_CHECK_NO_THROW(::Opm::Schedule(deck, es, parseContext, errors, python));
+    }
+
+    // A SEG coefficient whose target segment (item 6) does not exist in the
+    // well is a genuine missing-segment condition and is governed by the
+    // SCHEDULE_MISSING_SEGMENT error handler (default WARN, so the deck still
+    // loads).
+    BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 2 2 SEG 0.04 99 /\n/\n"));
+    {
+        const auto deck = ::Opm::Parser{}.parseString
+            (base + "WSEGHEAT\n 'PROD01' 2 2 SEG 0.04 99 /\n/\n");
+        const auto es     = ::Opm::EclipseState { deck };
+        const auto python = std::make_shared<const ::Opm::Python>();
+
+        ::Opm::ParseContext parseContext;
+        parseContext.update(::Opm::ParseContext::SCHEDULE_MISSING_SEGMENT,
+                            ::Opm::InputErrorAction::THROW_EXCEPTION);
+        ::Opm::ErrorGuard errors;
+        BOOST_CHECK_THROW(::Opm::Schedule(deck, es, parseContext, errors, python),
+                          ::Opm::OpmInputError);
+    }
 
     // WSEGHEAT applied to a regular (non-multisegment) well must not crash: it
     // is routed through ParseContext (default WARN) and skipped.  This covers
     // both a literal well name and a wildcard that also matches the MSW well.
     BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n 'PROD02' 2 2 COMP 0.02 /\n/\n"));
     BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n 'PROD*' 2 2 COMP 0.02 /\n/\n"));
+
+    // A range (items 2-3) that extends past the highest defined segment applies
+    // to the segments that do exist and does not abort, even under strict mode:
+    // segment numbering may legitimately be non-contiguous, so numbers absent
+    // from the range are not treated as missing segments.  PROD01 has segments
+    // 1-3, so the range 1-5 applies a COMP coefficient to all three.
+    {
+        const auto sched = makeSchedule("WSEGHEAT\n 'PROD01' 1 5 COMP 0.05 /\n/\n");
+        const auto& segs = sched[0].wells("PROD01").getSegments();
+        for (const int segment_number : {1, 2, 3}) {
+            BOOST_CHECK_EQUAL(segs.getFromSegmentNumber(segment_number)
+                              .heatTransfer().size(), 1);
+        }
+
+        const auto deck = ::Opm::Parser{}.parseString
+            (base + "WSEGHEAT\n 'PROD01' 1 5 COMP 0.05 /\n/\n");
+        const auto es     = ::Opm::EclipseState { deck };
+        const auto python = std::make_shared<const ::Opm::Python>();
+
+        ::Opm::ParseContext parseContext;
+        parseContext.update(::Opm::ParseContext::SCHEDULE_MISSING_SEGMENT,
+                            ::Opm::InputErrorAction::THROW_EXCEPTION);
+        ::Opm::ErrorGuard errors;
+        BOOST_CHECK_NO_THROW(::Opm::Schedule(deck, es, parseContext, errors, python));
+    }
+
+    // A range that matches no defined segment at all is a genuine
+    // missing-segment condition governed by SCHEDULE_MISSING_SEGMENT: it loads
+    // with the default WARN but aborts once the key is promoted to a hard error.
+    BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 8 9 COMP 0.05 /\n/\n"));
+    {
+        const auto deck = ::Opm::Parser{}.parseString
+            (base + "WSEGHEAT\n 'PROD01' 8 9 COMP 0.05 /\n/\n");
+        const auto es     = ::Opm::EclipseState { deck };
+        const auto python = std::make_shared<const ::Opm::Python>();
+
+        ::Opm::ParseContext parseContext;
+        parseContext.update(::Opm::ParseContext::SCHEDULE_MISSING_SEGMENT,
+                            ::Opm::InputErrorAction::THROW_EXCEPTION);
+        ::Opm::ErrorGuard errors;
+        BOOST_CHECK_THROW(::Opm::Schedule(deck, es, parseContext, errors, python),
+                          ::Opm::OpmInputError);
+    }
 
     // Setting or adding a coefficient requires a specific thermal resistance
     // (item 5).

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -1665,7 +1665,7 @@ COMPSEGS
                                       " 'PROD01' 3 3 SEG  0.04 2 /\n/\n"));
 
     // A reference to a non-existent segment is governed by the
-    // SCHEDULE_ICD_MISSING_SEGMENT error handler.
+    // SCHEDULE_MISSING_SEGMENT error handler.
     {
         const auto deck = ::Opm::Parser{}.parseString
             (base + "WSEGHEAT\n 'PROD01' 9 9 TEMP 0.02 1* 60 /\n/\n");
@@ -1677,7 +1677,7 @@ COMPSEGS
 
         // Promoted to a hard error -> construction throws.
         ::Opm::ParseContext parseContext;
-        parseContext.update(::Opm::ParseContext::SCHEDULE_ICD_MISSING_SEGMENT,
+        parseContext.update(::Opm::ParseContext::SCHEDULE_MISSING_SEGMENT,
                             ::Opm::InputErrorAction::THROW_EXCEPTION);
         ::Opm::ErrorGuard errors;
         BOOST_CHECK_THROW(::Opm::Schedule(deck, es, parseContext, errors, python),

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -1733,11 +1733,30 @@ COMPSEGS
                           ::Opm::OpmInputError);
     }
 
-    // WSEGHEAT applied to a regular (non-multisegment) well must not crash: it
-    // is routed through ParseContext (default WARN) and skipped.  This covers
-    // both a literal well name and a wildcard that also matches the MSW well.
-    BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n 'PROD02' 2 2 COMP 0.02 /\n/\n"));
-    BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n 'PROD*' 2 2 COMP 0.02 /\n/\n"));
+    // WSEGHEAT applied to a regular (non-multisegment) well is an unambiguous
+    // input error: SCHEDULE_MSW_KEYWORD_ON_NON_MSW_WELL defaults to THROW, so it
+    // aborts the run.  This covers both a literal well name and a wildcard that
+    // also matches the MSW well.
+    BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD02' 2 2 COMP 0.02 /\n/\n"),
+                      ::Opm::OpmInputError);
+    BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD*' 2 2 COMP 0.02 /\n/\n"),
+                      ::Opm::OpmInputError);
+
+    // The non-MSW case is governed by SCHEDULE_MSW_KEYWORD_ON_NON_MSW_WELL, not
+    // by SCHEDULE_MISSING_SEGMENT: relaxing the former to WARN lets the deck load
+    // (the keyword is dropped), independently of SCHEDULE_MISSING_SEGMENT.
+    {
+        const auto deck = ::Opm::Parser{}.parseString
+            (base + "WSEGHEAT\n 'PROD02' 2 2 COMP 0.02 /\n/\n");
+        const auto es     = ::Opm::EclipseState { deck };
+        const auto python = std::make_shared<const ::Opm::Python>();
+
+        ::Opm::ParseContext parseContext;
+        parseContext.update(::Opm::ParseContext::SCHEDULE_MSW_KEYWORD_ON_NON_MSW_WELL,
+                            ::Opm::InputErrorAction::WARN);
+        ::Opm::ErrorGuard errors;
+        BOOST_CHECK_NO_THROW(::Opm::Schedule(deck, es, parseContext, errors, python));
+    }
 
     // A range (items 2-3) that extends past the highest defined segment applies
     // to the segments that do exist and does not abort, even under strict mode:

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -27,6 +27,7 @@
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 
+#include <opm/input/eclipse/Schedule/MSW/SegmentHeatTransfer.hpp>
 #include <opm/input/eclipse/Schedule/MSW/SICD.hpp>
 #include <opm/input/eclipse/Schedule/MSW/Valve.hpp>
 #include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
@@ -1370,6 +1371,12 @@ COMPSEGS
   20    20     2     1   2525.0   2550.0  3*   20.0 /
   20    20     3     1   2550.0   2575.0 /
 /
+
+WSEGHEAT
+-- Name      Seg1 Seg2 Type Resist Target Temp Interp ContactLen
+   'PROD01'   2    2   TEMP  0.02   1*    60.0  1*    5.0 /
+   'PROD01'   3    3   SEG   0.04   2     1*    0.7   8.0 /
+/
 )");
 
     const auto es    = ::Opm::EclipseState { deck };
@@ -1402,6 +1409,29 @@ COMPSEGS
     BOOST_CHECK_CLOSE(connections.getFromIJK(19, 19, 0).thermalLength(), 10.0, 1.0e-8);
     BOOST_CHECK_CLOSE(connections.getFromIJK(19, 19, 1).thermalLength(), 20.0, 1.0e-8);
     BOOST_CHECK_EQUAL(connections.getFromIJK(19, 19, 2).thermalLength(), 0.0);
+
+    // WSEGHEAT: segment 2 gets a single fixed-temperature (TEMP) coefficient,
+    // segment 3 a single segment-to-segment (SEG) coefficient.  The specific
+    // thermal resistance has dimension 1/ThermalConductivity, so the SI value
+    // is the input scaled by day/kJ.
+    using HT = ::Opm::SegmentHeatTransfer;
+    const auto& ht2 = segments.getFromSegmentNumber(2).heatTransfer();
+    BOOST_REQUIRE_EQUAL(ht2.size(), 1);
+    BOOST_CHECK(ht2[0].type() == HT::Type::TEMP);
+    BOOST_CHECK_CLOSE(ht2[0].thermalResistance(), 0.02 * day / kJ, 1.0e-8);
+    BOOST_CHECK_CLOSE(ht2[0].temperature(), 60.0 + 273.15, 1.0e-8); // degC -> K
+    BOOST_CHECK_CLOSE(ht2[0].contactLength(), 5.0, 1.0e-8);
+
+    const auto& ht3 = segments.getFromSegmentNumber(3).heatTransfer();
+    BOOST_REQUIRE_EQUAL(ht3.size(), 1);
+    BOOST_CHECK(ht3[0].type() == HT::Type::SEG);
+    BOOST_CHECK_CLOSE(ht3[0].thermalResistance(), 0.04 * day / kJ, 1.0e-8);
+    BOOST_CHECK_EQUAL(ht3[0].targetSegment(), 2);
+    BOOST_CHECK_CLOSE(ht3[0].interpolationConstant(), 0.7, 1.0e-8);
+    BOOST_CHECK_CLOSE(ht3[0].contactLength(), 8.0, 1.0e-8);
+
+    // The top segment was never named in WSEGHEAT and has no coefficients.
+    BOOST_CHECK(segments.getFromSegmentNumber(1).heatTransfer().empty());
 }
 
 BOOST_AUTO_TEST_CASE(Node_XY_ABS_Range)

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -1416,7 +1416,7 @@ WSEGHEAT
     // segment 3 a single segment-to-segment (SEG) coefficient.  The specific
     // thermal resistance has dimension 1/ThermalConductivity, so the SI value
     // is the input scaled by day/kJ.
-    using HT = ::Opm::SegmentHeatTransfer;
+    using HT = ::Opm::SegmentHeatTransferCoeff;
     const auto& ht2 = segments.getFromSegmentNumber(2).heatTransfer();
     BOOST_REQUIRE_EQUAL(ht2.size(), 1);
     BOOST_CHECK(ht2[0].type() == HT::Type::TEMP);
@@ -1505,7 +1505,7 @@ namespace {
 
 BOOST_AUTO_TEST_CASE(WSEGHEAT_CoefficientOperations)
 {
-    using HT   = ::Opm::SegmentHeatTransfer;
+    using HT   = ::Opm::SegmentHeatTransferCoeff;
     using Type = HT::Type;
     using Op   = HT::Operation;
 

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -1419,8 +1419,10 @@ WSEGHEAT
     BOOST_REQUIRE_EQUAL(ht2.size(), 1);
     BOOST_CHECK(ht2[0].type() == HT::Type::TEMP);
     BOOST_CHECK_CLOSE(ht2[0].thermalResistance(), 0.02 * day / kJ, 1.0e-8);
-    BOOST_CHECK_CLOSE(ht2[0].temperature(), 60.0 + 273.15, 1.0e-8); // degC -> K
-    BOOST_CHECK_CLOSE(ht2[0].contactLength(), 5.0, 1.0e-8);
+    BOOST_REQUIRE(ht2[0].temperature().has_value());
+    BOOST_CHECK_CLOSE(*ht2[0].temperature(), 60.0 + 273.15, 1.0e-8); // degC -> K
+    BOOST_REQUIRE(ht2[0].contactLength().has_value());
+    BOOST_CHECK_CLOSE(*ht2[0].contactLength(), 5.0, 1.0e-8);
 
     const auto& ht3 = segments.getFromSegmentNumber(3).heatTransfer();
     BOOST_REQUIRE_EQUAL(ht3.size(), 1);
@@ -1428,10 +1430,259 @@ WSEGHEAT
     BOOST_CHECK_CLOSE(ht3[0].thermalResistance(), 0.04 * day / kJ, 1.0e-8);
     BOOST_CHECK_EQUAL(ht3[0].targetSegment(), 2);
     BOOST_CHECK_CLOSE(ht3[0].interpolationConstant(), 0.7, 1.0e-8);
-    BOOST_CHECK_CLOSE(ht3[0].contactLength(), 8.0, 1.0e-8);
+    BOOST_REQUIRE(ht3[0].contactLength().has_value());
+    BOOST_CHECK_CLOSE(*ht3[0].contactLength(), 8.0, 1.0e-8);
+    BOOST_CHECK(!ht3[0].temperature().has_value()); // SEG has no temperature
 
     // The top segment was never named in WSEGHEAT and has no coefficients.
     BOOST_CHECK(segments.getFromSegmentNumber(1).heatTransfer().empty());
+}
+
+BOOST_AUTO_TEST_CASE(WSEGHEAT_TypeFromString)
+{
+    using HT   = ::Opm::SegmentHeatTransfer;
+    using Type = HT::Type;
+    using Op   = HT::Operation;
+
+    // Bare types replace the existing set.
+    BOOST_CHECK(HT::typeFromString("COMP") == std::make_pair(Type::COMP, Op::REPLACE_ALL));
+    BOOST_CHECK(HT::typeFromString("SEG")  == std::make_pair(Type::SEG,  Op::REPLACE_ALL));
+    BOOST_CHECK(HT::typeFromString("TEMP") == std::make_pair(Type::TEMP, Op::REPLACE_ALL));
+
+    // A '+' suffix adds to the set, a '-' suffix removes from it.
+    BOOST_CHECK(HT::typeFromString("COMP+") == std::make_pair(Type::COMP, Op::ADD));
+    BOOST_CHECK(HT::typeFromString("SEG+")  == std::make_pair(Type::SEG,  Op::ADD));
+    BOOST_CHECK(HT::typeFromString("TEMP+") == std::make_pair(Type::TEMP, Op::ADD));
+    BOOST_CHECK(HT::typeFromString("COMP-") == std::make_pair(Type::COMP, Op::REMOVE));
+    BOOST_CHECK(HT::typeFromString("SEG-")  == std::make_pair(Type::SEG,  Op::REMOVE));
+    BOOST_CHECK(HT::typeFromString("TEMP-") == std::make_pair(Type::TEMP, Op::REMOVE));
+
+    // NONE clears the set.
+    BOOST_CHECK(HT::typeFromString("NONE") == std::make_pair(Type::NONE, Op::CLEAR));
+
+    // Anything else is an error.
+    BOOST_CHECK_THROW(HT::typeFromString("FOO"),   std::invalid_argument);
+    BOOST_CHECK_THROW(HT::typeFromString("NONE+"), std::invalid_argument);
+    BOOST_CHECK_THROW(HT::typeFromString(""),      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(WSEGHEAT_UpdateHeatTransfer)
+{
+    using HT   = ::Opm::SegmentHeatTransfer;
+    using Type = HT::Type;
+
+    // A sequence of records exercising replace / add / update / remove / clear.
+    const auto deck = ::Opm::Parser{}.parseString(R"(SCHEDULE
+WSEGHEAT
+   'W' 2 2 COMP  0.01 /
+   'W' 2 2 SEG+  0.02 3 /
+   'W' 2 2 SEG+  0.03 4 /
+   'W' 2 2 TEMP+ 0.04 1* 70 /
+   'W' 2 2 SEG+  0.05 3 /
+   'W' 2 2 COMP- /
+   'W' 2 2 SEG-  0   4 /
+   'W' 2 2 TEMP  0.06 1* 80 /
+   'W' 2 2 NONE /
+/
+)");
+
+    const auto records =
+        ::Opm::segmentHeatTransferFromWSEGHEAT(deck["WSEGHEAT"].back()).at("W");
+    BOOST_REQUIRE_EQUAL(records.size(), 9);
+
+    const double kJ  = 1.0e3;
+    const double day = 86400.0;
+
+    auto findSeg = [](const std::vector<HT>& set, const int target) -> const HT*
+    {
+        for (const auto& c : set) {
+            if ((c.type() == Type::SEG) && (c.targetSegment() == target)) {
+                return &c;
+            }
+        }
+        return nullptr;
+    };
+
+    ::Opm::Segment seg{};
+    const auto& ht = seg.heatTransfer();
+    BOOST_CHECK(ht.empty());
+
+    // COMP (replace-all on an empty set) -> a single COMP coefficient.
+    seg.updateHeatTransfer(records[0]);
+    BOOST_REQUIRE_EQUAL(ht.size(), 1);
+    BOOST_CHECK(ht[0].type() == Type::COMP);
+
+    // SEG+ to two distinct targets -> coefficients accumulate.
+    seg.updateHeatTransfer(records[1]);
+    seg.updateHeatTransfer(records[2]);
+    BOOST_REQUIRE_EQUAL(ht.size(), 3);
+
+    // TEMP+ -> the one permitted external-temperature coefficient is added.
+    seg.updateHeatTransfer(records[3]);
+    BOOST_REQUIRE_EQUAL(ht.size(), 4);
+
+    // SEG+ to an existing target updates in place (size unchanged).
+    seg.updateHeatTransfer(records[4]);
+    BOOST_REQUIRE_EQUAL(ht.size(), 4);
+    {
+        const auto* s3 = findSeg(ht, 3);
+        BOOST_REQUIRE(s3 != nullptr);
+        BOOST_CHECK_CLOSE(s3->thermalResistance(), 0.05 * day / kJ, 1.0e-8);
+    }
+
+    // COMP- removes the completion coefficient only.
+    seg.updateHeatTransfer(records[5]);
+    BOOST_REQUIRE_EQUAL(ht.size(), 3);
+    for (const auto& c : ht) {
+        BOOST_CHECK(c.type() != Type::COMP);
+    }
+
+    // SEG- removes the matching segment-to-segment coefficient (target 4).
+    seg.updateHeatTransfer(records[6]);
+    BOOST_REQUIRE_EQUAL(ht.size(), 2);
+    BOOST_CHECK(findSeg(ht, 4) == nullptr);
+    BOOST_CHECK(findSeg(ht, 3) != nullptr);
+
+    // Bare TEMP replaces the whole set with a single TEMP coefficient.
+    seg.updateHeatTransfer(records[7]);
+    BOOST_REQUIRE_EQUAL(ht.size(), 1);
+    BOOST_CHECK(ht[0].type() == Type::TEMP);
+    BOOST_REQUIRE(ht[0].temperature().has_value());
+    BOOST_CHECK_CLOSE(*ht[0].temperature(), 80.0 + 273.15, 1.0e-8);
+
+    // NONE clears everything.
+    seg.updateHeatTransfer(records[8]);
+    BOOST_CHECK(ht.empty());
+}
+
+BOOST_AUTO_TEST_CASE(WSEGHEAT_SegmentCoefficientCap)
+{
+    using HT   = ::Opm::SegmentHeatTransfer;
+    using Type = HT::Type;
+
+    // Six SEG coefficients to distinct targets, but a segment may carry at
+    // most five; the sixth (target 7) must be silently ignored.
+    const auto deck = ::Opm::Parser{}.parseString(R"(SCHEDULE
+WSEGHEAT
+   'W' 2 2 SEG+ 0.01 1 /
+   'W' 2 2 SEG+ 0.02 3 /
+   'W' 2 2 SEG+ 0.03 4 /
+   'W' 2 2 SEG+ 0.04 5 /
+   'W' 2 2 SEG+ 0.05 6 /
+   'W' 2 2 SEG+ 0.06 7 /
+/
+)");
+
+    const auto records =
+        ::Opm::segmentHeatTransferFromWSEGHEAT(deck["WSEGHEAT"].back()).at("W");
+    BOOST_REQUIRE_EQUAL(records.size(), 6);
+
+    ::Opm::Segment seg{};
+    for (const auto& record : records) {
+        seg.updateHeatTransfer(record);
+    }
+
+    const auto& ht = seg.heatTransfer();
+    BOOST_CHECK_EQUAL(ht.size(), 5);
+
+    int n_target1 = 0, n_target7 = 0;
+    for (const auto& c : ht) {
+        BOOST_CHECK(c.type() == Type::SEG);
+        if (c.targetSegment() == 1) { ++n_target1; }
+        if (c.targetSegment() == 7) { ++n_target7; }
+    }
+    BOOST_CHECK_EQUAL(n_target1, 1); // first one kept
+    BOOST_CHECK_EQUAL(n_target7, 0); // sixth one dropped
+}
+
+BOOST_AUTO_TEST_CASE(WSEGHEAT_Validation)
+{
+    // A three-segment well to attach WSEGHEAT records to.
+    const std::string base = R"(RUNSPEC
+DIMENS
+  20 20 20 /
+GRID
+DXV
+  20*100 /
+DYV
+  20*100 /
+DZV
+  20*10 /
+DEPTHZ
+  441*2000.0 /
+PORO
+    8000*0.1 /
+PERMX
+    8000*1 /
+PERMY
+    8000*0.1 /
+PERMZ
+    8000*0.01 /
+SCHEDULE
+WELSPECS
+ 'PROD01' 'P' 20 20 1* OIL /
+/
+COMPDAT
+ 'PROD01' 20 20 1 3 'OPEN' /
+/
+WELSEGS
+'PROD01' 2512.5 2512.5 1.0e-5 'ABS' /
+2  2  1  1  2537.5 2525.5  0.3  0.00010 /
+3  3  1  2  2562.5 2562.5  0.2  0.00010 /
+/
+COMPSEGS
+  'PROD01' /
+  20    20     1     1   2512.5   2525.0 /
+  20    20     2     1   2525.0   2550.0 /
+  20    20     3     1   2550.0   2575.0 /
+/
+)";
+
+    auto makeSchedule = [&base](const std::string& wsegheat)
+    {
+        const auto deck = ::Opm::Parser{}.parseString(base + wsegheat);
+        const auto es   = ::Opm::EclipseState { deck };
+        return ::Opm::Schedule {
+            deck, es, std::make_shared<const ::Opm::Python>()
+        };
+    };
+
+    // A TEMP coefficient requires an external temperature (item 7).
+    BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 2 2 TEMP 0.02 /\n/\n"),
+                      ::Opm::OpmInputError);
+
+    // A SEG coefficient requires a target segment (item 6).
+    BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 3 3 SEG 0.04 /\n/\n"),
+                      ::Opm::OpmInputError);
+
+    // A SEG coefficient may not target its own segment.
+    BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 3 3 SEG 0.04 3 /\n/\n"),
+                      ::Opm::OpmInputError);
+
+    // Fully specified records are accepted.
+    BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n"
+                                      " 'PROD01' 2 2 TEMP 0.02 1* 60 /\n"
+                                      " 'PROD01' 3 3 SEG  0.04 2 /\n/\n"));
+
+    // A reference to a non-existent segment is governed by the
+    // SCHEDULE_ICD_MISSING_SEGMENT error handler.
+    {
+        const auto deck = ::Opm::Parser{}.parseString
+            (base + "WSEGHEAT\n 'PROD01' 9 9 TEMP 0.02 1* 60 /\n/\n");
+        const auto es     = ::Opm::EclipseState { deck };
+        const auto python = std::make_shared<const ::Opm::Python>();
+
+        // Default action is WARN -> construction succeeds.
+        BOOST_CHECK_NO_THROW(::Opm::Schedule(deck, es, python));
+
+        // Promoted to a hard error -> construction throws.
+        ::Opm::ParseContext parseContext;
+        parseContext.update(::Opm::ParseContext::SCHEDULE_ICD_MISSING_SEGMENT,
+                            ::Opm::InputErrorAction::THROW_EXCEPTION);
+        ::Opm::ErrorGuard errors;
+        BOOST_CHECK_THROW(::Opm::Schedule(deck, es, parseContext, errors, python),
+                          ::Opm::OpmInputError);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(Node_XY_ABS_Range)

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -1319,7 +1319,8 @@ BOOST_AUTO_TEST_CASE(ThermalMSW_ScheduleIntegration)
     //
     // COMPSEGS item 10 (THERMAL_LENGTH) provides the effective connection
     // length used by the same thermal option; connections that leave it
-    // defaulted keep a thermal length of zero.
+    // defaulted have an unset (nullopt) thermal length.  A downstream thermal
+    // consumer is expected to use the grid-block thickness.
     const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
 DIMENS
   20 20 20 /
@@ -1404,11 +1405,13 @@ WSEGHEAT
 
     // COMPSEGS thermal length: explicitly specified on the first two
     // connections (metric length is in metres, so the SI value equals the
-    // input value) and defaulted to zero on the third.
+    // input value) and defaulted (empty) on the third.
     const auto& connections = sched[0].wells("PROD01").getConnections();
-    BOOST_CHECK_CLOSE(connections.getFromIJK(19, 19, 0).thermalLength(), 10.0, 1.0e-8);
-    BOOST_CHECK_CLOSE(connections.getFromIJK(19, 19, 1).thermalLength(), 20.0, 1.0e-8);
-    BOOST_CHECK_EQUAL(connections.getFromIJK(19, 19, 2).thermalLength(), 0.0);
+    BOOST_REQUIRE(connections.getFromIJK(19, 19, 0).thermalLength().has_value());
+    BOOST_CHECK_CLOSE(*connections.getFromIJK(19, 19, 0).thermalLength(), 10.0, 1.0e-8);
+    BOOST_REQUIRE(connections.getFromIJK(19, 19, 1).thermalLength().has_value());
+    BOOST_CHECK_CLOSE(*connections.getFromIJK(19, 19, 1).thermalLength(), 20.0, 1.0e-8);
+    BOOST_CHECK(! connections.getFromIJK(19, 19, 2).thermalLength().has_value());
 
     // WSEGHEAT: segment 2 gets a single fixed-temperature (TEMP) coefficient,
     // segment 3 a single segment-to-segment (SEG) coefficient.  The specific
@@ -1671,7 +1674,9 @@ WSEGHEAT
 
 BOOST_AUTO_TEST_CASE(WSEGHEAT_Validation)
 {
-    // A three-segment well to attach WSEGHEAT records to.
+    // A three-segment well 'PROD01' to attach WSEGHEAT records to, plus a
+    // regular (non-multisegment) well 'PROD02' used to check that WSEGHEAT
+    // applied to a well without a segment structure is handled gracefully.
     const std::string base = R"(RUNSPEC
 DIMENS
   20 20 20 /
@@ -1695,9 +1700,11 @@ PERMZ
 SCHEDULE
 WELSPECS
  'PROD01' 'P' 20 20 1* OIL /
+ 'PROD02' 'P' 10 10 1* OIL /
 /
 COMPDAT
  'PROD01' 20 20 1 3 'OPEN' /
+ 'PROD02' 10 10 1 3 'OPEN' /
 /
 WELSEGS
 'PROD01' 2512.5 2512.5 1.0e-5 'ABS' /
@@ -1729,9 +1736,16 @@ COMPSEGS
     BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 3 3 SEG 0.04 /\n/\n"),
                       ::Opm::OpmInputError);
 
-    // A SEG coefficient may not target its own segment.
-    BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 3 3 SEG 0.04 3 /\n/\n"),
-                      ::Opm::OpmInputError);
+    // A SEG coefficient that targets its own segment is skipped with a warning
+    // (routed through ParseContext::SCHEDULE_MISSING_SEGMENT) rather than
+    // aborting the parse, so an otherwise-usable deck still loads.
+    BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 3 3 SEG 0.04 3 /\n/\n"));
+
+    // WSEGHEAT applied to a regular (non-multisegment) well must not crash: it
+    // is routed through ParseContext (default WARN) and skipped.  This covers
+    // both a literal well name and a wildcard that also matches the MSW well.
+    BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n 'PROD02' 2 2 COMP 0.02 /\n/\n"));
+    BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n 'PROD*' 2 2 COMP 0.02 /\n/\n"));
 
     // Setting or adding a coefficient requires a specific thermal resistance
     // (item 5).
@@ -1776,6 +1790,16 @@ COMPSEGS
         BOOST_CHECK_THROW(::Opm::Schedule(deck, es, parseContext, errors, python),
                           ::Opm::OpmInputError);
     }
+
+    // An inverted segment range (item 3 < item 2) is self-inconsistent and can
+    // never match a well, so it is rejected at parse time.
+    BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 3 2 TEMP 0.02 1* 60 /\n/\n"),
+                      ::Opm::OpmInputError);
+
+    // A non-positive first segment (item 2) is likewise rejected; segment
+    // numbers are 1-based.
+    BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 0 2 TEMP 0.02 1* 60 /\n/\n"),
+                      ::Opm::OpmInputError);
 }
 
 BOOST_AUTO_TEST_CASE(Node_XY_ABS_Range)

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -1659,10 +1659,29 @@ COMPSEGS
     BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 3 3 SEG 0.04 3 /\n/\n"),
                       ::Opm::OpmInputError);
 
+    // Setting or adding a coefficient requires a specific thermal resistance
+    // (item 5).
+    BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 2 2 COMP /\n/\n"),
+                      ::Opm::OpmInputError);
+    BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 2 2 COMP+ /\n/\n"),
+                      ::Opm::OpmInputError);
+
     // Fully specified records are accepted.
     BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n"
                                       " 'PROD01' 2 2 TEMP 0.02 1* 60 /\n"
                                       " 'PROD01' 3 3 SEG  0.04 2 /\n/\n"));
+
+    // A removal ('-') only identifies an existing coefficient, so neither the
+    // thermal resistance (item 5) nor, for TEMP, the external temperature
+    // (item 7) need be specified.
+    BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 2 2 COMP- /\n/\n"));
+    BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 2 2 TEMP- /\n/\n"));
+    BOOST_CHECK_NO_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 3 3 SEG- 1* 2 /\n/\n"));
+
+    // The target segment (item 6) is still required to identify which SEG
+    // coefficient a removal applies to.
+    BOOST_CHECK_THROW(makeSchedule("WSEGHEAT\n 'PROD01' 3 3 SEG- /\n/\n"),
+                      ::Opm::OpmInputError);
 
     // A reference to a non-existent segment is governed by the
     // SCHEDULE_MISSING_SEGMENT error handler.

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -1315,6 +1315,10 @@ BOOST_AUTO_TEST_CASE(PipeWallThermalProperties)
     // WELSEGS items 10-12 (record 1) and 13-15 (subsequent records) provide
     // the pipe-wall properties used by the thermal option.  Segment 2 sets its
     // own values while the remaining segments fall back to the record 1 values.
+    //
+    // COMPSEGS item 10 (THERMAL_LENGTH) provides the effective connection
+    // length used by the same thermal option; connections that leave it
+    // defaulted keep a thermal length of zero.
     const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
 DIMENS
   20 20 20 /
@@ -1361,9 +1365,9 @@ WELSEGS
 COMPSEGS
 -- Name
   'PROD01' /
--- I    J     K   Branch
-  20    20     1     1   2512.5   2525.0 /
-  20    20     2     1   2525.0   2550.0 /
+-- I    J     K   Branch  Dstart  Dend   3*    ThermLen
+  20    20     1     1   2512.5   2525.0  3*   10.0 /
+  20    20     2     1   2525.0   2550.0  3*   20.0 /
   20    20     3     1   2550.0   2575.0 /
 /
 )");
@@ -1390,6 +1394,14 @@ COMPSEGS
     BOOST_CHECK_CLOSE(segment2.wallArea(), 2.5, 1.0e-8);
     BOOST_CHECK_CLOSE(segment2.wallVolumetricHeatCapacity(), 3000.0 * kJ, 1.0e-8);
     BOOST_CHECK_CLOSE(segment2.wallThermalConductivity(), 80.0 * kJ / day, 1.0e-8);
+
+    // COMPSEGS thermal length: explicitly specified on the first two
+    // connections (metric length is in metres, so the SI value equals the
+    // input value) and defaulted to zero on the third.
+    const auto& connections = sched[0].wells("PROD01").getConnections();
+    BOOST_CHECK_CLOSE(connections.getFromIJK(19, 19, 0).thermalLength(), 10.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(connections.getFromIJK(19, 19, 1).thermalLength(), 20.0, 1.0e-8);
+    BOOST_CHECK_EQUAL(connections.getFromIJK(19, 19, 2).thermalLength(), 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(Node_XY_ABS_Range)

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -1310,6 +1310,88 @@ COMPSEGS
     }
 }
 
+BOOST_AUTO_TEST_CASE(PipeWallThermalProperties)
+{
+    // WELSEGS items 10-12 (record 1) and 13-15 (subsequent records) provide
+    // the pipe-wall properties used by the thermal option.  Segment 2 sets its
+    // own values while the remaining segments fall back to the record 1 values.
+    const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
+DIMENS
+  20 20 20 /
+
+GRID
+
+DXV
+  20*100 /
+
+DYV
+  20*100 /
+
+DZV
+  20*10 /
+
+DEPTHZ
+  441*2000.0 /
+
+PORO
+    8000*0.1 /
+PERMX
+    8000*1 /
+PERMY
+    8000*0.1 /
+PERMZ
+    8000*0.01 /
+
+SCHEDULE
+
+WELSPECS
+ 'PROD01' 'P' 20 20 1* OIL /
+/
+
+COMPDAT
+ 'PROD01' 20 20 1 3 'OPEN' /
+/
+
+WELSEGS
+'PROD01' 2512.5 2512.5 1.0e-5 'ABS' 'HF-' 'HO' 0.0 0.0 1.5 2000 50 /
+2  2  1  1  2537.5 2525.5  0.3  0.00010 2* 0.0 0.0 2.5 3000 80 /
+3  3  1  2  2562.5 2562.5  0.2  0.00010 2* 0.0 0.0 /
+/
+
+COMPSEGS
+-- Name
+  'PROD01' /
+-- I    J     K   Branch
+  20    20     1     1   2512.5   2525.0 /
+  20    20     2     1   2525.0   2550.0 /
+  20    20     3     1   2550.0   2575.0 /
+/
+)");
+
+    const auto es    = ::Opm::EclipseState { deck };
+    const auto sched = ::Opm::Schedule { deck, es, std::make_shared<const ::Opm::Python>() };
+
+    const auto& segments = sched[0].wells("PROD01").getSegments();
+
+    // Metric to SI conversion factors for the thermal quantities.
+    const double kJ  = 1.0e3;     // kJ -> J (Energy)
+    const double day = 86400.0;   // day -> s  (ThermalConductivity uses /day)
+
+    // Top segment and segment 3 use the record 1 (default) values.
+    for (const int segment_number : {1, 3}) {
+        const auto& segment = segments.getFromSegmentNumber(segment_number);
+        BOOST_CHECK_CLOSE(segment.wallArea(), 1.5, 1.0e-8);
+        BOOST_CHECK_CLOSE(segment.wallVolumetricHeatCapacity(), 2000.0 * kJ, 1.0e-8);
+        BOOST_CHECK_CLOSE(segment.wallThermalConductivity(), 50.0 * kJ / day, 1.0e-8);
+    }
+
+    // Segment 2 overrides the defaults with its own record values.
+    const auto& segment2 = segments.getFromSegmentNumber(2);
+    BOOST_CHECK_CLOSE(segment2.wallArea(), 2.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(segment2.wallVolumetricHeatCapacity(), 3000.0 * kJ, 1.0e-8);
+    BOOST_CHECK_CLOSE(segment2.wallThermalConductivity(), 80.0 * kJ / day, 1.0e-8);
+}
+
 BOOST_AUTO_TEST_CASE(Node_XY_ABS_Range)
 {
     const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -381,6 +381,27 @@ BOOST_AUTO_TEST_CASE(TestNew) {
 }
 
 
+BOOST_AUTO_TEST_CASE(TestRenamedKey) {
+    ParseContext parseContext;
+
+    // SCHEDULE_ICD_MISSING_SEGMENT was renamed to SCHEDULE_MISSING_SEGMENT
+    // after release 2026.04.  The original name must remain usable in user
+    // configurations for a transition period.
+    BOOST_CHECK_NO_THROW( parseContext.updateKey("SCHEDULE_ICD_MISSING_SEGMENT", InputErrorAction::IGNORE) );
+    BOOST_CHECK_EQUAL( parseContext.get(ParseContext::SCHEDULE_MISSING_SEGMENT), InputErrorAction::IGNORE );
+
+    // Also through the string-based update() used for e.g. environment
+    // variables and command line options.
+    parseContext.update("SCHEDULE_ICD_MISSING_SEGMENT", InputErrorAction::EXIT1);
+    BOOST_CHECK_EQUAL( parseContext.get(ParseContext::SCHEDULE_MISSING_SEGMENT), InputErrorAction::EXIT1 );
+
+    // The original name is only translated, not registered as a category
+    // of its own.
+    BOOST_CHECK_EQUAL( false, parseContext.hasKey("SCHEDULE_ICD_MISSING_SEGMENT") );
+    BOOST_CHECK_THROW( parseContext.get("SCHEDULE_ICD_MISSING_SEGMENT"), std::invalid_argument );
+}
+
+
 BOOST_AUTO_TEST_CASE( test_constructor_with_values) {
     ParseContext parseContext( {{ParseContext::PARSE_RANDOM_SLASH , InputErrorAction::IGNORE},
                 {"UNSUPPORTED_*" , InputErrorAction::WARN},


### PR DESCRIPTION
- WELSEGS: parse the pipe-wall thermal properties (items 10-15) — wall area, volumetric heat capacity and thermal conductivity — with per-segment fallback to the record-1 defaults.

- COMPSEGS: parse the effective thermal connection length (item 10),  if defaulted, using the grid thickness.

- WSEGHEAT: parse and apply the new keyword — COMP/SEG/TEMP heat-transfer coefficients with +/-/NONE set operations, a five-coefficient-per-segment cap, input validation, and deck-order application across overlapping well-name patterns.
