### PR TITLE
Schedule: handle LGRON / LGROFF instead of silently discarding them

### DIFF
--- a/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -47,6 +47,8 @@
 #include "GasLiftOptKeywordHandlers.hpp"
 #include "Group/GroupKeywordHandlers.hpp"
 #include "Group/GuideRateKeywordHandlers.hpp"
+#include <opm/input/eclipse/Schedule/ScheduleGrid.hpp>
+
 #include "HandlerContext.hpp"
 #include "MixingRateControlKeywordHandlers.hpp"
 #include "MSW/MSWKeywordHandlers.hpp"
@@ -161,6 +163,52 @@ void handleNEXTSTEP(HandlerContext& handlerContext)
 
     handlerContext.state().next_tstep = NextStep{next_tstep, apply_to_all};
     handlerContext.state().events().addEvent(ScheduleEvents::TUNING_CHANGE);
+}
+
+void handleLGROnOff(HandlerContext& handlerContext, const bool active)
+{
+    const auto& record = handlerContext.keyword.getRecord(0);
+
+    const auto& nameItem = record.getItem("LOCAL_GRID_REFINMENT");
+    if (! nameItem.hasValue(0)) {
+        throw OpmInputError(fmt::format("{} requires the name of a local grid refinement",
+                                        handlerContext.keyword.name()),
+                            handlerContext.keyword.location());
+    }
+    const auto lgr_name = nameItem.getTrimmedString(0);
+
+    // Validate the name whenever the grid is available; an empty label table
+    // then means the run has no LGRs at all.
+    if ((handlerContext.grid.get_grid() != nullptr) &&
+        ! handlerContext.grid.has_lgr(lgr_name))
+    {
+        throw OpmInputError(fmt::format("{}: unknown local grid refinement '{}'",
+                                        handlerContext.keyword.name(), lgr_name),
+                            handlerContext.keyword.location());
+    }
+
+    const auto& wellsItem = record.getItem("ACTIVE_WELLS");
+    if (wellsItem.hasValue(0) && ! wellsItem.defaultApplied(0) &&
+        (wellsItem.get<int>(0) != 0))
+    {
+        OpmLog::warning(OpmInputError::format(
+            fmt::format("{{keyword}}: the well-activation item of {} is not supported "
+                        "and is ignored in {{file}} line {{line}}",
+                        handlerContext.keyword.name()),
+            handlerContext.keyword.location()));
+    }
+
+    handlerContext.state().update_lgr_active(lgr_name, active);
+}
+
+void handleLGRON(HandlerContext& handlerContext)
+{
+    handleLGROnOff(handlerContext, true);
+}
+
+void handleLGROFF(HandlerContext& handlerContext)
+{
+    handleLGROnOff(handlerContext, false);
 }
 
 void handleNUPCOL(HandlerContext& handlerContext)
@@ -434,6 +482,8 @@ KeywordHandlers::KeywordHandlers()
         { "EXIT",     &handleEXIT       },
         { "FBHPDEF",  &handleFBHPDEF    },
         { "GPTABLE",  &handleGPTABLE    },
+        { "LGROFF"  , &handleLGROFF     },
+        { "LGRON"   , &handleLGRON      },
         { "MESSAGES", &handleMESSAGES   },
         { "MULTFLT" , &handleGEOKeyword },
         { "MULTPV"  , &handleMXUNSUPP   },

--- a/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -182,8 +182,8 @@ void handleLGROnOff(HandlerContext& handlerContext, const bool active)
     if ((handlerContext.grid.get_grid() != nullptr) &&
         ! handlerContext.grid.has_lgr(lgr_name))
     {
-        throw OpmInputError(fmt::format("{}: unknown local grid refinement '{}'",
-                                        handlerContext.keyword.name(), lgr_name),
+        throw OpmInputError(fmt::format("Unknown local grid refinement '{}'",
+                                        lgr_name),
                             handlerContext.keyword.location());
     }
 
@@ -192,9 +192,9 @@ void handleLGROnOff(HandlerContext& handlerContext, const bool active)
         (wellsItem.get<int>(0) != 0))
     {
         OpmLog::warning(OpmInputError::format(
-            fmt::format("{{keyword}}: the well-activation item of {} is not supported "
-                        "and is ignored in {{file}} line {{line}}",
-                        handlerContext.keyword.name()),
+            "Problem with keyword {keyword}\n"
+            "In {file} line {line}\n"
+            "The well-activation item is not supported and is ignored",
             handlerContext.keyword.location()));
     }
 

--- a/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -169,7 +169,7 @@ void handleLGROnOff(HandlerContext& handlerContext, const bool active)
 {
     const auto& record = handlerContext.keyword.getRecord(0);
 
-    const auto& nameItem = record.getItem("LOCAL_GRID_REFINMENT");
+    const auto& nameItem = record.getItem("LOCAL_GRID_REFINEMENT");
     if (! nameItem.hasValue(0)) {
         throw OpmInputError(fmt::format("{} requires the name of a local grid refinement",
                                         handlerContext.keyword.name()),

--- a/opm/input/eclipse/Schedule/ScheduleGrid.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleGrid.cpp
@@ -140,8 +140,7 @@ int Opm::ScheduleGrid::get_lgr_grid_number(const std::optional<std::string>& lgr
 
 bool Opm::ScheduleGrid::has_lgr(const std::string& lgr_label) const
 {
-    const auto& labels = this->label_to_index.get();
-    return labels.find(lgr_label) != labels.end();
+    return this->label_to_index.get().contains(lgr_label);
 }
 
 // ===========================================================================

--- a/opm/input/eclipse/Schedule/ScheduleGrid.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleGrid.cpp
@@ -138,6 +138,12 @@ int Opm::ScheduleGrid::get_lgr_grid_number(const std::optional<std::string>& lgr
         : 0;
 }
 
+bool Opm::ScheduleGrid::has_lgr(const std::string& lgr_label) const
+{
+    const auto& labels = this->label_to_index.get();
+    return labels.find(lgr_label) != labels.end();
+}
+
 // ===========================================================================
 // Private member functions and helpers below separator
 // ===========================================================================

--- a/opm/input/eclipse/Schedule/ScheduleGrid.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleGrid.hpp
@@ -180,6 +180,10 @@ public:
     /// \return Numeric grid index.
     int get_lgr_grid_number(const std::optional<std::string>& lgr_label) const;
 
+    /// Whether \p lgr_label names a local grid refinement known to the
+    /// simulation grids.
+    bool has_lgr(const std::string& lgr_label) const;
+
 private:
     /// Underlying grid object.
     const EclipseGrid* grid{nullptr};

--- a/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -344,6 +344,22 @@ void ScheduleState::update_sumthin(double sumthin) {
         this->m_sumthin = sumthin;
 }
 
+void ScheduleState::update_lgr_active(const std::string& lgr_name, const bool active)
+{
+    this->m_lgr_active.insert_or_assign(lgr_name, active);
+}
+
+bool ScheduleState::lgr_active(const std::string& lgr_name) const
+{
+    const auto it = this->m_lgr_active.find(lgr_name);
+    return (it == this->m_lgr_active.end()) || it->second;
+}
+
+const std::map<std::string, bool>& ScheduleState::lgr_activation() const
+{
+    return this->m_lgr_active;
+}
+
 bool ScheduleState::rptonly() const
 {
     return this->m_rptonly;
@@ -404,6 +420,7 @@ bool ScheduleState::operator==(const ScheduleState& other) const {
         && this->vfpinj == other.vfpinj
         && this->gptable == other.gptable
         && this->m_sumthin == other.m_sumthin
+        && this->m_lgr_active == other.m_lgr_active
         && this->next_tstep == other.next_tstep
         && this->m_rptonly == other.m_rptonly
         ;
@@ -424,6 +441,7 @@ ScheduleState ScheduleState::serializationTestObject() {
     ts.groups = map_member<std::string, Group>::serializationTestObject();
     ts.m_events = Events::serializationTestObject();
     ts.m_nupcol = Nupcol::serializationTestObject();
+    ts.m_lgr_active = {{"LGR1", false}, {"LGR2", true}};
     ts.m_message_limits = MessageLimits::serializationTestObject();
     ts.m_whistctl_mode = Well::ProducerCMode::THP;
     ts.target_wellpi = {{"WELL1", 1000}, {"WELL2", 2000}};

--- a/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -355,11 +355,6 @@ bool ScheduleState::lgr_active(const std::string& lgr_name) const
     return (it == this->m_lgr_active.end()) || it->second;
 }
 
-const std::map<std::string, bool>& ScheduleState::lgr_activation() const
-{
-    return this->m_lgr_active;
-}
-
 bool ScheduleState::rptonly() const
 {
     return this->m_rptonly;

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -515,10 +515,6 @@ namespace Opm {
         /// which is the deck default.
         bool lgr_active(const std::string& lgr_name) const;
 
-        /// Every explicit LGRON/LGROFF setting in effect at this report step,
-        /// keyed by refinement name.  Refinements using the default (active)
-        /// do not appear.
-        const std::map<std::string, bool>& lgr_activation() const;
 
         bool rptonly() const;
         void rptonly(const bool only);

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -47,6 +47,7 @@
 #include <array>
 #include <cstddef>
 #include <iterator>
+#include <map>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -506,6 +507,19 @@ namespace Opm {
         const std::optional<double>& sumthin() const;
         void update_sumthin(double sumthin);
 
+        /// Switch a named local grid refinement on or off (LGRON / LGROFF).
+        void update_lgr_active(const std::string& lgr_name, bool active);
+
+        /// Whether the named local grid refinement is active at this report
+        /// step.  A refinement never mentioned by LGRON/LGROFF is active,
+        /// which is the deck default.
+        bool lgr_active(const std::string& lgr_name) const;
+
+        /// Every explicit LGRON/LGROFF setting in effect at this report step,
+        /// keyed by refinement name.  Refinements using the default (active)
+        /// do not appear.
+        const std::map<std::string, bool>& lgr_activation() const;
+
         bool rptonly() const;
         void rptonly(const bool only);
 
@@ -713,6 +727,7 @@ namespace Opm {
             serializer(m_whistctl_mode);
             serializer(m_sumthin);
             serializer(this->m_rptonly);
+            serializer(m_lgr_active);
         }
 
     private:
@@ -737,6 +752,7 @@ namespace Opm {
         WellProducerCMode m_whistctl_mode = WellProducerCMode::CMODE_UNDEFINED;
         std::optional<double> m_sumthin{};
         bool m_rptonly{false};
+        std::map<std::string, bool> m_lgr_active{};
     };
 
 } // namespace Opm

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/L/LGRFREE
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/L/LGRFREE
@@ -5,7 +5,7 @@
   ],
   "items": [
     {
-      "name": "LOCAL_GRID_REFINMENT",
+      "name": "LOCAL_GRID_REFINEMENT",
       "value_type": "STRING"
     }
   ]

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/L/LGRLOCK
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/L/LGRLOCK
@@ -5,7 +5,7 @@
   ],
   "items": [
     {
-      "name": "LOCAL_GRID_REFINMENT",
+      "name": "LOCAL_GRID_REFINEMENT",
       "value_type": "STRING"
     }
   ]

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/L/LGROFF
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/L/LGROFF
@@ -6,7 +6,7 @@
   "size": 1,
   "items": [
     {
-      "name": "LOCAL_GRID_REFINMENT",
+      "name": "LOCAL_GRID_REFINEMENT",
       "value_type": "STRING"
     },
     {

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/L/LGRON
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/L/LGRON
@@ -6,7 +6,7 @@
   "size": 1,
   "items": [
     {
-      "name": "LOCAL_GRID_REFINMENT",
+      "name": "LOCAL_GRID_REFINEMENT",
       "value_type": "STRING"
     },
     {

--- a/tests/parser/WellTestsLGR.cpp
+++ b/tests/parser/WellTestsLGR.cpp
@@ -21,6 +21,8 @@
 #define BOOST_TEST_MODULE WellTestLGR
 #include <boost/test/unit_test.hpp>
 
+#include <opm/common/utility/OpmInputError.hpp>
+
 #include <opm/input/eclipse/Units/Units.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
@@ -286,5 +288,88 @@ COMPDATL
     for (std::size_t i = 0; i < dim_cell1.size(); ++i) {
         BOOST_TEST_MESSAGE("Cell dimension " << i);
         BOOST_CHECK_CLOSE(dim_cell1[i], dim_cell2[i], tol);
+    }
+}
+
+namespace {
+    // 3x3x1 grid with one LGR and enough SCHEDULE to advance two report
+    // steps; the LGRON/LGROFF lines are injected between the steps.
+    std::string lgrOnOffDeck(const std::string& stepOne,
+                             const std::string& stepTwo)
+    {
+        return R"(RUNSPEC
+DIMENS
+3 3 1 /
+GRID
+CARFIN
+'LGR1'  1  1  1  1  1  1  3  3  1 /
+ENDFIN
+INIT
+DX
+   	9*1000 /
+DY
+	9*1000 /
+DZ
+	9*50 /
+TOPS
+	9*8325 /
+PORO
+   	9*0.3 /
+PERMX
+	9*500 /
+PERMY
+	9*200 /
+PERMZ
+	9*200 /
+SCHEDULE
+)" + stepOne + R"(
+TSTEP
+10 /
+)" + stepTwo + R"(
+TSTEP
+10 /
+)";
+    }
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(LgrOnOffSchedule)
+{
+    // Default: a refinement never mentioned is active.
+    {
+        const auto deck = Parser{}.parseString(lgrOnOffDeck("", ""));
+        const auto es = EclipseState { deck };
+        const auto sched = Schedule { deck, es };
+        BOOST_CHECK(sched[0].lgr_active("LGR1"));
+        BOOST_CHECK(sched[1].lgr_active("LGR1"));
+        BOOST_CHECK(sched[0].lgr_activation().empty());
+    }
+
+    // Off at the start, on again at the second report step; the setting
+    // persists across steps in between.
+    {
+        const auto deck = Parser{}.parseString(
+            lgrOnOffDeck("LGROFF\n'LGR1' /\n", "LGRON\n'LGR1' /\n"));
+        const auto es = EclipseState { deck };
+        const auto sched = Schedule { deck, es };
+        BOOST_CHECK(! sched[0].lgr_active("LGR1"));
+        BOOST_CHECK(sched[1].lgr_active("LGR1"));
+    }
+
+    // Off stays off when never switched back on.
+    {
+        const auto deck = Parser{}.parseString(
+            lgrOnOffDeck("LGROFF\n'LGR1' /\n", ""));
+        const auto es = EclipseState { deck };
+        const auto sched = Schedule { deck, es };
+        BOOST_CHECK(! sched[0].lgr_active("LGR1"));
+        BOOST_CHECK(! sched[1].lgr_active("LGR1"));
+    }
+
+    // A name the grid does not know is a deck error.
+    {
+        const auto deck = Parser{}.parseString(
+            lgrOnOffDeck("LGRON\n'NOSUCH' /\n", ""));
+        const auto es = EclipseState { deck };
+        BOOST_CHECK_THROW((Schedule { deck, es }), OpmInputError);
     }
 }

--- a/tests/parser/WellTestsLGR.cpp
+++ b/tests/parser/WellTestsLGR.cpp
@@ -341,7 +341,6 @@ BOOST_AUTO_TEST_CASE(LgrOnOffSchedule)
         const auto sched = Schedule { deck, es };
         BOOST_CHECK(sched[0].lgr_active("LGR1"));
         BOOST_CHECK(sched[1].lgr_active("LGR1"));
-        BOOST_CHECK(sched[0].lgr_activation().empty());
     }
 
     // Off at the start, on again at the second report step; the setting


### PR DESCRIPTION
## What

`LGRON` and `LGROFF` are standard SCHEDULE keywords for switching a named local grid refinement on or off at a report step. opm-common parses them — they are in the keyword catalogue — and then silently discards them: nothing outside the generated parser references either keyword.

So a deck saying "this refinement is inactive until year 2" runs with it active from the start, with no diagnostic. Whatever a simulator chooses to *do* with the information, silently dropping it is wrong.

## The change

- `ScheduleState` carries a per-report-step `name → active` map. `lgr_active(name)` defaults to **active** for refinements the deck never mentions (the deck default), and the setting persists across steps like every other Schedule setting, so `LGROFF` at step 3 holds until an `LGRON`.
- The map is serialized (it must survive the Schedule broadcast in parallel runs) and compared in `operator==`; `serializationTestObject` populates it. Verified the round-trip test **fails** with the `serializer(...)` line removed:

  ```
  tests/test_Serialization.cpp:324: error: in "Schedule": Deserialized Schedule differ
  ```

- The refinement name is validated against the simulation grids' LGR label table (via a new one-line `ScheduleGrid::has_lgr`); an unknown name is reported as a deck error with the keyword location.

## Behavioural notes

- A deck whose `LGRON`/`LGROFF` names a refinement that does not exist now **fails to parse** instead of being silently accepted.
- A defaulted refinement name is rejected, and the well-activation item is ignored with a warning — both can be added if there is a real deck that needs them.

## Consumers

A simulator detects an activation change at report step *n* by comparing `lgr_activation()` between consecutive steps. Nothing reacts to it yet; this PR makes the deck's request visible instead of dropped, which is the prerequisite for ever honouring it.

## Testing

New `LgrOnOffSchedule` case in `tests/parser/WellTestsLGR.cpp`: default-active, off-then-on across report steps, off-stays-off, and unknown-name → `OpmInputError`. Full parser/Schedule/serialization test group passes (21/21).
