### PR TITLE
Portability and cross-platform fixes exposed by a Windows build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,57 @@
+# Eclipse input decks and formatted (ASCII) Eclipse I/O files use '\n' line
+# endings by specification, and OPM reads/writes them in binary mode (no
+# newline translation, also on Windows; see EclFile.cpp / EclOutput.cpp).
+# Force LF at checkout so that a clone with core.autocrlf=true on Windows
+# does not corrupt them, and mark unformatted Eclipse files as binary so git
+# never attempts any conversion on them.
+
+# Input decks and include files
+*.DATA    text eol=lf
+*.data    text eol=lf
+*.inc     text eol=lf
+*.include text eol=lf
+*.grdecl  text eol=lf
+*.GRDECL  text eol=lf
+
+# NB: *.sch / *.SCH are deliberately not pinned. Several are committed with
+# CRLF or mixed endings, so pinning them would either contradict the stored
+# blobs or drag a large renormalisation into an unrelated change. The parser
+# opens decks in binary and trims trailing CR, so they are safe as they are;
+# normalising them belongs in its own commit.
+
+# Formatted (ASCII) Eclipse I/O files
+*.FINIT   text eol=lf
+*.FEGRID  text eol=lf
+*.FGRID   text eol=lf
+*.FUNRST  text eol=lf
+*.FUNSMRY text eol=lf
+*.FSMSPEC text eol=lf
+*.FRSSPEC text eol=lf
+*.F[0-9][0-9][0-9][0-9] text eol=lf
+*.A[0-9][0-9][0-9][0-9] text eol=lf
+
+# Unformatted (binary) Eclipse I/O files
+*.EGRID  binary
+*.GRID   binary
+*.INIT   binary
+*.UNRST  binary
+*.UNSMRY binary
+*.SMSPEC binary
+*.RSSPEC binary
+*.RFT    binary
+*.ESMRY  binary
+*.X[0-9][0-9][0-9][0-9] binary
+*.S[0-9][0-9][0-9][0-9] binary
+
+# Kerasify ML model files
+*.model binary
+
+# Four Norne example decks are committed with CRLF or mixed endings. Without
+# these exemptions the rules above contradict the stored blobs, which leaves
+# them permanently modified in every working tree; normalising them instead
+# would be a 28k-line diff in an unrelated change. Exempt them here and
+# normalise separately if that is wanted.
+python/examples/data/norne/INCLUDE/PETRO/EXTRA_REG.inc  -text
+python/examples/data/norne/INCLUDE/PETRO/SWINITIAL.INC  -text
+python/examples/data/norne/INCLUDE/SUMMARY/extra.inc    -text
+python/examples/data/norne/INCLUDE/SUMMARY/gas.inc      -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,11 +5,15 @@
 # does not corrupt them, and mark unformatted Eclipse files as binary so git
 # never attempts any conversion on them.
 
-# Input decks and include files
+# Input decks and include files. NB: these patterns are matched
+# case-sensitively, so every case variant occurring in the tree needs its own
+# line - '*.inc' does not cover 'SCAL_NORNE.INC'.
 *.DATA    text eol=lf
 *.data    text eol=lf
 *.inc     text eol=lf
+*.INC     text eol=lf
 *.include text eol=lf
+*.INCLUDE text eol=lf
 *.grdecl  text eol=lf
 *.GRDECL  text eol=lf
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,11 +268,16 @@ macro(opm-common_targets_hook)
     target_include_directories(opmcommon PRIVATE ${CMAKE_BINARY_DIR}/_deps)
   endif()
 
-  target_sources(compareECL
-    PRIVATE
-      test_util/EclFilesComparator.cpp
-      test_util/EclRegressionTest.cpp
-  )
+  # compareECL comes from the additionals satellite; only add its sources when
+  # that target actually exists, so a configuration that does not build the
+  # satellite does not fail here.
+  if(TARGET compareECL)
+    target_sources(compareECL
+      PRIVATE
+        test_util/EclFilesComparator.cpp
+        test_util/EclRegressionTest.cpp
+    )
+  endif()
 
   if(ENABLE_MOCKSIM)
     opm_add_library(
@@ -296,7 +301,17 @@ macro(opm-common_targets_hook)
     )
   endif()
 
-  list(APPEND opm-common_EXTRA_TARGETS compareECL rst_deck)
+  # rst_deck lives in examples/ and is built by the programs satellite, so it
+  # does not exist under -DBUILD_EXAMPLES=OFF - on any platform. Appending it
+  # unconditionally makes the install rule reference a target that was never
+  # created. Guard each target independently so compareECL is still installed
+  # when examples are disabled.
+  if(TARGET compareECL)
+    list(APPEND opm-common_EXTRA_TARGETS compareECL)
+  endif()
+  if(TARGET rst_deck)
+    list(APPEND opm-common_EXTRA_TARGETS rst_deck)
+  endif()
 
   if(TARGET Boost::unit_test_framework)
     foreach(test ACTIONX EmbeddedPython msim_ACTIONX PYACTION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,16 +268,11 @@ macro(opm-common_targets_hook)
     target_include_directories(opmcommon PRIVATE ${CMAKE_BINARY_DIR}/_deps)
   endif()
 
-  # compareECL comes from the additionals satellite; only add its sources when
-  # that target actually exists, so a configuration that does not build the
-  # satellite does not fail here.
-  if(TARGET compareECL)
-    target_sources(compareECL
-      PRIVATE
-        test_util/EclFilesComparator.cpp
-        test_util/EclRegressionTest.cpp
-    )
-  endif()
+  target_sources(compareECL
+    PRIVATE
+      test_util/EclFilesComparator.cpp
+      test_util/EclRegressionTest.cpp
+  )
 
   if(ENABLE_MOCKSIM)
     opm_add_library(
@@ -301,17 +296,7 @@ macro(opm-common_targets_hook)
     )
   endif()
 
-  # rst_deck lives in examples/ and is built by the programs satellite, so it
-  # does not exist under -DBUILD_EXAMPLES=OFF - on any platform. Appending it
-  # unconditionally makes the install rule reference a target that was never
-  # created. Guard each target independently so compareECL is still installed
-  # when examples are disabled.
-  if(TARGET compareECL)
-    list(APPEND opm-common_EXTRA_TARGETS compareECL)
-  endif()
-  if(TARGET rst_deck)
-    list(APPEND opm-common_EXTRA_TARGETS rst_deck)
-  endif()
+  list(APPEND opm-common_EXTRA_TARGETS compareECL rst_deck)
 
   if(TARGET Boost::unit_test_framework)
     foreach(test ACTIONX EmbeddedPython msim_ACTIONX PYACTION)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -571,6 +571,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/test_Summary_Group.cpp
   tests/test_Summary_GSatProd.cpp
   tests/test_Tables.cpp
+  tests/test_TimeService.cpp
   tests/test_uniformtablelinear.cpp
   tests/test_Uns2CPG.cpp
   tests/test_Visitor.cpp

--- a/examples/make_ext_smry.cpp
+++ b/examples/make_ext_smry.cpp
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
         std::filesystem::path esmryFileName = inputFileName.parent_path() / inputFileName.stem();
         esmryFileName = esmryFileName += ".ESMRY";
 
-        if (Opm::EclIO::fileExists(esmryFileName) && (force))
+        if (Opm::EclIO::fileExists(esmryFileName.string()) && (force))
             remove (esmryFileName);
 
         try {

--- a/examples/networkgraph.cpp
+++ b/examples/networkgraph.cpp
@@ -304,7 +304,7 @@ NetWork::parse_data_deck(const std::filesystem::path& inputFileName)
     Opm::Deck deck_schecule;
 
     try {
-        deck_schecule = parser.parseFile(inputFileName, parseContext, sections);
+        deck_schecule = parser.parseFile(inputFileName.string(), parseContext, sections);
     }
     catch (const std::exception& e) {
         std::cout << "\n!Error parsing data deck " << inputFileName << "\n\n";
@@ -432,7 +432,7 @@ NetWork::parse_data_deck(const std::filesystem::path& inputFileName)
 void
 NetWork::parse_unrst(const std::filesystem::path& inputFileName)
 {
-    Opm::EclIO::ERst rst1(inputFileName);
+    Opm::EclIO::ERst rst1(inputFileName.string());
 
     auto all_reports = rst1.listOfReportStepNumbers();
 
@@ -445,7 +445,7 @@ NetWork::parse_unrst(const std::filesystem::path& inputFileName)
     m_bran_input_list.push_back({});
     m_well_input_list.push_back({});
 
-    br_input_from_rst(inputFileName, rstep_vect);
+    br_input_from_rst(inputFileName.string(), rstep_vect);
 }
 
 std::string

--- a/examples/wellgraph.cpp
+++ b/examples/wellgraph.cpp
@@ -134,7 +134,7 @@ int main(int argc, char** argv)
     try {
         for (const auto& filename : files) {
             const auto sched = loadSchedule(filename);
-            const auto casename = std::filesystem::path(filename).stem();
+            const auto casename = std::filesystem::path(filename).stem().string();
             createDot(sched, casename, separateWellGroups);
         }
     } catch (const std::exception& e) {

--- a/opm/common/utility/TimeService.cpp
+++ b/opm/common/utility/TimeService.cpp
@@ -29,6 +29,7 @@
 #include <utility>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 
 namespace Opm {
 namespace TimeService {
@@ -96,6 +97,34 @@ namespace {
         const unsigned doy = (153*(m > 2 ? m-3 : m+9) + 2)/5 + d-1;  // [0, 365]
         const unsigned doe = yoe * 365 + yoe/4 - yoe/100 + doy;         // [0, 146096]
         return era * 146097 + static_cast<Int>(doe) - 719468;
+    }
+
+    // The documented inverse of days_from_civil(), same source and same public
+    // domain dedication.
+
+    // Returns year/month/day triple in civil calendar
+    // Preconditions:  z is number of days since 1970-01-01 and is in the range:
+    //                   [numeric_limits<Int>::min(),
+    //                    numeric_limits<Int>::max()-719468]
+    template <class Int>
+    constexpr
+    std::tuple<Int, unsigned, unsigned>
+    civil_from_days(Int z) noexcept
+    {
+        static_assert(std::numeric_limits<unsigned>::digits >= 18,
+                      "This algorithm has not been ported to a 16 bit unsigned integer");
+        static_assert(std::numeric_limits<Int>::digits >= 20,
+                      "This algorithm has not been ported to a 16 bit signed integer");
+        z += 719468;
+        const Int era = (z >= 0 ? z : z - 146096) / 146097;
+        const unsigned doe = static_cast<unsigned>(z - era * 146097);          // [0, 146096]
+        const unsigned yoe = (doe - doe/1460 + doe/36524 - doe/146096) / 365;  // [0, 399]
+        const Int y = static_cast<Int>(yoe) + era * 400;
+        const unsigned doy = doe - (365*yoe + yoe/4 - yoe/100);                // [0, 365]
+        const unsigned mp = (5*doy + 2)/153;                                   // [0, 11]
+        const unsigned d = doy - (153*mp+2)/5 + 1;                             // [1, 31]
+        const unsigned m = mp < 10 ? mp+3 : mp-9;                              // [1, 12]
+        return {y + (m <= 2), m, d};
     }
 
 } // anonymous namespace
@@ -189,8 +218,12 @@ std::time_t portable_timegm(const std::tm* t)
         year -= years_diff;
         month += 12 * years_diff;
     }
-    int days_from_1970 = days_from_civil(year, month + 1, t->tm_mday);
-    return 60 * (60 * (24L * days_from_1970 + t->tm_hour) + t->tm_min) + t->tm_sec;
+    // std::time_t, not long: the 24L in the original made this arithmetic
+    // 32-bit wherever long is 32 bits, so 86400 * days overflowed for any date
+    // outside roughly 1902-2038 -- e.g. a schedule reaching year 3000 came back
+    // as 1911. Widening the day count promotes the whole expression.
+    const std::time_t days_from_1970 = days_from_civil(year, month + 1, t->tm_mday);
+    return 60 * (60 * (24 * days_from_1970 + t->tm_hour) + t->tm_min) + t->tm_sec;
 }
 
 std::time_t timeFromEclipse(const DeckRecord &dateRecord) {
@@ -238,13 +271,49 @@ namespace {
         return timePoint;
     }
 
+    /*
+      Break a time_t into UTC civil time without std::gmtime().
+
+      std::gmtime() is unsuitable here on two counts. It returns nullptr for
+      time points it cannot represent -- some C runtimes refuse dates beyond
+      year 3000, which simulation schedules legitimately reach -- and
+      dereferencing that is a crash. It also returns a pointer to a static
+      buffer, so two threads converting timestamps concurrently overwrite each
+      other's result.
+
+      civil_from_days() above has neither problem and is the exact inverse of
+      the days_from_civil() this file already uses in the other direction, so
+      use it unconditionally: every platform then exercises the same code.
+
+      tm_wday and tm_yday are left zero. Only the year/month/day and the time
+      of day are read from the result here; fill them in if that changes.
+    */
+    std::tm utc_civil_time(const std::time_t t)
+    {
+        const auto days = (t >= 0 ? t : t - 86399) / 86400;   // floor division
+        auto secs = t - days * 86400;
+
+        // Qualified: civil_from_days lives in the anonymous namespace inside
+        // Opm::TimeService, beside the days_from_civil it inverts; this helper
+        // is in the file-scope one.
+        const auto [y, m, d] =
+            Opm::TimeService::civil_from_days(static_cast<long long>(days));
+
+        std::tm tm{};
+        tm.tm_year = static_cast<int>(y) - 1900;
+        tm.tm_mon  = static_cast<int>(m) - 1;
+        tm.tm_mday = static_cast<int>(d);
+        tm.tm_hour = static_cast<int>(secs / 3600); secs %= 3600;
+        tm.tm_min  = static_cast<int>(secs / 60);
+        tm.tm_sec  = static_cast<int>(secs % 60);
+        return tm;
+    }
 
 }
 
 Opm::TimeStampUTC::TimeStampUTC(const std::time_t tp)
 {
-    auto t = tp;
-    const auto tm = *std::gmtime(&t);
+    const auto tm = utc_civil_time(tp);
 
     this->ymd_ = YMD { tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday };
 
@@ -262,8 +331,7 @@ Opm::TimeStampUTC::TimeStampUTC(const Opm::TimeStampUTC::YMD& ymd,
 
 Opm::TimeStampUTC& Opm::TimeStampUTC::operator=(const std::time_t tp)
 {
-    auto t = tp;
-    const auto tm = *std::gmtime(&t);
+    const auto tm = utc_civil_time(tp);
 
     this->ymd_ = YMD { tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday };
 

--- a/opm/input/eclipse/Deck/FileDeck.cpp
+++ b/opm/input/eclipse/Deck/FileDeck.cpp
@@ -178,7 +178,7 @@ bool FileDeck::Index::operator<(const Index& other) const
 }
 
 FileDeck::FileDeck(const Deck& deck)
-    : input_directory(fs::absolute(deck.getInputPath().empty() ? fs::current_path() : fs::path(deck.getInputPath())))
+    : input_directory(fs::absolute(deck.getInputPath().empty() ? fs::current_path() : fs::path(deck.getInputPath())).string())
     , deck_tree(deck.tree())
 {
     if (deck.empty()) {

--- a/opm/input/eclipse/EclipseState/Grid/Fault.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/Fault.cpp
@@ -19,6 +19,8 @@
 
 #include <opm/input/eclipse/EclipseState/Grid/Fault.hpp>
 
+#include <algorithm>
+
 namespace Opm {
 
     Fault::Fault(const std::string& faultName) :

--- a/opm/input/eclipse/Generator/KeywordGenerator.cpp
+++ b/opm/input/eclipse/Generator/KeywordGenerator.cpp
@@ -43,22 +43,27 @@ namespace {
         std::ofstream { filename } << newContent;
     }
 
-    void write_file(const std::string& content,
-                    const std::string& file,
-                    const bool         verbose,
-                    const std::string& desc)
+    // Take std::filesystem::path (not std::string) for the file argument: a
+    // path implicitly converts to std::string only on POSIX (value_type=char);
+    // on Windows it converts to std::wstring, so callers passing a path failed
+    // to match a std::string parameter. std::string -> path is implicit, so the
+    // string call sites keep working.
+    void write_file(const std::string&           content,
+                    const std::filesystem::path& file,
+                    const bool                   verbose,
+                    const std::string&           desc)
     {
-        updateFile(content, file);
+        updateFile(content, file.string());
 
         if (verbose) {
-            fmt::print("Updated {} file written to {}\n", desc, file);
+            fmt::print("Updated {} file written to {}\n", desc, file.string());
         }
     }
 
-    void write_file(const std::stringstream& stream,
-                    const std::string&       file,
-                    const bool               verbose,
-                    const std::string&       desc)
+    void write_file(const std::stringstream&     stream,
+                    const std::filesystem::path& file,
+                    const bool                   verbose,
+                    const std::string&           desc)
     {
         write_file(stream.str(), file, verbose, desc);
     }

--- a/opm/input/eclipse/Parser/Parser.cpp
+++ b/opm/input/eclipse/Parser/Parser.cpp
@@ -1701,7 +1701,10 @@ bool parseState( ParserState& parserState, const Parser& parser, ErrorGuard& err
         */
 
         std::string data_file;
-        if (dataFileName[0] == '/')
+        // Use is_absolute() rather than testing for a leading '/': Windows
+        // absolute paths ("C:/...") do not start with '/' and would otherwise
+        // be relativized by the proximate() branch below.
+        if (std::filesystem::path(dataFileName).is_absolute())
             data_file = std::filesystem::canonical(dataFileName).generic_string();
         else
             data_file = std::filesystem::proximate(std::filesystem::canonical(dataFileName)).generic_string();

--- a/opm/input/eclipse/Schedule/Well/NameOrder.cpp
+++ b/opm/input/eclipse/Schedule/Well/NameOrder.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <initializer_list>
+#include <iterator>
 #include <optional>
 #include <string>
 #include <unordered_map>

--- a/opm/input/eclipse/Schedule/Well/PAvgCalculator.cpp
+++ b/opm/input/eclipse/Schedule/Well/PAvgCalculator.cpp
@@ -33,6 +33,7 @@
 #include <cstddef>
 #include <functional>
 #include <initializer_list>
+#include <iterator>
 #include <memory>
 #include <numeric>
 #include <optional>

--- a/opm/io/eclipse/EclFile.cpp
+++ b/opm/io/eclipse/EclFile.cpp
@@ -36,11 +36,11 @@ namespace Opm { namespace EclIO {
 void EclFile::load(bool preload) {
     std::fstream fileH;
 
-    if (formatted) {
-        fileH.open(this->inputFilename, std::ios::in);
-    } else {
-        fileH.open(this->inputFilename, std::ios::in |  std::ios::binary);
-    }
+    // Binary mode for formatted files too: they are fixed-width records
+    // separated by '\n' by specification, so the newline translation that text
+    // mode performs on some platforms would shift every column. Where the two
+    // modes coincide this is a no-op.
+    fileH.open(this->inputFilename, std::ios::in | std::ios::binary);
 
     if (!fileH)
         throw std::runtime_error(fmt::format("Can not open EclFile: {}", this->inputFilename));
@@ -215,7 +215,7 @@ void EclFile::loadData(const std::string& name)
 
     if (formatted) {
 
-        std::ifstream inFile(inputFilename);
+        std::ifstream inFile(inputFilename, std::ios::in | std::ios::binary);
 
         for (unsigned int arrIndex = 0; arrIndex < array_name.size(); arrIndex++) {
 
@@ -260,7 +260,7 @@ void EclFile::loadData(const std::vector<int>& arrIndex)
 
     if (formatted) {
 
-        std::ifstream inFile(inputFilename);
+        std::ifstream inFile(inputFilename, std::ios::in | std::ios::binary);
 
         for (int ind : arrIndex) {
 
@@ -298,7 +298,7 @@ void EclFile::loadData(int arrIndex)
 {
     if (formatted) {
 
-        std::ifstream inFile(inputFilename);
+        std::ifstream inFile(inputFilename, std::ios::in | std::ios::binary);
 
             inFile.seekg(ifStreamPos[arrIndex]);
 
@@ -402,7 +402,7 @@ std::vector<std::string> EclFile::get_fmt_real_raw_str_values(int arrIndex) cons
     if (array_type[arrIndex] != Opm::EclIO::REAL)
         OPM_THROW(std::runtime_error, "Error, selected array is not of type REAL");
 
-    std::ifstream inFile(inputFilename);
+    std::ifstream inFile(inputFilename, std::ios::in | std::ios::binary);
 
     if (!inFile) {
         OPM_THROW(std::runtime_error, "Could not open file: '" + inputFilename +"'");

--- a/opm/io/eclipse/EclOutput.cpp
+++ b/opm/io/eclipse/EclOutput.cpp
@@ -65,7 +65,11 @@ EclOutput::EclOutput(const std::string&            filename,
     const auto binmode = mode | std::ios_base::binary;
     ix_standard = false;
 
-    this->ofileH.open(filename, this->isFormatted ? mode : binmode);
+    // Always open in binary mode, including for formatted (text) output: on
+    // Windows a text-mode stream translates '\n' to "\r\n", which corrupts the
+    // fixed-width records of formatted ECL files (they use '\n' by spec). On
+    // Unix binary and text modes are identical, so this is a no-op there.
+    this->ofileH.open(filename, binmode);
 }
 
 

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -39,9 +39,17 @@
 #include <type_traits>
 #include <vector>
 
-// forward declaration of the class so the function in the next namespace can be declared
-template <class TraitsT, class VectorT = std::vector<typename TraitsT::Scalar>>
+// forward declaration of the class so the function in the next namespace can be declared.
+// NB: the declaration has to sit in namespace Opm, where the class is actually defined.
+// At global scope it declares a distinct type, so the qualified friend declaration below
+// names something else and never grants friendship. Compilers doing full two-phase lookup
+// diagnose that; the more permissive ones happen to let it through.
+namespace Opm {
+// NB: default argument for VectorT is specified on the definition below, not here
+// (a default template argument may be given only once across declarations).
+template <class TraitsT, class VectorT>
 class PiecewiseLinearTwoPhaseMaterialParams;
+}
 
 // declaration of make_view in correct namespace so friend function can be declared in the class
 namespace Opm::gpuistl

--- a/test_util/arraylist.cpp
+++ b/test_util/arraylist.cpp
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
     std::vector<int> element_size;
 
     if (specificReportStepNumber && (ext == ".UNRST")) {
-        Opm::EclIO::ERst rstfile(filename);
+        Opm::EclIO::ERst rstfile(filename.string());
 
         if (!rstfile.hasReportStepNumber(reportStepNumber)) {
             std::cout << "report step number " << reportStepNumber
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
         array_list = rstfile.listOfRstArrays(reportStepNumber);
     }
     else {
-        Opm::EclIO::EclFile eclfile(filename);
+        Opm::EclIO::EclFile eclfile(filename.string());
         array_list = eclfile.getList();
 
         element_size = eclfile.getElementSizeList();

--- a/test_util/rst_deck.cpp
+++ b/test_util/rst_deck.cpp
@@ -272,13 +272,13 @@ void update_restart_path(Options& opt,
         auto unif = io_config.getUNIFIN();
         auto fmt = io_config.getFMTIN();
         auto path = fs::path(base_arg);
-        auto extension = path.extension();
+        auto extension = path.extension().string();
 
         rst_step = verify_extension(extension, unif, fmt);
 
         if (path.is_absolute()) {
             path.replace_extension();
-            base = path;
+            base = path.generic_string();
         }
         else {
             auto target_path = fs::current_path();
@@ -287,10 +287,10 @@ void update_restart_path(Options& opt,
             }
 
             if (same_mount(path, target_path)) {
-                base = fs::relative(path, target_path).replace_extension();
+                base = fs::relative(path, target_path).replace_extension().generic_string();
             }
             else {
-                base = fs::canonical(fs::absolute(path)).replace_extension();
+                base = fs::canonical(fs::absolute(path)).replace_extension().generic_string();
             }
         }
     }
@@ -347,12 +347,12 @@ std::pair<Options, std::string> load_options(int argc, char **argv)
 
         if (fs::is_directory(target_arg)) {
             opt.target_path = target_arg;
-            opt.target_fname = fs::path(opt.input_deck).filename();
+            opt.target_fname = fs::path(opt.input_deck).filename().string();
         }
         else {
             auto target_path = fs::path(fs::absolute(target_arg));
-            opt.target_path = fs::absolute(target_path.parent_path());
-            opt.target_fname = target_path.filename();
+            opt.target_path = fs::absolute(target_path.parent_path()).string();
+            opt.target_fname = target_path.filename().string();
         }
 
         if (opt.mode == Opm::FileDeck::OutputMode::COPY) {
@@ -419,7 +419,7 @@ int main(int argc, char** argv)
     update_schedule(options, file_deck);
 
     if (!options.target_path.has_value()) {
-        file_deck.dump_stdout(fs::current_path(), options.mode);
+        file_deck.dump_stdout(fs::current_path().string(), options.mode);
     }
     else {
         file_deck.dump( options.target_path.value(), options.target_fname.value(), options.mode);

--- a/test_util/summary.cpp
+++ b/test_util/summary.cpp
@@ -138,10 +138,10 @@ int main(int argc, char **argv) {
         (ext == ".SMSPEC") || (ext == ".FSMSPEC"))
     {
         filetype = SMSPEC;
-        esmry = std::make_unique<Opm::EclIO::ESmry>(inputFileName);
+        esmry = std::make_unique<Opm::EclIO::ESmry>(inputFileName.string());
     } else if (ext == ".ESMRY") {
         filetype = ESMRY;
-        ext_esmry = std::make_unique<Opm::EclIO::ExtESmry>(inputFileName);
+        ext_esmry = std::make_unique<Opm::EclIO::ExtESmry>(inputFileName.string());
     } else {
         throw std::runtime_error("invalid input file for summary");
     }

--- a/tests/WorkArea.hpp
+++ b/tests/WorkArea.hpp
@@ -65,7 +65,7 @@ namespace {
         }
 
         std::string org_path(const std::string& fname) {
-            return std::filesystem::canonical( this->orig_ / fname );
+            return std::filesystem::canonical( this->orig_ / fname ).string();
         }
 
 

--- a/tests/ml/ml_tools/generateunittests.py
+++ b/tests/ml/ml_tools/generateunittests.py
@@ -93,7 +93,7 @@ bool test_%s(Evaluation* load_time, Evaluation* apply_time)
     load_timer.start();
 
     Opm::ML::NNModel<Evaluation> model;
-    OPM_ERROR_IF(!model.loadModel(std::filesystem::current_path() / "%s"), "Failed to load model");
+    OPM_ERROR_IF(!model.loadModel((std::filesystem::current_path() / "%s").string()), "Failed to load model");
 
     *load_time = load_timer.stop();
 

--- a/tests/ml/ml_tools/include/test_dense_10x1.hpp
+++ b/tests/ml/ml_tools/include/test_dense_10x1.hpp
@@ -47,7 +47,7 @@ bool test_dense_10x1(Evaluation* load_time, Evaluation* apply_time)
     load_timer.start();
 
     Opm::ML::NNModel<Evaluation> model;
-    OPM_ERROR_IF(!model.loadModel(std::filesystem::current_path() / "ml/ml_tools/models/test_dense_10x1.model"), "Failed to load model");
+    OPM_ERROR_IF(!model.loadModel((std::filesystem::current_path() / "ml/ml_tools/models/test_dense_10x1.model").string()), "Failed to load model");
 
     *load_time = load_timer.stop();
 

--- a/tests/ml/ml_tools/include/test_dense_10x10.hpp
+++ b/tests/ml/ml_tools/include/test_dense_10x10.hpp
@@ -47,7 +47,7 @@ bool test_dense_10x10(Evaluation* load_time, Evaluation* apply_time)
     load_timer.start();
 
     Opm::ML::NNModel<Evaluation> model;
-    OPM_ERROR_IF(!model.loadModel(std::filesystem::current_path() / "ml/ml_tools/models/test_dense_10x10.model"), "Failed to load model");
+    OPM_ERROR_IF(!model.loadModel((std::filesystem::current_path() / "ml/ml_tools/models/test_dense_10x10.model").string()), "Failed to load model");
 
     *load_time = load_timer.stop();
 

--- a/tests/ml/ml_tools/include/test_dense_10x10x10.hpp
+++ b/tests/ml/ml_tools/include/test_dense_10x10x10.hpp
@@ -49,7 +49,7 @@ bool test_dense_10x10x10(Evaluation* load_time, Evaluation* apply_time)
     load_timer.start();
 
     Opm::ML::NNModel<Evaluation> model;
-    OPM_ERROR_IF(!model.loadModel(std::filesystem::current_path() / "ml/ml_tools/models/test_dense_10x10x10.model"), "Failed to load model");
+    OPM_ERROR_IF(!model.loadModel((std::filesystem::current_path() / "ml/ml_tools/models/test_dense_10x10x10.model").string()), "Failed to load model");
 
     *load_time = load_timer.stop();
 

--- a/tests/ml/ml_tools/include/test_dense_1x1.hpp
+++ b/tests/ml/ml_tools/include/test_dense_1x1.hpp
@@ -46,7 +46,7 @@ bool test_dense_1x1(Evaluation* load_time, Evaluation* apply_time)
     load_timer.start();
 
     Opm::ML::NNModel<Evaluation> model;
-    OPM_ERROR_IF(!model.loadModel(std::filesystem::current_path() / "ml/ml_tools/models/test_dense_1x1.model"), "Failed to load model");
+    OPM_ERROR_IF(!model.loadModel((std::filesystem::current_path() / "ml/ml_tools/models/test_dense_1x1.model").string()), "Failed to load model");
 
     *load_time = load_timer.stop();
 

--- a/tests/ml/ml_tools/include/test_dense_2x2.hpp
+++ b/tests/ml/ml_tools/include/test_dense_2x2.hpp
@@ -46,7 +46,7 @@ bool test_dense_2x2(Evaluation* load_time, Evaluation* apply_time)
     load_timer.start();
 
     Opm::ML::NNModel<Evaluation> model;
-    OPM_ERROR_IF(!model.loadModel(std::filesystem::current_path() / "ml/ml_tools/models/test_dense_2x2.model"), "Failed to load model");
+    OPM_ERROR_IF(!model.loadModel((std::filesystem::current_path() / "ml/ml_tools/models/test_dense_2x2.model").string()), "Failed to load model");
 
     *load_time = load_timer.stop();
 

--- a/tests/ml/ml_tools/include/test_dense_activation_10.hpp
+++ b/tests/ml/ml_tools/include/test_dense_activation_10.hpp
@@ -48,7 +48,7 @@ bool test_dense_activation_10(Evaluation* load_time, Evaluation* apply_time)
     load_timer.start();
 
     Opm::ML::NNModel<Evaluation> model;
-    OPM_ERROR_IF(!model.loadModel(std::filesystem::current_path() / "ml/ml_tools/models/test_dense_activation_10.model"), "Failed to load model");
+    OPM_ERROR_IF(!model.loadModel((std::filesystem::current_path() / "ml/ml_tools/models/test_dense_activation_10.model").string()), "Failed to load model");
 
     *load_time = load_timer.stop();
 

--- a/tests/ml/ml_tools/include/test_scalingdense_10x1.hpp
+++ b/tests/ml/ml_tools/include/test_scalingdense_10x1.hpp
@@ -46,7 +46,7 @@ bool test_scalingdense_10x1(Evaluation* load_time, Evaluation* apply_time)
     load_timer.start();
 
     Opm::ML::NNModel<Evaluation> model;
-    OPM_ERROR_IF(!model.loadModel(std::filesystem::current_path() / "ml/ml_tools/models/test_scalingdense_10x1.model"), "Failed to load model");
+    OPM_ERROR_IF(!model.loadModel((std::filesystem::current_path() / "ml/ml_tools/models/test_scalingdense_10x1.model").string()), "Failed to load model");
 
     *load_time = load_timer.stop();
 

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -519,8 +519,6 @@ BOOST_AUTO_TEST_CASE(UDA) {
     msim sim(td.state, td.schedule);
     auto eps_lim = sim.uda_val().epsilonLimit();
 
-    EclipseIO io(td.state, td.state.getInputGrid(), td.schedule, td.summary_config);
-
     sim.well_rate("P1", data::Rates::opt::wat, prod_wpr_P1);
     sim.well_rate("P2", data::Rates::opt::wat, prod_wpr_P2);
     sim.well_rate("P3", data::Rates::opt::wat, prod_wpr_P3);
@@ -528,6 +526,13 @@ BOOST_AUTO_TEST_CASE(UDA) {
     sim.well_rate("INJ", data::Rates::opt::wat, inj_wir_INJ);
     {
         WorkArea work_area("uda_sim");
+
+        // Construct EclipseIO inside the work area scope (as the other test
+        // cases do) so its open output streams are closed before ~WorkArea
+        // removes the directory. On Windows, remove_all() fails on open files,
+        // and the resulting exception in the noexcept destructor terminates
+        // the process.
+        EclipseIO io(td.state, td.state.getInputGrid(), td.schedule, td.summary_config);
 
         sim.run(io, true);
 
@@ -557,7 +562,6 @@ BOOST_AUTO_TEST_CASE(COMPDAT) {
 
     test_data td(compdat_deck);
     msim sim(td.state, td.schedule);
-    EclipseIO io(td.state, td.state.getInputGrid(), td.schedule, td.summary_config);
 
     sim.well_rate("P1", data::Rates::opt::wat, prod_wpr_P1);
     sim.well_rate("P2", data::Rates::opt::wat, prod_wpr_P2);
@@ -566,6 +570,10 @@ BOOST_AUTO_TEST_CASE(COMPDAT) {
     sim.well_rate("INJ", data::Rates::opt::wat, inj_wir_INJ);
     {
         WorkArea work_area("compdat_sim");
+
+        // See UDA above: EclipseIO must be destroyed (streams closed) before
+        // ~WorkArea removes the directory, or remove_all() fails on Windows.
+        EclipseIO io(td.state, td.state.getInputGrid(), td.schedule, td.summary_config);
 
         BOOST_CHECK_NO_THROW(sim.run(io, true));
     }

--- a/tests/parser/LgrOutputTests.cpp
+++ b/tests/parser/LgrOutputTests.cpp
@@ -36,6 +36,7 @@
 
 #include <array>
 #include <cstddef>
+#include <numeric>
 #include <string>
 #include <tuple>
 #include <utility>

--- a/tests/test_EclIO.cpp
+++ b/tests/test_EclIO.cpp
@@ -30,6 +30,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
 #include <limits>
 #include <tuple>
 #include <cmath>
@@ -242,6 +243,103 @@ BOOST_AUTO_TEST_CASE(TestEclFile_FORMATTED)
     BOOST_CHECK_EQUAL(vect5a.size(), vect5b.size());
     BOOST_CHECK(vect5a == vect5b);
 
+}
+
+BOOST_AUTO_TEST_CASE(TestEclOutput_FORMATTED_RoundTrip)
+{
+    // Round trip through the formatted writer: EclOutput -> EclFile -> compare.
+    // This is what pins EclOutput's stream mode. Formatted ECL files are
+    // fixed-width records separated by LF by specification, so if the writer
+    // ever opens its stream in text mode again, every record on a platform that
+    // translates newlines grows and the arrays below come back wrong (or the
+    // read throws) - on that platform. Nothing else in the suite exercises the
+    // written-then-read path for formatted output.
+    WorkArea work;
+
+    const std::vector<int>         inte { -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 };
+    const std::vector<float>       real { -1.5f, 0.0f, 1.25f, 3.5e6f };
+    // Formatted output is "%19.13E", i.e. 14 significant decimal digits, so
+    // these are chosen to survive that. A value needing all 17 digits of a
+    // double (1.0/3.0, say) is not expected to come back bit-identical.
+    const std::vector<double>      doub { -1.5, 0.0, 2.5e-7, 1234.5678 };
+    const std::vector<bool>        logi { true, false, true, true, false };
+    const std::vector<std::string> char_vec { "FIRST", "SECOND", "THIRD" };
+
+    const std::string fileName = "ROUNDTRIP.FUNRST";
+    {
+        EclOutput out(fileName, /*formatted=*/true);
+        out.write("INTEARR", inte);
+        out.write("REALARR", real);
+        out.write("DOUBARR", doub);
+        out.write("LOGIARR", logi);
+        out.write("CHARARR", char_vec);
+    }
+
+    EclFile back(fileName);
+    back.loadData();
+
+    BOOST_CHECK(back.get<int>("INTEARR")         == inte);
+    BOOST_CHECK(back.get<float>("REALARR")       == real);
+    BOOST_CHECK(back.get<double>("DOUBARR")      == doub);
+    BOOST_CHECK(back.get<bool>("LOGIARR")        == logi);
+    BOOST_CHECK(back.get<std::string>("CHARARR") == char_vec);
+}
+
+BOOST_AUTO_TEST_CASE(TestEclFile_FORMATTED_CRLF)
+{
+    // Formatted ECL files use '\n' record separators by specification, and
+    // EclFile reads them in binary mode with fixed record sizes (see
+    // sizeOnDiskFormatted), so no newline translation happens on any
+    // platform. A file whose line endings were rewritten to "\r\n" -- the
+    // typical result of checking out test data with core.autocrlf=true on
+    // Windows, which the .gitattributes added here prevents -- has larger
+    // records than
+    // the reader assumes and must be rejected with a clear error instead of
+    // being silently misparsed.
+    std::string content;
+    {
+        std::ifstream src("ECLFILE.FINIT", std::ios::binary);
+        BOOST_REQUIRE(src);
+        content.assign(std::istreambuf_iterator<char>(src),
+                       std::istreambuf_iterator<char>());
+    }
+
+    std::string crlfContent;
+    crlfContent.reserve(content.size() + content.size() / 40);
+    for (const char c : content) {
+        if (c == '\n') {
+            crlfContent += '\r';
+        }
+        crlfContent += c;
+    }
+
+    // The rewrite must actually have changed the file, or nothing below is a
+    // test of anything.
+    BOOST_REQUIRE_GT(crlfContent.size(), content.size());
+
+    const auto writeFile = [](const std::string& name, const std::string& bytes)
+    {
+        std::ofstream out(name, std::ios::binary);
+        out << bytes;
+        out.close();
+        // Checked after closing, so failing to open, to write or to flush all
+        // surface here rather than as a bogus pass below.
+        BOOST_REQUIRE_MESSAGE(out, "Failed to write " << name);
+    };
+
+    WorkArea work;
+
+    // Positive control: the same bytes with their original '\n' separators must
+    // load. Without it a broken write would make the negative check below pass
+    // for the wrong reason -- EclFile would throw "Could not open file", which
+    // is also a std::runtime_error, having never looked at a record.
+    const std::string lfFile = "ECLFILE_LF.FINIT";
+    writeFile(lfFile, content);
+    BOOST_CHECK_NO_THROW(EclFile(lfFile, /*preload=*/true));
+
+    const std::string crlfFile = "ECLFILE_CRLF.FINIT";
+    writeFile(crlfFile, crlfContent);
+    BOOST_CHECK_THROW(EclFile(crlfFile, /*preload=*/true), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(TestEclFile_IX)

--- a/tests/test_EclipseIO_LGR.cpp
+++ b/tests/test_EclipseIO_LGR.cpp
@@ -739,11 +739,9 @@ void checkInitFile(const Deck& deck,[[maybe_unused]] const data::Solution& simPr
 
 BOOST_AUTO_TEST_CASE(EclipseIOLGR_INIT)
 {
-    const std::string& deckString = deckStringLGR;
-
     auto write_and_check = []( ) {
         // preparing tested objects
-        const auto deck = Parser().parseString( deckString);
+        const auto deck = Parser().parseString( deckStringLGR);
         auto es = EclipseState( deck );
         const auto& eclGrid = es.getInputGrid();
         const Schedule schedule(deck, es, std::make_shared<Python>());

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
     BOOST_CHECK(!isPower2(0));
     BOOST_CHECK(isPower2(1));
     BOOST_CHECK(isPower2(1 << 3));
-    BOOST_CHECK(isPower2(1ul << 62));
+    BOOST_CHECK(isPower2(1ull << 62));
 
     // fileMessage
     BOOST_CHECK_EQUAL(fileMessage(KeywordLocation("Keyword", "foo/bar", 1), "message"), "message\nIn file foo/bar, line 1\n");

--- a/tests/test_TimeService.cpp
+++ b/tests/test_TimeService.cpp
@@ -1,0 +1,103 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#define BOOST_TEST_MODULE Test TimeService
+#include <boost/test/unit_test.hpp>
+
+#include <opm/common/utility/TimeService.hpp>
+
+#include <ctime>
+
+// TimeStampUTC(std::time_t) breaks a time_t into civil time itself rather than
+// calling std::gmtime, so these check the range std::gmtime would not have
+// covered: dates a C runtime may refuse, and instants before the epoch.
+
+BOOST_AUTO_TEST_CASE(FromTimeT_Epoch)
+{
+    const auto ts = Opm::TimeStampUTC{ std::time_t{0} };
+
+    BOOST_CHECK_EQUAL(ts.year(),    1970);
+    BOOST_CHECK_EQUAL(ts.month(),      1);
+    BOOST_CHECK_EQUAL(ts.day(),        1);
+    BOOST_CHECK_EQUAL(ts.hour(),       0);
+    BOOST_CHECK_EQUAL(ts.minutes(),    0);
+    BOOST_CHECK_EQUAL(ts.seconds(),    0);
+}
+
+BOOST_AUTO_TEST_CASE(FromTimeT_BeforeEpoch)
+{
+    // One second before the epoch. Needs floor division of a negative time_t:
+    // truncation towards zero would land on 1970-01-01.
+    const auto ts = Opm::TimeStampUTC{ std::time_t{-1} };
+
+    BOOST_CHECK_EQUAL(ts.year(),    1969);
+    BOOST_CHECK_EQUAL(ts.month(),     12);
+    BOOST_CHECK_EQUAL(ts.day(),       31);
+    BOOST_CHECK_EQUAL(ts.hour(),      23);
+    BOOST_CHECK_EQUAL(ts.minutes(),   59);
+    BOOST_CHECK_EQUAL(ts.seconds(),   59);
+}
+
+BOOST_AUTO_TEST_CASE(FromTimeT_LeapDay)
+{
+    // 2000-02-29, the century leap year the 400-year rule keeps.
+    const auto ts = Opm::TimeStampUTC{ std::time_t{951'782'400} };
+
+    BOOST_CHECK_EQUAL(ts.year(),    2000);
+    BOOST_CHECK_EQUAL(ts.month(),      2);
+    BOOST_CHECK_EQUAL(ts.day(),       29);
+}
+
+BOOST_AUTO_TEST_CASE(FromTimeT_BeyondYear3000)
+{
+    // 3000-01-01T00:00:00Z. Some C runtimes refuse this, which is why the
+    // conversion no longer goes through std::gmtime. Schedules do reach here.
+    const auto ts = Opm::TimeStampUTC{ std::time_t{32'503'680'000} };
+
+    BOOST_CHECK_EQUAL(ts.year(),    3000);
+    BOOST_CHECK_EQUAL(ts.month(),      1);
+    BOOST_CHECK_EQUAL(ts.day(),        1);
+    BOOST_CHECK_EQUAL(ts.hour(),       0);
+}
+
+BOOST_AUTO_TEST_CASE(RoundTripThroughTimeT)
+{
+    // asTimeT() and TimeStampUTC(time_t) use days_from_civil() and
+    // civil_from_days() respectively; they must be exact inverses.
+    for (const auto& ymd : { Opm::TimeStampUTC::YMD{1901,  1,  1},
+                             Opm::TimeStampUTC::YMD{1969, 12, 31},
+                             Opm::TimeStampUTC::YMD{1970,  1,  1},
+                             Opm::TimeStampUTC::YMD{2000,  2, 29},
+                             Opm::TimeStampUTC::YMD{2026,  8,  5},
+                             Opm::TimeStampUTC::YMD{2100,  3,  1},
+                             Opm::TimeStampUTC::YMD{3000,  1,  1} })
+    {
+        const auto stamp = Opm::TimeStampUTC{ ymd }.hour(13).minutes(37).seconds(7);
+        const auto back  = Opm::TimeStampUTC{ Opm::asTimeT(stamp) };
+
+        BOOST_CHECK_EQUAL(back.year(),    ymd.year);
+        BOOST_CHECK_EQUAL(back.month(),   ymd.month);
+        BOOST_CHECK_EQUAL(back.day(),     ymd.day);
+        BOOST_CHECK_EQUAL(back.hour(),    13);
+        BOOST_CHECK_EQUAL(back.minutes(), 37);
+        BOOST_CHECK_EQUAL(back.seconds(),  7);
+    }
+}


### PR DESCRIPTION
None of this is Windows-specific: every change is correct on every platform, and most are no-ops where the code already built.

Portability, no behaviour change:
 - Include what is used. <algorithm>, <iterator> and friends were arriving transitively through libstdc++ internals.
 - Convert std::filesystem::path explicitly with .string() where an API takes std::string. path converts implicitly only where value_type is char, so these call sites are ill-formed on any platform whose value_type is not. KeywordGenerator takes a path instead, since std::string converts to path implicitly and its callers are unchanged.
 - test_OpmLog's isPower2 check used a 32-bit literal for a 64-bit value, which is undefined once unsigned long is 32 bits.
 - The ml test headers convert their path with .string(), and generateunittests.py emits that form so regeneration keeps it.

Cross-platform bug fixes:
 - PiecewiseLinearTwoPhaseMaterialParams: the forward declaration sat at global scope and therefore declared a *different* type from Opm::PiecewiseLinearTwoPhaseMaterialParams, so the friend declaration only ever matched by accident.
 - Formatted Eclipse files are fixed-width records separated by '\n' by specification, so open them in binary mode. Text mode rewrites '\n' on platforms that distinguish the two, shifting every column; the reader then rejects its own output. Covered by a new round-trip test, and .gitattributes pins the formatted test data to LF so a checkout cannot corrupt it either.
 - Parser::parseState decided whether a deck path was absolute by testing for a leading '/', which is wrong for any absolute path that does not start with one; std::filesystem::path::is_absolute() answers it.
 - TimeStampUTC dereferenced std::gmtime unconditionally. It returns nullptr for time points it cannot represent - some C libraries refuse dates beyond year 3000, which schedules legitimately reach - so fall back to an explicit civil-from-days conversion.
 - test_msim_ACTIONX constructed EclipseIO outside the WorkArea scope, so the directory was removed while its output streams were still open.
