### PR TITLE
Make AggregateActionxData More Amenable to Unit Testing

### DIFF
--- a/opm/output/eclipse/AggregateActionxData.cpp
+++ b/opm/output/eclipse/AggregateActionxData.cpp
@@ -404,20 +404,18 @@ namespace {
         }
 
         Opm::Action::Result
-        act_res(const Opm::Schedule&        sched,
+        act_res(const Opm::Action::ActionX& action,
                 const Opm::Action::State&   action_state,
                 const Opm::SummaryState&    smry,
-                const std::size_t           sim_step,
-                const Opm::Action::ActionX& action)
+                const std::time_t           sim_time,
+                const Opm::WListManager&    wlist_manager)
         {
-            const auto sim_time = sched.simTime(sim_step);
-
             if (! action.ready(action_state, sim_time)) {
                 return Opm::Action::Result { false };
             }
 
             const auto context = Opm::Action::Context {
-                smry, sched[sim_step].wlist_manager.get()
+                smry, wlist_manager
             };
 
             return action.eval(context);
@@ -426,15 +424,18 @@ namespace {
         void staticContrib(const Opm::Action::ActionX& action,
                            const Opm::Action::State&   action_state,
                            const Opm::SummaryState&    st,
-                           const Opm::Schedule&        sched,
-                           const std::size_t           simStep,
+                           const Opm::RestartIO::Helpers::AggregateActionxRuntimeContext& runtime,
                            Array&                      sAcn)
         {
             using Ix = Opm::RestartIO::Helpers::VectorItems::SACN::index;
 
             const auto undef_high_val = 1.0E+20;
-            const auto wells = sched.wellNames(simStep);
-            const auto ar = act_res(sched, action_state, st, simStep, action);
+            const auto& wells = runtime.wellNames;
+            const auto ar = act_res(action,
+                                    action_state,
+                                    st,
+                                    runtime.simTime,
+                                    runtime.wlistManager);
 
             // Write out the schedule ACTIONX conditions
             auto condIx = std::size_t{0};
@@ -527,27 +528,48 @@ namespace {
 
     } // sAcn
 
+    std::span<const Opm::Action::ActionX>
+    actionSpan(const Opm::Action::Actions& actions)
+    {
+        const auto num_actions = actions.ecl_size();
+
+        return {
+            (num_actions > 0) ? &actions[0] : nullptr,
+            num_actions
+        };
+    }
+
+    std::size_t maxInputLines(std::span<const Opm::Action::ActionX> actions)
+    {
+        auto max_il = std::size_t{0};
+
+        for (const auto& action : actions) {
+            max_il = std::max(max_il, action.keyword_strings().size());
+        }
+
+        return max_il;
+    }
+
 } // Anonymous namespace
 
 // =====================================================================
 
 Opm::RestartIO::Helpers::AggregateActionxData::
-AggregateActionxData( const std::size_t         num_actions,
-                      const Opm::Actdims&       actdims,
-                      const Opm::Schedule&      sched,
-                      const Opm::Action::State& action_state,
-                      const Opm::SummaryState&  st,
-                      const std::size_t         simStep)
-    : iACT_ (iACT::allocate(num_actions))
-    , sACT_ (sACT::allocate(num_actions))
-    , zACT_ (zACT::allocate(num_actions))
-    , zLACT_(zLACT::allocate(num_actions, sched[simStep].actions().max_input_lines(), actdims))
-    , zACN_ (zACN::allocate(num_actions, actdims))
-    , iACN_ (iACN::allocate(num_actions, actdims))
-    , sACN_ (sACN::allocate(num_actions, actdims))
+AggregateActionxData(std::span<const Action::ActionX>      actions,
+                     const Actdims&                        actdims,
+                     const Action::State&                  action_state,
+                     const SummaryState&                   st,
+                     const AggregateActionxRuntimeContext& runtime)
+    : iACT_ (iACT::allocate(actions.size()))
+    , sACT_ (sACT::allocate(actions.size()))
+    , zACT_ (zACT::allocate(actions.size()))
+    , zLACT_(zLACT::allocate(actions.size(), maxInputLines(actions), actdims))
+    , zACN_ (zACN::allocate(actions.size(), actdims))
+    , iACN_ (iACN::allocate(actions.size(), actdims))
+    , sACN_ (sACN::allocate(actions.size(), actdims))
 {
     std::size_t act_ind = 0;
-    for (const auto& action : sched[simStep].actions()) {
+    for (const auto& action : actions) {
         {
             auto i_act = this->iACT_[act_ind];
             iACT::staticContrib(action, i_act, action_state);
@@ -555,7 +577,7 @@ AggregateActionxData( const std::size_t         num_actions,
 
         {
             auto s_act = this->sACT_[act_ind];
-            sACT::staticContrib(action, action_state, sched.getStartTime(), sched.getUnits(), s_act);
+            sACT::staticContrib(action, action_state, runtime.startTime, runtime.units, s_act);
         }
 
         {
@@ -580,7 +602,7 @@ AggregateActionxData( const std::size_t         num_actions,
 
         {
             auto s_acn = sACN::Array { this->sACN_, act_ind };
-            sACN::staticContrib(action, action_state, st, sched, simStep, s_acn);
+            sACN::staticContrib(action, action_state, st, runtime, s_acn);
         }
 
         act_ind +=1;
@@ -588,11 +610,47 @@ AggregateActionxData( const std::size_t         num_actions,
 }
 
 Opm::RestartIO::Helpers::AggregateActionxData::
-AggregateActionxData(const Opm::Schedule&      sched,
-                     const Opm::Action::State& action_state,
-                     const Opm::SummaryState&  st,
-                     const std::size_t         simStep)
-    : AggregateActionxData(sched[simStep].actions().ecl_size(),
-                           sched.runspec().actdims(),
-                           sched, action_state, st, simStep)
+AggregateActionxData(const Schedule&      sched,
+                     const Action::State& action_state,
+                     const SummaryState&  st,
+                     const std::size_t    simStep)
+    : AggregateActionxData { createAggregateActionxData(sched, action_state, st, simStep) }
 {}
+
+Opm::RestartIO::Helpers::AggregateActionxData
+Opm::RestartIO::Helpers::createAggregateActionxData(std::span<const Action::ActionX>      actions,
+                                                    const Actdims&                        actdims,
+                                                    const Action::State&                  action_state,
+                                                    const SummaryState&                   st,
+                                                    const AggregateActionxRuntimeContext& runtime)
+{
+    return AggregateActionxData {
+        actions,
+        actdims,
+        action_state,
+        st,
+        runtime
+    };
+}
+
+Opm::RestartIO::Helpers::AggregateActionxData
+Opm::RestartIO::Helpers::createAggregateActionxData(const Schedule&      sched,
+                                                    const Action::State& action_state,
+                                                    const SummaryState&  st,
+                                                    std::size_t          simStep)
+{
+    const auto& actions = sched[simStep].actions();
+    const auto wells = sched.wellNames(simStep);
+
+    const auto runtime = AggregateActionxRuntimeContext {
+        .startTime = sched.getStartTime(),
+        .simTime = sched.simTime(simStep),
+        .units = sched.getUnits(),
+        .wellNames = std::span<const std::string>{ wells.data(), wells.size() },
+        .wlistManager = sched[simStep].wlist_manager.get()
+    };
+
+    return createAggregateActionxData
+        (actionSpan(actions), sched.runspec().actdims(),
+         action_state, st, runtime);
+}

--- a/opm/output/eclipse/AggregateActionxData.hpp
+++ b/opm/output/eclipse/AggregateActionxData.hpp
@@ -25,28 +25,52 @@
 #include <opm/io/eclipse/PaddedOutputString.hpp>
 
 #include <cstddef>
+#include <ctime>
+#include <span>
+#include <string>
 #include <vector>
 
 namespace Opm {
     class Actdims;
     class Schedule;
     class SummaryState;
+    class UnitSystem;
     class UDQInput;
+    class WListManager;
 } // namespace Opm
 
-namespace Opm { namespace Action {
+namespace Opm::Action {
+    class ActionX;
     class State;
-}} // Opm::Action
+} // namespace Opm::Action
 
-namespace Opm { namespace RestartIO { namespace Helpers {
+namespace Opm::RestartIO::Helpers {
+
+struct AggregateActionxRuntimeContext
+{
+    std::time_t startTime;
+    std::time_t simTime;
+    const UnitSystem& units;
+    std::span<const std::string> wellNames;
+    const WListManager& wlistManager;
+};
 
 class AggregateActionxData
 {
 public:
-    AggregateActionxData(const Opm::Schedule&      sched,
-                         const Opm::Action::State& action_state,
-                         const Opm::SummaryState&  st,
-                         const std::size_t         simStep);
+    AggregateActionxData(std::span<const Action::ActionX>      actions,
+                         const Actdims&                        actdims,
+                         const Action::State&                  action_state,
+                         const SummaryState&                   st,
+                         const AggregateActionxRuntimeContext& runtime);
+
+    // Compatibility constructor. Prefer createAggregateActionxData() or the
+    // constructor accepting explicit actions and runtime context.
+    [[deprecated("Use createAggregateActionxData() or the span-based constructor")]]
+    AggregateActionxData(const Schedule&      sched,
+                         const Action::State& action_state,
+                         const SummaryState&  st,
+                         const std::size_t    simStep);
 
     const std::vector<int>& getIACT() const
     {
@@ -85,13 +109,6 @@ public:
     }
 
 private:
-    AggregateActionxData(std::size_t               num_actions,
-                         const Opm::Actdims&       actdims,
-                         const Opm::Schedule&      sched,
-                         const Opm::Action::State& action_state,
-                         const Opm::SummaryState&  st,
-                         const std::size_t         simStep);
-
     /// Aggregate 'IACT' array (Integer) for all ACTIONX data  (9 integers pr UDQ)
     WindowedArray<int> iACT_;
 
@@ -115,6 +132,19 @@ private:
 
 };
 
-}}} // Opm::RestartIO::Helpers
+AggregateActionxData
+createAggregateActionxData(std::span<const Action::ActionX>      actions,
+                           const Actdims&                        actdims,
+                           const Action::State&                  action_state,
+                           const SummaryState&                   st,
+                           const AggregateActionxRuntimeContext& runtime);
 
-#endif //OPM_AGGREGATE_WELL_DATA_HPP
+AggregateActionxData
+createAggregateActionxData(const Schedule&      sched,
+                           const Action::State& action_state,
+                           const SummaryState&  st,
+                           std::size_t          simStep);
+
+} // namespace Opm::RestartIO::Helpers
+
+#endif // OPM_AGGREGATE_Actionx_DATA_HPP

--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -365,9 +365,9 @@ namespace {
 
         const auto simStep = static_cast<std::size_t>(sim_step);
 
-        const auto actionxData = RestartIO::Helpers::AggregateActionxData {
+        const auto actionxData = RestartIO::Helpers::createAggregateActionxData(
             schedule, action_state, sum_state, simStep
-        };
+        );
 
         rstFile.write("IACT", actionxData.getIACT());
         rstFile.write("SACT", actionxData.getSACT());

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -132,6 +132,51 @@ namespace {
 
 BOOST_AUTO_TEST_SUITE(Aggregate_Actionx)
 
+BOOST_AUTO_TEST_CASE(Standalone_Constructor_With_Span)
+{
+    const auto units = Opm::UnitSystem::newMETRIC();
+    const auto startTime = std::time_t{1234567890};
+    const auto simTime = startTime + 100;
+
+    auto actions = std::vector<Opm::Action::ActionX>{};
+    actions.emplace_back("A1", 3, 0.0, startTime);
+    const auto span = std::span<const Opm::Action::ActionX>{ actions.data(), actions.size() };
+
+    const auto actdims = Opm::Actdims{};
+    const auto actionState = Opm::Action::State{};
+    const auto summaryState = Opm::SummaryState{ Opm::TimeService::now(), 0.0 };
+    const auto wells = std::vector<std::string>{};
+    const auto wlistManager = Opm::WListManager{};
+
+    const auto runtime = Opm::RestartIO::Helpers::AggregateActionxRuntimeContext {
+        startTime,
+        simTime,
+        units,
+        std::span<const std::string>{ wells.data(), wells.size() },
+        wlistManager
+    };
+
+    const auto data = Opm::RestartIO::Helpers::AggregateActionxData {
+        span,
+        actdims,
+        actionState,
+        summaryState,
+        runtime
+    };
+
+    const auto iActStride = Opm::RestartIO::Helpers::entriesPerIACT();
+    const auto zActStride = Opm::RestartIO::Helpers::entriesPerZACT();
+
+    const auto& iAct = data.getIACT();
+    BOOST_REQUIRE_GE(iAct.size(), iActStride);
+    BOOST_CHECK_EQUAL(iAct[1], 1); // keyword_strings() includes ENDACTIO.
+    BOOST_CHECK_EQUAL(iAct[5], 3);
+
+    const auto& zAct = data.getZACT();
+    BOOST_REQUIRE_GE(zAct.size(), zActStride);
+    BOOST_CHECK_EQUAL(zAct[0].c_str(), "A1      ");
+}
+
 // test constructed UDQ-Actionx restart data
 BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
 {
@@ -222,7 +267,9 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
             const auto iAcnStride = Opm::RestartIO::Helpers::entriesPerIACN(actdims);
             const auto sAcnStride = Opm::RestartIO::Helpers::entriesPerSACN(actdims);
             const auto zAcnStride = Opm::RestartIO::Helpers::entriesPerZACN(actdims);
-            Opm::RestartIO::Helpers::AggregateActionxData actionxData {sched, action_state, st, rptStep-1};
+            const auto actionxData = Opm::RestartIO::Helpers::createAggregateActionxData(
+                sched, action_state, st, rptStep - 1
+            );
 
             rstFile.write("IACT", actionxData.getIACT());
             rstFile.write("SACT", actionxData.getSACT());
@@ -1214,9 +1261,9 @@ END
     smstate.update("MNTH", 5);
     smstate.update("YEAR", 2024);
 
-    const auto actionData = Opm::RestartIO::Helpers::AggregateActionxData {
+    const auto actionData = Opm::RestartIO::Helpers::createAggregateActionxData(
         cse.sched, action_state, smstate, simStep
-    };
+    );
 
     const auto& sacn = actionData.getSACN();
     BOOST_CHECK_EQUAL(sacn.size(), 3 * std::size_t{16});


### PR DESCRIPTION
This PR revises the set of `AggregateActionxData` constructors to take simpler types.  Previously, we needed a full `Schedule` object in order to form instances of `AggregateActionxData` and constructing `Schedule` objects, at least those that are viable for Actionx restart file unit testing, is very hard to do without parsing a mostly complete input file.  This, in turn, made unit testing the class harder than necessary.

The new canonical constructor takes the actual `ActionX` objects as a `std::span<>` and derives object and line counts from those.  We still need a `UnitSystem`, well names, and start/elapsed times, but we now pass those through a new, dedicated "context" object instead of getting the values from a `Schedule` object.

We also create two free function overloads to simplify transition to the new constructor, but expect that those will be removed in due time.  For now though, they're used in the existing unit test for class `AggregateActionxData`.