### PR TITLE
RegionCache: skip LGR-completed connections when building the global-grid region cache

### DIFF
--- a/opm/output/eclipse/RegionCache.cpp
+++ b/opm/output/eclipse/RegionCache.cpp
@@ -67,7 +67,24 @@ void Opm::out::RegionCache::buildCache(const std::set<std::string>& fip_regions,
             auto first = true;
 
             for (const auto& conn : conns) {
-                if (! grid.cellActive(conn.global_index())) {
+                // LGR-completed connections (incl. recomputed WELTRAJ-in-LGR
+                // connections) carry a cell index in their LGR's numbering,
+                // which is not a valid index in this global grid.  The region
+                // cache is built over the global grid, so they cannot be
+                // placed in it and are skipped.
+                //
+                // Testing the index range alone is not enough: an LGR-local
+                // index that happens to fall inside the global grid is a
+                // perfectly valid index for an unrelated cell, so the
+                // connection would be silently filed under the wrong FIP
+                // region.  Key on the refinement level, and keep the range
+                // check for the out-of-range case.
+                if (conn.get_lgr_level() != 0) {
+                    continue;
+                }
+
+                if ((conn.global_index() >= grid.getCartesianSize()) ||
+                    ! grid.cellActive(conn.global_index())) {
                     continue;
                 }
 


### PR DESCRIPTION
## What

`RegionCache::buildCache` maps each well connection to a FIP region through the **global** grid:

```cpp
if (! grid.cellActive(conn.global_index())) { continue; }
const auto region = regID->get()[grid.activeIndex(conn.global_index())];
```

A connection completed inside a local grid refinement carries a cell index in its LGR's own numbering, which is not a valid index in the global grid. Two things go wrong with it:

1. **If the index falls outside the global grid**, `cellActive()` throws *"Input global index N above valid range"* during problem setup. Observed on a `model5`-derived deck with wells completed in a refinement and FIP-region summary keywords requested.
2. **If it happens to fall inside the global grid**, it is a perfectly valid index for an unrelated cell, so the connection is silently filed under the **wrong FIP region** — no error, just wrong region sums.

## The change

Skip connections with `get_lgr_level() != 0`, which covers both cases, and keep a range check as a guard for anything else out of bounds.

Decks without refinement are unaffected: every connection has `lgr_level == 0` and every index is in range, so the cache is built exactly as before.

## Note

The second failure mode is the same one as in OPM/opm-grid#1053 — an LGR-local position that is coincidentally a valid coarse index is far more dangerous than one that is obviously out of range, because nothing rejects it. Testing the index range alone is not sufficient; the refinement level is the thing that actually distinguishes these connections.

## Testing

opm-common test suite passes (34/34 in the Summary/Restart/region group). Built against opm-grid master.
