### PR TITLE
Remove stray debug prints from the vendored well-log extractor

### DIFF
--- a/external/resinsight/ReservoirDataModel/RigWellLogExtractor.cpp
+++ b/external/resinsight/ReservoirDataModel/RigWellLogExtractor.cpp
@@ -294,7 +294,6 @@ void RigWellLogExtractor::populateReturnArrays( std::map<RigMDCellIdxEnterLeaveK
                         // errorMessages +=
                         //     QString( "Well Log Extraction : " ) + QString::fromStdString( m_wellCaseErrorMsgName ) +
                         //     ( " Discards a point at MD:  " ) + QString::number( (double)( it1->first.measuredDepth ) );
-                        std::cout << "error message \n"<< std::endl;
                         // Found that 8 to 10 is not connected, after finding 7 to 9
                         it1 = it21; // Discard 8 by Jumping to 10
                         continue;
@@ -305,7 +304,6 @@ void RigWellLogExtractor::populateReturnArrays( std::map<RigMDCellIdxEnterLeaveK
                     // errorMessages += QString( "Well Log Extraction : " ) +
                     //                  QString::fromStdString( m_wellCaseErrorMsgName ) + ( " Discards a point at MD:  " ) +
                     //                  QString::number( (double)( it1->first.measuredDepth ) );
-                    std::cout << "error message\n"<< std::endl;
                     // Found that 10 to 11 is not connected, and not 10 to 12 either
                     ++it1; // Discard 10 and jump to 11 and hope that recovers us
                     continue;
@@ -341,7 +339,6 @@ void RigWellLogExtractor::appendIntersectionToArrays( double                    
             // errorMessage +=
             //     QString( "Well Log Extraction : %1 does not have a monotonically increasing measured depth." )
             //         .arg( QString::fromStdString( m_wellCaseErrorMsgName ) );
-            std::cout << "error message\n"<< std::endl;
         }
 
         // Allow alterations of up to 0.1 percent as long as we keep the measured depth monotonically increasing.
@@ -351,7 +348,6 @@ void RigWellLogExtractor::appendIntersectionToArrays( double                    
             if ( diff > warningLimit )
             {
                 // errorMessage += "The well path has been slightly adjusted";
-                std::cout << "error message\n"<< std::endl;
             }
             measuredDepth = m_intersectionMeasuredDepths.back();
         }


### PR DESCRIPTION
## What

`RigWellLogExtractor::populateReturnArrays` and `appendIntersectionToArrays` print an unconditional `"error message"` to stdout in four recovery paths — where an intersection pair could not be matched, or where the measured depth was adjusted to keep it monotonic.

These are OPM-local additions sitting next to the commented-out proper error-message code; upstream ResInsight does not print here.

## Why it matters

They fire benignly on any well path that grazes a cell boundary, so a single well can flood stdout during parsing with a message that names no well, no depth and no cause, and that the user can do nothing about.

## Notes

- Deletions only; no behaviour change beyond the printing.
- All four `std::cout` uses in the file are removed, and no `#include <iostream>` is orphaned — they were relying on a transitive include.
