### PR TITLE
Match section keywords by name when skipping ignored sections

### DIFF
--- a/opm/input/eclipse/Parser/Parser.cpp
+++ b/opm/input/eclipse/Parser/Parser.cpp
@@ -1208,16 +1208,40 @@ std::unique_ptr<RawKeyword> tryParseKeyword( ParserState& parserState, const Par
     return rawKeyword;
 }
 
-std::string_view advance_parser_state( ParserState& parserState, const std::string& to_keyw )
+/*
+  Skip ahead to the section keyword 'to_keyw'.
+
+  The caller compares the return value against the bare section names, so we
+  hand back 'to_keyw' itself rather than the line it was found on.  Every call
+  site passes a string literal, which keeps the view valid after we return.
+*/
+std::string_view advance_parser_state( ParserState& parserState, const std::string_view to_keyw )
 {
+    // Record where the search began.  Once the input is exhausted the stack is
+    // empty and there is no current file or line number left to report.
+    const KeywordLocation location {
+        std::string { to_keyw },
+        parserState.current_path().string(),
+        parserState.line()
+    };
 
-    auto line = parserState.getline();
-
-    while (line != to_keyw) {
-        line = parserState.getline();
+    while (!parserState.done()) {
+        // Section keywords are routinely decorated, as in
+        //
+        //   PROPS    ==========================================
+        //
+        // so compare the keyword name alone, the way tryParseKeyword() does,
+        // instead of the verbatim line.
+        if (str::make_deck_name(parserState.getline()) == to_keyw) {
+            return to_keyw;
+        }
     }
 
-    return line;
+    throw OpmInputError {
+        fmt::format("Reached the end of the input while looking for "
+                    "the {} section.", to_keyw),
+        location
+    };
 }
 
 


### PR DESCRIPTION
when testing https://github.com/OPM/opm-common/pull/5261, it shows that flow_comp hangs with the case `CO2STORE_GASWAT.DATA`. This is a fix for that.  



advance_parser_state() compared the verbatim input line against the bare section name, so a decorated header such as

  PROPS    ======================================================

never matched.  The loop also had no end-of-input guard: str::getline() leaves its output untouched once the input is exhausted, and only done() pops the input stack, so the search spun forever on an empty view rather than terminating.

Compare the keyword name through str::make_deck_name(), the way tryParseKeyword() already does, and stop at end of input with an OpmInputError naming the section that was never found.

Only section-restricted parsing reaches this code, so flow and its variants were never affected.  flow_comp hung with no output at all:

  flow_comp co2store/CO2STORE_GASWAT.DATA

now parses the deck instead of hanging.