### PR TITLE
Add Mapping Facility for Region Level Summary Variables

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -397,6 +397,7 @@ list(APPEND MAIN_SOURCE_FILES
   opm/ml/ml_model.cpp
   opm/output/data/Aquifer.cpp
   opm/output/data/InterRegFlowMap.cpp
+  opm/output/data/RegionVariableMapping.cpp
   opm/output/data/Solution.cpp
   opm/output/eclipse/ActiveIndexByColumns.cpp
   opm/output/eclipse/AggregateActionxData.cpp
@@ -513,6 +514,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/test_data_GuideRateValue.cpp
   tests/test_data_InterRegFlow.cpp
   tests/test_data_InterRegFlowMap.cpp
+  tests/test_data_regionvariablemapping.cpp
   tests/test_DatumDepth.cpp
   tests/test_DoubHEAD.cpp
   tests/test_EclipseIO.cpp
@@ -1502,6 +1504,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/output/data/GuideRateValue.hpp
   opm/output/data/InterRegFlow.hpp
   opm/output/data/InterRegFlowMap.hpp
+  opm/output/data/RegionVariableMapping.hpp
   opm/output/data/Solution.hpp
   opm/output/data/Wells.hpp
   opm/output/eclipse/ActiveIndexByColumns.hpp

--- a/opm/output/data/RegionVariableMapping.cpp
+++ b/opm/output/data/RegionVariableMapping.cpp
@@ -1,0 +1,167 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#include <opm/output/data/RegionVariableMapping.hpp>
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <numeric>
+#include <optional>
+#include <ranges>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+void Opm::data::RegionVariableMapping::prepareRegistration()
+{
+    this->regsets_.clear();
+    this->vars_.clear();
+    this->is_cumulative_.clear();
+
+    this->is_final_ = false;
+}
+
+void Opm::data::RegionVariableMapping::commitStructure()
+{
+    this->regsets_.commit();
+
+    this->makeUniqueCumulative(this->vars_.commit());
+
+    this->is_final_ = true;
+}
+
+void Opm::data::RegionVariableMapping::add(const RegionSet& rset)
+{
+    this->ensureRegistrationPossible("region set", rset.name);
+
+    this->regsets_.add(rset.name);
+}
+
+void
+Opm::data::RegionVariableMapping::add(const Variable& var, const bool is_cumulative)
+{
+    this->ensureRegistrationPossible("variable", var.name);
+
+    this->vars_.add(var.name);
+
+    this->is_cumulative_.push_back(is_cumulative);
+}
+
+// ===========================================================================
+// Private member functions below separator
+// ===========================================================================
+
+std::vector<std::vector<std::string>::size_type>
+Opm::data::RegionVariableMapping::NameLookup::commit()
+{
+    auto i = std::vector<std::vector<std::string>::size_type>(this->names_.size());
+    std::iota(i.begin(), i.end(), std::vector<std::string>::size_type{});
+
+    std::ranges::sort(i, [this](const auto i1, const auto i2)
+    {
+        return std::tie(this->names_[i1], i1)
+            <  std::tie(this->names_[i2], i2);
+    });
+
+    {
+        auto [first, last] = std::ranges::unique(i, [this](const auto i1, const auto i2)
+        { return this->names_[i1] == this->names_[i2]; });
+
+        i.erase(first, last);
+    }
+
+    auto unames = std::vector<std::string>(i.size());
+    std::ranges::transform(i, unames.begin(),
+                           [this](const auto ix)
+                           { return this->names_[ix]; });
+
+    this->names_.swap(unames);
+
+    return i;
+}
+
+std::optional<std::vector<std::string>::size_type>
+Opm::data::RegionVariableMapping::NameLookup::index(const std::string& name) const
+{
+    const auto namePos = std::ranges::lower_bound(this->names_, name);
+
+    if ((namePos == this->names_.end()) || (*namePos != name)) {
+        // Name does not exist in this->names_;
+        return {};
+    }
+
+    return {
+        std::ranges::distance(this->names_.begin(), namePos)
+    };
+}
+
+// ---------------------------------------------------------------------------
+
+void
+Opm::data::RegionVariableMapping::
+ensureRegistrationPossible(std::string_view type,
+                           std::string_view name) const
+{
+    if (! this->is_final_) {
+        // Structure is not yet committed.  This is fine.
+        return;
+    }
+
+    throw std::logic_error {
+        fmt::format("Cannot register a {} named '{}' after the "
+                    "mapping's structure is finalised", type, name)
+    };
+}
+
+void
+Opm::data::RegionVariableMapping::ensureFinalStructure(std::string_view type,
+                                                       std::string_view name) const
+{
+    if (this->is_final_) {
+        // Structure is finalised.  This is fine.
+        return;
+    }
+
+    throw std::logic_error {
+        fmt::format("Cannot request properties of {} named '{}' "
+                    "before the mapping's structure is finalised", type, name)
+    };
+}
+
+void
+Opm::data::RegionVariableMapping::
+makeUniqueCumulative(const std::vector<std::vector<std::string>::size_type>& i)
+{
+    auto unique_is_cumulative = std::vector<bool>(i.size(), false);
+
+    std::ranges::for_each(i, [this,
+                              new_idx = 0 * unique_is_cumulative.size(),
+                              &unique_is_cumulative]
+        (const auto orig_idx) mutable
+    {
+        unique_is_cumulative[new_idx++] = this->is_cumulative_[orig_idx];
+    });
+
+    this->is_cumulative_.swap(unique_is_cumulative);
+}

--- a/opm/output/data/RegionVariableMapping.hpp
+++ b/opm/output/data/RegionVariableMapping.hpp
@@ -1,0 +1,286 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_OUTPUT_DATA_REGIONVARIABLEMAPPING_HPP
+#define OPM_OUTPUT_DATA_REGIONVARIABLEMAPPING_HPP
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+/// \file Component for mapping region set names and region variable names
+/// to numeric indices.
+
+namespace Opm::data {
+
+    /// Map named region sets and named region variables to numeric indices
+    class RegionVariableMapping
+    {
+    public:
+        /// Named region set.
+        struct RegionSet
+        {
+            /// Region set name.
+            ///
+            /// Common examples include "FIPNUM" and "FIPABC" or similar.
+            std::string name{};
+        };
+
+        /// Named region variable.
+        struct Variable
+        {
+            /// Region variable name.
+            ///
+            /// Common examples include "ROPR", "RGIT", and "ROEW".
+            std::string name{};
+        };
+
+        /// Numeric variable index.
+        ///
+        /// Provided as an optimisation to bypass the name-to-index lookup
+        /// when client code needs to query whether or not a particular
+        /// region level variable is a cumulative quantity.
+        ///
+        /// It is the client code's responsibility to ensure that the
+        /// numeric index is correct as no checking will be performed.
+        struct VariableIdx
+        {
+            /// Numeric index of particular region level variable.
+            std::size_t idx{};
+        };
+
+        /// Prepare internal structures to register name-to-index region set
+        /// and variable mappings.
+        void prepareRegistration();
+
+        /// Finalise internal name-to-index mapping structures.
+        ///
+        /// Ensures that all region set and variable names are unique.  If a
+        /// name is registered multiple times, then the index corresponding
+        /// to that name will be that of the first registration.
+        void commitStructure();
+
+        /// Register a named region set.
+        ///
+        /// Must not be called after commitStructure() and will throw an
+        /// exception of type \code std::logic_error \endcode if this
+        /// happens.
+        ///
+        /// \param[in] rset Region set.
+        void add(const RegionSet& rset);
+
+        /// Register a named region level variable.
+        ///
+        /// Must not be called after commitStructure() and will throw an
+        /// exception of type \code std::logic_error \endcode if this
+        /// happens.
+        ///
+        /// \param[in] var Region level variable.
+        ///
+        /// \param[in] is_cumulative Whether or not the variable \p var is a
+        /// cumulative quantity.
+        void add(const Variable& var, const bool is_cumulative);
+
+        /// Number of unique named region sets known to current mapping.
+        ///
+        /// Only meaningful after calling member function commitStructure().
+        auto numRegionSets() const { return this->regsets_.names().size(); }
+
+        /// Number of unique named region level variables.
+        ///
+        /// Only meaningful after calling member function commitStructure().
+        auto numVariables() const { return this->vars_.names().size(); }
+
+        /// Read-only sequence of named region sets known to current mapping.
+        ///
+        /// Only meaningful after calling member function commitStructure().
+        ///
+        /// Region sets presented in alphabetical order.
+        decltype(auto) regionSets() const { return this->regsets_.names(); }
+
+        /// Read-only sequence of named region level variables.
+        ///
+        /// Only meaningful after calling member function commitStructure().
+        ///
+        /// Region variables presented in alphabetical order.
+        decltype(auto) variables() const { return this->vars_.names(); }
+
+        /// Retrieve numeric index of named region set.
+        ///
+        /// Not meaningful before calling commitStructure() and will throw
+        /// an exception of type \code std::logic_error \endcode in that
+        /// case.
+        ///
+        /// \param[in] rset Named region set.
+        ///
+        /// \return Numeric index of region set \p rset.
+        auto index(const RegionSet& rset) const
+        {
+            this->ensureFinalStructure("region set", rset.name);
+            return this->regsets_.index(rset.name);
+        }
+
+        /// Retrieve numeric index of named region level variable.
+        ///
+        /// Not meaningful before calling commitStructure() and will throw
+        /// an exception of type \code std::logic_error \endcode in that
+        /// case.
+        ///
+        /// \param[in] var Named region level variable.
+        ///
+        /// \return Numeric index of region variable \p var.
+        auto index(const Variable& var) const
+        {
+            this->ensureFinalStructure("variable", var.name);
+            return this->vars_.index(var.name);
+        }
+
+        /// Query whether or not a named region variable represents a
+        /// cumulative quantity.
+        ///
+        /// Not meaningful before calling commitStructure() and will throw
+        /// an exception of type \code std::logic_error \endcode in that
+        /// case.
+        ///
+        /// \param[in] var Named region level variable.
+        ///
+        /// \return Whether or not \p var is a cumulative quantity.
+        /// Effectively returns the \c is_cumulative parameter of the add()
+        /// member function call that first registered \p var.  Nullopt if
+        /// \p var is not a known region level variable.
+        std::optional<bool> isCumulative(const Variable& var) const
+        {
+            const auto i = this->index(var);
+            if (! i.has_value()) { return {}; }
+
+            return { this->isCumulative(VariableIdx { *i }) };
+        }
+
+        /// Query whether or not a region variable is a cumulative quantity.
+        ///
+        /// Not meaningful before calling commitStructure().
+        ///
+        /// \param[in] i Numeric index of specific region variable.  Must be
+        /// in the range [0..numVariables()-1], and should typically be the
+        /// result of a prior call to member function index() for a
+        /// particular region variable name.
+        ///
+        /// \return Whether or not region variable \p i is a cumulative
+        /// quantity.  Effectively returns the \c is_cumulative parameter of
+        /// add() member function call that first registered the i-th region
+        /// variable in index() order.
+        bool isCumulative(const VariableIdx& i) const
+        { return this->is_cumulative_[i.idx]; }
+
+    private:
+        /// Sorted collection of names
+        class NameLookup
+        {
+        public:
+            /// Clear internal data structures.
+            void clear() { this->names_.clear(); }
+
+            /// Add a new name to current collection.
+            void add(const std::string& name) { this->names_.push_back(name); }
+
+            /// Sort name collection and prune duplicates.
+            ///
+            /// \return Indices, in sorted order, of original names that are
+            /// preserved after sorting and pruning.
+            std::vector<std::vector<std::string>::size_type> commit();
+
+            /// Current collection of names.
+            ///
+            /// Sorted and unique when called *after* commit().
+            const std::vector<std::string>& names() const { return this->names_; }
+
+            /// Numeric index of particular name.
+            ///
+            /// Uses binary search and must therefore not be called prior to
+            /// calling commit().
+            ///
+            /// \return Numeric index of \p name in current collection.
+            /// Nullopt if \p name does not exist in the collection.
+            std::optional<std::vector<std::string>::size_type>
+            index(const std::string& name) const;
+
+        private:
+            /// Current collection of names.
+            ///
+            /// Sorted and unique after client code calls commit().
+            std::vector<std::string> names_{};
+        };
+
+        /// Collection of named region sets.
+        NameLookup regsets_{};
+
+        /// Collection of named region level variables.
+        NameLookup vars_{};
+
+        /// Flags for whether or not a particular region level variable is a
+        /// cumulative quantity.
+        std::vector<bool> is_cumulative_{};
+
+        /// Whether or not client code has called commitStructure().
+        bool is_final_{false};
+
+        /// Ensure that registering a new name is possible.
+        ///
+        /// Inspects the \c is_final_ flag and throws an exception of type
+        /// \code std::logic_error \endcode if is_final_ is \c true.
+        ///
+        /// \param[in] type Name type.  Typically "region set" or
+        /// "variable".  Used for diagnostic message if is_final_ is \c
+        /// true.
+        ///
+        /// \param[in] name Object name.  Used in diagnostic message if
+        /// is_final_ is \c true.
+        void ensureRegistrationPossible(std::string_view type,
+                                        std::string_view name) const;
+
+        /// Ensure that name lookup structure is complete.
+        ///
+        /// Inspects the \c is_final_ flag and throws an exception of type
+        /// \code std::logic_error \endcode if is_final_ is \c false.
+        ///
+        /// \param[in] type Name type.  Typically "region set" or
+        /// "variable".  Used for diagnostic message if is_final_ is \c
+        /// false.
+        ///
+        /// \param[in] name Object name.  Used in diagnostic message if
+        /// is_final_ is \c false.
+        void ensureFinalStructure(std::string_view type,
+                                  std::string_view name) const;
+
+        /// Reorder and compress variables' cumulative flags.
+        ///
+        /// This is one of the last steps of commitStructure().
+        ///
+        /// \param[in] i Sorted and unique original indices of those region
+        /// level variables that are preserved after finalising the
+        /// name-lookup structure.  Expected to be the return value from
+        /// \code NameLookup::commit() \endcode.
+        void makeUniqueCumulative(const std::vector<std::vector<std::string>::size_type>& i);
+    };
+
+} // namespace Opm::data
+
+#endif // OPM_OUTPUT_DATA_REGIONVARIABLEMAPPING_HPP

--- a/tests/test_data_regionvariablemapping.cpp
+++ b/tests/test_data_regionvariablemapping.cpp
@@ -1,0 +1,427 @@
+/*
+  Copyright (c) 2025 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE data_RegionVariableMapping
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/output/data/RegionVariableMapping.hpp>
+
+#include <array>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Basic_Operations)
+
+BOOST_AUTO_TEST_CASE(Empty_Mapping)
+{
+    using RegionSet = Opm::data::RegionVariableMapping::RegionSet;
+    using Variable = Opm::data::RegionVariableMapping::Variable;
+
+    auto m = Opm::data::RegionVariableMapping{};
+
+    m.prepareRegistration();
+    m.commitStructure();
+
+    BOOST_CHECK_EQUAL(m.numRegionSets(), std::size_t{0});
+    BOOST_CHECK_EQUAL(m.numVariables(), std::size_t{0});
+
+    BOOST_CHECK_MESSAGE(m.regionSets().empty(),
+                        "Region set collection must be empty");
+
+    BOOST_CHECK_MESSAGE(m.variables().empty(),
+                        "Variable collection must be empty");
+
+    BOOST_CHECK_MESSAGE(! m.index(RegionSet { "hello" }).has_value(),
+                        R"(There must be no index for region set "hello")");
+
+    BOOST_CHECK_MESSAGE(! m.index(Variable { "v" }).has_value(),
+                        R"(There must be no index for variable "v")");
+
+    BOOST_CHECK_MESSAGE(! m.isCumulative(Variable { "v" }).has_value(),
+                        R"(There must be no cumulative flag for variable "v")");
+}
+
+BOOST_AUTO_TEST_CASE(Unique_Region_Sets)
+{
+    using RegionSet = Opm::data::RegionVariableMapping::RegionSet;
+    using namespace std::string_literals;
+
+    auto m = Opm::data::RegionVariableMapping{};
+
+    m.prepareRegistration();
+
+    m.add(RegionSet { "FIPNUM" });
+    m.add(RegionSet { "EQLNUM" });
+    m.add(RegionSet { "FIPABC" });
+    m.add(RegionSet { "FIPF00" });
+
+    m.commitStructure();
+
+    BOOST_CHECK_EQUAL(m.numRegionSets(), std::size_t{4});
+
+    BOOST_CHECK_MESSAGE(! m.regionSets().empty(),
+                        "Region set collection must not be empty");
+
+    BOOST_CHECK_MESSAGE(! m.index(RegionSet { "hello" }).has_value(),
+                        R"(There must be no index for region set "hello")");
+
+    {
+        const auto expect = std::array {
+            "EQLNUM"s, "FIPABC"s, "FIPF00"s, "FIPNUM"s,
+        };
+
+        const auto& rset = m.regionSets();
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(rset  .begin(), rset  .end(),
+                                      expect.begin(), expect.end());
+    }
+
+    BOOST_REQUIRE_MESSAGE(m.index(RegionSet{"FIPNUM"}).has_value(),
+                          R"(Region set "FIPNUM" must be known to mapping)");
+
+    BOOST_REQUIRE_MESSAGE(m.index(RegionSet{"EQLNUM"}).has_value(),
+                          R"(Region set "EQLNUM" must be known to mapping)");
+
+    BOOST_REQUIRE_MESSAGE(m.index(RegionSet{"FIPABC"}).has_value(),
+                          R"(Region set "FIPABC" must be known to mapping)");
+
+    BOOST_REQUIRE_MESSAGE(m.index(RegionSet{"FIPF00"}).has_value(),
+                          R"(Region set "FIPF00" must be known to mapping)");
+
+    BOOST_CHECK_EQUAL(m.index(RegionSet{"FIPNUM"}).value(), std::size_t{3});
+    BOOST_CHECK_EQUAL(m.index(RegionSet{"EQLNUM"}).value(), std::size_t{0});
+    BOOST_CHECK_EQUAL(m.index(RegionSet{"FIPABC"}).value(), std::size_t{1});
+    BOOST_CHECK_EQUAL(m.index(RegionSet{"FIPF00"}).value(), std::size_t{2});
+}
+
+BOOST_AUTO_TEST_CASE(Repeated_Region_Sets)
+{
+    using RegionSet = Opm::data::RegionVariableMapping::RegionSet;
+    using namespace std::string_literals;
+
+    auto m = Opm::data::RegionVariableMapping{};
+
+    m.prepareRegistration();
+
+    m.add(RegionSet { "FIPNUM" });
+    m.add(RegionSet { "FIPNUM" });
+    m.add(RegionSet { "FIPNUM" });
+    m.add(RegionSet { "FIPNUM" });
+    m.add(RegionSet { "EQLNUM" });
+    m.add(RegionSet { "FIPABC" });
+    m.add(RegionSet { "FIPF00" });
+    m.add(RegionSet { "FIPNUM" });
+    m.add(RegionSet { "FIPNUM" });
+    m.add(RegionSet { "FIPNUM" });
+    m.add(RegionSet { "FIPF00" });
+    m.add(RegionSet { "FIPF00" });
+    m.add(RegionSet { "PVTNUM" });
+
+    m.commitStructure();
+
+    BOOST_CHECK_EQUAL(m.numRegionSets(), std::size_t{5});
+
+    BOOST_CHECK_MESSAGE(! m.regionSets().empty(),
+                        "Region set collection must not be empty");
+
+    {
+        const auto expect = std::array {
+            "EQLNUM"s, "FIPABC"s, "FIPF00"s, "FIPNUM"s, "PVTNUM"s,
+        };
+
+        const auto& rset = m.regionSets();
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(rset  .begin(), rset  .end(),
+                                      expect.begin(), expect.end());
+    }
+
+    BOOST_REQUIRE_MESSAGE(m.index(RegionSet{"FIPNUM"}).has_value(),
+                          R"(Region set "FIPNUM" must be known to mapping)");
+
+    BOOST_REQUIRE_MESSAGE(m.index(RegionSet{"EQLNUM"}).has_value(),
+                          R"(Region set "EQLNUM" must be known to mapping)");
+
+    BOOST_REQUIRE_MESSAGE(m.index(RegionSet{"FIPABC"}).has_value(),
+                          R"(Region set "FIPABC" must be known to mapping)");
+
+    BOOST_REQUIRE_MESSAGE(m.index(RegionSet{"FIPF00"}).has_value(),
+                          R"(Region set "FIPF00" must be known to mapping)");
+
+    BOOST_REQUIRE_MESSAGE(m.index(RegionSet{"PVTNUM"}).has_value(),
+                          R"(Region set "PVTNUM" must be known to mapping)");
+
+    BOOST_CHECK_EQUAL(m.index(RegionSet{"FIPNUM"}).value(), std::size_t{3});
+    BOOST_CHECK_EQUAL(m.index(RegionSet{"EQLNUM"}).value(), std::size_t{0});
+    BOOST_CHECK_EQUAL(m.index(RegionSet{"FIPABC"}).value(), std::size_t{1});
+    BOOST_CHECK_EQUAL(m.index(RegionSet{"FIPF00"}).value(), std::size_t{2});
+    BOOST_CHECK_EQUAL(m.index(RegionSet{"PVTNUM"}).value(), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Unique_Variables)
+{
+    using Variable = Opm::data::RegionVariableMapping::Variable;
+    using VariableIdx = Opm::data::RegionVariableMapping::VariableIdx;
+
+    using namespace std::string_literals;
+
+    auto m = Opm::data::RegionVariableMapping{};
+
+    m.prepareRegistration();
+
+    m.add(Variable { "OPTW" }, /* is_cumulative = */ true);
+    m.add(Variable { "OPR"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "SIP"  }, /* is_cumulative = */ false);
+
+    m.commitStructure();
+
+    BOOST_CHECK_EQUAL(m.numVariables(), std::size_t{4});
+
+    BOOST_CHECK_MESSAGE(! m.variables().empty(),
+                        "Variable collection must not be empty");
+
+    BOOST_CHECK_MESSAGE(! m.index(Variable { "hello" }).has_value(),
+                        R"(There must be no index for variable "hello")");
+
+    {
+        const auto expect = std::array {
+            "GIP"s, "OPR"s, "OPTW"s, "SIP"s,
+        };
+
+        const auto& vars = m.variables();
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(vars  .begin(), vars  .end(),
+                                      expect.begin(), expect.end());
+    }
+
+    BOOST_REQUIRE_MESSAGE(m.index(Variable{"OPTW"}).has_value(),
+                          R"(Variable "OPTW" must be known to mapping)");
+
+    BOOST_REQUIRE_MESSAGE(m.index(Variable{"OPR"}).has_value(),
+                          R"(Variable "OPR" must be known to mapping)");
+
+    BOOST_REQUIRE_MESSAGE(m.index(Variable{"GIP"}).has_value(),
+                          R"(Variable "GIP" must be known to mapping)");
+
+    BOOST_REQUIRE_MESSAGE(m.index(Variable{"SIP"}).has_value(),
+                          R"(Variable "SIP" must be known to mapping)");
+
+    BOOST_CHECK_EQUAL(m.index(Variable{"OPTW"}).value(), std::size_t{2});
+    BOOST_CHECK_EQUAL(m.index(Variable{"OPR"}).value(), std::size_t{1});
+    BOOST_CHECK_EQUAL(m.index(Variable{"GIP"}).value(), std::size_t{0});
+    BOOST_CHECK_EQUAL(m.index(Variable{"SIP"}).value(), std::size_t{3});
+
+    BOOST_CHECK_MESSAGE(m.isCumulative(Variable{"OPTW"}).has_value(),
+                        R"(Variable "OPTW" must have cumulative flag)");
+
+    BOOST_CHECK_MESSAGE(m.isCumulative(Variable{"OPR"}).has_value(),
+                        R"(Variable "OPR" must have cumulative flag)");
+
+    BOOST_CHECK_MESSAGE(m.isCumulative(Variable{"GIP"}).has_value(),
+                        R"(Variable "GIP" must have cumulative flag)");
+
+    BOOST_CHECK_MESSAGE(m.isCumulative(Variable{"SIP"}).has_value(),
+                        R"(Variable "SIP" must have cumulative flag)");
+
+    BOOST_CHECK_MESSAGE(*m.isCumulative(Variable{"OPTW"}),
+                        R"(Variable "OPTW" must be cumulative)");
+
+    BOOST_CHECK_MESSAGE(! *m.isCumulative(Variable{"OPR"}),
+                        R"(Variable "OPR" must not be cumulative)");
+
+    BOOST_CHECK_MESSAGE(! *m.isCumulative(Variable{"GIP"}),
+                        R"(Variable "GIP" must not be cumulative)");
+
+    BOOST_CHECK_MESSAGE(! *m.isCumulative(Variable{"SIP"}),
+                        R"(Variable "SIP" must not be cumulative)");
+
+    BOOST_CHECK_MESSAGE(! m.isCumulative(VariableIdx{0}),
+                        "Variable at index 0 must not be cumulative");
+
+    BOOST_CHECK_MESSAGE(! m.isCumulative(VariableIdx{1}),
+                        "Variable at index 1 must not be cumulative");
+
+    BOOST_CHECK_MESSAGE(m.isCumulative(VariableIdx{2}),
+                        "Variable at index 2 must be cumulative");
+
+    BOOST_CHECK_MESSAGE(! m.isCumulative(VariableIdx{3}),
+                        "Variable at index 3 must not be cumulative");
+}
+
+BOOST_AUTO_TEST_CASE(Repeated_Variables)
+{
+    using Variable = Opm::data::RegionVariableMapping::Variable;
+    using VariableIdx = Opm::data::RegionVariableMapping::VariableIdx;
+
+    using namespace std::string_literals;
+
+    auto m = Opm::data::RegionVariableMapping{};
+
+    m.prepareRegistration();
+
+    m.add(Variable { "OPTW" }, /* is_cumulative = */ true);
+    m.add(Variable { "OPR"  }, /* is_cumulative = */ false);
+    m.add(Variable { "OPR"  }, /* is_cumulative = */ false);
+    m.add(Variable { "OPR"  }, /* is_cumulative = */ false);
+    m.add(Variable { "OPR"  }, /* is_cumulative = */ false);
+    m.add(Variable { "OPR"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "SIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "OPTW" }, /* is_cumulative = */ true);
+    m.add(Variable { "OPTW" }, /* is_cumulative = */ true);
+    m.add(Variable { "OPTW" }, /* is_cumulative = */ true);
+    m.add(Variable { "OPTW" }, /* is_cumulative = */ true);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+    m.add(Variable { "GIP"  }, /* is_cumulative = */ false);
+
+    m.commitStructure();
+
+    BOOST_CHECK_EQUAL(m.numVariables(), std::size_t{4});
+
+    BOOST_CHECK_MESSAGE(! m.variables().empty(),
+                        "Variable collection must not be empty");
+
+    BOOST_CHECK_MESSAGE(! m.index(Variable { "hello" }).has_value(),
+                        R"(There must be no index for variable "hello")");
+
+    {
+        const auto expect = std::array {
+            "GIP"s, "OPR"s, "OPTW"s, "SIP"s,
+        };
+
+        const auto& vars = m.variables();
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(vars  .begin(), vars  .end(),
+                                      expect.begin(), expect.end());
+    }
+
+    BOOST_REQUIRE_MESSAGE(m.index(Variable{"OPTW"}).has_value(),
+                          R"(Variable "OPTW" must be known to mapping)");
+
+    BOOST_REQUIRE_MESSAGE(m.index(Variable{"OPR"}).has_value(),
+                          R"(Variable "OPR" must be known to mapping)");
+
+    BOOST_REQUIRE_MESSAGE(m.index(Variable{"GIP"}).has_value(),
+                          R"(Variable "GIP" must be known to mapping)");
+
+    BOOST_REQUIRE_MESSAGE(m.index(Variable{"SIP"}).has_value(),
+                          R"(Variable "SIP" must be known to mapping)");
+
+    BOOST_CHECK_EQUAL(m.index(Variable{"OPTW"}).value(), std::size_t{2});
+    BOOST_CHECK_EQUAL(m.index(Variable{"OPR"}).value(), std::size_t{1});
+    BOOST_CHECK_EQUAL(m.index(Variable{"GIP"}).value(), std::size_t{0});
+    BOOST_CHECK_EQUAL(m.index(Variable{"SIP"}).value(), std::size_t{3});
+
+    BOOST_CHECK_MESSAGE(m.isCumulative(Variable{"OPTW"}).has_value(),
+                        R"(Variable "OPTW" must have cumulative flag)");
+
+    BOOST_CHECK_MESSAGE(m.isCumulative(Variable{"OPR"}).has_value(),
+                        R"(Variable "OPR" must have cumulative flag)");
+
+    BOOST_CHECK_MESSAGE(m.isCumulative(Variable{"GIP"}).has_value(),
+                        R"(Variable "GIP" must have cumulative flag)");
+
+    BOOST_CHECK_MESSAGE(m.isCumulative(Variable{"SIP"}).has_value(),
+                        R"(Variable "SIP" must have cumulative flag)");
+
+    BOOST_CHECK_MESSAGE(*m.isCumulative(Variable{"OPTW"}),
+                        R"(Variable "OPTW" must be cumulative)");
+
+    BOOST_CHECK_MESSAGE(! *m.isCumulative(Variable{"OPR"}),
+                        R"(Variable "OPR" must not be cumulative)");
+
+    BOOST_CHECK_MESSAGE(! *m.isCumulative(Variable{"GIP"}),
+                        R"(Variable "GIP" must not be cumulative)");
+
+    BOOST_CHECK_MESSAGE(! *m.isCumulative(Variable{"SIP"}),
+                        R"(Variable "SIP" must not be cumulative)");
+
+    BOOST_CHECK_MESSAGE(! m.isCumulative(VariableIdx{0}),
+                        "Variable at index 0 must not be cumulative");
+
+    BOOST_CHECK_MESSAGE(! m.isCumulative(VariableIdx{1}),
+                        "Variable at index 1 must not be cumulative");
+
+    BOOST_CHECK_MESSAGE(m.isCumulative(VariableIdx{2}),
+                        "Variable at index 2 must be cumulative");
+
+    BOOST_CHECK_MESSAGE(! m.isCumulative(VariableIdx{3}),
+                        "Variable at index 3 must not be cumulative");
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Basic_Operations
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Erroneous_Accesses)
+
+BOOST_AUTO_TEST_CASE(Add_After_Commit)
+{
+    using RegionSet = Opm::data::RegionVariableMapping::RegionSet;
+    using Variable = Opm::data::RegionVariableMapping::Variable;
+
+    auto m = Opm::data::RegionVariableMapping{};
+
+    m.prepareRegistration();
+    m.commitStructure();
+
+    BOOST_CHECK_THROW(m.add(RegionSet{"hello"}), std::logic_error);
+    BOOST_CHECK_THROW(m.add(Variable{"hello"}, true), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(Index_Before_Commit)
+{
+    using RegionSet = Opm::data::RegionVariableMapping::RegionSet;
+    using Variable = Opm::data::RegionVariableMapping::Variable;
+
+    auto m = Opm::data::RegionVariableMapping{};
+
+    m.prepareRegistration();
+
+    m.add(RegionSet{"rs1"});
+    m.add(RegionSet{"rs2"});
+    m.add(RegionSet{"rs17"});
+    m.add(RegionSet{"rs29"});
+    m.add(Variable{"v1"}, true);
+    m.add(Variable{"v10"}, true);
+    m.add(Variable{"v02"}, false);
+
+    BOOST_CHECK_THROW(m.index(Variable{"v1"}), std::logic_error);
+    BOOST_CHECK_THROW(m.index(RegionSet{"rs17"}), std::logic_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Erroneous_Accesses


### PR DESCRIPTION
This commit introduces a new facility,

    class RegionVariableMapping

for translating region set and variable names to linear numeric indices.  The initial intended use case is to support an alternative, more compact, representation of region level summary variables.

Building a mapping object is three-stage process

1. Prepare mapping object for registration
2. Register region set and variable names
3. Committing mapping structure

Once fully formed, the mapping provides logarithmic translation of region set or variable names to numeric indices based on sorted vectors.

When registering variable names, client code should also inform the mapping object whether or not the variable represents a cumulative quantity.  The cumulative flags will be reordered as needed to have the same indices as the variable names.