### PR TITLE
Leave the compositional configuration empty for H2STORE too

### DIFF
--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -462,8 +462,11 @@ namespace Opm {
 CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspec) {
     if (!DeckSection::hasPROPS(deck)) return;
 
-    // Return if CO2STORE is active with compositional keywords
-    if (deck.hasKeyword("CO2STORE"))
+    // CO2STORE and H2STORE are black-oil options.  They never carry a
+    // compositional description, not even when COMPS is present, so leave the
+    // configuration empty rather than reading the compositional keywords.
+    // Runspec::compositional() excludes both for the same reason.
+    if (runspec.co2Storage() || runspec.h2Storage())
         return;
 
     const PROPSSection props_section {deck};

--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
@@ -405,7 +405,12 @@ namespace {
         }
     }
 
-    void warningForExistingCompKeywords(const Opm::PROPSSection& section)
+    // Co2StoreConfig reads CNAMES for the Ezrokhi tables of a CO2STORE run, so
+    // that run must not be told the keyword is ignored.
+    void
+    warningForExistingCompKeywords(const Opm::PROPSSection& section,
+                                   const std::string_view reason,
+                                   const bool cnames_is_read = false)
     {
         using namespace std::string_view_literals;
 
@@ -442,10 +447,12 @@ namespace {
         };
 
         bool any_comp_prop_kw = false;
-        std::string msg {" COMPS is not specified, the following keywords related to compositional simulation in PROPS section will be ignored:\n"};
+        std::string msg = fmt::format(" {}, the following keywords related to compositional "
+                                      "simulation in PROPS section will be ignored:\n",
+                                      reason);
 
         for (const auto& [kwname, hasKw] : keywordCheckers) {
-            if (hasKw) {
+            if (hasKw && !(cnames_is_read && (kwname == "CNAMES"sv))) {
                 any_comp_prop_kw = true;
                 fmt::format_to(std::back_inserter(msg), " {}", kwname);
             }
@@ -462,17 +469,23 @@ namespace Opm {
 CompositionalConfig::CompositionalConfig(const Deck& deck, const Runspec& runspec) {
     if (!DeckSection::hasPROPS(deck)) return;
 
+    const PROPSSection props_section {deck};
+
     // CO2STORE and H2STORE are black-oil options.  They never carry a
     // compositional description, not even when COMPS is present, so leave the
     // configuration empty rather than reading the compositional keywords.
     // Runspec::compositional() excludes both for the same reason.
-    if (runspec.co2Storage() || runspec.h2Storage())
+    if (runspec.co2Storage() || runspec.h2Storage()) {
+        warningForExistingCompKeywords(props_section,
+                                       runspec.co2Storage() ? "CO2STORE is active"
+                                                            : "H2STORE is active",
+                                       /* cnames_is_read = */ runspec.co2Storage());
         return;
+    }
 
-    const PROPSSection props_section {deck};
     const bool comp_mode_runspec = runspec.compositionalMode(); // TODO: the way to use comp_mode_runspec should be refactored
     if (!comp_mode_runspec) {
-        warningForExistingCompKeywords(props_section);
+        warningForExistingCompKeywords(props_section, "COMPS is not specified");
         return; // not processing compositional props keywords
     }
 

--- a/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
+++ b/opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp
@@ -147,16 +147,15 @@ namespace Opm {
             // const std::size_t num_eos_region = comp_config.
 
             // CompositionalConfig is left empty for input the compositional path
-            // cannot handle - a CO2STORE run returns before any of it is read -
-            // so reading the EOS properties below would index an empty container.
-            // (H2STORE joins that set once opm-common #5265 lands; update the
-            // message below when it does.)
+            // cannot handle - CO2STORE and H2STORE runs return before any of it
+            // is read - so reading the EOS properties below would index an empty
+            // container.
             if (num_comps == 0) {
                 throw std::runtime_error {
                     fmt::format("The deck has no equation-of-state description, but "
                                 "this run needs a compositional fluid system with {} "
-                                "components.  A CO2STORE run does not carry one; use "
-                                "flow for that deck.", NumComp)
+                                "components.  CO2STORE and H2STORE runs do not carry "
+                                "one; use flow for those decks.", NumComp)
                 };
             }
 

--- a/tests/parser/CompositionalTests.cpp
+++ b/tests/parser/CompositionalTests.cpp
@@ -280,6 +280,40 @@ END
 )");
 }
 
+// A black-oil storage run with H2STORE or CO2STORE, which nevertheless carries COMPS and CNAMES
+Deck
+createStorageDeck(const std::string& storage_keyword)
+{
+    const std::string deck_string = std::string {R"(
+------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------
+METRIC
+
+)"} + storage_keyword
+        + R"(
+
+COMPS
+2 /
+
+DIMENS
+ 4 1 1 /
+
+GAS
+WATER
+
+------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------
+CNAMES
+ 'H2' 'H2O' /
+
+END
+)";
+
+    return Parser {}.parseString(deck_string);
+}
+
 Deck createCompositionalDeckWithoutDefaultedKeywords()
 {
     return Parser{}.parseString(R"(
@@ -388,6 +422,31 @@ BOOST_AUTO_TEST_CASE(DefaultedCompositionalKeywordsArePopulatedWhenAbsent) {
     const auto& lbc = comp_config.lbcCoefficients();
     check_vectors_close(std::vector<double>{0.1023, 0.023364, 0.058533, -0.040758, 0.0093324},
                         std::vector<double>(lbc.begin(), lbc.end()), tolerance);
+}
+
+BOOST_AUTO_TEST_CASE(StorageRunsLeaveCompositionalConfigEmpty)
+{
+    // CO2STORE and H2STORE are black-oil options.  Both must leave the
+    // compositional configuration empty even though the deck sets COMPS,
+    // otherwise consumers see a component count with no EOS data behind it.
+    for (const auto* storage : {"CO2STORE", "H2STORE"}) {
+        BOOST_TEST_CONTEXT(storage)
+        {
+            const Deck deck = createStorageDeck(storage);
+            const Runspec runspec {deck};
+            const CompositionalConfig comp_config {deck, runspec};
+
+            // COMPS is read, so the run looks compositional by that measure
+            // alone ...
+            BOOST_CHECK_EQUAL(2U, runspec.numComps());
+            BOOST_CHECK(runspec.compositionalMode());
+
+            // ... but it is a black-oil run, and carries no EOS description.
+            BOOST_CHECK(!runspec.compositional());
+            BOOST_CHECK_EQUAL(0U, comp_config.numComps());
+            BOOST_CHECK(comp_config.compName().empty());
+        }
+    }
 }
 
 BOOST_AUTO_TEST_CASE(CompositionalParsingTest) {

--- a/tests/parser/CompositionalTests.cpp
+++ b/tests/parser/CompositionalTests.cpp
@@ -18,19 +18,24 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <boost/test/unit_test.hpp>
 
+#include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
-
 #include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
-#include <opm/common/utility/OpmInputError.hpp>
 
 #include <cstddef>
 #include <initializer_list>
+#include <memory>
+#include <sstream>
 #include <stdexcept>
+#include <string>
 
 using namespace Opm;
 
@@ -305,6 +310,9 @@ WATER
 ------------------------------------------------------------------------
 PROPS
 ------------------------------------------------------------------------
+NCOMPS
+ 2 /
+
 CNAMES
  'H2' 'H2O' /
 
@@ -434,7 +442,12 @@ BOOST_AUTO_TEST_CASE(StorageRunsLeaveCompositionalConfigEmpty)
         {
             const Deck deck = createStorageDeck(storage);
             const Runspec runspec {deck};
+
+            std::ostringstream warnings;
+            OpmLog::addBackend("STREAM",
+                               std::make_shared<StreamLog>(warnings, Log::MessageType::Warning));
             const CompositionalConfig comp_config {deck, runspec};
+            OpmLog::removeBackend("STREAM");
 
             // COMPS is read, so the run looks compositional by that measure
             // alone ...
@@ -445,6 +458,18 @@ BOOST_AUTO_TEST_CASE(StorageRunsLeaveCompositionalConfigEmpty)
             BOOST_CHECK(!runspec.compositional());
             BOOST_CHECK_EQUAL(0U, comp_config.numComps());
             BOOST_CHECK(comp_config.compName().empty());
+
+            // The ignored keywords are reported.  CNAMES is only among them for
+            // H2STORE: Co2StoreConfig reads it for the Ezrokhi tables of a
+            // CO2STORE run, but nothing reads it for H2STORE.
+            const auto reported = warnings.str();
+            BOOST_CHECK(reported.find("NCOMPS") != std::string::npos);
+
+            if (std::string {storage} == "CO2STORE") {
+                BOOST_CHECK(reported.find("CNAMES") == std::string::npos);
+            } else {
+                BOOST_CHECK(reported.find("CNAMES") != std::string::npos);
+            }
         }
     }
 }


### PR DESCRIPTION
CO2STORE and H2STORE are both black-oil options - Runspec::compositional() excludes the two together, "co2store and h2store are only in blackoil setting for now" - but only CO2STORE returned early here.  The gate below it is Runspec::compositionalMode(), which is just numComps() > 0 with no storage exclusion, so an H2STORE deck that sets COMPS fell through and was read as a compositional case.