### PR TITLE
Deprecate Action RST Dimension Function

### DIFF
--- a/opm/input/eclipse/Schedule/Action/Actdims.cpp
+++ b/opm/input/eclipse/Schedule/Action/Actdims.cpp
@@ -16,76 +16,148 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <cstdlib>
 
 #include <opm/input/eclipse/Schedule/Action/Actdims.hpp>
+
 #include <opm/input/eclipse/Deck/Deck.hpp>
+
 #include <opm/input/eclipse/Parser/ParserKeywords/A.hpp>
+
+#include <fmt/format.h>
+
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
 
 namespace Opm {
 
-Actdims::Actdims():
-    keywords(ParserKeywords::ACTDIMS::MAX_ACTION::defaultValue),
-    line_count(ParserKeywords::ACTDIMS::MAX_ACTION_LINES::defaultValue),
-    characters(ParserKeywords::ACTDIMS::MAX_ACTION_LINE_CHARACTERS::defaultValue),
-    conditions(ParserKeywords::ACTDIMS::MAX_ACTION_COND::defaultValue)
+Actdims::Actdims()
+    : keywords_   { ParserKeywords::ACTDIMS::MAX_ACTION::defaultValue }
+    , line_count_ { ParserKeywords::ACTDIMS::MAX_ACTION_LINES::defaultValue }
+    , characters_ { ParserKeywords::ACTDIMS::MAX_ACTION_LINE_CHARACTERS::defaultValue }
+    , conditions_ { ParserKeywords::ACTDIMS::MAX_ACTION_COND::defaultValue }
 {}
 
-
 Actdims::Actdims(const Deck& deck)
-    : Actdims()
+    : Actdims{}
 {
-    if (deck.hasKeyword<ParserKeywords::ACTDIMS>()) {
-        const auto& keyword = deck.get<ParserKeywords::ACTDIMS>().back();
-        const auto& record = keyword.getRecord(0);
+    if (!deck.hasKeyword<ParserKeywords::ACTDIMS>()) {
+        return;
+    }
 
-        this->keywords   = record.getItem<ParserKeywords::ACTDIMS::MAX_ACTION>().get<int>(0);
-        this->line_count = record.getItem<ParserKeywords::ACTDIMS::MAX_ACTION_LINES>().get<int>(0);
-        this->characters = record.getItem<ParserKeywords::ACTDIMS::MAX_ACTION_LINE_CHARACTERS>().get<int>(0);
-        this->conditions = record.getItem<ParserKeywords::ACTDIMS::MAX_ACTION_COND>().get<int>(0);
+    const auto& keyword = deck.get<ParserKeywords::ACTDIMS>().back();
+    const auto& record = keyword.getRecord(0);
+
+    if (const auto max_actions = record.getItem<ParserKeywords::ACTDIMS::MAX_ACTION>().get<int>(0);
+        max_actions < 0)
+    {
+        throw std::runtime_error {
+            "Maximum number of actions in ACTDIMS must be non-negative."
+        };
+    }
+    else if (max_actions > 10'000) {
+        throw std::runtime_error {
+            "Value for MAX_ACTION in ACTDIMS exceeds maximum permissible value 10000."
+        };
+    }
+    else {
+        this->keywords_ = static_cast<std::size_t>(max_actions);
+    }
+
+    if (const auto max_lines = record.getItem<ParserKeywords::ACTDIMS::MAX_ACTION_LINES>().get<int>(0);
+        max_lines < 0)
+    {
+        throw std::runtime_error {
+            "Maximum number of keyword lines in "
+            "ACTDIMS must be non-negative."
+        };
+    }
+    else if (max_lines > 10'000) {
+        throw std::runtime_error {
+            "Maximum number of keyword lines in "
+            "ACTDIMS exceeds maximum permissible value 10000."
+        };
+    }
+    else {
+        this->line_count_ = static_cast<std::size_t>(max_lines);
+    }
+
+    if (const auto max_chars = record.getItem<ParserKeywords::ACTDIMS::MAX_ACTION_LINE_CHARACTERS>().get<int>(0);
+        max_chars <= 0)
+    {
+        throw std::runtime_error {
+            "Maximum number of characters per keyword line "
+            "in ACTDIMS must be positive."
+        };
+    }
+    else if (max_chars > 128) {
+        throw std::runtime_error {
+            "Maximum number of characters per keyword line in "
+            "ACTDIMS exceeds maximum permissible value 128."
+        };
+    }
+    else {
+        this->characters_ = static_cast<std::size_t>(max_chars);
+    }
+
+    if (const auto max_conditions = record.getItem<ParserKeywords::ACTDIMS::MAX_ACTION_COND>().get<int>(0);
+        max_conditions <= 0)
+    {
+        throw std::runtime_error {
+            "Maximum number of conditions in ACTDIMS must be positive."
+        };
+    }
+    else if (max_conditions > 10'000) {
+        throw std::runtime_error {
+            "Maximum number of conditions in ACTDIMS exceeds maximum permissible value 10000."
+        };
+    }
+    else {
+        this->conditions_ = static_cast<std::size_t>(max_conditions);
     }
 }
 
 Actdims Actdims::serializationTestObject()
 {
-    Actdims result;
-    result.keywords = 1;
-    result.line_count = 2;
-    result.characters = 3;
-    result.conditions = 4;
+    Actdims result{};
+
+    result.keywords_ = 1;
+    result.line_count_ = 2;
+    result.characters_ = 3;
+    result.conditions_ = 4;
 
     return result;
 }
 
-std::size_t Actdims::max_keywords() const {
-    return this->keywords;
+std::size_t Actdims::line_size() const
+{
+    constexpr std::size_t chars_per_string = 8;
+    constexpr std::size_t max_chars_per_line =
+        std::numeric_limits<std::size_t>::max() - (chars_per_string - 1);
+
+    const std::size_t total_chars = this->max_characters();
+
+    // Guard against overflow: if total_chars is close to SIZE_MAX,
+    // adding chars_per_string - 1 would wrap around.
+    if (total_chars > max_chars_per_line) {
+        throw std::overflow_error {
+            fmt::format("Overflow in Actdims::line_size(): "
+                        "max_characters() ({:#x}) is too large.",
+                        total_chars)
+        };
+    }
+
+    // Divide by chars_per_string, rounding up to the nearest whole integer
+    return (total_chars + chars_per_string - 1) / chars_per_string;
 }
 
-std::size_t Actdims::max_line_count() const {
-    return this->line_count;
+bool Actdims::operator==(const Actdims& data) const
+{
+    return (this->max_keywords() == data.max_keywords())
+        && (this->max_line_count() == data.max_line_count())
+        && (this->max_characters() == data.max_characters())
+        && (this->max_conditions() == data.max_conditions())
+        ;
 }
 
-std::size_t Actdims::max_characters() const {
-    return this->characters;
-}
-
-std::size_t Actdims::max_conditions() const {
-    return this->conditions;
-}
-
-std::size_t Actdims::line_size() const {
-    auto [ls, rem] = std::div(this->max_characters(), 8);
-    if (rem != 0)
-        ls += 1;
-    return ls;
-}
-
-bool Actdims::operator==(const Actdims& data) const {
-    return this->max_keywords() == data.max_keywords() &&
-           this->max_line_count() == data.max_line_count() &&
-           this->max_characters() == data.max_characters() &&
-           this->max_conditions() == data.max_conditions();
-}
-
-
-}
+} // namespace Opm

--- a/opm/input/eclipse/Schedule/Action/Actdims.hpp
+++ b/opm/input/eclipse/Schedule/Action/Actdims.hpp
@@ -17,47 +17,121 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef ACTDIMS_HPP_
 #define ACTDIMS_HPP_
 
 #include <cstddef>
 
 namespace Opm {
-
 class Deck;
+} // namespace Opm
 
-class Actdims {
+namespace Opm {
+
+/// Class representing the ACTDIMS keyword in an Eclipse deck.
+///
+/// The ACTDIMS keyword specifies the maximum number of actions, lines,
+/// characters, and conditions that can be present in the deck.  This class
+/// provides methods to access these values and to perform related calculations.
+class Actdims
+{
 public:
+    /// Default constructor.
+    ///
+    /// Initializes the Actdims object with default values for the maximum
+    /// number of actions, lines, characters, and conditions.
     Actdims();
+
+    /// Constructor that initializes the Actdims object from a Deck.
+    ///
+    /// \param[in] deck The Deck object from which to extract the ACTDIMS
+    /// keyword.  Default values used if the keyword is not present.
     explicit Actdims(const Deck& deck);
 
+    /// Create a serialization test object.
+    ///
+    /// \return An Actdims object with test values for serialization.
     static Actdims serializationTestObject();
 
-    std::size_t max_keywords() const;
-    std::size_t max_line_count() const;
-    std::size_t max_characters() const;
-    std::size_t max_conditions() const;
+    /// Get the maximum number of ACTIONX keywords in the deck.
+    ///
+    /// \return The maximum number of ACTIONX keywords.
+    std::size_t max_keywords() const
+    {
+        return this->keywords_;
+    }
+
+    /// Get the maximum number of lines in a single action block.
+    ///
+    /// \return The maximum number of lines in a single action block.
+    std::size_t max_line_count() const
+    {
+        return this->line_count_;
+    }
+
+    /// Get the maximum number of characters in a single line.
+    ///
+    /// \return The maximum number of characters in a single line.
+    std::size_t max_characters() const
+    {
+        return this->characters_;
+    }
+
+    /// Get the maximum number of conditions in a single action.
+    ///
+    /// \return The maximum number of conditions in a single action.
+    std::size_t max_conditions() const
+    {
+        return this->conditions_;
+    }
+
+    /// Get the maximum number of characters in a single line of
+    /// action block keywords, rounded up to the nearest multiple of 8.
+    /// This is used to determine the number of 8-character strings
+    /// needed to store a line of action block keywords in the restart file.
+    ///
+    /// \details The number of 8-character strings is calculated as
+    /// (max_characters + 7) / 8, which effectively rounds up to the
+    /// nearest multiple of 8.
+    ///
+    /// \return The maximum size of a line in terms of 8-character strings.
     std::size_t line_size() const;
 
+    /// Equality operator.
+    ///
+    /// \param[in] data The Actdims object to compare with.
+    ///
+    /// \return True if the objects are equal, false otherwise.
     bool operator==(const Actdims& data) const;
 
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
-        serializer(keywords);
-        serializer(line_count);
-        serializer(characters);
-        serializer(conditions);
+        serializer(this->keywords_);
+        serializer(this->line_count_);
+        serializer(this->characters_);
+        serializer(this->conditions_);
     }
 
 private:
-    std::size_t keywords;
-    std::size_t line_count;
-    std::size_t characters;
-    std::size_t conditions;
+    /// Maximum number of actions in a single deck.
+    std::size_t keywords_{};
+
+    /// Maximum number of lines in a single action.
+    std::size_t line_count_{};
+
+    /// Maximum number of characters in a single line.
+    std::size_t characters_{};
+
+    /// Maximum number of conditions in a single action.
+    std::size_t conditions_{};
 };
 
-}
+} // namespace Opm
 
-#endif
+#endif // ACTDIMS_HPP_

--- a/opm/output/eclipse/AggregateActionxData.cpp
+++ b/opm/output/eclipse/AggregateActionxData.cpp
@@ -56,15 +56,13 @@ namespace {
     namespace iACT {
 
         Opm::RestartIO::Helpers::WindowedArray<int>
-        allocate(const std::vector<int>& actDims)
+        allocate(const std::size_t num_actions)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<int>;
 
-            int nwin = std::max(actDims[0], 1);
-            int nitPrWin = std::max(actDims[1], 1);
             return WV {
-                WV::NumWindows{ static_cast<std::size_t>(nwin) },
-                WV::WindowSize{ static_cast<std::size_t>(nitPrWin) }
+                WV::NumWindows{ std::max(num_actions, std::size_t{1}) },
+                WV::WindowSize{ Opm::RestartIO::Helpers::entriesPerIACT() }
             };
         }
 
@@ -96,15 +94,13 @@ namespace {
         namespace sACT {
 
         Opm::RestartIO::Helpers::WindowedArray<float>
-        allocate(const std::vector<int>& actDims)
+        allocate(const std::size_t num_actions)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<float>;
 
-            int nwin = std::max(actDims[0], 1);
-            int nitPrWin = std::max(actDims[2], 1);
             return WV {
-                WV::NumWindows{ static_cast<std::size_t>(nwin) },
-                WV::WindowSize{ static_cast<std::size_t>(nitPrWin) }
+                WV::NumWindows{ std::max(num_actions, std::size_t{1}) },
+                WV::WindowSize{ Opm::RestartIO::Helpers::entriesPerSACT() }
             };
         }
 
@@ -132,17 +128,15 @@ namespace {
         Opm::RestartIO::Helpers::WindowedArray<
             Opm::EclIO::PaddedOutputString<8>
         >
-        allocate(const std::vector<int>& actDims)
+        allocate(const std::size_t num_actions)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<
                 Opm::EclIO::PaddedOutputString<8>
             >;
 
-            int nwin = std::max(actDims[0], 1);
-            int nitPrWin = std::max(actDims[3], 1);
             return WV {
-                WV::NumWindows{ static_cast<std::size_t>(nwin) },
-                WV::WindowSize{ static_cast<std::size_t>(nitPrWin) }
+                WV::NumWindows{ std::max(num_actions, std::size_t{1}) },
+                WV::WindowSize{ Opm::RestartIO::Helpers::entriesPerZACT() }
             };
         }
 
@@ -538,16 +532,15 @@ namespace {
 // =====================================================================
 
 Opm::RestartIO::Helpers::AggregateActionxData::
-AggregateActionxData( const std::vector<int>&   rst_dims,
-                      std::size_t               num_actions,
+AggregateActionxData( const std::size_t         num_actions,
                       const Opm::Actdims&       actdims,
                       const Opm::Schedule&      sched,
                       const Opm::Action::State& action_state,
                       const Opm::SummaryState&  st,
                       const std::size_t         simStep)
-    : iACT_ (iACT::allocate(rst_dims))
-    , sACT_ (sACT::allocate(rst_dims))
-    , zACT_ (zACT::allocate(rst_dims))
+    : iACT_ (iACT::allocate(num_actions))
+    , sACT_ (sACT::allocate(num_actions))
+    , zACT_ (zACT::allocate(num_actions))
     , zLACT_(zLACT::allocate(num_actions, sched[simStep].actions().max_input_lines(), actdims))
     , zACN_ (zACN::allocate(num_actions, actdims))
     , iACN_ (iACN::allocate(num_actions, actdims))
@@ -599,8 +592,7 @@ AggregateActionxData(const Opm::Schedule&      sched,
                      const Opm::Action::State& action_state,
                      const Opm::SummaryState&  st,
                      const std::size_t         simStep)
-    : AggregateActionxData(createActionRSTDims(sched, simStep),
-                           sched[simStep].actions().ecl_size(),
+    : AggregateActionxData(sched[simStep].actions().ecl_size(),
                            sched.runspec().actdims(),
                            sched, action_state, st, simStep)
 {}

--- a/opm/output/eclipse/AggregateActionxData.hpp
+++ b/opm/output/eclipse/AggregateActionxData.hpp
@@ -85,8 +85,7 @@ public:
     }
 
 private:
-    AggregateActionxData(const std::vector<int>&   rst_dims,
-                         std::size_t               num_actions,
+    AggregateActionxData(std::size_t               num_actions,
                          const Opm::Actdims&       actdims,
                          const Opm::Schedule&      sched,
                          const Opm::Action::State& action_state,

--- a/opm/output/eclipse/CreateActionRSTDims.cpp
+++ b/opm/output/eclipse/CreateActionRSTDims.cpp
@@ -18,89 +18,51 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <opm/output/eclipse/AggregateUDQData.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
-#include <opm/output/eclipse/InteHEAD.hpp>
-#include <opm/output/eclipse/DoubHEAD.hpp>
 #include <opm/output/eclipse/VectorItems/action.hpp>
+
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+
 #include <opm/input/eclipse/Schedule/Action/Actdims.hpp>
-#include <opm/input/eclipse/Schedule/Action/ActionX.hpp>
 #include <opm/input/eclipse/Schedule/Action/Actions.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>
-#include <opm/input/eclipse/Units/UnitSystem.hpp>
-#include <opm/input/eclipse/Units/Units.hpp>
+#include <opm/input/eclipse/Schedule/ScheduleState.hpp>
 
-#include <chrono>
 #include <cstddef>
 #include <vector>
 
-namespace {
-
-
-// (The max number of characters in an action statement / (8 - chars pr string)) * (max over actions of number of lines pr ACTIONX)
-std::size_t entriesPerZLACT(const Opm::Actdims& actdims, const Opm::Action::Actions& acts)
-{
-    int max_char_pr_line = actdims.max_characters();
-    std::size_t no_entries_pr_line = ((max_char_pr_line % 8) == 0) ? max_char_pr_line / 8 : (max_char_pr_line / 8) + 1;
-    std::size_t no_entries = no_entries_pr_line * acts.max_input_lines();
-
-    return no_entries;
-}
-
-// The max number of characters in an action statement * (max over actions of number of lines pr ACTIONX) / (8 - chars pr string)
-std::size_t entriesPerLine(const Opm::Actdims& actdims)
-{
-    int max_char_pr_line = actdims.max_characters();
-    std::size_t no_entries_pr_line = ((max_char_pr_line % 8) == 0) ? max_char_pr_line / 8 : (max_char_pr_line / 8) + 1;
-
-    return no_entries_pr_line;
-}
-
-
-
-
-
-
-} // Anonymous
-
-// #####################################################################
-// Public Interface (createUdqDims()) Below Separator
+// ---------------------------------------------------------------------
+// Public interface for restart file action dimensioning information.
 // ---------------------------------------------------------------------
 
-std::size_t Opm::RestartIO::Helpers::entriesPerZACT()
+std::size_t
+Opm::RestartIO::Helpers::entriesPerLine(const Actdims& actdims)
 {
-    std::size_t no_entries = 4;
-    return no_entries;
+    return actdims.line_size();
 }
 
-std::size_t Opm::RestartIO::Helpers::entriesPerZACN(const Opm::Actdims& actdims)
+std::size_t
+Opm::RestartIO::Helpers::entriesPerZLACT(const Actdims& actdims,
+                                         const Action::Actions& acts)
 {
-    return Opm::RestartIO::Helpers::VectorItems::ZACN::ConditionSize * actdims.max_conditions();
+    return entriesPerLine(actdims)
+        *  static_cast<std::size_t>(acts.max_input_lines());
 }
 
-std::size_t Opm::RestartIO::Helpers::entriesPerIACN(const Opm::Actdims& actdims)
+std::size_t Opm::RestartIO::Helpers::entriesPerIACN(const Actdims& actdims)
 {
-    return Opm::RestartIO::Helpers::VectorItems::IACN::ConditionSize * actdims.max_conditions();
+    return VectorItems::IACN::ConditionSize * actdims.max_conditions();
 }
 
-std::size_t Opm::RestartIO::Helpers::entriesPerSACN(const Opm::Actdims& actdims)
+std::size_t Opm::RestartIO::Helpers::entriesPerSACN(const Actdims& actdims)
 {
-    return Opm::RestartIO::Helpers::VectorItems::SACN::ConditionSize * actdims.max_conditions();
+    return VectorItems::SACN::ConditionSize * actdims.max_conditions();
 }
 
-std::size_t Opm::RestartIO::Helpers::entriesPerIACT()
+std::size_t Opm::RestartIO::Helpers::entriesPerZACN(const Actdims& actdims)
 {
-    std::size_t no_entries = 9;
-    return no_entries;
-}
-
-std::size_t Opm::RestartIO::Helpers::entriesPerSACT()
-{
-    std::size_t no_entries = 5;
-    return no_entries;
+    return VectorItems::ZACN::ConditionSize * actdims.max_conditions();
 }
 
 

--- a/opm/output/eclipse/WriteRestartHelpers.hpp
+++ b/opm/output/eclipse/WriteRestartHelpers.hpp
@@ -37,7 +37,11 @@ namespace Opm {
     class UDQActive;
     class Actdims;
 
-} // Opm
+} // namespace Opm
+
+namespace Opm::Action {
+    class Actions;
+} // namespace Opm::Action
 
 namespace Opm::RestartIO::Helpers {
 
@@ -86,28 +90,58 @@ namespace Opm::RestartIO::Helpers {
     std::vector<bool>
     createLogiHead(const EclipseState& es, const ScheduleState& sched);
 
-    std::size_t
-    entriesPerSACT();
+    /// Number of elements per action in IACT.
+    constexpr std::size_t entriesPerIACT() noexcept { return std::size_t{9}; }
 
-    std::size_t
-    entriesPerIACT();
+    /// Number of elements per action in SACT.
+    constexpr std::size_t entriesPerSACT() noexcept { return std::size_t{5}; }
 
-    std::size_t
-    entriesPerZACT();
+    /// Number of elements per action in ZACT.
+    constexpr std::size_t entriesPerZACT() noexcept { return std::size_t{4}; }
 
-    std::size_t
-    entriesPerZACN(const Opm::Actdims& actdims);
+    /// Compute number of elements per line in ZLACT.
+    ///
+    /// \param[in] actdims Action dimensioning information.
+    ///
+    /// \return Number of elements per line in ZLACT.
+    std::size_t entriesPerLine(const Actdims& actdims);
 
-    std::size_t
-    entriesPerIACN(const Opm::Actdims& actdims);
+    /// Compute number of elements per action in ZLACT.
+    ///
+    /// \param[in] actdims Action dimensioning information.
+    ///
+    /// \param[in] acts Actions information.
+    ///
+    /// \return Number of elements per action in ZLACT.
+    std::size_t entriesPerZLACT(const Actdims& actdims,
+                                const Action::Actions& acts);
 
-    std::size_t
-    entriesPerSACN(const Opm::Actdims& actdims);
+    /// Compute number of elements per action in IACN.
+    ///
+    /// \param[in] actdims Action dimensioning information.
+    ///
+    /// \return Number of elements per action in IACN.
+    std::size_t entriesPerIACN(const Actdims& actdims);
 
+    /// Compute number of elements per action in SACN.
+    ///
+    /// \param[in] actdims Action dimensioning information.
+    ///
+    /// \return Number of elements per action in SACN.
+    std::size_t entriesPerSACN(const Actdims& actdims);
+
+    /// Compute number of elements per action in ZACN.
+    ///
+    /// \param[in] actdims Action dimensioning information.
+    ///
+    /// \return Number of elements per action in ZACN.
+    std::size_t entriesPerZACN(const Actdims& actdims);
+
+    [[deprecated("Restart file action dimensions represented as a linear array are deprecated. Use entriesPer*() instead.")]]
     std::vector<int>
     createActionRSTDims(const Schedule&     sched,
                         const std::size_t   simStep);
 
-} // Opm::RestartIO::Helpers
+} // namespace Opm::RestartIO::Helpers
 
-#endif  // OPM_WRITE_RESTART_HELPERS_HPP
+#endif // OPM_WRITE_RESTART_HELPERS_HPP

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -15,6 +15,7 @@
 #include <opm/output/eclipse/AggregateWellData.hpp>
 #include <opm/output/eclipse/DoubHEAD.hpp>
 #include <opm/output/eclipse/InteHEAD.hpp>
+#include <opm/output/eclipse/VectorItems/action.hpp>
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
@@ -211,7 +212,16 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 rstFile.write("XCON", conn_aggregator.getXConn());
             }
 
-            const auto actDims = Opm::RestartIO::Helpers::createActionRSTDims(sched, rptStep-1);
+            const auto& actions = sched[rptStep - 1].actions();
+            const auto& actdims = sched.runspec().actdims();
+            const auto iActStride = Opm::RestartIO::Helpers::entriesPerIACT();
+            const auto sActStride = Opm::RestartIO::Helpers::entriesPerSACT();
+            const auto zActStride = Opm::RestartIO::Helpers::entriesPerZACT();
+            const auto zLActActionStride = Opm::RestartIO::Helpers::entriesPerZLACT(actdims, actions);
+            const auto zLActLineStride = Opm::RestartIO::Helpers::entriesPerLine(actdims);
+            const auto iAcnStride = Opm::RestartIO::Helpers::entriesPerIACN(actdims);
+            const auto sAcnStride = Opm::RestartIO::Helpers::entriesPerSACN(actdims);
+            const auto zAcnStride = Opm::RestartIO::Helpers::entriesPerZACN(actdims);
             Opm::RestartIO::Helpers::AggregateActionxData actionxData {sched, action_state, st, rptStep-1};
 
             rstFile.write("IACT", actionxData.getIACT());
@@ -260,7 +270,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
             {
                 /*
                   SACT
-                  --length is equal to 9*the number of ACTIONX keywords
+                  --length is equal to 5*the number of ACTIONX keywords
                   //item [0]: is unknown, (=0)
                   //item [1]: is unknown, (=0)
                   //item [2]: is unknown, (=0)
@@ -271,12 +281,12 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
 
                 const auto& sAct = actionxData.getSACT();
 
-                auto start = 0 * actDims[2];
+                auto start = 0 * sActStride;
                 BOOST_CHECK_CLOSE(sAct[start + 3], 0.543, 1.0e-5f);
-                start = 1 * actDims[2];
+                start = 1 * sActStride;
                 BOOST_CHECK_CLOSE(sAct[start + 3], 0.567, 1.0e-5f);
                 // actx_14
-                start = 13 * actDims[2];
+                start = 13 * sActStride;
                 BOOST_CHECK_CLOSE(sAct[start + 4], 1.E09 / 86400., 1.0e-5f);
             }
 
@@ -298,7 +308,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
 
                 const auto& iAct = actionxData.getIACT();
 
-                auto start = 0 * actDims[1];
+                auto start = 0 * iActStride;
                 BOOST_CHECK_EQUAL(iAct[start + 0], 0);
                 BOOST_CHECK_EQUAL(iAct[start + 1], 10);
                 BOOST_CHECK_EQUAL(iAct[start + 2], 1);
@@ -310,7 +320,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK_EQUAL(iAct[start + 8], 3);
 
 
-                start = 1 * actDims[1];
+                start = 1 * iActStride;
                 BOOST_CHECK_EQUAL(iAct[start + 0], 0);
                 BOOST_CHECK_EQUAL(iAct[start + 1], 7);
                 BOOST_CHECK_EQUAL(iAct[start + 2], 1);
@@ -321,7 +331,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK_EQUAL(iAct[start + 7], 0);
                 BOOST_CHECK_EQUAL(iAct[start + 8], 3);
 
-                start = 2 * actDims[1];
+                start = 2 * iActStride;
                 BOOST_CHECK_EQUAL(iAct[start + 0], 0);
                 BOOST_CHECK_EQUAL(iAct[start + 1], 4);
                 BOOST_CHECK_EQUAL(iAct[start + 2], 1);
@@ -332,14 +342,14 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK_EQUAL(iAct[start + 7], 0);
                 BOOST_CHECK_EQUAL(iAct[start + 8], 3);
 
-                start = 13 * actDims[1];
+                start = 13 * iActStride;
                 BOOST_CHECK_EQUAL(iAct[start + 2], 2);
             }
 
             {
                 /*
                   SACT
-                  --length is equal to 9*the number of ACTIONX keywords
+                  --length is equal to 5*the number of ACTIONX keywords
                   //item [0]: is unknown, (=0)
                   //item [1]: is unknown, (=0)
                   //item [2]: is unknown, (=0)
@@ -350,9 +360,9 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
 
                 const auto& sAct = actionxData.getSACT();
 
-                auto start = 0 * actDims[2];
+                auto start = 0 * sActStride;
                 BOOST_CHECK_CLOSE(sAct[start + 3], 0.543, 1.0e-5f);
-                start = 1 * actDims[2];
+                start = 1 * sActStride;
                 BOOST_CHECK_CLOSE(sAct[start + 3], 0.567, 1.0e-5f);
             }
 
@@ -367,13 +377,13 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
 
                 const auto& zAct = actionxData.getZACT();
 
-                auto start = 0 * actDims[3];
+                auto start = 0 * zActStride;
                 BOOST_CHECK_EQUAL(zAct[start + 0].c_str(), "ACT01   ");
 
-                start = 1 * actDims[3];
+                start = 1 * zActStride;
                 BOOST_CHECK_EQUAL(zAct[start + 0].c_str(), "ACT02   ");
 
-                start = 2 * actDims[3];
+                start = 2 * zActStride;
                 BOOST_CHECK_EQUAL(zAct[start + 0].c_str(), "ACT03   ");
             }
 
@@ -387,47 +397,47 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 const auto& zLact = actionxData.getZLACT();
 
                 // First action
-                auto start_a = 0 * actDims[4];
-                auto start = start_a + 0 * actDims[8];
+                auto start_a = 0 * zLActActionStride;
+                auto start = start_a + 0 * zLActLineStride;
                 BOOST_CHECK_EQUAL(zLact[start + 0].c_str(), "WELOPEN ");
 
-                start = start_a + 1 * actDims[8];
+                start = start_a + 1 * zLActLineStride;
                 BOOST_CHECK_EQUAL(zLact[start + 0].c_str(), "'?' 'SHU");
                 BOOST_CHECK_EQUAL(zLact[start + 1].c_str(), "T' 0 0 0");
                 BOOST_CHECK_EQUAL(zLact[start + 2].c_str(), " /      ");
 
-                start = start_a + 2 * actDims[8];
+                start = start_a + 2 * zLActLineStride;
                 BOOST_CHECK_EQUAL(zLact[start + 0].c_str(), "/       ");
 
-                start = start_a + 3 * actDims[8];
+                start = start_a + 3 * zLActLineStride;
                 BOOST_CHECK_EQUAL(zLact[start + 0].c_str(), "WELOPEN ");
 
                 // Second action
-                start_a = 1 * actDims[4];
-                start = start_a + 0 * actDims[8];
+                start_a = 1 * zLActActionStride;
+                start = start_a + 0 * zLActLineStride;
                 BOOST_CHECK_EQUAL(zLact[start + 0].c_str(), "WELOPEN ");
 
-                start = start_a + 1 * actDims[8];
+                start = start_a + 1 * zLActLineStride;
                 BOOST_CHECK_EQUAL(zLact[start + 0].c_str(), "'?' 'SHU");
                 BOOST_CHECK_EQUAL(zLact[start + 1].c_str(), "T' 0 0 0");
                 BOOST_CHECK_EQUAL(zLact[start + 2].c_str(), " /      ");
 
-                start = start_a + 2 * actDims[8];
+                start = start_a + 2 * zLActLineStride;
                 BOOST_CHECK_EQUAL(zLact[start + 0].c_str(), "/       ");
 
-                start = start_a + 3 * actDims[8];
+                start = start_a + 3 * zLActLineStride;
                 BOOST_CHECK_EQUAL(zLact[start + 0].c_str(), "WELOPEN ");
 
-                start = start_a + 4 * actDims[8];
+                start = start_a + 4 * zLActLineStride;
                 BOOST_CHECK_EQUAL(zLact[start + 0].c_str(), "'OPL01' ");
                 BOOST_CHECK_EQUAL(zLact[start + 1].c_str(), "'OPEN' /");
                 BOOST_CHECK_EQUAL(zLact[start + 2].c_str(), "        ");
 
-                start = start_a + 5 * actDims[8];
+                start = start_a + 5 * zLActLineStride;
                 BOOST_CHECK_EQUAL(zLact[start + 0].c_str(), "/       ");
 
 
-                start = start_a + 6 * actDims[8];
+                start = start_a + 6 * zLActLineStride;
                 BOOST_CHECK_EQUAL(zLact[start + 0].c_str(), "ENDACTIO");
             }
 
@@ -439,17 +449,19 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
 
                 */
 
+                constexpr auto condSize = Opm::RestartIO::Helpers::VectorItems::ZACN::ConditionSize;
+
                 const auto& zAcn = actionxData.getZACN();
 
                 // First action
-                auto start_a = 0 * actDims[5];
-                auto start = start_a + 0 * 13;
+                auto start_a = 0 * zAcnStride;
+                auto start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(zAcn[start + 0].c_str(), "FMWPR   ");
                 BOOST_CHECK_EQUAL(zAcn[start + 1].c_str(), "        ");
                 BOOST_CHECK_EQUAL(zAcn[start + 2].c_str(), ">       ");
                 BOOST_CHECK_EQUAL(zAcn[start + 3].c_str(), "        ");
 
-                start = start_a + 1 * 13;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(zAcn[start + 0].c_str(), "WUPR3   ");
                 BOOST_CHECK_EQUAL(zAcn[start + 1].c_str(), "        ");
                 BOOST_CHECK_EQUAL(zAcn[start + 2].c_str(), ">       ");
@@ -457,7 +469,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK_EQUAL(zAcn[start + 4].c_str(), "        ");
                 BOOST_CHECK_EQUAL(zAcn[start + 5].c_str(), "        ");
 
-                start = start_a + 2 * 13;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(zAcn[start + 0].c_str(), "        ");
                 BOOST_CHECK_EQUAL(zAcn[start + 1].c_str(), "        ");
                 BOOST_CHECK_EQUAL(zAcn[start + 2].c_str(), "<       ");
@@ -467,14 +479,14 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
 
 
                 // Second action
-                start_a = 1 * actDims[5];
-                start = start_a + 0 * 13;
+                start_a = 1 * zAcnStride;
+                start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(zAcn[start + 0].c_str(), "FMWPR   ");
                 BOOST_CHECK_EQUAL(zAcn[start + 1].c_str(), "        ");
                 BOOST_CHECK_EQUAL(zAcn[start + 2].c_str(), ">       ");
                 BOOST_CHECK_EQUAL(zAcn[start + 3].c_str(), "        ");
 
-                start = start_a + 1 * 13;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(zAcn[start + 0].c_str(), "WGPR    ");
                 BOOST_CHECK_EQUAL(zAcn[start + 1].c_str(), "GGPR    ");
                 BOOST_CHECK_EQUAL(zAcn[start + 2].c_str(), ">       ");
@@ -483,7 +495,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK_EQUAL(zAcn[start + 5].c_str(), "        ");
                 BOOST_CHECK_EQUAL(zAcn[start + 6].c_str(), "LOWER   ");
 
-                start = start_a + 2 * 13;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(zAcn[start + 0].c_str(), "        ");
                 BOOST_CHECK_EQUAL(zAcn[start + 1].c_str(), "        ");
                 BOOST_CHECK_EQUAL(zAcn[start + 2].c_str(), ">       ");
@@ -498,11 +510,12 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
 
                 */
 
+                constexpr auto condSize = Opm::RestartIO::Helpers::VectorItems::IACN::ConditionSize;
 
                 const auto& iAcn = actionxData.getIACN();
 
-                auto start_a = 0 * actDims[6];
-                auto start = start_a + 0 * 26;
+                auto start_a = 0 * iAcnStride;
+                auto start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 0], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 1], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 2], 0);
@@ -522,7 +535,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK_EQUAL(iAcn[start + 16], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 1 * 26;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 0], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 1], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 2], 0);
@@ -542,8 +555,8 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK_EQUAL(iAcn[start + 16], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start_a = 1 * actDims[6];
-                start = start_a + 0 * 26;
+                start_a = 1 * iAcnStride;
+                start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 0], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 1], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 2], 0);
@@ -563,7 +576,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK_EQUAL(iAcn[start + 16], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 1 * 26;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 0], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 1], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 2], 0);
@@ -583,7 +596,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK_EQUAL(iAcn[start + 16], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 2 * 26;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 0], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 1], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 2], 0);
@@ -603,326 +616,326 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK_EQUAL(iAcn[start + 16], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start_a = 3 * actDims[6];
-                start = start_a + 0 * 26;
+                start_a = 3 * iAcnStride;
+                start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 1 * 26;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 2 * 26;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 3 * 26;
+                start = start_a + 3 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 4 * 26;
+                start = start_a + 4 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start_a = 4 * actDims[6];
-                start = start_a + 0 * 26;
+                start_a = 4 * iAcnStride;
+                start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 1 * 26;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 2 * 26;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 3 * 26;
+                start = start_a + 3 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 4 * 26;
+                start = start_a + 4 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start_a = 5 * actDims[6];
-                start = start_a + 0 * 26;
+                start_a = 5 * iAcnStride;
+                start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 1 * 26;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 2 * 26;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 3 * 26;
+                start = start_a + 3 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 4 * 26;
+                start = start_a + 4 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start_a = 6 * actDims[6];
-                start = start_a + 0 * 26;
+                start_a = 6 * iAcnStride;
+                start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 1 * 26;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 2 * 26;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 3 * 26;
+                start = start_a + 3 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 4 * 26;
+                start = start_a + 4 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start_a = 7 * actDims[6];
-                start = start_a + 0 * 26;
+                start_a = 7 * iAcnStride;
+                start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 1 * 26;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 2 * 26;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 3 * 26;
+                start = start_a + 3 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 4 * 26;
+                start = start_a + 4 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 5 * 26;
+                start = start_a + 5 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 6 * 26;
+                start = start_a + 6 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start_a = 8 * actDims[6];
-                start = start_a + 0 * 26;
+                start_a = 8 * iAcnStride;
+                start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 1 * 26;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 2 * 26;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 3 * 26;
+                start = start_a + 3 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 4 * 26;
+                start = start_a + 4 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 5 * 26;
+                start = start_a + 5 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 6 * 26;
+                start = start_a + 6 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
 
-                start_a = 9 * actDims[6];
-                start = start_a + 0 * 26;
+                start_a = 9 * iAcnStride;
+                start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 1 * 26;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 2 * 26;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 3 * 26;
+                start = start_a + 3 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 4 * 26;
+                start = start_a + 4 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 5 * 26;
+                start = start_a + 5 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 6 * 26;
+                start = start_a + 6 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
 
-                start_a = 10 * actDims[6];
-                start = start_a + 0 * 26;
+                start_a = 10 * iAcnStride;
+                start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 1 * 26;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 2 * 26;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 3 * 26;
+                start = start_a + 3 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 4 * 26;
+                start = start_a + 4 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 5 * 26;
+                start = start_a + 5 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 6 * 26;
+                start = start_a + 6 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
 
-                start_a = 11 * actDims[6];
-                start = start_a + 0 * 26;
+                start_a = 11 * iAcnStride;
+                start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 1 * 26;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 2 * 26;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 3 * 26;
+                start = start_a + 3 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 4 * 26;
+                start = start_a + 4 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 5 * 26;
+                start = start_a + 5 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 6 * 26;
+                start = start_a + 6 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
 
-                start_a = 12 * actDims[6];
-                start = start_a + 0 * 26;
+                start_a = 12 * iAcnStride;
+                start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 1 * 26;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 2 * 26;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 3 * 26;
+                start = start_a + 3 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 4 * 26;
+                start = start_a + 4 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 2);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 1);
 
-                start = start_a + 5 * 26;
+                start = start_a + 5 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 1);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
 
-                start = start_a + 6 * 26;
+                start = start_a + 6 * condSize;
                 BOOST_CHECK_EQUAL(iAcn[start + 13], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 15], 0);
                 BOOST_CHECK_EQUAL(iAcn[start + 17], 0);
@@ -933,15 +946,16 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
             {
                 /*
                   SACN
-                  26*Max number of conditions pr ACTIONX
+                  16*Max number of conditions pr ACTIONX
 
                 */
 
 
+                constexpr auto condSize = Opm::RestartIO::Helpers::VectorItems::SACN::ConditionSize;
                 const auto& sAcn = actionxData.getSACN();
 
-                auto start_a = 0 * actDims[6];
-                auto start = start_a + 0 * 16;
+                auto start_a = 0 * sAcnStride;
+                auto start = start_a + 0 * condSize;
                 BOOST_CHECK_EQUAL(sAcn[start + 0], 0);
                 BOOST_CHECK_EQUAL(sAcn[start + 1], 0);
                 BOOST_CHECK_EQUAL(sAcn[start + 2], 45);
@@ -959,7 +973,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK_EQUAL(sAcn[start + 14], 0);
                 BOOST_CHECK_EQUAL(sAcn[start + 15], 0);
 
-                start = start_a + 1 * 16;
+                start = start_a + 1 * condSize;
                 BOOST_CHECK_EQUAL(sAcn[start + 0], 0);
                 BOOST_CHECK_EQUAL(sAcn[start + 1], 0);
                 BOOST_CHECK_EQUAL(sAcn[start + 2], 46);
@@ -977,7 +991,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 BOOST_CHECK_EQUAL(sAcn[start + 14], 0);
                 BOOST_CHECK_EQUAL(sAcn[start + 15], 0);
 
-                start = start_a + 2 * 16;
+                start = start_a + 2 * condSize;
                 BOOST_CHECK_EQUAL(sAcn[start + 0], 0);
                 BOOST_CHECK_EQUAL(sAcn[start + 1], 0);
                 BOOST_CHECK_EQUAL(sAcn[start + 2], 5);


### PR DESCRIPTION
This PR moves away from representing restart file action dimensions as a linear array with unnamed indices and instead switches to using the named helper functions `entriesPer*()` as a means of allocating the individual `ACTIONX` restart file arrays. This, in turn, requires making the `entriesPerLine()` and `entriesPerZLACT()` helper functions public instead of private in `CreateActionRSTDims.cpp`.

While here, simplify the implementations of these functions and fix a latent bug in `Actdims::line_size()` which used `std::div()` with mixed mode arithmetic (`std::size_t` and `int`) for which there is no direct overload in the standard library.  We also introduce range checking for the various `ACTDIMS` items and add Doxygen style documentation to class `Actdims` and the `entriesPer*()` functions.