### PR TITLE
Fixing warnings

### DIFF
--- a/tests/parser/BoxTests.cpp
+++ b/tests/parser/BoxTests.cpp
@@ -61,9 +61,9 @@ BOOST_AUTO_TEST_CASE(CreateSubBox) {
     const Opm::GridDims gridDims(10,10,10);
     const Opm::Box globalBox(gridDims, allActive(), identityMapping());
 
-    BOOST_CHECK_THROW(std::make_unique<Opm::Box>( gridDims, allActive(), identityMapping(), -1 ,  9 , 1 , 8 , 1, 8), std::invalid_argument);   //  Negative throw
-    BOOST_CHECK_THROW(std::make_unique<Opm::Box>( gridDims, allActive(), identityMapping(),  1 , 19 , 1 , 8 , 1, 8), std::invalid_argument);   //  Bigger than global: throw
-    BOOST_CHECK_THROW(std::make_unique<Opm::Box>( gridDims, allActive(), identityMapping(),  9 ,  1 , 1 , 8 , 1, 8), std::invalid_argument);   //  Inverted order: throw
+    BOOST_CHECK_THROW(static_cast<void>(std::make_unique<Opm::Box>( gridDims, allActive(), identityMapping(), -1 ,  9 , 1 , 8 , 1, 8)), std::invalid_argument);   //  Negative throw
+    BOOST_CHECK_THROW(static_cast<void>(std::make_unique<Opm::Box>( gridDims, allActive(), identityMapping(),  1 , 19 , 1 , 8 , 1, 8)), std::invalid_argument);   //  Bigger than global: throw
+    BOOST_CHECK_THROW(static_cast<void>(std::make_unique<Opm::Box>( gridDims, allActive(), identityMapping(),  9 ,  1 , 1 , 8 , 1, 8)), std::invalid_argument);   //  Inverted order: throw
 
     Opm::Box subBox1(gridDims, allActive(), identityMapping(), 0,9,0,9,0,9);
     BOOST_CHECK( subBox1.isGlobal());

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -1493,7 +1493,7 @@ BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_withSizeOther) {
 
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_missingName_throws) {
     Json::JsonObject jsonObject("{\"nameXX\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100}");
-    BOOST_CHECK_THROW(std::make_shared<const ParserKeyword>(jsonObject) , std::invalid_argument);
+    BOOST_CHECK_THROW(static_cast<void>(std::make_shared<const ParserKeyword>(jsonObject)) , std::invalid_argument);
 }
 
 /*
@@ -1501,25 +1501,25 @@ BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_missingName_throws) {
 */
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_invalidItems_throws) {
     Json::JsonObject jsonObject("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100 , \"items\" : 100}");
-    BOOST_CHECK_THROW(std::make_shared<const ParserKeyword>(jsonObject) , std::invalid_argument);
+    BOOST_CHECK_THROW(static_cast<void>(std::make_shared<const ParserKeyword>(jsonObject)) , std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_ItemMissingName_throws) {
     Json::JsonObject jsonObject("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100 , \"items\" : [{\"nameX\" : \"I\"  , \"value_type\" : \"INT\"}]}");
-    BOOST_CHECK_THROW(std::make_shared<const ParserKeyword>(jsonObject) , std::invalid_argument);
+    BOOST_CHECK_THROW(static_cast<void>(std::make_shared<const ParserKeyword>(jsonObject)) , std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_ItemMissingValueType_throws) {
     Json::JsonObject jsonObject("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100 , \"items\" : [{\"name\" : \"I\" , \"size_type\" : \"SINGLE\" , \"Xvalue_type\" : \"INT\"}]}");
-    BOOST_CHECK_THROW(std::make_shared<const ParserKeyword>(jsonObject) , std::invalid_argument);
+    BOOST_CHECK_THROW(static_cast<void>(std::make_shared<const ParserKeyword>(jsonObject)) , std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_ItemInvalidEnum_throws) {
     Json::JsonObject jsonObject1("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100 , \"items\" : [{\"name\" : \"I\" , \"size_type\" : \"XSINGLE\" , \"value_type\" : \"INT\"}]}");
     Json::JsonObject jsonObject2("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100 , \"items\" : [{\"name\" : \"I\" , \"size_type\" : \"SINGLE\" , \"value_type\" : \"INTX\"}]}");
 
-    BOOST_CHECK_THROW(std::make_shared<const ParserKeyword>(jsonObject1) , std::invalid_argument);
-    BOOST_CHECK_THROW(std::make_shared<const ParserKeyword>(jsonObject2) , std::invalid_argument);
+    BOOST_CHECK_THROW(static_cast<void>(std::make_shared<const ParserKeyword>(jsonObject1)) , std::invalid_argument);
+    BOOST_CHECK_THROW(static_cast<void>(std::make_shared<const ParserKeyword>(jsonObject2)) , std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObjectItemsOK) {
@@ -1534,7 +1534,7 @@ BOOST_AUTO_TEST_CASE(ConstructFromJsonObjectItemsOK) {
 
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_sizeFromOther) {
     Json::JsonObject jsonConfig("{\"name\": \"EQUILX\", \"sections\":[\"PROPS\"], \"size\" : {\"keyword\":\"EQLDIMS\" , \"item\" : \"NTEQUL\"},  \"items\" :[{\"name\":\"ItemX\" ,\"value_type\" : \"DOUBLE\"}]}");
-    BOOST_CHECK_NO_THROW( std::make_shared<const ParserKeyword>(jsonConfig) );
+    BOOST_CHECK_NO_THROW( static_cast<void>(std::make_shared<const ParserKeyword>(jsonConfig)) );
 }
 
 BOOST_AUTO_TEST_CASE(Default_NotData) {

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -6401,7 +6401,7 @@ END
     BOOST_REQUIRE_MESSAGE(!sched[5].sumthin().has_value(),
                           R"("SUMTHIN" must NOT be configured on report step 6)");
 
-    BOOST_CHECK_THROW(sched[5].sumthin().value(), std::bad_optional_access);
+    BOOST_CHECK_THROW(static_cast<void>(sched[5].sumthin().value()), std::bad_optional_access);
 
     BOOST_REQUIRE_MESSAGE(!sched[6].sumthin().has_value(),
                           R"("SUMTHIN" must NOT be configured on report step 7)");

--- a/tests/test_Solution.cpp
+++ b/tests/test_Solution.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(Create)
 
         BOOST_CHECK_EQUAL( c.find("NAME")->first, "NAME");
 
-        BOOST_CHECK_THROW( c.at("NotLikeThis") , std::out_of_range );
+        BOOST_CHECK_THROW( static_cast<void>(c.at("NotLikeThis")) , std::out_of_range );
 
 
         c.insert( "NAME2" , UnitSystem::measure::identity, data , data::TargetType::RESTART_SOLUTION );

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -3494,7 +3494,7 @@ BOOST_AUTO_TEST_CASE(READ_WRITE_WELLDATA)
 
             // No data for segment 10 of well W_2 (or no such segment).
             const auto& W2 = wellRatesCopy.at("W_2");
-            BOOST_CHECK_THROW(W2.segments.at(10), std::out_of_range);
+            BOOST_CHECK_THROW(static_cast<void>(W2.segments.at(10)), std::out_of_range);
 
             const auto& W6 = wellRatesCopy.at("W_6");
             const auto& curr = W6.current_control;


### PR DESCRIPTION
Fixing warnings of the type:
```bash
opm/opm-common/tests/test_Solution.cpp:48:28: warning: ignoring return value of function declared with
      'nodiscard' attribute [-Wunused-result]
   48 |         BOOST_CHECK_THROW( c.at("NotLikeThis") , std::out_of_range );
```