### PR TITLE
Nested CARFIN: validate and index against the parent LGR

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/LgrCollection.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/LgrCollection.cpp
@@ -77,6 +77,35 @@ namespace Opm {
     }
 
     void LgrCollection::addLgr(const EclipseGrid& grid, const DeckRecord&  lgrRecord) {
+       // A nested CARFIN (PARENT != GLOBAL) addresses cells in its parent LGR's
+       // own refined Cartesian space, so its I/J/K range and divisions must be
+       // validated against the parent LGR's dimensions - not the global grid.
+       // (CARFIN records are processed in deck order, parent before child, so
+       // the parent LGR is already in the collection.)
+       const auto& parentItem = lgrRecord.getItem<ParserKeywords::CARFIN::PARENT>();
+       const std::string parent_name = parentItem.defaultApplied(0)
+           ? std::string{"GLOBAL"} : parentItem.get<std::string>(0);
+
+       if (parent_name != "GLOBAL") {
+           if (m_lgrs.count(parent_name) == 0) {
+               throw std::invalid_argument("Nested CARFIN names parent LGR '" + parent_name
+                   + "', which has not been defined yet. Parent LGRs must precede their "
+                     "children in the deck.");
+           }
+           const Carfin& parent = m_lgrs.get(parent_name);
+           // The parent LGR is a refined Cartesian block: every local cell is
+           // active and the active index is the identity in its local space.
+           const GridDims parentDims(static_cast<std::size_t>(parent.NX()),
+                                     static_cast<std::size_t>(parent.NY()),
+                                     static_cast<std::size_t>(parent.NZ()));
+           Carfin lgr(parentDims,
+                      [](const std::size_t) { return true; },
+                      [](const std::size_t local_index) { return local_index; });
+           lgr.update(lgrRecord);
+           m_lgrs.insert(std::make_pair(lgr.NAME(), lgr));
+           return;
+       }
+
        Carfin lgr(grid,
             [&grid](const std::size_t global_index)
             {

--- a/opm/input/eclipse/EclipseState/Grid/LgrCollection.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/LgrCollection.cpp
@@ -16,12 +16,15 @@
 #include <opm/input/eclipse/EclipseState/Grid/LgrCollection.hpp>
 
 #include <opm/common/utility/OpmInputError.hpp>
+#include <opm/common/OpmLog/KeywordLocation.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <opm/input/eclipse/EclipseState/Grid/Carfin.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/CarfinManager.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
+
+#include <fmt/format.h>
 
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/DeckSection.hpp>
@@ -47,7 +50,7 @@ namespace Opm {
             OpmLog::info(OpmInputError::format("\nLoading lgrs from {keyword} in {file} line {line}", lgrsKeyword->location()));
 
             for (const auto& lgrRecord : *lgrsKeyword) {
-                addLgr(grid, lgrRecord);
+                addLgr(grid, lgrRecord, lgrsKeyword->location());
             }
         }
     }
@@ -76,7 +79,9 @@ namespace Opm {
         return m_lgrs.iget( lgrIndex );
     }
 
-    void LgrCollection::addLgr(const EclipseGrid& grid, const DeckRecord&  lgrRecord) {
+    void LgrCollection::addLgr(const EclipseGrid& grid,
+                               const DeckRecord& lgrRecord,
+                               const KeywordLocation& location) {
        // A nested CARFIN (PARENT != GLOBAL) addresses cells in its parent LGR's
        // own refined Cartesian space, so its I/J/K range and divisions must be
        // validated against the parent LGR's dimensions - not the global grid.
@@ -88,9 +93,12 @@ namespace Opm {
 
        if (parent_name != "GLOBAL") {
            if (m_lgrs.count(parent_name) == 0) {
-               throw std::invalid_argument("Nested CARFIN names parent LGR '" + parent_name
-                   + "', which has not been defined yet. Parent LGRs must precede their "
-                     "children in the deck.");
+               throw OpmInputError {
+                   fmt::format("Nested CARFIN names parent LGR '{}', which has not been "
+                               "defined yet. Parent LGRs must precede their children "
+                               "in the deck.", parent_name),
+                   location
+               };
            }
            const Carfin& parent = m_lgrs.get(parent_name);
            // The parent LGR is a refined Cartesian block: every local cell is

--- a/opm/input/eclipse/EclipseState/Grid/LgrCollection.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/LgrCollection.hpp
@@ -30,6 +30,7 @@ namespace Opm {
     class DeckRecord;
     class GridDims;
     class GRIDSection;
+    class KeywordLocation;
 
 class LgrCollection {
 public:
@@ -47,7 +48,9 @@ public:
     Carfin& getLgr(std::size_t lgrIndex);
     const Carfin& getLgr(std::size_t lgrIndex) const;
 
-    void addLgr(const EclipseGrid& grid, const DeckRecord& lgrRecord);
+    void addLgr(const EclipseGrid& grid,
+                const DeckRecord& lgrRecord,
+                const KeywordLocation& location);
 
     bool operator==(const LgrCollection& data) const;
 


### PR DESCRIPTION
Split out of #5250 so the serialization fix there can land on its own — akva2 approved that part but was reasonably unsure about the nested semantics, which is all that is here.

`LgrCollection::addLgr` always built the `Carfin` against the global `GridDims`. A nested CARFIN (`PARENT` other than `GLOBAL`) addresses cells in its parent LGR's refined space, so one whose parent-local extent exceeds the global grid — a child in a parent with refined NZ=9 over a global NZ=3 — was rejected with *"Index values for lgr greater than global grid size"* despite being valid.

It now reads `CARFIN::PARENT` and, for a non-`GLOBAL` parent, constructs against that parent's `NX/NY/NZ`. Requires parent-before-child ordering in the deck; an undefined parent throws `OpmInputError` carrying the CARFIN keyword location (the second commit — this was the bare `throw` akva2 flagged on #5250).

No change for `PARENT GLOBAL`, which is every existing deck.

Depends on nothing; #5250 is independent.