### PR TITLE
bump required dune to 2.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ macro(opm-common_prereqs_hook)
 
   if(OPM_ENABLE_DUNE)
     find_package(dune-common REQUIRED)
-    target_link_libraries(opmcommon PUBLIC dunecommon)
+    target_link_libraries(opmcommon PUBLIC Dune::Common)
   endif()
 endmacro()
 

--- a/cmake/Modules/Finddune-alugrid.cmake
+++ b/cmake/Modules/Finddune-alugrid.cmake
@@ -20,7 +20,7 @@ else()
 endif()
 
 if(dune-alugrid_FOUND)
-  target_compile_definitions(dunealugrid INTERFACE HAVE_DUNE_ALUGRID=1)
+  target_compile_definitions(Dune::ALUGrid INTERFACE HAVE_DUNE_ALUGRID=1)
   # make version number available in config.h
   include (UseDuneVer)
   find_dune_version ("dune" "alugrid")

--- a/cmake/Modules/Finddune-common.cmake
+++ b/cmake/Modules/Finddune-common.cmake
@@ -23,11 +23,5 @@ if(dune-common_FOUND)
   # make version number available in config.h
   include (UseDuneVer)
   find_dune_version ("dune" "common")
-  target_compile_definitions(dunecommon INTERFACE HAVE_DUNE_COMMON=1)
-
-  if(dune-common_VERSION VERSION_LESS 2.11)
-    find_package(Threads)
-    find_package(TBB)
-    target_include_directories(dunecommon INTERFACE ${dune-common_INCLUDE_DIRS})
-  endif()
+  target_compile_definitions(Dune::Common INTERFACE HAVE_DUNE_COMMON=1)
 endif()

--- a/cmake/Modules/Finddune-fem.cmake
+++ b/cmake/Modules/Finddune-fem.cmake
@@ -25,7 +25,7 @@ if(dune-fem_FOUND)
   # make version number available in config.h
   include (UseDuneVer)
   find_dune_version ("dune" "fem")
-  target_compile_definitions(dunefem
+  target_compile_definitions(Dune::Fem
     INTERFACE
       HAVE_DUNE_FEM=1
       DUNE_FEM_VERSION_MAJOR=${DUNE_FEM_VERSION_MAJOR}

--- a/cmake/Modules/Finddune-geometry.cmake
+++ b/cmake/Modules/Finddune-geometry.cmake
@@ -20,7 +20,7 @@ else()
 endif()
 
 if(dune-geometry_FOUND)
-  target_compile_definitions(dunegeometry INTERFACE HAVE_DUNE_GEOMETRY=1)
+  target_compile_definitions(Dune::Geometry INTERFACE HAVE_DUNE_GEOMETRY=1)
   # make version number available in config.h
   include (UseDuneVer)
   find_dune_version ("dune" "geometry")

--- a/cmake/Modules/Finddune-grid.cmake
+++ b/cmake/Modules/Finddune-grid.cmake
@@ -20,7 +20,7 @@ else()
 endif()
 
 if(dune-grid_FOUND)
-  target_compile_definitions(dunegrid INTERFACE HAVE_DUNE_GRID=1)
+  target_compile_definitions(Dune::Grid INTERFACE HAVE_DUNE_GRID=1)
   # make version number available in config.h
   include (UseDuneVer)
   find_dune_version ("dune" "grid")

--- a/cmake/Modules/Finddune-istl.cmake
+++ b/cmake/Modules/Finddune-istl.cmake
@@ -23,11 +23,5 @@ if(dune-istl_FOUND)
   # make version number available in config.h
   include (UseDuneVer)
   find_dune_version ("dune" "istl")
-
-  if(NOT TARGET Dune::ISTL)
-    add_library(Dune::ISTL INTERFACE IMPORTED)
-    target_link_libraries(Dune::ISTL INTERFACE dunecommon)
-    target_include_directories(Dune::ISTL INTERFACE ${dune-istl_INCLUDE_DIRS})
-  endif()
   target_compile_definitions(Dune::ISTL INTERFACE HAVE_DUNE_ISTL=1)
 endif()

--- a/cmake/Modules/Finddune-localfunctions.cmake
+++ b/cmake/Modules/Finddune-localfunctions.cmake
@@ -20,7 +20,7 @@ else()
 endif()
 
 if(dune-localfunctions_FOUND)
-  target_compile_definitions(dunelocalfunctions INTERFACE HAVE_DUNE_LOCALFUNCTIONS=1)
+  target_compile_definitions(Dune::LocalFunctions INTERFACE HAVE_DUNE_LOCALFUNCTIONS=1)
   # make version number available in config.h
   include (UseDuneVer)
   find_dune_version ("dune" "localfunctions")

--- a/cmake/Modules/Finddune-polygongrid.cmake
+++ b/cmake/Modules/Finddune-polygongrid.cmake
@@ -20,7 +20,7 @@ else()
 endif()
 
 if(dune-polygongrid_FOUND)
-  target_compile_definitions(dunepolygongrid INTERFACE HAVE_DUNE_POLYGONGRID=1)
+  target_compile_definitions(Dune::PolygonGrid INTERFACE HAVE_DUNE_POLYGONGRID=1)
   # make version number available in config.h
   include (UseDuneVer)
   find_dune_version ("dune" "polygongrid")

--- a/cmake/Modules/Finddune-uggrid.cmake
+++ b/cmake/Modules/Finddune-uggrid.cmake
@@ -9,7 +9,7 @@ else()
 endif()
 
 if(dune-uggrid_FOUND)
-  target_compile_definitions(duneuggrid INTERFACE HAVE_DUNE_UGGRID=1)
+  target_compile_definitions(Dune::UGGrid INTERFACE HAVE_DUNE_UGGRID=1)
   # make version number available in config.h
   include (UseDuneVer)
   find_dune_version ("dune" "uggrid")

--- a/dune.module
+++ b/dune.module
@@ -10,4 +10,4 @@ Label: 2026.10-pre
 Maintainer: opm@opm-project.org
 MaintainerName: OPM community
 Url: http://opm-project.org
-Depends: dune-common (>= 2.9)
+Depends: dune-common (>= 2.11)

--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -15,7 +15,7 @@ if(TARGET opmcommon)
     find_package(Python3 COMPONENTS Development.Embed REQUIRED)
   endif()
 
-  if(opm-common_LIBS MATCHES dunecommon)
+  if(opm-common_LIBS MATCHES Dune::Common)
     find_package(dune-common REQUIRED)
   endif()
 


### PR DESCRIPTION
and remove workarounds required for 2.9.

as far as i know there is no reason why we cannot do this now.