### PR TITLE
Add View for Accessing Elements of Region Level Summary Vector

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -517,6 +517,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/test_data_InterRegFlowMap.cpp
   tests/test_data_regionsetvariabledescriptor.cpp
   tests/test_data_regionvariablemapping.cpp
+  tests/test_data_regionvariableview.cpp
   tests/test_DatumDepth.cpp
   tests/test_DoubHEAD.cpp
   tests/test_EclipseIO.cpp
@@ -1507,6 +1508,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/output/data/InterRegFlow.hpp
   opm/output/data/InterRegFlowMap.hpp
   opm/output/data/RegionVariableMapping.hpp
+  opm/output/data/RegionVariableView.hpp
   opm/output/data/RegionsetVariableDescriptor.hpp
   opm/output/data/Solution.hpp
   opm/output/data/Wells.hpp

--- a/opm/output/data/RegionVariableView.hpp
+++ b/opm/output/data/RegionVariableView.hpp
@@ -1,0 +1,148 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_OUTPUT_DATA_REGION_VARIABLE_VIEW_HPP
+#define OPM_OUTPUT_DATA_REGION_VARIABLE_VIEW_HPP
+
+#include <opm/output/data/RegionsetVariableDescriptor.hpp>
+
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <span>
+#include <stdexcept>
+#include <type_traits>
+
+/// \file Component that gives a view into a sequence of (numerical) values
+/// keyed by region sets and region indices.
+
+namespace Opm::data {
+
+    /// Linear sequence of read-only or read/write values associated to a
+    /// collection of region sets and regions within each region set.
+    ///
+    /// The value range is expected to have one scalar element for each
+    /// region in each region set.
+    ///
+    /// \tparam T Element type of the underlying value range.  If \c T is
+    /// const-qualified, the view provides read-only access.  Otherwise, the
+    /// view provides read/write access.
+    template <typename T>
+    class RegionVariableView
+    {
+    public:
+        /// Constructor.
+        ///
+        /// \param[in] values Range of values for a single region level variable.
+        /// The range must have one scalar value for each region in each region
+        /// set known to \p variableDescriptor.  Expected to outlive the view object.
+        ///
+        /// \param[in] variableDescriptor Collection of region sets and
+        /// associated region indices per region set.  The value range
+        /// \p values must have one scalar value for each region in each
+        /// region set known to \p variableDescriptor.  If not, this constructor
+        /// will throw an exception of type \code std::logic_error \endcode.
+        explicit RegionVariableView(std::span<T>                       values,
+                                    const RegionsetVariableDescriptor& variableDescriptor)
+            : values_             { values }
+            , variableDescriptor_ { std::cref(variableDescriptor) }
+        {
+            const auto numElements = values.size();
+
+            if (numElements != this->variableDescriptor_.get().numVariableSlots()) {
+                throw std::logic_error {
+                    "Element range does not match expected number of values"
+                };
+            }
+        }
+
+        /// Read/write access to an element in the value range.
+        ///
+        /// Inaccessible if element type \c T is const-qualified.
+        ///
+        /// \param[in] regSetID Region set ID.  Must be in the range 0..#S-1
+        /// with S being the number of region sets known to the variable
+        /// descriptor from which view was constructed.
+        ///
+        /// \param[in] region Region index within the specific \p regSetID.
+        ///
+        /// \return Mutable element within the value range.
+        T& element(const std::size_t regSetID, const std::size_t region)
+        requires (! std::is_const_v<T>)
+        {
+            return this->values_[ this->index(regSetID, region) ];
+        }
+
+        /// Read-only access to an element in the value range.
+        ///
+        /// \param[in] regSetID Region set ID.  Must be in the range 0..#S-1
+        /// with S being the number of region sets known to the variable
+        /// descriptor from which view was constructed.
+        ///
+        /// \param[in] region Region index within the specific \p regSetID.
+        ///
+        /// \return Read-only element within the value range.
+        std::conditional_t<std::is_arithmetic_v<std::remove_cvref_t<T>>,
+                           std::remove_cvref_t<T>,
+                           const std::remove_cvref_t<T>&>
+        element(const std::size_t regSetID, const std::size_t region) const
+        {
+            return this->values_[ this->index(regSetID, region) ];
+        }
+
+    private:
+        /// Convenience type alias for a wrapped variable descriptor.
+        using VarDesc = std::reference_wrapper<const RegionsetVariableDescriptor>;
+
+        /// Value range.
+        std::span<T> values_;
+
+        /// Collection of region sets and associated region IDs.
+        VarDesc variableDescriptor_;
+
+        /// Translate a pair of region set and region indices to a linear index.
+        ///
+        /// \param[in] regSetID Region set ID.  Must be in the range 0..#S-1
+        /// with S being the number of region sets known to the variable
+        /// descriptor from which view was constructed.
+        ///
+        /// \param[in] region Region index within the specific \p regSetID.
+        ///
+        /// \return Linear index within value range corresponding to the
+        /// index pair (\p regSetID, \p region).
+        std::size_t index(const std::size_t regSetID, const std::size_t region) const
+        {
+            const auto& d = this->variableDescriptor_.get();
+
+            assert (regSetID < d.numRegionSets());
+
+            const auto begin = d.startIndex(regSetID);
+            const auto end = (regSetID + 1 < d.numRegionSets())
+                ? d.startIndex(regSetID + 1)
+                : d.numVariableSlots();
+
+            assert (begin + region < end);
+
+            return begin + region;
+        }
+    };
+
+} // namespace Opm::data
+
+#endif // OPM_OUTPUT_DATA_REGION_VARIABLE_VIEW_HPP

--- a/tests/test_data_regionvariableview.cpp
+++ b/tests/test_data_regionvariableview.cpp
@@ -1,0 +1,276 @@
+/*
+  Copyright (c) 2026 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE data_RegionVariableView
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/output/data/RegionVariableView.hpp>
+
+#include <opm/output/data/RegionsetVariableDescriptor.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <numeric>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+    template <typename Elm>
+    std::vector<Elm> iota(const std::size_t n)
+    {
+        auto v = std::vector<Elm>(n);
+        std::iota(v.begin(), v.end(), Elm{});
+        return v;
+    }
+
+    template <typename Elm>
+    std::vector<Elm> reverse(std::vector<Elm>&& v)
+    {
+        std::reverse(v.begin(), v.end());
+        return v;
+    }
+
+} // namespace anonymous
+
+BOOST_AUTO_TEST_SUITE(Single_RegSet)
+
+namespace {
+
+    std::vector<int> fipabc()
+    {
+        return { 1, 2, 3, 3, 2, 1, 1, 1, 1, 1, };
+    }
+
+    Opm::data::RegionsetVariableDescriptor descriptor(const int maxID)
+    {
+        auto descr = Opm::data::RegionsetVariableDescriptor{};
+
+        descr.prepareDescriptorSet();
+        descr.addRegionSet(maxID);
+        descr.finaliseDescriptorSet();
+
+        return descr;
+    }
+
+    Opm::data::RegionsetVariableDescriptor
+    descriptor(const std::vector<int>& regset)
+    {
+        auto descr = Opm::data::RegionsetVariableDescriptor{};
+
+        descr.prepareDescriptorSet();
+        descr.addRegionSet(0, regset);
+        descr.finaliseDescriptorSet();
+
+        return descr;
+    }
+
+} // namespace anonymous
+
+BOOST_AUTO_TEST_CASE(Read_Only_Float)
+{
+    const auto descr = descriptor(5);
+    const auto x = iota<float>(descr.numVariableSlots());
+
+    const auto vals = Opm::data::RegionVariableView { std::span{x}, descr };
+
+    BOOST_CHECK_CLOSE(vals.element(0, 0), 0.0f, 1.0e-6f);
+    BOOST_CHECK_CLOSE(vals.element(0, 1), 1.0f, 1.0e-6f);
+    BOOST_CHECK_CLOSE(vals.element(0, 2), 2.0f, 1.0e-6f);
+    BOOST_CHECK_CLOSE(vals.element(0, 3), 3.0f, 1.0e-6f);
+    BOOST_CHECK_CLOSE(vals.element(0, 4), 4.0f, 1.0e-6f);
+    BOOST_CHECK_CLOSE(vals.element(0, 5), 5.0f, 1.0e-6f);
+}
+
+BOOST_AUTO_TEST_CASE(Read_Only_Double)
+{
+    const auto descr = descriptor(fipabc());
+
+    const auto x = reverse(iota<double>(descr.numVariableSlots()));
+
+    const auto vals = Opm::data::RegionVariableView {
+        std::span{x}, descr
+    };
+
+    BOOST_CHECK_CLOSE(vals.element(0, 0), 3.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(vals.element(0, 1), 2.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(vals.element(0, 2), 1.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(vals.element(0, 3), 0.0, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Read_Only_Integer)
+{
+    const auto descr = descriptor(10);
+    const auto x = iota<std::size_t>(descr.numVariableSlots());
+
+    const auto vals = Opm::data::RegionVariableView {
+        std::span{x}, descr
+    };
+
+    BOOST_CHECK_EQUAL(vals.element(0, 0), std::size_t{ 0});
+    BOOST_CHECK_EQUAL(vals.element(0, 1), std::size_t{ 1});
+    BOOST_CHECK_EQUAL(vals.element(0, 2), std::size_t{ 2});
+    BOOST_CHECK_EQUAL(vals.element(0, 3), std::size_t{ 3});
+    BOOST_CHECK_EQUAL(vals.element(0, 4), std::size_t{ 4});
+    BOOST_CHECK_EQUAL(vals.element(0, 5), std::size_t{ 5});
+    BOOST_CHECK_EQUAL(vals.element(0, 6), std::size_t{ 6});
+    BOOST_CHECK_EQUAL(vals.element(0, 7), std::size_t{ 7});
+    BOOST_CHECK_EQUAL(vals.element(0, 8), std::size_t{ 8});
+    BOOST_CHECK_EQUAL(vals.element(0, 9), std::size_t{ 9});
+    BOOST_CHECK_EQUAL(vals.element(0,10), std::size_t{10});
+}
+
+BOOST_AUTO_TEST_CASE(Read_Write_Double)
+{
+    const auto descr = descriptor(fipabc());
+
+    auto x = reverse(iota<double>(descr.numVariableSlots()));
+
+    BOOST_CHECK_CLOSE(x[3], 0.0, 1.0e-8);
+
+    auto vals = Opm::data::RegionVariableView {
+        std::span{x}, descr
+    };
+
+    vals.element(0, 3) = 42.1729;
+
+    BOOST_CHECK_CLOSE(vals.element(0, 0), 3.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(vals.element(0, 1), 2.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(vals.element(0, 2), 1.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(vals.element(0, 3), 42.1729, 1.0e-8);
+
+    BOOST_CHECK_CLOSE(x[3], 42.1729, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Size_Mismatch)
+{
+    const auto descr = descriptor(5);
+    const auto x = iota<std::size_t>(2 * descr.numVariableSlots());
+
+    BOOST_CHECK_THROW(Opm::data::RegionVariableView(std::span{x}, descr),
+                      std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(Size_Mismatch_2)
+{
+    const auto descr = descriptor(5);
+    const auto x = iota<std::size_t>(descr.numVariableSlots());
+
+    BOOST_CHECK_THROW(Opm::data::RegionVariableView(std::span{x}.subspan(0, 1), descr),
+                      std::logic_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_RegSet
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Multiple_Regsets)
+
+namespace {
+
+    Opm::data::RegionsetVariableDescriptor descriptor(const int maxID)
+    {
+        auto descr = Opm::data::RegionsetVariableDescriptor{};
+
+        descr.prepareDescriptorSet();
+        descr.addRegionSet(maxID / 2);
+        descr.addRegionSet(maxID);
+        descr.finaliseDescriptorSet();
+
+        return descr;
+    }
+
+    template <typename Elm>
+    std::vector<Elm> concat(std::vector<Elm>&& a, std::vector<Elm>&& b)
+    {
+        a.insert(a.end(),
+                 std::make_move_iterator(b.begin()),
+                 std::make_move_iterator(b.end()));
+
+        return a;
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Read_Only_Float)
+{
+    const auto descr = descriptor(5); // { Max ID 2, Max ID 5 }
+
+    const auto x = concat(iota<float>(2 + 1), reverse(iota<float>(5 + 1)));
+
+    const auto vals = Opm::data::RegionVariableView {
+        std::span{x}, descr
+    };
+
+    BOOST_CHECK_CLOSE(vals.element(0, 0), 0.0f, 1.0e-6f);
+    BOOST_CHECK_CLOSE(vals.element(0, 1), 1.0f, 1.0e-6f);
+    BOOST_CHECK_CLOSE(vals.element(0, 2), 2.0f, 1.0e-6f);
+
+    BOOST_CHECK_CLOSE(vals.element(1, 0), 5.0f, 1.0e-6f);
+    BOOST_CHECK_CLOSE(vals.element(1, 1), 4.0f, 1.0e-6f);
+    BOOST_CHECK_CLOSE(vals.element(1, 2), 3.0f, 1.0e-6f);
+    BOOST_CHECK_CLOSE(vals.element(1, 3), 2.0f, 1.0e-6f);
+    BOOST_CHECK_CLOSE(vals.element(1, 4), 1.0f, 1.0e-6f);
+    BOOST_CHECK_CLOSE(vals.element(1, 5), 0.0f, 1.0e-6f);
+}
+
+BOOST_AUTO_TEST_CASE(Read_Write_Integer)
+{
+    const auto descr = descriptor(6); // { Max ID 3, Max ID 6 }
+
+    auto x = std::vector {
+        271828, -31, 41592, 1729,
+        1, -2, 3, -4, 5, -6, -42,
+    };
+
+    auto vals = Opm::data::RegionVariableView {
+        std::span{x}, descr
+    };
+
+    BOOST_CHECK_EQUAL(vals.element(0, 0),  271828);
+    BOOST_CHECK_EQUAL(vals.element(0, 1), -    31);
+    BOOST_CHECK_EQUAL(vals.element(0, 2),   41592);
+    BOOST_CHECK_EQUAL(vals.element(0, 3),    1729);
+
+    BOOST_CHECK_EQUAL(vals.element(1, 0),   1);
+    BOOST_CHECK_EQUAL(vals.element(1, 1), - 2);
+    BOOST_CHECK_EQUAL(vals.element(1, 2),   3);
+    BOOST_CHECK_EQUAL(vals.element(1, 3), - 4);
+    BOOST_CHECK_EQUAL(vals.element(1, 4),   5);
+    BOOST_CHECK_EQUAL(vals.element(1, 5), - 6);
+    BOOST_CHECK_EQUAL(vals.element(1, 6), -42);
+
+    // --------------------------------------------------
+
+    vals.element(0, 2) = 112233;
+    vals.element(1, 0) = 445566;
+    vals.element(0, 1) =   1618;
+
+    const auto expect = std::vector {
+        271828, 1618, 112233, 1729,
+        445566, -2, 3, -4, 5, -6, -42,
+    };
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(x     .begin(), x     .end(),
+                                  expect.begin(), expect.end());
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Multiple_Regsets


### PR DESCRIPTION
This PR introduces a new span-like view over a range of elements assumed to correspond to a single region level summary vector. Individual elements are identified by a linear region set index, typically managed by class `RegionVariableMapping` (#5274), and region ID within the corresponding region set.

If the view is over a range of constant values then we provide read-only access.  Conversely, if the view is over a range of mutable values then we additional provide read-write access to individual elements.