### PR TITLE
Reject a missing WCONPROD control mode when a well is first opened

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
@@ -261,13 +261,52 @@ Well {} specifies {} constraint, but {}. The constraint will be ignored.)",
         this->addProductionControl( ProducerCMode::BHP );
         {
             const auto& cmodeItem = record.getItem("CMODE");
-            if (cmodeItem.hasValue(0)) {
-                auto cmode = WellProducerCModeFromString(cmodeItem.getTrimmedString(0));
+            const auto cmode_string = cmodeItem.hasValue(0)
+                ? cmodeItem.getTrimmedString(0)
+                : std::string {};
 
-                if (this->hasProductionControl( cmode ))
+            // Item 3 may legitimately be omitted ('1*') or blank (''): a well
+            // that is not being opened needs no control mode - closing one
+            // with 'WCONPROD  W SHUT /' is idiomatic - and a later record that
+            // only revises limits keeps the mode the well already has.  What
+            // has no meaning is opening a well that has never been given one.
+            // That used to reach the simulator, where every time step failed
+            // with "Well control must be specified", or reached the enum
+            // conversion and surfaced as an internal error.  Reject it here,
+            // naming the keyword and line the user can act on.
+            if (cmode_string.empty()) {
+                const auto status = WellStatusFromString
+                    (record.getItem("STATUS").getTrimmedString(0));
+
+                if ((status == WellStatus::OPEN) &&
+                    (this->controlMode == ProducerCMode::CMODE_UNDEFINED))
+                {
+                    throw OpmInputError(fmt::format("Control mode (item 3) must be "
+                                                    "specified when well {} is first "
+                                                    "opened", well_name),
+                                        location);
+                }
+            }
+            else {
+                auto cmode = ProducerCMode::CMODE_UNDEFINED;
+                try {
+                    cmode = WellProducerCModeFromString(cmode_string);
+                }
+                catch (const std::invalid_argument&) {
+                    throw OpmInputError(fmt::format("Unknown control mode {} for well {}",
+                                                    cmode_string, well_name),
+                                        location);
+                }
+
+                if (this->hasProductionControl(cmode)) {
                     this->controlMode = cmode;
-                else
-                    throw std::invalid_argument("Trying to set CMODE to: " + cmodeItem.getTrimmedString(0) + " - no value has been specified for this control");
+                }
+                else {
+                    throw OpmInputError(fmt::format("Control mode {} for well {} has no "
+                                                    "target or limit specified",
+                                                    cmode_string, well_name),
+                                        location);
+                }
             }
         }
     }

--- a/tests/parser/data/integration_tests/SCHEDULE/SCHEDULE_MISSING_CMODE_OPEN
+++ b/tests/parser/data/integration_tests/SCHEDULE/SCHEDULE_MISSING_CMODE_OPEN
@@ -1,0 +1,30 @@
+START
+  10 MAI 2007   /
+
+RUNSPEC
+
+DIMENS
+  10 10 3  /
+
+GRID
+
+PERMX
+  300*0.25 /
+
+COPY
+  PERMX PERMY /
+  PERMX PERMZ /
+/
+
+
+SCHEDULE
+
+WELSPECS
+     'D-4H'        'OP'   30   37  3.33       'OIL'  7* /
+/
+
+-- Control mode (item 3) defaulted while the well is opened for the first
+-- time.  There is no earlier mode to keep, so this must be rejected.
+WCONPROD
+     'D-4H'      'OPEN' 1* 20000 14* /
+/

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -24,6 +24,8 @@
 
 #include <boost/version.hpp>
 
+#include <opm/common/utility/OpmInputError.hpp>
+
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
@@ -234,6 +236,23 @@ BOOST_AUTO_TEST_CASE(WCONPROD_MissingCmode) {
     const FieldPropsManager fp(deck, runspec.phases(), grid, table);
     auto python = std::make_shared<Python>();
     BOOST_CHECK_NO_THROW( Schedule(deck, grid, fp, NumericalAquifers{}, runspec, python) );
+}
+
+
+BOOST_AUTO_TEST_CASE(WCONPROD_MissingCmode_Open) {
+    Parser parser;
+    std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_MISSING_CMODE_OPEN");
+    auto deck =  parser.parseFile(scheduleFile);
+    EclipseGrid grid(10,10,3);
+    TableManager table ( deck );
+    const Runspec runspec (deck);
+    const FieldPropsManager fp(deck, runspec.phases(), grid, table);
+    auto python = std::make_shared<Python>();
+
+    // Defaulting the control mode is only meaningful when the well already
+    // has one, or when it is not being opened.
+    BOOST_CHECK_THROW( Schedule(deck, grid, fp, NumericalAquifers{}, runspec, python),
+                       OpmInputError );
 }
 
 


### PR DESCRIPTION
WCONPROD item 3 can legitimately be defaulted — a well that is not being opened needs no control mode, and a later record that only revises limits keeps the mode the well already has. Opening a well that never got one was accepted in two broken ways:

- `1*` left the mode undefined and the simulator failed every time step with `Well control must be specified for well ...`, chopped to the minimum step and aborted;
- `` reached `WellProducerCModeFromString()` and surfaced as `Internal error: Unknown enum state string:`.

Both are now rejected up front with keyword, file and line. Unknown/unsupported mode strings report the same way instead of as an internal error.

Covers `wconprod/WCONPROD-01 .. -12`; `WCONPROD-00` (which defaults the mode in a later record) still runs. Test added.