### PR TITLE
add well_close_reason() accessor to WellTestState

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WellTestState.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestState.cpp
@@ -120,6 +120,15 @@ namespace Opm {
     }
 
 
+    WellTestConfig::Reason WellTestState::well_close_reason(const std::string& well_name) const {
+        auto iter = this->wells.find(well_name);
+        if (iter == this->wells.end() || !iter->second.closed)
+            return WellTestConfig::Reason::NONE;
+
+        return iter->second.reason;
+    }
+
+
     void WellTestState::filter_wells(const std::vector<std::string>& existing_wells) {
         std::unordered_set<std::string> well_set{ existing_wells.begin(), existing_wells.end() };
         for (auto& [wname, test_well] : this->wells) {

--- a/opm/input/eclipse/Schedule/Well/WellTestState.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestState.hpp
@@ -217,6 +217,9 @@ public:
     */
     void close_well(const std::string& well_name, WTest::Reason reason, double sim_time);
     bool well_is_closed(const std::string& well_name) const;
+    // Reason the well was closed, or WTest::Reason::NONE if the well is
+    // not currently closed.
+    WTest::Reason well_close_reason(const std::string& well_name) const;
     void open_well(const std::string& well_name);
     std::size_t num_closed_wells() const;
     double lastTestTime(const std::string& well_name) const;


### PR DESCRIPTION
the motivation is that it was found that for a SHUT well due to economic reason, the WBP* output should be zero.  It was spotted during the development of https://github.com/OPM/opm-simulators/pull/7141 . 