### PR TITLE
Write INIT/restart LGR sections in EGRID grid order, and mirror integer maps onto LGR grids

### DIFF
--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -1104,26 +1104,31 @@ namespace {
                          int                                          lgrIndex,
                          int                                          index)
     {
-        const auto& all_lgr_names = grid.get_all_lgr_labels();
-        const auto& lgr_grid_name = all_lgr_names[lgrIndex];
+        // lgrIndex comes from grid.get_print_order_lgr(); address the LGR grid
+        // through the (father-sorted) child-cell storage so the restart writes
+        // its LGR sections in the same order as EclipseGrid::save_children()
+        // writes the EGRID grids.  The simulator-provided per-LGR restart
+        // values follow the deck order, so they are addressed via the label's
+        // deck index.
+        const auto& lgr_grid = grid.getLGRCell(static_cast<std::size_t>(lgrIndex));
+        const auto& lgr_grid_name = lgr_grid.get_lgr_tag();
+        const auto deckIdx = static_cast<int>(grid.get_lgr_cell_index(lgr_grid_name));
 
         rstFile.write("LGR", std::vector<std::string>{ lgr_grid_name });
 
-        const auto& lgr_grid = grid.getLGRCell(lgr_grid_name);
-
         // LGR HEADERS
-        writeHeaderLGR(es, rstFile, lgrIndex);
+        writeHeaderLGR(es, rstFile, deckIdx);
 
         // Global HEADERS for LGR GRIDS
         const auto inteHD =
-        writeHeader(report_step, sim_step, nextStepSize(values[lgrIndex+1]),
+        writeHeader(report_step, sim_step, nextStepSize(values[deckIdx+1]),
         seconds_elapsed, schedule, lgr_grid, es, rstFile);
 
         if (report_step > 0) {
-            writeDynamicDataLGR(sim_step, grid, es, schedule, values[lgrIndex+1].wells,
+            writeDynamicDataLGR(sim_step, grid, es, schedule, values[deckIdx+1].wells,
                                 action_state, wtest_state, sumState, inteHD,rstFile, lgr_grid_name);
         }
-        writeSolutionLGR(values[lgrIndex+1], es, schedule, udqState, report_step, sim_step,
+        writeSolutionLGR(values[deckIdx+1], es, schedule, udqState, report_step, sim_step,
         ecl_compatible_rst, write_double, inteHD, rstFile, lgr_grid_name);
 
         rstFile.write("ENDLGR", std::vector<int>{index});

--- a/opm/output/eclipse/WriteInit.cpp
+++ b/opm/output/eclipse/WriteInit.cpp
@@ -883,20 +883,30 @@ namespace {
     {
         bool fullProperties = simProps.size() > 1;
         if (grid.is_lgr()) {
-            std::vector<std::string> all_lgr_tag = grid.get_all_lgr_labels();
+            // Iterate the LGR grids in exactly the same order as
+            // EclipseGrid::save_children() writes them to the EGRID, i.e. the
+            // print order applied to the (father-sorted) child-cell storage
+            // (getLGRCell(index)).  Using get_all_lgr_labels()[index] here
+            // instead indexes the *deck-ordered* label list with the
+            // father-sorted print-order permutation, emitting the INIT LGR
+            // sections in a different order than the EGRID grids and breaking
+            // positional grid/section pairing in post-processors (ResInsight).
+            // The simulator-provided per-LGR data (simProps) follows the deck
+            // order, so it is addressed via the label's deck index.
             for (std::size_t index : grid.get_print_order_lgr())
             {
-                auto lgr_label = all_lgr_tag[index];
-                const ::Opm::EclipseGridLGR& lgr_grid = grid.getLGRCell(lgr_label);
+                const ::Opm::EclipseGridLGR& lgr_grid = grid.getLGRCell(index);
+                const auto lgr_label = lgr_grid.get_lgr_tag();
+                const auto deckIdx = grid.get_lgr_cell_index(lgr_label);
                 const std::array<int,3> subdivisions = grid.getCellSubdivisionRatioLGR(lgr_label);
                 std::vector<int> global_fathers = lgr_grid.getLGRCell_global_father(grid);
-                writeInitFileHeaderLGRCell(es, lgr_grid, schedule, initFile, index+1);
+                writeInitFileHeaderLGRCell(es, lgr_grid, schedule, initFile, deckIdx+1);
                 writePoreVolumeLGRCell(porv, global_fathers,
                 subdivisions[0]*subdivisions[1]*subdivisions[2], initFile);
                 writeGridGeometryLGRCell(grid, lgr_grid, units, initFile,
                                 subdivisions[0], subdivisions[1], subdivisions[2]);
                 writeDoubleCellProperties(es, units, initFile, global_fathers);
-                const auto& simProp = fullProperties ? simProps[index + 1] : simProps[0];
+                const auto& simProp = fullProperties ? simProps[deckIdx + 1] : simProps[0];
                 writeSimulatorPropertiesLGRCell(fullProperties ? lgr_grid : grid, simProp, initFile, global_fathers, fullProperties);
                 {
                     const auto writeAll = es.cfg().io().writeAllTransMultipliers();

--- a/opm/output/eclipse/WriteInit.cpp
+++ b/opm/output/eclipse/WriteInit.cpp
@@ -878,6 +878,7 @@ namespace {
                                  const ::Opm::Schedule& schedule,
                                  const std::vector<std::reference_wrapper<const ::Opm::data::Solution>> simProps,
                                  const std::vector<double>& porv,
+                                 const std::map<std::string, std::vector<int>>& int_data,
                                  const ::Opm::UnitSystem& units,
                                        ::Opm::EclIO::OutputStream::Init& initFile)
     {
@@ -921,6 +922,15 @@ namespace {
                     writeSimulatorPropertiesLGRCell(grid, multipliers, initFile, global_fathers);
                 }
                 writeIntegerCellPropertiesLGRCell(es, global_fathers, initFile);
+
+                // Simulator-supplied integer maps (e.g. MPI_RANK) are written
+                // for the main grid via writeIntegerMaps(); mirror them onto
+                // each LGR so the array also exists on the refined cells.  Each
+                // refined cell inherits its father coarse cell's value, which
+                // for rank-interior LGR boxes equals the box's owning rank.
+                for (const auto& [key, value] : int_data) {
+                    initFile.write(key, VectorUtil::filterArray(value, global_fathers));
+                }
             }
             initFile.message("LGRSGONE");
             }
@@ -1105,7 +1115,9 @@ void Opm::InitIO::write(const ::Opm::EclipseState&                  es,
 
     // GLOBAL REGION ARRAYS (SATNUM, PVTNUM, EQLNUM, FIPNUM, ...) - before NNC per reference output
     writeIntegerCellProperties(es, initFile);
-    writeIntegerMaps(std::move(int_data), initFile);
+    // Note: int_data (simulator integer maps, e.g. MPI_RANK) is reused by
+    // writeLGRLocalProperties() below, so it is not moved-from here.
+    writeIntegerMaps(int_data, initFile);
 
     // GLOBAL NNC - after integer region arrays, before LGR sections
     if (!nnc_col.empty()) {
@@ -1119,7 +1131,7 @@ void Opm::InitIO::write(const ::Opm::EclipseState&                  es,
     // LGR PROPERTY SECTION (per reference: after LGR NNC section)
     // For each LGR: LGRHEADI/Q/D, PORV, DEPTH, TRANX/Y/Z, PERMX/Y/Z, MULTX/Y/Z, PORO, SATNUM, ... + LGRSGONE
     // Not yet supported: LGR-specific aquifer and satfunc scaling - planned for upcoming versions
-    writeLGRLocalProperties(es, grid, schedule, simProps, porv, units, initFile);
+    writeLGRLocalProperties(es, grid, schedule, simProps, porv, int_data, units, initFile);
 
     // TABULAR DATA (TABDIMS, TAB, CON) - after all LGR sections per reference output
     writeTableData(es, units, initFile);


### PR DESCRIPTION
Two LGR output fixes. **This changes the order of the per-LGR sections in INIT and UNRST** — that is the fix, not a side effect.

## 1. Write INIT/restart LGR sections in EGRID grid order

`EclipseGrid::save_children()` writes the LGR grids to the EGRID by applying the print-order permutation to the **father-sorted** child-cell storage (`getLGRCell(index)`).

`WriteInit::writeLGRLocalProperties()` and `RestartIO::writeLGRRestart()` applied that same father-sorted permutation index to `get_all_lgr_labels()`, which is in **deck order**.

When deck order and father (host-cell) order differ — a CARFIN box with a low host-cell index declared *after* one with a high host-cell index — INIT and UNRST emit their per-LGR sections in a different order than the EGRID grids.

Post-processors pair the INIT/restart LGR sections to the EGRID LGR grids **positionally**, so the mismatch lines a grid's PORV array up with the wrong grid. In ResInsight it trips

```
ecl_grid_get_global_size(grid) == activeCellsForGrid.size()
```

Both writers now iterate through `getLGRCell(index)`, identical to `save_children`, so the section order matches the EGRID; the simulator-provided, deck-ordered per-LGR data is addressed via the label's deck index (`get_lgr_cell_index`).

EGRID, INIT and UNRST now list the LGR grids in the same order with matching per-grid sizes.

**Compatibility:** any deck whose CARFIN declaration order already matches host-cell order is byte-identical. Only decks that were previously being written inconsistently change — and for those the old output was not loadable.

## 2. Write simulator integer maps (MPI_RANK) per LGR grid

INIT integer maps such as `MPI_RANK` were written only for the main grid via `writeIntegerMaps()`, so the array was simply absent on refined cells and did not show up on the refined region in post-processors.

Each integer map is now mirrored onto every LGR section in `writeLGRLocalProperties`: a refined cell inherits its father coarse cell's value via `filterArray` on `global_fathers`, the same mechanism already used for EQLNUM/FIPNUM. `int_data` is reused after `writeIntegerMaps()` rather than being moved-from.

Verified on `SPE1CASE1_CARFIN1` at `np=2`: INIT now carries `MPI_RANK` in all three grid sections (main 300, each LGR 324, matching PORV/EQLNUM), the main grid carries ranks 0/1, and each box is uniformly its owning rank. Serial output is unchanged, since serial runs have no integer maps.

This one is additive rather than a bug fix — happy to split it out if you would rather take (1) alone.

## Testing

`test_RestartLGR`, `test_EclipseIO_LGR`, `test_HeadersLGR` and `test_AggregateWellDataLGR` all pass. Built against opm-grid master.
