### PR TITLE
Fix WATDENT dropping the pressure dependence of water density

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.cpp
@@ -88,6 +88,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
         for (unsigned regionIdx = 0; regionIdx < regions; ++ regionIdx) {
             pvtwRefPress_[regionIdx] = pvtwTables[regionIdx].reference_pressure;
             pvtwRefB_[regionIdx] = pvtwTables[regionIdx].volume_factor;
+            pvtwCompressibility_[regionIdx] = pvtwTables[regionIdx].compressibility;
         }
     }
 


### PR DESCRIPTION
## Summary

In a THERMAL run with the `WATDENT` keyword, water density loses all pressure dependence: the deck's PVTW compressibility is silently ignored.

**Root cause:** in `WaterPvtThermal::initFromState`
(`opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.cpp`), the WATDENT block reads `pvtwRefPress_` and `pvtwRefB_` from the PVTW table, but `pvtwCompressibility_` is only resized (value-initialized to zero) and never assigned. 

The pressure term `X = Cw*(p - pref)` in the thermal density formula

```cpp
return 1.0 / (((1 - X) * (1 + cT1 * Y + cT2 * Y * Y)) * BwRef);
```

is therefore identically zero in deck-driven runs. The fix is a one-line assignment in the existing loop.

## Reproduction

Minimal self-contained deck: a water-only 1x1x10 vertical column, no wells — the hydrostatic pressure gradient (~86 bar top to bottom) alone should make water density depth-dependent via PVTW's Cw. The WATDENT record uses **zero expansion coefficients**, so it should be a physical no-op.

<details>
<summary>MIN_WATDENT.DATA (remove the WATDENT record for the baseline run)</summary>

```eclipse
RUNSPEC
TITLE
  Minimal WATDENT bug reproduction
DIMENS
  1 1 10 /
WATER
THERMAL
METRIC
START
  1 'JAN' 2026 /
UNIFOUT

GRID
DX
  10*100.0 /
DY
  10*100.0 /
DZ
  10*100.0 /
TOPS
  1000.0 /
PORO
  10*0.2 /
PERMX
  10*100.0 /
PERMY
  10*100.0 /
PERMZ
  10*100.0 /
THCONR
  10*100.0 /

PROPS
DENSITY
   1*   1000.0  1* /
PVTW
-- Pref[barsa] Bw[rm3/sm3] Cw[1/bar] mu[cP] Cv[1/bar]
   150.0       1.02        4.67E-5   0.5    0.0 /
ROCK
   150.0  4.0E-5 /
SPECHEAT
     0.0   2.0    4.2      2.0
   200.0   2.0    4.2      2.0 /
SPECROCK
     0.0   2000.0
   200.0   2000.0 /
WATDENT
   1* 0.0 0.0 /
RTEMP
   80.0 /

SOLUTION
EQUIL
   1500.0   150.0 /

SUMMARY
BPR
  1 1 1  /
  1 1 10 /
/
BDENW
  1 1 1  /
  1 1 10 /
/

SCHEDULE
TSTEP
  1.0 /
END
```
</details>

## Verification

Water density (BDENW) in the top vs bottom cell:

| flow binary | deck | rho_w top [kg/m3] | rho_w bottom [kg/m3] | drho |
|---|---|---|---|---|
| release 2026.04 | no WATDENT | 978.415 | 982.377 | 3.962 |
| release 2026.04 | WATDENT | 980.392 | 980.392 | **0.000** (bug) |
| master + this fix | no WATDENT | 978.415 | 982.377 | 3.962 (unchanged) |
| master + this fix | WATDENT | 978.417 | 982.379 | **3.962** (fixed) |

With the bug, both cells sit at exactly `rho_surf / BwRef = 1000/1.02 = 980.392`. With the fix, the WATDENT run matches the baseline; the remaining 0.002 kg/m3 offset comes from the WATDENT branch using a linear pressure factor `(1 - X)` where the isothermal formula is second order (as noted in the code comment), a difference of O(X^2).

The opm-common unit test suite passes with the fix.
