### PR TITLE
Reduce Cost of Actions::Max_Input_Lines()

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ActionX.cpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.cpp
@@ -32,7 +32,6 @@
 #include <opm/input/eclipse/Utility/Typetools.hpp>
 
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/input/eclipse/Deck/DeckOutput.hpp>
 
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 
@@ -44,6 +43,7 @@
 #include <ctime>
 #include <iterator>
 #include <optional>
+#include <ranges>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -283,33 +283,43 @@ void ActionX::update_id(const std::size_t id)
 
 std::vector<std::string> ActionX::keyword_strings() const
 {
-    std::vector<std::string> keyword_strings;
-    std::string keyword_string;
-    {
-        std::stringstream ss;
-        DeckOutput::format fmt;
-        for (const auto& kw : this->keywords) {
-            ss << kw;
-            ss << fmt.keyword_sep;
+    auto kw_strings = std::vector<std::string>{};
+
+    std::stringstream ss;
+
+    for (auto line = std::string{}; const auto& kw : this->keywords) {
+        ss.str({});
+        ss.clear();
+        ss << kw;
+
+        auto kw_lines = std::ranges::subrange
+            (std::istreambuf_iterator<char>(ss), std::default_sentinel);
+
+        // Note: We need lazy_split() in C++20 instead of split() because the
+        // underlying stream buffer iterator is just an input iterator, not a
+        // forward iterator.  C++23 relaxes that requirement and allows split()
+        // to work with input iterators.
+        for (auto&& line_range : kw_lines | std::views::lazy_split('\n')) {
+            line.clear();
+
+            // C++20 limitation: Std::string cannot be constructed
+            // directly from lazy_view's subrange.  We need to copy
+            // the subrange into a string before putting it into the
+            // vector.  C++23 relaxes that requirement and allows
+            // constructing a string directly in the vector from a
+            // lazy_view's subrange.  See
+            // https://en.cppreference.com/w/cpp/ranges/lazy_split
+            std::ranges::copy(line_range, std::back_inserter(line));
+
+            if (! line.empty()) {
+                kw_strings.push_back(std::move(line));
+            }
         }
-
-        keyword_string = ss.str();
     }
 
-    std::size_t offset = 0;
-    while (true) {
-        auto eol_pos = keyword_string.find('\n', offset);
-        if (eol_pos == std::string::npos)
-            break;
+    kw_strings.emplace_back("ENDACTIO");
 
-        if (eol_pos > offset)
-            keyword_strings.push_back(keyword_string.substr(offset, eol_pos - offset));
-
-        offset = eol_pos + 1;
-    }
-    keyword_strings.push_back("ENDACTIO");
-
-    return keyword_strings;
+    return kw_strings;
 }
 
 bool ActionX::operator==(const ActionX& data) const

--- a/opm/input/eclipse/Schedule/Action/Actions.cpp
+++ b/opm/input/eclipse/Schedule/Action/Actions.cpp
@@ -25,6 +25,7 @@
 #include <cstddef>
 #include <ctime>
 #include <iterator>
+#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -98,13 +99,15 @@ std::size_t Actions::py_size() const
 
 int Actions::max_input_lines() const
 {
-    std::size_t max_il = 0;
-
-    for (const auto& act : this->actions_) {
-        if (act.keyword_strings().size() > max_il) {
-            max_il = act.keyword_strings().size();
-        }
+    if (this->actions_.empty()) {
+        return 0;
     }
+
+    const auto max_il = std::accumulate(this->actions_.begin(),
+                                        this->actions_.end(),
+                                        std::size_t{0},
+        [](const auto& max_so_far, const auto& action)
+        { return std::max(max_so_far, action.keyword_strings().size()); });
 
     return static_cast<int>(max_il);
 }


### PR DESCRIPTION
In particular, use `std::accumulate()` to simplify calculating the maximum and ensure that we call `ActionX::keyword_strings()` at most once for each action.  Secondly, reduce the number of allocations within `ActionX::keyword_strings()`.  We dot this by formatting one action block keyword at a time into a `stringstream` and using C++20's ranges to loop directly over that `stringstream` instead of calling `.str()` and manually splitting that up with `.substr()`.

We could arguably cache the keyword strings for an action, but that would make each `ActionX` object larger.  Another option would be to at least cache the number of input lines (`keyword_strings().size()`) so that we don't need to form the full set of strings just to have the number of strings.