### PR TITLE
[DualPorosity] Add Runspec dual-porosity accessors + register SIGMAV in FieldProps

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -134,6 +134,7 @@ namespace ALIAS {
 
 namespace GRID {
 static const std::unordered_map<std::string, keyword_info<double>> double_keywords = {{"DISPERC",keyword_info<double>{}.unit_string("Length")},
+                                                                                      {"SIGMAV",  keyword_info<double>{}.unit_string("1/Length*Length")},
                                                                                       {"MINPVV",  keyword_info<double>{}.init(0.0).unit_string("ReservoirVolume").global_kw(true)},
                                                                                       {"MULTPV",  keyword_info<double>{}.init(1.0).mult(true)},
                                                                                       {"NTG",     keyword_info<double>{}.init(1.0)},

--- a/opm/input/eclipse/EclipseState/Runspec.cpp
+++ b/opm/input/eclipse/EclipseState/Runspec.cpp
@@ -31,6 +31,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/A.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/B.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/D.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/F.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/H.hpp>
@@ -831,6 +832,8 @@ Runspec::Runspec(const Deck& deck)
     , m_mech       (false)
     , m_temp       (false)
     , m_biof       (false)
+    , m_dualporo   (false)
+    , m_nodppm     (false)
 {
     if (DeckSection::hasRUNSPEC(deck)) {
         const RUNSPECSection runspecSection{deck};
@@ -891,6 +894,14 @@ Runspec::Runspec(const Deck& deck)
             else {
                 throw std::runtime_error("\nThe CO2SOL option is given. Activate SOLVENT.");
             }
+        }
+
+        if (runspecSection.hasKeyword<ParserKeywords::DUALPORO>()) {
+            m_dualporo = true;
+        }
+
+        if (runspecSection.hasKeyword<ParserKeywords::NODPPM>()) {
+            m_nodppm = true;
         }
 
         if (runspecSection.hasKeyword<ParserKeywords::COMPS>()) {
@@ -1009,6 +1020,8 @@ Runspec Runspec::serializationTestObject()
     result.m_mech = true;
     result.m_temp = true;
     result.m_biof = true;
+    result.m_dualporo = true;
+    result.m_nodppm = true;
     result.m_geochem = Geochem::serializationTestObject();
 
     return result;
@@ -1135,6 +1148,16 @@ bool Runspec::biof() const noexcept
     return this->m_biof;
 }
 
+bool Runspec::dualPorosity() const noexcept
+{
+    return this->m_dualporo;
+}
+
+bool Runspec::fracturePermeabilityScalingDisabled() const noexcept
+{
+    return this->m_nodppm;
+}
+
 std::time_t Runspec::start_time() const noexcept
 {
     return this->m_start_time;
@@ -1186,6 +1209,8 @@ bool Runspec::rst_cmp(const Runspec& full_spec, const Runspec& rst_spec)
         full_spec.m_temp == rst_spec.m_temp &&
         full_spec.m_biof == rst_spec.m_biof &&
         full_spec.m_geochem == rst_spec.m_geochem &&
+        full_spec.m_dualporo == rst_spec.m_dualporo &&
+        full_spec.m_nodppm == rst_spec.m_nodppm &&
         Welldims::rst_cmp(full_spec.wellDimensions(), rst_spec.wellDimensions());
 }
 
@@ -1218,6 +1243,8 @@ bool Runspec::operator==(const Runspec& data) const
         && (this->m_temp == data.m_temp)
         && (this->m_biof == data.m_biof)
         && (this->m_geochem == data.m_geochem)
+        && (this->m_dualporo == data.m_dualporo)
+        && (this->m_nodppm == data.m_nodppm)
         ;
 }
 

--- a/opm/input/eclipse/EclipseState/Runspec.hpp
+++ b/opm/input/eclipse/EclipseState/Runspec.hpp
@@ -645,6 +645,8 @@ public:
     bool temp() const noexcept;
     bool compositional() const noexcept;
     bool biof() const noexcept;
+    bool dualPorosity() const noexcept;
+    bool fracturePermeabilityScalingDisabled() const noexcept;
 
     bool operator==(const Runspec& data) const;
     static bool rst_cmp(const Runspec& full_state, const Runspec& rst_state);
@@ -680,6 +682,8 @@ public:
         serializer(m_mechsolver);
         serializer(m_biof);
         serializer(m_geochem);
+        serializer(m_dualporo);
+        serializer(m_nodppm);
     }
 
 private:
@@ -711,6 +715,8 @@ private:
     bool m_frac{false};
     bool m_temp{false};
     bool m_biof{false};
+    bool m_dualporo{false};
+    bool m_nodppm{false};
 };
 
 std::size_t declaredMaxRegionID(const Runspec& rspec);

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/S/SIGMAV
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/S/SIGMAV
@@ -4,6 +4,7 @@
     "GRID"
   ],
   "data": {
-    "value_type": "DOUBLE"
+    "value_type": "DOUBLE",
+    "dimension": "1/Length*Length"
   }
 }

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -157,7 +157,7 @@ PERMX
 
 BOOST_AUTO_TEST_CASE(SigmaVFieldProps) {
     // SIGMAV is a per-cell array (JSON schema: "data", no "size") -- fits FieldProps'
-    // GRID::double_keywords registry exactly like PORO/PERMX. Registered in this PR.
+    // GRID::double_keywords registry exactly like PORO/PERMX.
     std::string deck_string_sigmav = R"(
 GRID
 

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -155,6 +155,52 @@ PERMX
 
 
 
+BOOST_AUTO_TEST_CASE(SigmaVFieldProps) {
+    // SIGMAV is a per-cell array (JSON schema: "data", no "size") -- fits FieldProps'
+    // GRID::double_keywords registry exactly like PORO/PERMX. Registered in this PR.
+    std::string deck_string_sigmav = R"(
+GRID
+
+PORO
+   8*0.10 /
+
+SIGMAV
+  8*0.12 /
+)";
+    EclipseGrid grid(EclipseGrid(2,2,2));
+    Deck deck_sigmav = Parser{}.parseString(deck_string_sigmav);
+    FieldPropsManager fpm_sigmav(deck_sigmav, Phases{true, true, false}, grid, TableManager());
+
+    BOOST_CHECK(fpm_sigmav.has_double("SIGMAV"));
+    const auto& sigmav = fpm_sigmav.get_double("SIGMAV");
+    BOOST_CHECK_EQUAL(sigmav.size(), grid.getNumActive());
+    for (const auto& value : sigmav) {
+        BOOST_CHECK_CLOSE(value, 0.12, 1e-10);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(SigmaDeckScalar) {
+    // SIGMA is a single global scalar (JSON schema: "size": 1), not a per-cell array like
+    // SIGMAV (schema: "data", no "size"). FieldProps::GRID::double_keywords is strictly a
+    // per-cell array registry: verify_deck_data() in FieldProps.cpp requires
+    // deck_data.size() == box.size() * num_value unconditionally, with no broadcast path for
+    // a single supplied value. SIGMA is intentionally not registered there; its value is read
+    // directly from the deck record by whichever code consumes it (computing
+    // TR = darcy*K*V*sigma), the same way any other single-record scalar keyword would be.
+    // This test proves the raw parse of a size-1 keyword works standalone.
+    std::string deck_string_sigma = R"(
+GRID
+
+SIGMA
+  0.12 /
+)";
+    auto deck_sigma = Parser{}.parseString(deck_string_sigma);
+    BOOST_CHECK(deck_sigma.hasKeyword("SIGMA"));
+    const auto sigma_value = deck_sigma["SIGMA"].back().getRecord(0).getItem(0).get<double>(0);
+    BOOST_CHECK_CLOSE(sigma_value, 0.12, 1e-10);
+}
+
+
 BOOST_AUTO_TEST_CASE(CreateFieldPropsForActnum) {
     std::string deck_string = R"(
 GRID

--- a/tests/parser/RunspecTests.cpp
+++ b/tests/parser/RunspecTests.cpp
@@ -1067,6 +1067,40 @@ BOOST_AUTO_TEST_CASE(Co2Storage_oilwater) {
     BOOST_CHECK_THROW( Runspec{deck}, std::runtime_error );
 }
 
+BOOST_AUTO_TEST_CASE(DualPorosity) {
+    const std::string input = R"(
+    RUNSPEC
+    OIL
+    WATER
+    DUALPORO
+    NODPPM
+    )";
+
+    Parser parser;
+
+    auto deck = parser.parseString(input);
+
+    Runspec runspec( deck );
+    BOOST_CHECK( runspec.dualPorosity() );
+    BOOST_CHECK( runspec.fracturePermeabilityScalingDisabled() );
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosity_absent) {
+    const std::string input = R"(
+    RUNSPEC
+    OIL
+    WATER
+    )";
+
+    Parser parser;
+
+    auto deck = parser.parseString(input);
+
+    Runspec runspec( deck );
+    BOOST_CHECK( !runspec.dualPorosity() );
+    BOOST_CHECK( !runspec.fracturePermeabilityScalingDisabled() );
+}
+
 BOOST_AUTO_TEST_CASE(H2Storage) {
     const std::string input = R"(
     RUNSPEC


### PR DESCRIPTION
# [DualPorosity] Add Runspec dual-porosity accessors + register SIGMAV in FieldProps

## Summary

- Adds `Runspec::dualPorosity()` and `Runspec::fracturePermeabilityScalingDisabled()` — RUNSPEC-section
  accessors mirroring the existing `co2Storage()` pattern (private member, ctor init-list entry,
  deck-read block, `serializeOp` entry, getter).
- Registers `SIGMAV` in `FieldProps::GRID::double_keywords` (per-cell, unit `1/Length*Length`).
  `SIGMA` is intentionally **not** registered there — its schema declares a single global scalar
  (`"size": 1`), not a per-cell array, and this registry has no broadcast path for a size-1 keyword.
  It's read directly from its deck record by whichever code consumes it instead.
- Adds a missing `"dimension"` field to `SIGMAV`'s own keyword schema so
  `DeckItem::getSIDoubleData()` can resolve its SI dimension at parse time.
- Purely additive: existing single-porosity decks are unaffected — the new accessors return
  `false`/absent unless the deck contains the corresponding keyword.

## Why

There was previously no way to query "does this deck have `DUALPORO`?", or to read `SIGMA`/`SIGMAV`
values through `FieldProps` — both keywords parse today but have zero consumers. This PR makes that
state queryable. It does not change any simulator behavior on its own (the simulator layer still
rejects these keywords today; lifting that is separate, follow-on work).

## Changes

- `Runspec.hpp` / `Runspec.cpp` — two new accessors, plus the two other field-completeness lists
  this pattern requires (`operator==()`, `rst_cmp()`) and `serializationTestObject()` (the factory
  the serialization round-trip test actually exercises — omitting it would let that test pass even
  with a broken `serializeOp`).
- `FieldProps.hpp` — register `SIGMAV` in `GRID::double_keywords`.
- `SIGMAV`'s keyword schema — add `"dimension": "1/Length*Length"`.

## Tests

- `RunspecTests`: `DualPorosity`, `DualPorosity_absent`
- `FieldPropsTests`: `SigmaVFieldProps`, `SigmaDeckScalar`
- `Serialization`: `Runspec` round-trip


## Notes

- `SIGMA` cannot go through `FieldProps` at all — registering it in `double_keywords` throws on any
  grid with more than one cell, since the registry has no single-value broadcast path.
- Out of scope here: lifting the simulator-side abort on these keywords, grid handling, and
  transfer-term physics — this PR only makes the deck state queryable in opm-common.
