### PR TITLE
MechSolver: no solver selected unless MECHSOLV is present

### DIFF
--- a/opm/input/eclipse/EclipseState/Runspec.hpp
+++ b/opm/input/eclipse/EclipseState/Runspec.hpp
@@ -466,7 +466,8 @@ class MechSolver
 public:
     enum class Solver
     {
-        TPSA
+        TPSA,
+        None
     };
 
     enum class CouplingScheme
@@ -518,7 +519,9 @@ public:
     }
 
 private:
-    Solver m_solver{};
+    // No mechanics solver is selected unless the deck contains MECHSOLV;
+    // MECH alone may be handled by an external mechanics module.
+    Solver m_solver{Solver::None};
     CouplingScheme m_coupling = CouplingScheme::Lagged;
     int m_fixed_stress_min_iter{};
     int m_fixed_stress_max_iter{};


### PR DESCRIPTION
`MechSolver::m_solver` is value-initialized to TPSA (the only enumerator), so every deck with MECH — including decks meant for external mechanics modules — reports `mechSolver().tpsa() == true`. That trips the TPSA guard in non-mech simulators and silently activates the TPSA porosity-coupling term when a different mechanics solver is used. This adds an explicit `None` default; MECHSOLV selects TPSA exactly as before.

Draft for discussion with the TPSA authors: it changes what `MECH` without `MECHSOLV` means (currently it implicitly selects TPSA).