### PR TITLE
Add Descriptor for Region Level Summary Variables

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -397,6 +397,7 @@ list(APPEND MAIN_SOURCE_FILES
   opm/ml/ml_model.cpp
   opm/output/data/Aquifer.cpp
   opm/output/data/InterRegFlowMap.cpp
+  opm/output/data/RegionsetVariableDescriptor.cpp
   opm/output/data/RegionVariableMapping.cpp
   opm/output/data/Solution.cpp
   opm/output/eclipse/ActiveIndexByColumns.cpp
@@ -514,6 +515,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/test_data_GuideRateValue.cpp
   tests/test_data_InterRegFlow.cpp
   tests/test_data_InterRegFlowMap.cpp
+  tests/test_data_regionsetvariabledescriptor.cpp
   tests/test_data_regionvariablemapping.cpp
   tests/test_DatumDepth.cpp
   tests/test_DoubHEAD.cpp
@@ -1505,6 +1507,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/output/data/InterRegFlow.hpp
   opm/output/data/InterRegFlowMap.hpp
   opm/output/data/RegionVariableMapping.hpp
+  opm/output/data/RegionsetVariableDescriptor.hpp
   opm/output/data/Solution.hpp
   opm/output/data/Wells.hpp
   opm/output/eclipse/ActiveIndexByColumns.hpp

--- a/opm/output/data/RegionsetVariableDescriptor.cpp
+++ b/opm/output/data/RegionsetVariableDescriptor.cpp
@@ -1,0 +1,89 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#include <opm/output/data/RegionsetVariableDescriptor.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+std::unique_ptr<Opm::data::RegionsetVariableDescriptor>
+Opm::data::RegionsetVariableDescriptor::clone() const
+{
+    return std::make_unique<RegionsetVariableDescriptor>(*this);
+}
+
+void Opm::data::RegionsetVariableDescriptor::prepareDescriptorSet()
+{
+    this->startPtr_.clear();
+    this->regsetMaxID_.emplace();
+}
+
+void Opm::data::RegionsetVariableDescriptor::addRegionSet(const int maxRegionID)
+{
+    if (! this->regsetMaxID_.has_value()) {
+        throw std::logic_error {
+            "Cannot register a new region set before "
+            "calling prepareDescriptorSet() or after "
+            "calling finaliseDescriptorSet()"
+        };
+    }
+
+    this->regsetMaxID_->push_back(std::max(maxRegionID, -1));
+}
+
+void Opm::data::RegionsetVariableDescriptor::finaliseDescriptorSet()
+{
+    if (! this->regsetMaxID_.has_value()) {
+        throw std::logic_error {
+            "Cannot finalise descriptor set before "
+            "calling prepareDescriptorSet()"
+        };
+    }
+
+    this->communicateGlobalRegsetMaxIDs();
+    this->defineStartPointers();
+
+    // Release ID storage to signal end of finalisation step.
+    this->regsetMaxID_.reset();
+}
+
+void Opm::data::RegionsetVariableDescriptor::defineStartPointers()
+{
+    this->startPtr_.assign(this->regsetMaxID_->size() + 1, std::size_t{0});
+
+    std::ranges::transform(*this->regsetMaxID_, this->startPtr_.begin() + 1,
+                           [](const int regsetMaxID)
+                           {
+                               // Note: +1 for the maximum region ID itself.
+                               return (regsetMaxID < 0)
+                                   ? std::size_t{0}
+                                   : static_cast<std::size_t>(regsetMaxID) + 1;
+                           });
+
+    std::partial_sum(this->startPtr_.begin(),
+                     this->startPtr_.end(),
+                     this->startPtr_.begin());
+}

--- a/opm/output/data/RegionsetVariableDescriptor.hpp
+++ b/opm/output/data/RegionsetVariableDescriptor.hpp
@@ -1,0 +1,225 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_OUTPUT_DATA_REGIONSET_VARIABLE_DESCRIPTOR_HPP
+#define OPM_OUTPUT_DATA_REGIONSET_VARIABLE_DESCRIPTOR_HPP
+
+#include <algorithm>
+#include <concepts>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <ranges>
+#include <stdexcept>
+#include <vector>
+
+/// \file Component to describe a collection of region sets.
+
+namespace Opm::data {
+
+    /// Basic information about a collection of region sets.
+    ///
+    /// In particular, this class tracks the maximum region ID for each
+    /// region set registered in the collection.  Common region sets in this
+    /// context include the built-in FIPNUM set as well as user defined
+    /// region sets named FIP*, such as FIPABC or FIP_UZ.  There is
+    /// nevertheless nothing that will prevent including a different
+    /// region set such as PVTNUM or KRNUMX in this collection.
+    ///
+    /// The primary use case for this class is assisting in allocating
+    /// region level summary vectors over region sets.  That allocation
+    /// requires knowing the maximum expected region ID for each pertinent
+    /// region set.
+    ///
+    /// Constructing a descriptor object is a multi-step process.
+    ///
+    ///  -# Create the object through the default constructor
+    ///  -# Call member function prepareDescriptorSet() to set the stage for
+    ///     adding new region sets.
+    ///  -# Incorporate one or more region sets through the addRegionSet()
+    ///     overload set.
+    ///  -# Call member function finaliseDescriptorSet() to analyse the data
+    ///     and set up internal data structures.
+    ///
+    /// Once member function finaliseDescriptorSet() has been called, the
+    /// object should be treated as read-only and only its \c const member
+    /// functions should be invoked by client code.  Calling member function
+    /// prepareDescriptorSet() after finaliseDescriptorSet() is allowed, but
+    /// doing so will discard all information collected until that point and
+    /// will require re-registering all pertinent region sets.
+    ///
+    /// The class provides a protected hook through which derived classes can
+    /// extend the protocol--e.g., to include communication in a parallel
+    /// context.
+    class RegionsetVariableDescriptor
+    {
+    public:
+        /// Default constructor.
+        ///
+        /// Forms an empty variable descriptor.
+        RegionsetVariableDescriptor() = default;
+
+        /// Virtual destructor.
+        ///
+        /// This class is intended for inheritance.
+        virtual ~RegionsetVariableDescriptor() = default;
+
+        /// Copy constructor.
+        RegionsetVariableDescriptor(const RegionsetVariableDescriptor&) = default;
+
+        /// Move constructor.
+        RegionsetVariableDescriptor(RegionsetVariableDescriptor&&) = default;
+
+        /// Assignment operator.
+        RegionsetVariableDescriptor& operator=(const RegionsetVariableDescriptor&) = default;
+
+        /// Move-assignment operator.
+        RegionsetVariableDescriptor& operator=(RegionsetVariableDescriptor&&) = default;
+
+        /// Create a deep copy of this object.
+        ///
+        /// Intended for when an object holds a pointer to a base class and
+        /// needs to make a copy of the derived class object.  Derived classes
+        /// should override this function to return a copy of the derived class
+        /// object.
+        ///
+        /// \return A deep copy of this object.
+        virtual std::unique_ptr<RegionsetVariableDescriptor> clone() const;
+
+        /// Discard all existing information and prepare for analysing new
+        /// collection of region sets.
+        void prepareDescriptorSet();
+
+        /// Include region set into collection.
+        ///
+        /// Meaningful only prior to calling finaliseDescriptorSet() and
+        /// will throw an exception of type \code std::logic_error \endcode
+        /// if called after finaliseDescriptorSet().
+        ///
+        /// \tparam R Range type. Needs to satisfy std::ranges::forward_range
+        /// and must have an integer value type, typically \c int.
+        ///
+        /// \param[in] declaredMaxRegionID Run's declared maximum region ID.
+        /// Typically entered in the TABDIMS or the REGDIMS keyword.
+        ///
+        /// \param[in] range Linear sequence of region IDs.
+        template <std::ranges::forward_range R>
+            requires std::integral<std::ranges::range_value_t<R>>
+        void addRegionSet(const int declaredMaxRegionID, R&& range)
+        {
+            const auto maxIdPos = std::ranges::max_element(range);
+            if (maxIdPos == std::ranges::end(range)) {
+                // Empty collection.  Unexpected, but valid.  Use
+                // the declared maximum region ID.
+                this->addRegionSet(declaredMaxRegionID);
+            }
+            else {
+                this->addRegionSet(std::max(declaredMaxRegionID,
+                                            static_cast<int>(*maxIdPos)));
+            }
+        }
+
+        /// Include region set into collection.
+        ///
+        /// Meaningful only prior to calling finaliseDescriptorSet() and
+        /// will throw an exception of type \code std::logic_error \endcode
+        /// if called after finaliseDescriptorSet().
+        ///
+        /// \param[in] maxRegionID Maximum region ID in region set.
+        void addRegionSet(const int maxRegionID);
+
+        /// Perform post-registration tasks
+        ///
+        /// Sets up internal CSR-like data structures to enable uniquely
+        /// identifying indices corresponding to a single region in a
+        /// particular region set.
+        ///
+        /// Valid even if no region sets have been registered (in which case
+        /// numRegionSets() and numVariableSlots() both return zero).
+        void finaliseDescriptorSet();
+
+        /// Retrieve value starting index for a particular region set.
+        ///
+        /// \param[in] Region set index.  Must be in the range [0
+        /// ... numRegionSets()-1].
+        ///
+        /// \return Starting index for the region set defined by the \code
+        /// regSet+1 \endcode-th call to addRegionSet().
+        std::size_t startIndex(const std::size_t regSet) const
+        {
+            if (this->startPtr_.empty()) {
+                throw std::logic_error {
+                    "Cannot request startIndex() before "
+                    "calling finaliseDescriptorSet()"
+                };
+            }
+
+            if (regSet >= this->startPtr_.size() - 1) {
+                throw std::out_of_range{"Region set index out of range"};
+            }
+
+            return this->startPtr_[regSet];
+        }
+
+        /// Total number of variable items needed for all regions in all
+        /// region sets known to this collection.
+        std::size_t numVariableSlots() const
+        {
+            return this->startPtr_.empty()
+                ? std::size_t{0}
+                : this->startPtr_.back();
+        }
+
+        /// Total number of region sets known to this collection.
+        std::size_t numRegionSets() const
+        {
+            return this->startPtr_.empty()
+                ? std::size_t{0}
+                : this->startPtr_.size() - 1;
+        }
+
+    private:
+        /// CSR-like start pointers for all region sets.
+        ///
+        /// Region 'j' in region set 'i' has variable index \code
+        /// startPtr_[i] + j \endcode.
+        std::vector<std::size_t> startPtr_{};
+
+        /// Form CSR-like start pointers for all region sets.
+        void defineStartPointers();
+
+    protected:
+        /// Maximum region IDs in all region sets.
+        ///
+        /// Nullopt prior to calling prepareDescriptorSet() *or* if
+        /// all region sets have been internalised through a call to
+        /// finaliseDescriptorSet().
+        std::optional<std::vector<int>> regsetMaxID_{};
+
+        /// Exchange maximum region set IDs if needed.
+        ///
+        /// This is a hook for derived classes that know about parallel
+        /// execution.  The default implementation, intended/suitable for
+        /// sequential runs, does nothing.
+        virtual void communicateGlobalRegsetMaxIDs() {}
+    };
+
+} // namespace Opm::data
+
+#endif // OPM_OUTPUT_DATA_REGIONSET_VARIABLE_DESCRIPTOR_HPP

--- a/tests/test_data_regionsetvariabledescriptor.cpp
+++ b/tests/test_data_regionsetvariabledescriptor.cpp
@@ -1,0 +1,469 @@
+/*
+  Copyright (c) 2026 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE data_RegionsetVariableDescriptor
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/output/data/RegionsetVariableDescriptor.hpp>
+
+#include <array>
+#include <cstddef>
+#include <deque>
+#include <forward_list>
+#include <stdexcept>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Basic_Operations)
+
+BOOST_AUTO_TEST_CASE(Empty)
+{
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_SUITE(Single_Regset)
+
+BOOST_AUTO_TEST_CASE(Single_Region)
+{
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 5); // Supports regions 0..5
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Single_Region_Scan_Regions)
+{
+    const auto regions = std::vector<int>(123, 0);
+
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 0, regions);
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Single_Region_Scan_Regions_List)
+{
+    const auto regions = std::forward_list {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    };
+
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 0, regions);
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Single_Region_Scan_Regions_Deque)
+{
+    const auto regions = std::deque {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    };
+
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 0, regions);
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_I)
+{
+    const auto regions = std::vector{ 1, 1, 2, 2, 1, 1, 3, };
+
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 5, regions);
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_II)
+{
+    const auto regions = std::vector{ 1, 1, 2, 2, 1, 1, 3, };
+
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 2, regions);
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{4});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_III)
+{
+    const auto regions = std::vector{ 1, 1, 2, 2, 1, 1, 3, };
+
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 3, regions);
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{4});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Regset
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Two_Regsets)
+
+BOOST_AUTO_TEST_CASE(Single_Region)
+{
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 5); // Supports regions 0..5
+    d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{6});
+}
+
+BOOST_AUTO_TEST_CASE(Single_Region_Scan_Regions)
+{
+    const auto reg_1 = std::vector { 0, 0, 0, 0, 0, };
+    const auto reg_2 = std::deque { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, };
+
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_1);
+    d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_2);
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_I)
+{
+    const auto reg_1 = std::vector { 1, 1, 2, 2, 1, 1, 3, };
+    const auto reg_2 = std::array { 1, 1, 2, 2, 1, 1, 3, };
+
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+    d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{6});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_II)
+{
+    const auto reg_1 = std::vector { 1, 1, 2, 2, 1, 1, 3, };
+    const auto reg_2 = std::array { 1, 1, 2, 2, 1, 1, 3, };
+
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+    d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_III)
+{
+    const auto reg_1 = std::vector { 1, 1, 2, 2, 1, 1, 3, };
+    const auto reg_2 = std::array { 1, 1, 2, 2, 1, 1, 3, };
+
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+    d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{8});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_IV)
+{
+    const auto reg_1 = std::vector { 1, 1, 2, 2, 1, 1, 3, };
+    const auto reg_2 = std::array { 1, 1, 2, 2, 1, 1, 3, };
+
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+    d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{48});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{18});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Two_Regsets
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Multiple_Regsets)
+
+BOOST_AUTO_TEST_CASE(Single_Region)
+{
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{3});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 4); // Supports regions 0..4
+    d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+    d.addRegionSet(/* maxRegionID = */ 2); // Supports regions 0..2
+    d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    d.addRegionSet(/* maxRegionID = */ 0); // Supports regions 0..0
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{15});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{ 0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{ 5});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{ 9});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{12});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{14});
+}
+
+BOOST_AUTO_TEST_CASE(Scan_Regions)
+{
+    const auto reg_1 = std::vector<int> {};
+    const auto reg_2 = std::vector { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, };
+    const auto reg_3 = std::vector { 3, 14, 1, 5, 9, 26, };
+    const auto reg_4 = std::forward_list { 0, 0, 0, 0, 0, 0, };
+    const auto reg_5 = std::deque { 11, 22, 33, 17, 29, };
+    const auto reg_6 = std::array { 0, 1, 0, 2, 3, 0, 1, };
+
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_1); // max ID =  5
+    d.addRegionSet(/* declaredMaxRegionID = */ 42, reg_2); // max ID = 42
+    d.addRegionSet(/* declaredMaxRegionID = */  0, reg_3); // max ID = 26
+    d.addRegionSet(/* declaredMaxRegionID = */  0, reg_4); // max ID =  0
+    d.addRegionSet(/* declaredMaxRegionID = */ 11, reg_5); // max ID = 33
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_6); // max ID =  5
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{117});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{  0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{  6});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{ 49});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{ 76});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{ 77});
+    BOOST_CHECK_EQUAL(d.startIndex(5), std::size_t{111});
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()     // Basic_Operations
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Erroneous_Accesses)
+
+BOOST_AUTO_TEST_CASE(Add_Before_Prepare)
+{
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    BOOST_CHECK_THROW(d.addRegionSet(/* maxRegionID = */ 0), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(Finalise_Before_Prepare)
+{
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    BOOST_CHECK_THROW(d.finaliseDescriptorSet(), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(Add_After_Finalise)
+{
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+    d.addRegionSet(/* maxRegionID = */ 0);
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_THROW(d.addRegionSet(/* maxRegionID = */ 0), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(StartIndex_Before_Finalise)
+{
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+    d.addRegionSet(/* maxRegionID = */ 0);
+
+    BOOST_CHECK_THROW(d.startIndex(0), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(StartIndex_Out_Of_Range)
+{
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+    d.addRegionSet(/* maxRegionID = */ 0);
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_THROW(d.startIndex(1), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE(StartIndex_Empty_Descriptor_Out_Of_Range)
+{
+    auto d = Opm::data::RegionsetVariableDescriptor{};
+
+    d.prepareDescriptorSet();
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_THROW(d.startIndex(0), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Erroneous_Accesses


### PR DESCRIPTION
This PR introduces a new descriptor for region level summary variables.  Class `RegionsetVariableDescriptor` tracks maximum region IDs, both declared and actual, for a sequence of region sets.  The region sets are implicitly identified by the order of registration so additional identification must be handled externally, typically by class `RegionVariableMapping` (#5274).

The primary use case for this class is assisting in allocating memory for region level summary vectors defined over one or more region sets.  To this end, member function
```
RegionsetVariableDescriptor::numVariableSlots()
```
returns the total number of distinct potential regions (maximum number of distinct regions per region set, summed over all region sets).  Furthermore,
```
RegionsetVariableDescriptor::startIndex(i)
```
returns the linear index in the range `[0 .. numVariableSlots()-1]` that corresponds to the start of the `i`-th region set in order of registration.

Forming a `RegionsetVariableDescriptor` object is a multi-stage process

1. Prepare for registration
2. Register new region set(s) by calling one of the `addRegionSet()` member function overloads
3. End registration by calling `finaliseDescriptorSet()`

`FinaliseDescriptorSet()` computes the start indices and the total number of variable slots.

This class also provides a hook for parallel computation.  The protected member function `communicateGlobalRegsetMaxIDs()` whose default implementation is trivial allows derived classes to exchange maximum region IDs across MPI ranks or perform other operations on the set of maximum region IDs.