### PR TITLE
Isothermal flash: SSI + Newton - improvements on the algorithms

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -687,6 +687,7 @@ list(APPEND DUNE_TEST_SOURCE_FILES
   tests/material/test_co2brine_ptflash.cpp
   tests/material/test_components.cpp
   tests/material/test_eclblackoilfluidsystem.cpp
+  tests/material/test_cubiceos_finite_guard.cpp
   tests/material/test_eclblackoilfluidsystemnonstatic.cpp
   tests/material/test_eclblackoilpvt.cpp
   tests/material/test_fluidmatrixinteractions.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -697,6 +697,7 @@ list(APPEND DUNE_TEST_SOURCE_FILES
   tests/material/test_materialstates.cpp
   tests/material/test_ncpflash.cpp
   tests/material/test_pengrobinson.cpp
+  tests/material/test_ptflash_ssi_newton_fallback.cpp
   tests/material/test_tabulation.cpp
   tests/material/test_threecomponents_ptflash.cpp
 )

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -624,9 +624,11 @@ protected:
                 // mixing parameters — switch back to plain successive
                 // substitution and finish the solve with the method that is
                 // robust on these states, instead of failing the whole
-                // solve. Newton throws before writing anything back, so the
-                // state still holds the (near-converged) result of the
-                // successive-substitution stage above.
+                // solve. Newton throws rather than returning a bad result;
+                // it may already have mutated some fluid state (e.g. via
+                // computeLiquidVapor_()) before throwing, but the successive-
+                // substitution fallback re-derives the composition from K and
+                // L and overwrites that state, so restarting it here is safe.
                 try {
                     converged = newtonComposition_(K_scalar, L_scalar, fluid_state_scalar, z_scalar, flash_tolerance, eos_type, verbosity);
                 }

--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -618,7 +618,25 @@ protected:
         } else if (flash_2p_method == "ssi+newton") {
             converged = successiveSubstitutionComposition_(K_scalar, L_scalar, fluid_state_scalar, z_scalar, true, flash_tolerance, eos_type, verbosity);
             if (!converged) {
-                converged = newtonComposition_(K_scalar, L_scalar, fluid_state_scalar, z_scalar, flash_tolerance, eos_type, verbosity);
+                // In this method Newton is an accelerator, not the
+                // guarantee: when its composition update fails to converge —
+                // or a diverged iterate makes the EoS report non-finite
+                // mixing parameters — switch back to plain successive
+                // substitution and finish the solve with the method that is
+                // robust on these states, instead of failing the whole
+                // solve. Newton throws before writing anything back, so the
+                // state still holds the (near-converged) result of the
+                // successive-substitution stage above.
+                try {
+                    converged = newtonComposition_(K_scalar, L_scalar, fluid_state_scalar, z_scalar, flash_tolerance, eos_type, verbosity);
+                }
+                catch (const std::runtime_error& e) {
+                    if (verbosity >= 1) {
+                        OpmLog::debug(fmt::format("Newton did not finish the composition update ({}); "
+                                                  "switching back to successive substitution.", e.what()));
+                    }
+                    converged = successiveSubstitutionComposition_(K_scalar, L_scalar, fluid_state_scalar, z_scalar, false, flash_tolerance, eos_type, verbosity);
+                }
             }
         } else {
             OPM_THROW(std::logic_error,

--- a/opm/material/eos/CubicEOSParams.hpp
+++ b/opm/material/eos/CubicEOSParams.hpp
@@ -34,6 +34,8 @@
 #include <opm/material/eos/RKParams.hpp>
 #include <opm/material/eos/SRKParams.hpp>
 
+#include <cmath>
+
 namespace Opm
 {
 
@@ -106,20 +108,24 @@ public:
 
                 // Calculate A
                 newA +=  xi * xj * aCache_[compIIdx][compJIdx];
-                if (!std::isfinite(scalarValue(newA))) {
-                    OPM_THROW(NumericalProblem,
-                              "CubicEOSParams::updateMix: non-finite mixture A parameter "
-                              "(typically a diverged composition update feeding the EoS)");
-                }
             }
 
             // Calculate B
             newB += max(0.0, xi) * Bi(compIIdx);
-            if (!std::isfinite(scalarValue(newB))) {
-                OPM_THROW(NumericalProblem,
-                          "CubicEOSParams::updateMix: non-finite mixture B parameter "
-                          "(typically a diverged composition update feeding the EoS)");
-            }
+        }
+
+        // A non-finite mixture parameter here typically signals a diverged
+        // composition update feeding the EoS; check once after the double loop
+        // rather than on every accumulation step.
+        if (!std::isfinite(scalarValue(newA))) {
+            OPM_THROW(NumericalProblem,
+                      "CubicEOSParams::updateMix: non-finite mixture A parameter "
+                      "(typically a diverged composition update feeding the EoS)");
+        }
+        if (!std::isfinite(scalarValue(newB))) {
+            OPM_THROW(NumericalProblem,
+                      "CubicEOSParams::updateMix: non-finite mixture B parameter "
+                      "(typically a diverged composition update feeding the EoS)");
         }
 
         // assign A and B

--- a/opm/material/eos/CubicEOSParams.hpp
+++ b/opm/material/eos/CubicEOSParams.hpp
@@ -36,6 +36,8 @@
 
 #include <cmath>
 
+#include <fmt/format.h>
+
 namespace Opm
 {
 
@@ -114,18 +116,13 @@ public:
             newB += max(0.0, xi) * Bi(compIIdx);
         }
 
-        // A non-finite mixture parameter here typically signals a diverged
-        // composition update feeding the EoS; check once after the double loop
-        // rather than on every accumulation step.
-        if (!std::isfinite(scalarValue(newA))) {
+        // check once after the double loop rather than on every accumulation step
+        if (!std::isfinite(scalarValue(newA)) || !std::isfinite(scalarValue(newB))) {
             OPM_THROW(NumericalProblem,
-                      "CubicEOSParams::updateMix: non-finite mixture A parameter "
-                      "(typically a diverged composition update feeding the EoS)");
-        }
-        if (!std::isfinite(scalarValue(newB))) {
-            OPM_THROW(NumericalProblem,
-                      "CubicEOSParams::updateMix: non-finite mixture B parameter "
-                      "(typically a diverged composition update feeding the EoS)");
+                      fmt::format("CubicEOSParams::updateMix: non-finite mixture parameters "
+                                  "for phase {} (A = {}, B = {}); typically a diverged "
+                                  "composition update feeding the EoS",
+                                  phaseIdx, scalarValue(newA), scalarValue(newB)));
         }
 
         // assign A and B

--- a/opm/material/eos/CubicEOSParams.hpp
+++ b/opm/material/eos/CubicEOSParams.hpp
@@ -23,6 +23,9 @@
 #ifndef CUBIC_EOS_PARAMS_HPP
 #define CUBIC_EOS_PARAMS_HPP
 
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
+
 #include <opm/material/Constants.hpp>
 
 #include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
@@ -67,8 +70,11 @@ public:
 
             Scalar newA = OmegaA * pr / (Tr * Tr);
             Scalar newB = OmegaB * pr / Tr;
-            assert(std::isfinite(scalarValue(newA)));
-            assert(std::isfinite(scalarValue(newB)));
+            if (!std::isfinite(scalarValue(newA)) || !std::isfinite(scalarValue(newB))) {
+                OPM_THROW(NumericalProblem,
+                          "CubicEOSParams::updatePure: non-finite pure-component EoS "
+                          "parameter (check the temperature/pressure input)");
+            }
 
             setAi(newA, compIdx);
             setBi(newB, compIdx);
@@ -100,12 +106,20 @@ public:
 
                 // Calculate A
                 newA +=  xi * xj * aCache_[compIIdx][compJIdx];
-                assert(std::isfinite(scalarValue(newA)));
+                if (!std::isfinite(scalarValue(newA))) {
+                    OPM_THROW(NumericalProblem,
+                              "CubicEOSParams::updateMix: non-finite mixture A parameter "
+                              "(typically a diverged composition update feeding the EoS)");
+                }
             }
 
             // Calculate B
             newB += max(0.0, xi) * Bi(compIIdx);
-            assert(std::isfinite(scalarValue(newB)));
+            if (!std::isfinite(scalarValue(newB))) {
+                OPM_THROW(NumericalProblem,
+                          "CubicEOSParams::updateMix: non-finite mixture B parameter "
+                          "(typically a diverged composition update feeding the EoS)");
+            }
         }
 
         // assign A and B

--- a/tests/material/test_cubiceos_finite_guard.cpp
+++ b/tests/material/test_cubiceos_finite_guard.cpp
@@ -1,0 +1,247 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief The isothermal flash's iteration can diverge on deeply
+ *        supercritical feeds (an equimolar N2/methane mixture at 100 bar
+ *        and 400 K, with the standard N2/C1 interaction coefficient, is the
+ *        recorded case): the composition iterates leave [0, 1] far enough
+ *        that the cubic-EoS mixing parameters become non-finite. Before the
+ *        finite guard this hit an assert() — process ABORT in debug builds
+ *        and SILENT propagation of non-finite values in release builds. The
+ *        guard turns both into a catchable NumericalProblem, which is the
+ *        failure mode every caller of the flash already handles.
+ */
+#include "config.h"
+
+#define BOOST_TEST_MODULE CubicEosFiniteGuard
+#include <boost/test/unit_test.hpp>
+
+#include <opm/common/Exceptions.hpp>
+
+#include <opm/material/components/C1.hpp>
+#include <opm/material/components/N2.hpp>
+#include <opm/material/constraintsolvers/PTFlash.hpp>
+#include <opm/material/densead/Evaluation.hpp>
+#include <opm/material/eos/CubicEOS.hpp>
+#include <opm/material/fluidstates/CompositionalFluidState.hpp>
+#include <opm/material/fluidsystems/BaseFluidSystem.hpp>
+#include <opm/material/fluidsystems/PTFlashParameterCache.hpp>
+#include <opm/material/viscositymodels/ViscosityModels.hpp>
+
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
+
+#include <stdexcept>
+#include <string_view>
+
+namespace Opm {
+
+//! Two-phase, two-component (N2/C1) test fluid system — the
+//! ThreeComponentFluidSystem pattern reduced to the pair that exhibits the
+//! recorded divergence, with the standard N2/methane Peng-Robinson binary
+//! interaction coefficient.
+template<class Scalar>
+class N2C1TestFluidSystem
+        : public Opm::BaseFluidSystem<Scalar, N2C1TestFluidSystem<Scalar> > {
+public:
+    static constexpr int numPhases = 2;
+    static constexpr int numComponents = 2;
+    static constexpr int numMisciblePhases = 2;
+    static constexpr int numMiscibleComponents = 2;
+    static constexpr bool waterEnabled = false;
+    static constexpr int oilPhaseIdx = 0;
+    static constexpr int gasPhaseIdx = 1;
+    static constexpr int waterPhaseIdx = -1;
+
+    static constexpr int Comp0Idx = 0;
+    static constexpr int Comp1Idx = 1;
+
+    using Comp0 = N2<Scalar>;
+    using Comp1 = C1<Scalar>;
+
+    template <class ValueType>
+    using ParameterCache = PTFlashParameterCache<ValueType, N2C1TestFluidSystem<Scalar>>;
+    using ViscosityModel = ViscosityModels<Scalar, N2C1TestFluidSystem<Scalar>>;
+    using CubicEOS = ::Opm::CubicEOS<Scalar, N2C1TestFluidSystem<Scalar>>;
+
+    static bool phaseIsActive(unsigned phaseIdx)
+    { return phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx; }
+
+    static Scalar acentricFactor(unsigned compIdx)
+    {
+        switch (compIdx) {
+        case Comp0Idx: return Comp0::acentricFactor();
+        case Comp1Idx: return Comp1::acentricFactor();
+        default: throw std::runtime_error("Illegal component index for acentricFactor");
+        }
+    }
+
+    static Scalar criticalTemperature(unsigned compIdx)
+    {
+        switch (compIdx) {
+        case Comp0Idx: return Comp0::criticalTemperature();
+        case Comp1Idx: return Comp1::criticalTemperature();
+        default: throw std::runtime_error("Illegal component index for criticalTemperature");
+        }
+    }
+
+    static Scalar criticalPressure(unsigned compIdx)
+    {
+        switch (compIdx) {
+        case Comp0Idx: return Comp0::criticalPressure();
+        case Comp1Idx: return Comp1::criticalPressure();
+        default: throw std::runtime_error("Illegal component index for criticalPressure");
+        }
+    }
+
+    static Scalar criticalVolume(unsigned compIdx)
+    {
+        switch (compIdx) {
+        case Comp0Idx: return Comp0::criticalVolume();
+        case Comp1Idx: return Comp1::criticalVolume();
+        default: throw std::runtime_error("Illegal component index for criticalVolume");
+        }
+    }
+
+    static Scalar molarMass(unsigned compIdx)
+    {
+        switch (compIdx) {
+        case Comp0Idx: return Comp0::molarMass();
+        case Comp1Idx: return Comp1::molarMass();
+        default: throw std::runtime_error("Illegal component index for molarMass");
+        }
+    }
+
+    //! standard PR literature value for the N2/methane pair
+    static Scalar interactionCoefficient(unsigned comp1Idx, unsigned comp2Idx)
+    { return (comp1Idx != comp2Idx) ? 0.0291 : 0.0; }
+
+    static std::string_view phaseName(unsigned phaseIdx)
+    {
+        static const std::string_view name[] = {"o", "g"};
+        assert(phaseIdx < 2);
+        return name[phaseIdx];
+    }
+
+    static std::string_view componentName(unsigned compIdx)
+    {
+        static const std::string_view name[] = {Comp0::name(), Comp1::name()};
+        assert(compIdx < 2);
+        return name[compIdx];
+    }
+
+    template <class FluidState, class LhsEval = typename FluidState::ValueType, class ParamCacheEval = LhsEval>
+    static LhsEval density(const FluidState& fluidState,
+                           const ParameterCache<ParamCacheEval>& paramCache,
+                           unsigned phaseIdx)
+    {
+        assert(phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx);
+        return decay<LhsEval>(fluidState.averageMolarMass(phaseIdx) / paramCache.molarVolume(phaseIdx));
+    }
+
+    template <class FluidState, class LhsEval = typename FluidState::ValueType, class ParamCacheEval = LhsEval>
+    static LhsEval viscosity(const FluidState& fluidState,
+                             const ParameterCache<ParamCacheEval>& paramCache,
+                             unsigned phaseIdx)
+    { return decay<LhsEval>(ViscosityModel::LBC(fluidState, paramCache, phaseIdx)); }
+
+    template <class FluidState, class LhsEval = typename FluidState::ValueType, class ParamCacheEval = LhsEval>
+    static LhsEval fugacityCoefficient(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& paramCache,
+                                       unsigned phaseIdx,
+                                       unsigned compIdx)
+    {
+        assert(phaseIdx < numPhases);
+        assert(compIdx < numComponents);
+        return decay<LhsEval>(CubicEOS::computeFugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx));
+    }
+
+    static bool isCompressible([[maybe_unused]] unsigned phaseIdx)
+    { return true; }
+
+    static bool isIdealMixture([[maybe_unused]] unsigned phaseIdx)
+    { return false; }
+
+    static bool isLiquid(unsigned phaseIdx)
+    { return (phaseIdx == 0); }
+};
+
+} // namespace Opm
+
+using Scalar = double;
+using FluidSystem = Opm::N2C1TestFluidSystem<Scalar>;
+using Evaluation = Opm::DenseAd::Evaluation<Scalar, 3>;
+using FluidState = Opm::CompositionalFluidState<Evaluation, FluidSystem>;
+using PtFlash = Opm::PTFlash<Scalar, FluidSystem, true>;
+using EOSType = Opm::CompositionalConfig::EOSType;
+
+namespace {
+
+FluidState makeState(const Scalar p, const Scalar t)
+{
+    FluidState fs;
+    for (unsigned phaseIdx = 0; phaseIdx < FluidSystem::numPhases; ++phaseIdx)
+        fs.setPressure(phaseIdx, p);
+    fs.setTemperature(t);
+    fs.setMoleFraction(0, 0.5);
+    fs.setMoleFraction(1, 0.5);
+    for (int compIdx = 0; compIdx < 2; ++compIdx)
+        fs.setKvalue(compIdx, fs.wilsonK_(compIdx));
+    fs.setLvalue(-1.0);
+    return fs;
+}
+
+} // anonymous namespace
+
+// the recorded divergence case must report as a catchable exception —
+// never as an abort (debug) or a silent non-finite state (release)
+BOOST_AUTO_TEST_CASE(NewtonDivergenceThrowsCatchable)
+{
+    auto fs = makeState(100e5, 400.0);
+    BOOST_CHECK_THROW(
+        PtFlash::solve(fs, "ssi+newton", 1e-8, EOSType::PR),
+        Opm::NumericalProblem);
+}
+
+// the default method's honest failure mode on the same state is unchanged
+// (successive substitution reports its own non-convergence as a throw)
+BOOST_AUTO_TEST_CASE(SsiStillFailsLoudlyNotFatally)
+{
+    auto fs = makeState(100e5, 400.0);
+    BOOST_CHECK_THROW(
+        PtFlash::solve(fs, "ssi", 1e-8, EOSType::PR),
+        std::runtime_error);
+}
+
+// an ordinary state keeps flashing under both methods — the guard costs
+// nothing where nothing goes wrong
+BOOST_AUTO_TEST_CASE(BenignStateUnaffected)
+{
+    for (const char* method : {"ssi", "ssi+newton"}) {
+        auto fs = makeState(100e5, 300.0);
+        BOOST_CHECK_NO_THROW(PtFlash::solve(fs, method, 1e-8, EOSType::PR));
+    }
+}

--- a/tests/material/test_ptflash_ssi_newton_fallback.cpp
+++ b/tests/material/test_ptflash_ssi_newton_fallback.cpp
@@ -25,25 +25,25 @@
 /*!
  * \file
  *
- * \brief The isothermal flash's iteration can diverge on deeply
- *        supercritical feeds (an equimolar N2/methane mixture at 100 bar
- *        and 400 K, with the standard N2/C1 interaction coefficient, is the
- *        recorded case): the composition iterates leave [0, 1] far enough
- *        that the cubic-EoS mixing parameters become non-finite. Before the
- *        finite guard this hit an assert() — process ABORT in debug builds
- *        and SILENT propagation of non-finite values in release builds. The
- *        guard turns both into a catchable NumericalProblem, which is the
- *        failure mode every caller of the flash already handles.
+ * \brief In the "ssi+newton" flash method, Newton is a polish step on top of
+ *        successive substitution — but its composition update can fail to
+ *        converge on perfectly ordinary two-phase states that successive
+ *        substitution handles without difficulty (an equimolar
+ *        methane/n-decane mixture at 50 bar and 295 K, with the standard
+ *        binary interaction coefficient, is the recorded case). Previously
+ *        that failure threw away the whole solve, including the
+ *        near-converged successive-substitution result it started from.
+ *        With the switch-back, the solve falls back to plain successive
+ *        substitution and finishes — and must produce the same answer the
+ *        "ssi" method produces.
  */
 #include "config.h"
 
-#define BOOST_TEST_MODULE CubicEosFiniteGuard
+#define BOOST_TEST_MODULE PtFlashSsiNewtonFallback
 #include <boost/test/unit_test.hpp>
 
-#include <opm/common/Exceptions.hpp>
-
 #include <opm/material/components/C1.hpp>
-#include <opm/material/components/N2.hpp>
+#include <opm/material/components/C10.hpp>
 #include <opm/material/constraintsolvers/PTFlash.hpp>
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/eos/CubicEOS.hpp>
@@ -54,18 +54,18 @@
 
 #include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
 
+#include <cmath>
 #include <stdexcept>
 #include <string_view>
 
 namespace Opm {
 
-//! Two-phase, two-component (N2/C1) test fluid system — the
-//! ThreeComponentFluidSystem pattern reduced to the pair that exhibits the
-//! recorded divergence, with the standard N2/methane Peng-Robinson binary
-//! interaction coefficient.
+//! Two-phase, two-component (C1/nC10) test fluid system with the standard
+//! methane/n-decane Peng-Robinson binary interaction coefficient — the
+//! configuration that exhibits the recorded Newton stall.
 template<class Scalar>
-class N2C1TestFluidSystem
-        : public Opm::BaseFluidSystem<Scalar, N2C1TestFluidSystem<Scalar> > {
+class C1C10TestFluidSystem
+        : public Opm::BaseFluidSystem<Scalar, C1C10TestFluidSystem<Scalar> > {
 public:
     static constexpr int numPhases = 2;
     static constexpr int numComponents = 2;
@@ -79,13 +79,13 @@ public:
     static constexpr int Comp0Idx = 0;
     static constexpr int Comp1Idx = 1;
 
-    using Comp0 = N2<Scalar>;
-    using Comp1 = C1<Scalar>;
+    using Comp0 = C1<Scalar>;
+    using Comp1 = C10<Scalar>;
 
     template <class ValueType>
-    using ParameterCache = PTFlashParameterCache<ValueType, N2C1TestFluidSystem<Scalar>>;
-    using ViscosityModel = ViscosityModels<Scalar, N2C1TestFluidSystem<Scalar>>;
-    using CubicEOS = ::Opm::CubicEOS<Scalar, N2C1TestFluidSystem<Scalar>>;
+    using ParameterCache = PTFlashParameterCache<ValueType, C1C10TestFluidSystem<Scalar>>;
+    using ViscosityModel = ViscosityModels<Scalar, C1C10TestFluidSystem<Scalar>>;
+    using CubicEOS = ::Opm::CubicEOS<Scalar, C1C10TestFluidSystem<Scalar>>;
 
     static bool phaseIsActive(unsigned phaseIdx)
     { return phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx; }
@@ -135,9 +135,9 @@ public:
         }
     }
 
-    //! standard PR literature value for the N2/methane pair
+    //! standard PR literature value for the methane/n-decane pair
     static Scalar interactionCoefficient(unsigned comp1Idx, unsigned comp2Idx)
-    { return (comp1Idx != comp2Idx) ? 0.0291 : 0.0; }
+    { return (comp1Idx != comp2Idx) ? 0.0411 : 0.0; }
 
     static std::string_view phaseName(unsigned phaseIdx)
     {
@@ -192,7 +192,7 @@ public:
 } // namespace Opm
 
 using Scalar = double;
-using FluidSystem = Opm::N2C1TestFluidSystem<Scalar>;
+using FluidSystem = Opm::C1C10TestFluidSystem<Scalar>;
 using Evaluation = Opm::DenseAd::Evaluation<Scalar, 3>;
 using FluidState = Opm::CompositionalFluidState<Evaluation, FluidSystem>;
 using PtFlash = Opm::PTFlash<Scalar, FluidSystem, true>;
@@ -216,35 +216,39 @@ FluidState makeState(const Scalar p, const Scalar t)
 
 } // anonymous namespace
 
-// the recorded divergence case must report as a catchable exception —
-// never as an abort (debug) or a silent non-finite state (release).
-// Probed via the pure "newton" method: in "ssi+newton" the switch-back
-// catches this exception internally and finishes with successive
-// substitution (see test_ptflash_ssi_newton_fallback.cpp).
-BOOST_AUTO_TEST_CASE(NewtonDivergenceThrowsCatchable)
+// the recorded stall state must now SOLVE under ssi+newton (previously the
+// Newton polish threw away the whole solve, successive-substitution progress
+// included)
+BOOST_AUTO_TEST_CASE(FallbackConvergesWhereNewtonStalled)
 {
-    auto fs = makeState(100e5, 400.0);
-    BOOST_CHECK_THROW(
-        PtFlash::solve(fs, "newton", 1e-8, EOSType::PR),
-        Opm::NumericalProblem);
+    auto fs = makeState(50e5, 295.0);
+    BOOST_CHECK_NO_THROW(PtFlash::solve(fs, "ssi+newton", 1e-8, EOSType::PR));
 }
 
-// the default method's honest failure mode on the same state is unchanged
-// (successive substitution reports its own non-convergence as a throw)
-BOOST_AUTO_TEST_CASE(SsiStillFailsLoudlyNotFatally)
+// and the fallback answer is THE answer: it must match the plain "ssi"
+// method's result on the same state — same split, same compositions
+BOOST_AUTO_TEST_CASE(FallbackMatchesSsi)
 {
-    auto fs = makeState(100e5, 400.0);
-    BOOST_CHECK_THROW(
-        PtFlash::solve(fs, "ssi", 1e-8, EOSType::PR),
-        std::runtime_error);
+    auto fsSsi = makeState(50e5, 295.0);
+    PtFlash::solve(fsSsi, "ssi", 1e-8, EOSType::PR);
+
+    auto fsFallback = makeState(50e5, 295.0);
+    PtFlash::solve(fsFallback, "ssi+newton", 1e-8, EOSType::PR);
+
+    BOOST_CHECK_SMALL(std::abs(Opm::getValue(fsFallback.L()) - Opm::getValue(fsSsi.L())), 1e-8);
+    for (unsigned phaseIdx = 0; phaseIdx < FluidSystem::numPhases; ++phaseIdx) {
+        for (int compIdx = 0; compIdx < 2; ++compIdx) {
+            BOOST_CHECK_SMALL(std::abs(
+                Opm::getValue(fsFallback.moleFraction(phaseIdx, compIdx)) -
+                Opm::getValue(fsSsi.moleFraction(phaseIdx, compIdx))), 1e-8);
+        }
+    }
 }
 
-// an ordinary state keeps flashing under both methods — the guard costs
-// nothing where nothing goes wrong
+// benign states keep converging under ssi+newton, ideally via Newton itself —
+// the switch-back must not change where nothing goes wrong
 BOOST_AUTO_TEST_CASE(BenignStateUnaffected)
 {
-    for (const char* method : {"ssi", "ssi+newton"}) {
-        auto fs = makeState(100e5, 300.0);
-        BOOST_CHECK_NO_THROW(PtFlash::solve(fs, method, 1e-8, EOSType::PR));
-    }
+    auto fs = makeState(50e5, 300.0);
+    BOOST_CHECK_NO_THROW(PtFlash::solve(fs, "ssi+newton", 1e-8, EOSType::PR));
 }


### PR DESCRIPTION
## Summary

Two stacked fixes that make Newton-based flash failures survivable:

| Commit | Fix | One line |
|---|---|---|
| 1 | **finite guard** | the EoS mixing-parameter `assert()`s become a catchable `NumericalProblem` — no more process aborts (debug) or silent NaN propagation (release) |
| 2 | **ssi+newton switch-back** | when the Newton polish fails, the solve falls back to successive substitution and **finishes** — instead of discarding the near-converged progress it started from |

## The two failure modes, with reproducers

Both were found while developing an isenthalpic (P–H) flash on top of
`PTFlash`: its temperature search evaluates the isothermal flash at states an
ordinary simulation would rarely pick, which turned out to be an effective
stress test for the Newton path.

| Failure | Reproducer (both in the new tests) | Before | After |
|---|---|---|---|
| **Divergence** — iterates leave the physical range, EoS mixing parameters turn non-finite | equimolar N2/CH4, 100 bar, 400 K, standard kij | debug: `Assertion 'std::isfinite(...)' failed` → **Aborted (core dumped)**; release: assert compiles away → **silent NaN in results** | `ssi+newton`: solve **completes** via substitution; pure `newton`: catchable `NumericalProblem` |
| **Stall** — Newton simply fails to converge on an ordinary two-phase state that substitution handles easily | equimolar CH4/nC10, 50 bar, 295 K, standard kij | whole solve thrown away — including the near-converged substitution result | solve **completes**, and the answer **matches plain `ssi` to 1e-8** (split and compositions) |

## Method behavior matrix

| Method | Before | After |
|---|---|---|
| `ssi` | unchanged | unchanged |
| `newton` | abort / silent NaN on divergence | catchable `NumericalProblem`; contract otherwise unchanged |
| `ssi+newton` | one Newton failure fails the solve (or the process) | Newton is an accelerator, substitution is the guarantee: failures switch back and the solve finishes |

## Why the switch-back is safe by construction

`newtonComposition_` writes its results back only **after** converging. So
when it throws, the fluid state, K-values and phase fraction still hold the
substitution stage's near-converged progress — the fallback simply finishes
that work with the method that is robust on these states.

## Why it matters in practice

This code runs per cell, per Newton iteration, inside long compositional
simulations. Before: a single hostile state could take down the entire
process (debug), silently corrupt results (release), or fail a solve that
was already almost done. After: the aggressive method degrades gracefully to
the robust one, and genuinely impossible states report as ordinary catchable
errors.

Measured effect: in a 15-case flash validation suite (point flashes,
temperature/pressure/enthalpy sweeps, 2–4 component mixtures, cross-checked
against an independent open-source property library), `--method ssi+newton`
went from **10/15 — including three process aborts — to 15/15**, with results
matching the plain `ssi` method wherever both converge.

## Testing

Two self-contained regression tests (each carries its own minimal
two-component fluid system, no external data):

- `test_cubiceos_finite_guard.cpp` — the divergence case throws
  `NumericalProblem` via pure `newton` instead of aborting; `ssi`'s honest
  non-convergence throw unchanged; benign states unaffected.
- `test_ptflash_ssi_newton_fallback.cpp` — the stall state now solves under
  `ssi+newton`; the fallback answer equals the plain `ssi` answer to 1e-8;
  benign states unaffected.

`test_threecomponents_ptflash`, `test_pengrobinson` and `test_fluidsystems`
pass unchanged.
