### PR TITLE
make sure doxygen folder exists

### DIFF
--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -105,6 +105,7 @@ function build_module {
   CMAKE_PARAMS="$1"
   DO_TEST_FLAG="$2"
   MOD_SRC_DIR="$3"
+  mkdir -p $PWD/doc/doxygen
   cmake "$MOD_SRC_DIR" \
         -DCMAKE_BUILD_TYPE=${configurations_build_type[$configuration]} \
         -DBUILD_TESTING=$DO_TEST_FLAG \


### PR DESCRIPTION
opm-common uses a docs dir rather than doc that is used for the other modules.

This meant we were missing the log file used by jenkins. We should probably really consider
to make the folder 'doc' in opm-common as well, but for now this workaround does the job.