### PR TITLE
Add Manager Class for Region Level Summary Variables

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -428,6 +428,7 @@ list(APPEND MAIN_SOURCE_FILES
   opm/output/eclipse/LinearisedOutputTable.cpp
   opm/output/eclipse/LoadRestart.cpp
   opm/output/eclipse/LogiHEAD.cpp
+  opm/output/eclipse/RegionVariableCollection.cpp
   opm/output/eclipse/RestartIO.cpp
   opm/output/eclipse/Inplace.cpp
   opm/output/eclipse/Summary.cpp
@@ -554,6 +555,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/test_PAvgCalculator.cpp
   tests/test_PAvgDynamicSourceData.cpp
   tests/test_regionCache.cpp
+  tests/test_region_variable_collection.cpp
   tests/test_RegionSetMatcher.cpp
   tests/test_Restart.cpp
   tests/test_RestartFileView.cpp
@@ -1536,6 +1538,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/output/eclipse/LgrHEADQ.hpp
   opm/output/eclipse/LinearisedOutputTable.hpp
   opm/output/eclipse/LogiHEAD.hpp
+  opm/output/eclipse/RegionVariableCollection.hpp
   opm/output/eclipse/RegionCache.hpp
   opm/output/eclipse/RestartIO.hpp
   opm/output/eclipse/RestartValue.hpp

--- a/opm/output/eclipse/RegionVariableCollection.cpp
+++ b/opm/output/eclipse/RegionVariableCollection.cpp
@@ -1,0 +1,179 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/output/eclipse/RegionVariableCollection.hpp>
+
+#include <opm/output/data/RegionsetVariableDescriptor.hpp>
+#include <opm/output/data/RegionVariableValues.hpp>
+#include <opm/output/data/RegionVariableView.hpp>
+
+#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+Opm::RegionVariableCollection::
+RegionVariableCollection(std::unique_ptr<data::RegionsetVariableDescriptor> descr,
+                         std::unique_ptr<data::RegionVariableValues>        vals)
+    : descr_ { std::move(descr) }
+    , vals_  { std::move(vals)  }
+{}
+
+Opm::RegionVariableCollection::
+RegionVariableCollection(const RegionVariableCollection& rhs)
+    : descr_  { rhs.descr_->clone() }
+    , vals_   { rhs.vals_->clone()  }
+    , regSet_ { rhs.regSet_         }
+{}
+
+Opm::RegionVariableCollection::
+RegionVariableCollection(RegionVariableCollection&& rhs) = default;
+
+Opm::RegionVariableCollection&
+Opm::RegionVariableCollection::operator=(const RegionVariableCollection& rhs)
+{
+    this->descr_  = rhs.descr_->clone();
+    this->vals_   = rhs.vals_->clone();
+    this->regSet_ = rhs.regSet_;
+
+    return *this;
+}
+
+Opm::RegionVariableCollection&
+Opm::RegionVariableCollection::operator=(RegionVariableCollection&& rhs) = default;
+
+Opm::RegionVariableCollection::~RegionVariableCollection() = default;
+
+void
+Opm::RegionVariableCollection::
+initialise(const int                          declaredMaxRegID,
+           const FieldPropsManager&           fpMgr,
+           const data::RegionVariableMapping& rvarMap)
+{
+    this->initialiseRegionDescriptors(declaredMaxRegID, fpMgr, rvarMap);
+
+    this->initialiseRegionValues(rvarMap);
+}
+
+void
+Opm::RegionVariableCollection::
+addCellValue(const std::size_t var_ix,
+             const std::size_t cell_ix,
+             const double      x)
+{
+    auto regset_ix = std::size_t{0};
+
+    // FIELD => region_ix == 0.
+    this->vals_->addRegionValue(var_ix, regset_ix, /* region_ix = */ 0, x);
+
+    for (; regset_ix < this->regSet_.size(); ++regset_ix) {
+        this->vals_->addRegionValue(var_ix, regset_ix + 1, // +1 for FIELD
+                                    this->regSet_[regset_ix][cell_ix],
+                                    x);
+    }
+}
+
+void
+Opm::RegionVariableCollection::prepareValueAccumulation()
+{
+    this->vals_->prepareValueAccumulation();
+}
+
+void
+Opm::RegionVariableCollection::commitValues()
+{
+    this->vals_->commitValues();
+}
+
+std::optional<std::size_t>
+Opm::RegionVariableCollection::
+regionSetIndex(const data::RegionVariableMapping& varMap,
+               const std::string&                 regionSet) const
+{
+    if (regionSet == "FIELD") {
+        return { std::size_t{0} };
+    }
+
+    auto i = varMap.index(data::RegionVariableMapping::RegionSet { regionSet });
+    if (! i.has_value()) {
+        return {};
+    }
+
+    // Note: 1+ to account for internal representation of "FIELD".
+    return { 1 + *i };
+}
+
+std::optional<std::size_t>
+Opm::RegionVariableCollection::
+variableIndex(const data::RegionVariableMapping& varMap,
+              const std::string&                 variable) const
+{
+    return varMap.index(data::RegionVariableMapping::Variable { variable });
+}
+
+const Opm::data::RegionVariableValues&
+Opm::RegionVariableCollection::regionVariableValues() const
+{
+    return *this->vals_;
+}
+
+// ===========================================================================
+// Private member functions below separator
+// ===========================================================================
+
+void
+Opm::RegionVariableCollection::
+initialiseRegionDescriptors(const int                          declaredMaxRegID,
+                            const FieldPropsManager&           fpMgr,
+                            const data::RegionVariableMapping& rvarMap)
+{
+    this->descr_->prepareDescriptorSet();
+
+    this->regSet_.clear();
+
+    if (rvarMap.numVariables() > 0) {
+        // FIELD
+        this->descr_->addRegionSet(0);
+
+        for (const auto& regset : rvarMap.regionSets()) {
+            const auto& regIDs = fpMgr.get_int(regset);
+
+            this->regSet_.emplace_back(regIDs);
+
+            this->descr_->addRegionSet(declaredMaxRegID, regIDs);
+        }
+    }
+
+    this->descr_->finaliseDescriptorSet();
+}
+
+void Opm::RegionVariableCollection::
+initialiseRegionValues(const data::RegionVariableMapping& rvarMap)
+{
+    auto is_cumulative = std::vector<bool>(rvarMap.numVariables(), false);
+
+    for (std::size_t varIx = 0; varIx < is_cumulative.size(); ++varIx) {
+        is_cumulative[varIx] = rvarMap.isCumulative
+            (data::RegionVariableMapping::VariableIdx { varIx });
+    }
+
+    this->vals_->defineVariables(*this->descr_, is_cumulative);
+}

--- a/opm/output/eclipse/RegionVariableCollection.hpp
+++ b/opm/output/eclipse/RegionVariableCollection.hpp
@@ -1,0 +1,226 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_OUTPUT_REGION_VARIABLE_COLLECTION_HPP
+#define OPM_OUTPUT_REGION_VARIABLE_COLLECTION_HPP
+
+#include <opm/output/data/RegionVariableMapping.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace Opm {
+    class FieldPropsManager;
+} // namespace Opm
+
+namespace Opm::data {
+    class RegionsetVariableDescriptor;
+    class RegionVariableValues;
+} // namespace Opm::data
+
+/// \file Component that gives a view into a sequence of (numerical) values
+/// keyed by region sets and region indices.
+
+namespace Opm {
+
+    /// Management structure for the numerical values of all region level
+    /// variables for all region sets.
+    class RegionVariableCollection
+    {
+    public:
+        /// Constructor.
+        ///
+        /// \param[in] descr Empty container of region sets.  Typically a
+        /// default-constructed object (\code make_unique<>() \endcode) of
+        /// type \c RegionsetVariableDescriptor or a type derived from this.
+        ///
+        /// \param[in] vals Empty container of variable values.  Typically
+        /// a default-constructed object (\code make_unique<>() \endcode) of
+        /// type \c RegionVariableValues or a type derived from this.
+        explicit RegionVariableCollection(std::unique_ptr<data::RegionsetVariableDescriptor> descr,
+                                          std::unique_ptr<data::RegionVariableValues>        vals);
+
+        /// Copy constructor.
+        ///
+        /// \param[in] rhs Source object from which to form an independent
+        /// copy.
+        RegionVariableCollection(const RegionVariableCollection& rhs);
+
+        /// Move constructor.
+        ///
+        /// \param[in,out] rhs Source object from which to form a new
+        /// object.  Left in an empty state on return from the move
+        /// constructor.
+        RegionVariableCollection(RegionVariableCollection&& rhs);
+
+        /// Destructor.
+        ~RegionVariableCollection();
+
+        /// Assignment operator.
+        ///
+        /// \param[in] rhs Source object whose value will overwrite \code
+        /// *this \endcode.
+        ///
+        /// \return *this.
+        RegionVariableCollection& operator=(const RegionVariableCollection& rhs);
+
+        /// Move-assignment operator.
+        ///
+        /// \param[in] rhs Source object which will be moved into \code
+        /// *this \endcode.  Left in an empty state on return from the move
+        /// constructor.
+        ///
+        /// \return *this.
+        RegionVariableCollection& operator=(RegionVariableCollection&& rhs);
+
+        /// Build internal structures and allocate value storage for all
+        /// variables and all region sets.
+        ///
+        /// \param[in] declaredMaxRegID Run's declared maximum region ID.
+        /// Typically entered in the TABDIMS or the REGDIMS keyword.
+        ///
+        /// \param[in] fpMgr Run's static properties, particularly the
+        /// region definition arrays such as FIPNUM.  Note that this
+        /// RegionVariableCollection object will store iterators to the
+        /// region definition arrays so the \p fpMgr must outlive the
+        /// RegionVariableCollection.
+        ///
+        /// \param[in] rvarMap Mapping from named region sets and named
+        /// region variables to numeric indices.
+        void initialise(const int                          declaredMaxRegID,
+                        const FieldPropsManager&           fpMgr,
+                        const data::RegionVariableMapping& rvarMap);
+
+        /// Add contribution to a single variable for all region sets.
+        ///
+        /// \param[in] var_ix Variable index.  Assumed to be in the range
+        /// \code 0..rvarMap.numVariables()-1 \endcode with \c rvarMap being
+        /// the mapping object passed to initialise().
+        ///
+        /// \param[in] cell_ix Active cell index to which to attribute this
+        /// cell level contribution.
+        ///
+        /// \param[in] x Numerical value of cell level contribution to this
+        /// region level variable.
+        void addCellValue(const std::size_t var_ix,
+                          const std::size_t cell_ix,
+                          const double      x);
+
+        /// Prepare internal value arrays for accumulating
+        /// per-variable/per-region values.
+        ///
+        /// Essentially zeroes an internal increment buffer.
+        ///
+        /// Must be called before the first call to addCellValue().
+        void prepareValueAccumulation();
+
+        /// Aggregate current increments into internal value array.
+        ///
+        /// Adds increment values for cumulative quantities and overwrites
+        /// current values for non-cumulative quantities.
+        ///
+        /// Must be called after the last call to addCellValue().
+        void commitValues();
+
+        /// Translate region set name to numeric region set identifier.
+        ///
+        /// Knows about special purpose "FIELD" region set.
+        ///
+        /// \param[in] varMap Mapping from named region sets and named
+        /// region variables to numeric indices.  Must be the same mapping
+        /// object used to initialise() this RegionVariableCollection.
+        ///
+        /// \param[in] regionSet Region set name.  Should be one of the
+        /// region sets registered in the \p varMap or the special purpose
+        /// region set named "FIELD".
+        ///
+        /// \return Numeric region set identifier.  Nullopt if \p regionSet
+        /// does not exist in \p varMap and is not "FIELD".
+        std::optional<std::size_t>
+        regionSetIndex(const data::RegionVariableMapping& varMap,
+                       const std::string&                 regionSet) const;
+
+        /// Translate region variable name to numeric region variable
+        /// identifier.
+        ///
+        /// \param[in] varMap Mapping from named region sets and named
+        /// region variables to numeric indices.  Must be the same mapping
+        /// object used to initialise() this RegionVariableCollection.
+        ///
+        /// \param[in] variable Region variable name.  Should be one of the
+        /// region variables registered in the \p varMap.
+        ///
+        /// \return Numeric region variable identifier.  Nullopt if \p
+        /// variable does not exist in \p varMap.
+        std::optional<std::size_t>
+        variableIndex(const data::RegionVariableMapping& varMap,
+                      const std::string&                 variable) const;
+
+        /// Current numerical values of all region level variables for all
+        /// known region sets.
+        const data::RegionVariableValues& regionVariableValues() const;
+
+    private:
+        /// Region sets.
+        std::unique_ptr<data::RegionsetVariableDescriptor> descr_{};
+
+        /// Numerical values of all variables for all region sets.
+        std::unique_ptr<data::RegionVariableValues> vals_{};
+
+        /// Region IDs.
+        ///
+        /// One entry for each region set registered in the variable mapping
+        /// passed to initialise().
+        std::vector<std::span<const int>> regSet_{};
+
+        /// Construct region set descriptor and region ID sequences.
+        ///
+        /// Writes to \code descr_ \endcode and \code regSet_ \endcode.
+        ///
+        /// \param[in] declaredMaxRegID Run's declared maximum region ID.
+        /// Typically entered in the TABDIMS or the REGDIMS keyword.
+        ///
+        /// \param[in] fpMgr Run's static properties, particularly the
+        /// region definition arrays such as FIPNUM.  Note that this
+        /// RegionVariableCollection object will store iterators to the
+        /// region definition arrays so the \p fpMgr must outlive the
+        /// RegionVariableCollection.
+        ///
+        /// \param[in] rvarMap Mapping from named region sets and named
+        /// region variables to numeric indices.
+        void initialiseRegionDescriptors(const int                          declaredMaxRegID,
+                                         const FieldPropsManager&           fpMgr,
+                                         const data::RegionVariableMapping& rvarMap);
+
+        /// Construct region variable value object
+        ///
+        /// Writes to \code vals_ \endcode
+        ///
+        /// \param[in] rvarMap Mapping from named region sets and named
+        /// region variables to numeric indices.
+        void initialiseRegionValues(const data::RegionVariableMapping& rvarMap);
+    };
+
+} // namespace Opm
+
+#endif // OPM_OUTPUT_REGION_VARIABLE_COLLECTION_HPP

--- a/tests/test_region_variable_collection.cpp
+++ b/tests/test_region_variable_collection.cpp
@@ -1,0 +1,12530 @@
+/*
+  Copyright (c) 2026 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE Region_Variable_Collection
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/output/eclipse/RegionVariableCollection.hpp>
+
+#include <opm/output/data/RegionsetVariableDescriptor.hpp>
+#include <opm/output/data/RegionVariableMapping.hpp>
+#include <opm/output/data/RegionVariableValues.hpp>
+
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <memory>
+#include <optional>
+
+namespace {
+
+    Opm::EclipseState staticProperties()
+    {
+        return Opm::EclipseState {
+            Opm::Parser{}.parseString(R"(RUNSPEC
+DIMENS
+1 5 2 /
+OIL
+GAS
+WATER
+TABDIMS
+/
+
+GRID
+DXV
+100 /
+DYV
+5*100 /
+DZV
+2*10 /
+DEPTHZ
+12*2000 /
+EQUALS
+ PERMX 100 /
+ PERMY 100 /
+ PERMZ  10 /
+ PORO    0.3 /
+/
+
+PROPS
+DENSITY
+ 800 1000 1 /
+
+REGIONS
+FIPNUM
+ 5*1 5*2 /
+FIPABC
+ 1 1 3 3 2
+ 1 1 3 3 2 /
+END
+)")
+        };
+    }
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Single_Regset)
+
+namespace {
+
+    Opm::data::RegionVariableMapping mapping(const std::string& regset = "FIPNUM")
+    {
+        auto varMap = Opm::data::RegionVariableMapping{};
+
+        varMap.prepareRegistration();
+
+        varMap.add(Opm::data::RegionVariableMapping::RegionSet { regset });
+
+        return varMap;
+    }
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Non_Cumulative)
+
+BOOST_AUTO_TEST_SUITE(Single_Var)
+
+BOOST_AUTO_TEST_SUITE(Single_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(1, 0), 0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2), 0.0 , 1.0e-8); // FIPNUM == 2
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 4 * 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 4 * 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2),     0.0 , 1.0e-8); // FIPNUM == 2
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 2 * 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 1 * 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 1.23, 1.0e-8); // FIPNUM == 2
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping("FIPABC");
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 6 * 1.23, 1.0e-8);
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0 , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 3 * 1.23, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 1.23, 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(1, 3), 2 * 1.23, 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Accumulation
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Multi_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 4.56, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(1, 0), 0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 4.56, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2), 0.0 , 1.0e-8); // FIPNUM == 2
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 4 * 4.56, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 4 * 4.56, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2),     0.0 , 1.0e-8); // FIPNUM == 2
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 2 * 4.56, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 1 * 4.56, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 4.56, 1.0e-8); // FIPNUM == 2
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping("FIPABC");
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 6 * 4.56, 1.0e-8);
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0 , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 3 * 4.56, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 4.56, 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(1, 3), 2 * 4.56, 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Accumulation
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Var
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Multi_Var)
+
+BOOST_AUTO_TEST_SUITE(Single_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 4.4, 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // -----------------------------------------------------------------
+
+    coll.commitValues();
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 4 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 4 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2),     0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 4 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 4 * 2.2, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 4 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 4 * 3.3, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 4 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 4 * 4.4, 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 2 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 1 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 1.1, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 2 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 1 * 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 1 * 2.2, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 2 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 1 * 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 1 * 3.3, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 2 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 1 * 4.4, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 1 * 4.4, 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping("FIPABC");
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 6 * 1.1, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 3 * 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 1.1, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(1, 3), 2 * 1.1, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 6 * 2.2, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 3 * 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 1 * 2.2, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(1, 3), 2 * 2.2, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 6 * 3.3, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 3 * 3.3, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 1 * 3.3, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(1, 3), 2 * 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 6 * 4.4, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 3 * 4.4, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 1 * 4.4, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(1, 3), 2 * 4.4, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Accumulation
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Multi_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 5.5, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 5.5, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 8.8, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 8.8, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 4 * 5.5, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 4 * 5.5, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2),     0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 4 * 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 4 * 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2),     0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 4 * 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 4 * 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2),     0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 4 * 8.8, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 4 * 8.8, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2),     0.0, 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 2 * 5.5, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 1 * 5.5, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 5.5, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 2 * 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 1 * 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 1 * 6.6, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 2 * 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 1 * 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 1 * 7.7, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 2 * 8.8, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 1 * 8.8, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 1 * 8.8, 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping("FIPABC");
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 6 * 5.5, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 3 * 5.5, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 5.5, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(1, 3), 2 * 5.5, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 6 * 6.6, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 3 * 6.6, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 1 * 6.6, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(1, 3), 2 * 6.6, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 6 * 7.7, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 3 * 7.7, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 1 * 7.7, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(1, 3), 2 * 7.7, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 6 * 8.8, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 3 * 8.8, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 1 * 8.8, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(1, 3), 2 * 8.8, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Accumulation
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Var
+
+BOOST_AUTO_TEST_SUITE_END()     // Non_Cumulative
+
+// ###########################################################################
+
+BOOST_AUTO_TEST_SUITE(Cumulative)
+
+BOOST_AUTO_TEST_SUITE(Single_Var)
+
+BOOST_AUTO_TEST_SUITE(Single_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(1, 0), 0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2), 0.0 , 1.0e-8); // FIPNUM == 2
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 4 * 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 4 * 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2),     0.0 , 1.0e-8); // FIPNUM == 2
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 2 * 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 1 * 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 1.23, 1.0e-8); // FIPNUM == 2
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping("FIPABC");
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 6 * 1.23, 1.0e-8);
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0 , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 3 * 1.23, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 1.23, 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(1, 3), 2 * 1.23, 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Accumulation
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Multi_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 1.23 + 4.56, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(1, 0), 0.0        , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 1.23 + 4.56, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2), 0.0        , 1.0e-8); // FIPNUM == 2
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 4 * (1.23 + 4.56), 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0          , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 4 * (1.23 + 4.56), 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2),     0.0          , 1.0e-8); // FIPNUM == 2
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 2 * (1.23 + 4.56), 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0          , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 1 * (1.23 + 4.56), 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * (1.23 + 4.56), 1.0e-8); // FIPNUM == 2
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping("FIPABC");
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto v1 = coll.regionVariableValues().values(0);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(0, 0), 6 * (1.23 + 4.56), 1.0e-8);
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0          , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(1, 1), 3 * (1.23 + 4.56), 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * (1.23 + 4.56), 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(1, 3), 2 * (1.23 + 4.56), 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Accumulation
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Var
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Multi_Var)
+
+BOOST_AUTO_TEST_SUITE(Single_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 4.4, 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // -----------------------------------------------------------------
+
+    coll.commitValues();
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 4 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 4 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2),     0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 4 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 4 * 2.2, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 4 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 4 * 3.3, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 4 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 4 * 4.4, 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 2 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 1 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 1.1, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 2 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 1 * 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 1 * 2.2, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 2 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 1 * 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 1 * 3.3, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 2 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 1 * 4.4, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 1 * 4.4, 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping("FIPABC");
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 6 * 1.1, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 3 * 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 1.1, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(1, 3), 2 * 1.1, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 6 * 2.2, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 3 * 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 1 * 2.2, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(1, 3), 2 * 2.2, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 6 * 3.3, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 3 * 3.3, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 1 * 3.3, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(1, 3), 2 * 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 6 * 4.4, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 3 * 4.4, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 1 * 4.4, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(1, 3), 2 * 4.4, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Accumulation
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Multi_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 0.11 + 5.5, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0), 0.0       , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 0.11 + 5.5, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 0.0       , 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 0.22 + 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0), 0.0       , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 0.22 + 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 0.0       , 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 0.33 + 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0), 0.0       , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 0.33 + 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 0.0       , 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 0.44 + 8.8, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0), 0.0       , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 0.44 + 8.8, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 0.0       , 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.11);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.22);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.33);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 4 * (0.11 + 5.5), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 4 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2),     0.0         , 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 4 * (0.22 + 6.6), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 4 * (0.22 + 6.6), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2),     0.0         , 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 4 * (0.33 + 7.7), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 4 * (0.33 + 7.7), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2),     0.0         , 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 4 * (0.44 + 8.8), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 4 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2),     0.0         , 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.11);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.22);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.33);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 2 * (0.11 + 5.5), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 1 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 2 * (0.22 + 6.6), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 1 * (0.22 + 6.6), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 1 * (0.22 + 6.6), 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 2 * (0.33 + 7.7), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 1 * (0.33 + 7.7), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 1 * (0.33 + 7.7), 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 2 * (0.44 + 8.8), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 1 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 1 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping("FIPABC");
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.11);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.22);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.33);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 6 * (0.11 + 5.5), 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 3 * (0.11 + 5.5), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * (0.11 + 5.5), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(1, 3), 2 * (0.11 + 5.5), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 6 * (0.22 + 6.6), 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 3 * (0.22 + 6.6), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 1 * (0.22 + 6.6), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(1, 3), 2 * (0.22 + 6.6), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 6 * (0.33 + 7.7), 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 3 * (0.33 + 7.7), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 1 * (0.33 + 7.7), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(1, 3), 2 * (0.33 + 7.7), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 6 * (0.44 + 8.8), 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 3 * (0.44 + 8.8), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 1 * (0.44 + 8.8), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(1, 3), 2 * (0.44 + 8.8), 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Accumulation
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Var
+
+BOOST_AUTO_TEST_SUITE_END()     // Cumulative
+
+// ###########################################################################
+
+BOOST_AUTO_TEST_SUITE(Mix_Var_Type)
+
+BOOST_AUTO_TEST_SUITE(Single_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 4.4, 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // -----------------------------------------------------------------
+
+    coll.commitValues();
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 4 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 4 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2),     0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 4 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 4 * 2.2, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 4 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 4 * 3.3, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 4 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 4 * 4.4, 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 2 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 1 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 1.1, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 2 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 1 * 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 1 * 2.2, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 2 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 1 * 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 1 * 3.3, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 2 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 1 * 4.4, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 1 * 4.4, 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping("FIPABC");
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 6 * 1.1, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 3 * 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * 1.1, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(1, 3), 2 * 1.1, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 6 * 2.2, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 3 * 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 1 * 2.2, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(1, 3), 2 * 2.2, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 6 * 3.3, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 3 * 3.3, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 1 * 3.3, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(1, 3), 2 * 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 6 * 4.4, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 3 * 4.4, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 1 * 4.4, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(1, 3), 2 * 4.4, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Accumulation
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Multi_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 0.11 + 5.5, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0), 0.0       , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 0.11 + 5.5, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 0.0       , 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 0.44 + 8.8, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0), 0.0       , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 0.44 + 8.8, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 0.0       , 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.11);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.22);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.33);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 4 * (0.11 + 5.5), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 4 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2),     0.0         , 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 4 * 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 4 * 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2),     0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 4 * 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 4 * 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2),     0.0, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 4 * (0.44 + 8.8), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 4 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2),     0.0         , 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.11);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.22);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.33);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 2 * (0.11 + 5.5), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 1 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 2 * 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 1 * 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 1 * 6.6, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 2 * 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 1 * 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 1 * 7.7, 1.0e-8); // FIPNUM == 2
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 2 * (0.44 + 8.8), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 1 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 1 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 2
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping("FIPABC");
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.11);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.22);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.33);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    {
+        const auto v1 = coll.regionVariableValues().values(0);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(0, 0), 6 * (0.11 + 5.5), 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(1, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(1, 1), 3 * (0.11 + 5.5), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(1, 2), 1 * (0.11 + 5.5), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(1, 3), 2 * (0.11 + 5.5), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v2 = coll.regionVariableValues().values(1);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(0, 0), 6 * 6.6, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(1, 1), 3 * 6.6, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(1, 2), 1 * 6.6, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(1, 3), 2 * 6.6, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v3 = coll.regionVariableValues().values(2);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(0, 0), 6 * 7.7, 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(1, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(1, 1), 3 * 7.7, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(1, 2), 1 * 7.7, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(1, 3), 2 * 7.7, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto v4 = coll.regionVariableValues().values(3);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(0, 0), 6 * (0.44 + 8.8), 1.0e-8);
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(1, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(1, 1), 3 * (0.44 + 8.8), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(1, 2), 1 * (0.44 + 8.8), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(1, 3), 2 * (0.44 + 8.8), 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Accumulation
+
+BOOST_AUTO_TEST_SUITE_END()     // Mix_Var_Type
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Regset
+
+// ///////////////////////////////////////////////////////////////////////////
+// ###########################################################################
+// ///////////////////////////////////////////////////////////////////////////
+
+BOOST_AUTO_TEST_SUITE(Two_Regsets)
+
+namespace {
+
+    Opm::data::RegionVariableMapping mapping()
+    {
+        auto varMap = Opm::data::RegionVariableMapping{};
+
+        varMap.prepareRegistration();
+
+        varMap.add(Opm::data::RegionVariableMapping::RegionSet { "FIPNUM" });
+        varMap.add(Opm::data::RegionVariableMapping::RegionSet { "FIPABC" });
+
+        return varMap;
+    }
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Non_Cumulative)
+
+BOOST_AUTO_TEST_SUITE(Single_Var)
+
+BOOST_AUTO_TEST_SUITE(Single_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0), 0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 0.0 , 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0), 0.0 , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1.23, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 0.0 , 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 0.0 , 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 4 * 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 4 * 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2),     0.0 , 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0), 0.0     , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 2 * 1.23, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 1.23, 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * 1.23, 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 2 * 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 1 * 1.23, 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0), 0.0     , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1 * 1.23, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 0.0     , 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * 1.23, 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 6 * 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 5 * 1.23, 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0 , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 3 * 1.23, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 1.23, 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 2 * 1.23, 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Accumulation
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Multi_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 4.56, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0), 0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 4.56, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 0.0 , 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0), 0.0 , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 4.56, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 0.0 , 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 0.0 , 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 4 * 4.56, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 4 * 4.56, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2),     0.0 , 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0 , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 2 * 4.56, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 4.56, 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 4.56, 1.0e-8); // FIPABC == 2
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 2 * 4.56, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 4.56, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 1 * 4.56, 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0 , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1 * 4.56, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2),     0.0 , 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * 4.56, 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 6 * 4.56, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 4.56, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 5 * 4.56, 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0 , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 3 * 4.56, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 4.56, 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 2 * 4.56, 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Accumulation
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Var
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Multi_Var)
+
+BOOST_AUTO_TEST_SUITE(Single_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 0.0, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 4.4, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 0.0, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 4.4, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // -----------------------------------------------------------------
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 4 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 4 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2),     0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 2 * 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 1.1, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 1.1, 1.0e-8); // FIPABC == 2
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 4 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 4 * 2.2, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 2 * 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 1 * 2.2, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 1 * 2.2, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 4 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 4 * 3.3, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 2 * 3.3, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 1 * 3.3, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 1 * 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 4 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 4 * 4.4, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 2 * 4.4, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 1 * 4.4, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 1 * 4.4, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 2 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 1 * 1.1, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1 * 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * 1.1, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 2 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 1 * 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 1 * 2.2, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 1 * 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 1 * 2.2, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 2 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 1 * 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 1 * 3.3, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 1 * 3.3, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 1 * 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 2 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 1 * 4.4, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 1 * 4.4, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 1 * 4.4, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 1 * 4.4, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 6 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 5 * 1.1, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 3 * 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 1.1, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 2 * 1.1, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 6 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 1 * 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 5 * 2.2, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 3 * 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 1 * 2.2, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 2 * 2.2, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 6 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 1 * 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 5 * 3.3, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 3 * 3.3, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 1 * 3.3, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 2 * 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 6 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 1 * 4.4, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 5 * 4.4, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 3 * 4.4, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 1 * 4.4, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 2 * 4.4, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Accumulation
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Multi_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 5.5, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 5.5, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 5.5, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 6.6, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 7.7, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 8.8, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 8.8, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 8.8, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 4 * 5.5, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 4 * 5.5, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2),     0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 2 * 5.5, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 5.5, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * 5.5, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 4 * 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 4 * 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2),     0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 2 * 6.6, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 1 * 6.6, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 1 * 6.6, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 4 * 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 4 * 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2),     0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 2 * 7.7, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 1 * 7.7, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 1 * 7.7, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 4 * 8.8, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 4 * 8.8, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2),     0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 2 * 8.8, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 1 * 8.8, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 1 * 8.8, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 2 * 5.5, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 5.5, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 1 * 5.5, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1 * 5.5, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * 5.5, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 2 * 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 1 * 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 1 * 6.6, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 1 * 6.6, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 1 * 6.6, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 2 * 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 1 * 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 1 * 7.7, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 1 * 7.7, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 1 * 7.7, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 2 * 8.8, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 1 * 8.8, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 1 * 8.8, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 1 * 8.8, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 1 * 8.8, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 6 * 5.5, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 5.5, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 5 * 5.5, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 3 * 5.5, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 5.5, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 2 * 5.5, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 6 * 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 1 * 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 5 * 6.6, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 3 * 6.6, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 1 * 6.6, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 2 * 6.6, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 6 * 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 1 * 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 5 * 7.7, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 3 * 7.7, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 1 * 7.7, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 2 * 7.7, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 6 * 8.8, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 1 * 8.8, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 5 * 8.8, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 3 * 8.8, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 1 * 8.8, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 2 * 8.8, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Accumulation
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Var
+
+BOOST_AUTO_TEST_SUITE_END()     // Non_Cumulative
+
+// ###########################################################################
+
+BOOST_AUTO_TEST_SUITE(Cumulative)
+
+BOOST_AUTO_TEST_SUITE(Single_Var)
+
+BOOST_AUTO_TEST_SUITE(Single_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    // -----------------------------------------------------------------
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0), 0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 0.0 , 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0), 0.0 , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1.23, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 0.0 , 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 0.0 , 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.23);
+
+    // -----------------------------------------------------------------
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 4 * 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 4 * 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2),     0.0 , 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0 , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 2 * 1.23, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 1.23, 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * 1.23, 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    // -----------------------------------------------------------------
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 2 * 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 1 * 1.23, 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0 , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1 * 1.23, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2),     0.0 , 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * 1.23, 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    coll.prepareValueAccumulation();
+
+    const auto& grid = es.getInputGrid();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.23);
+
+    // -----------------------------------------------------------------
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 6 * 1.23, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0 , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 1.23, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 5 * 1.23, 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0 , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 3 * 1.23, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 1.23, 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 2 * 1.23, 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Accumulation
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Multi_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 1.23 + 4.56, 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0), 0.0        , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1.23 + 4.56, 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 0.0        , 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0), 0.0        , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1.23 + 4.56, 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 0.0        , 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 0.0        , 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 4 * (1.23 + 4.56), 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0          , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 4 * (1.23 + 4.56), 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2),     0.0          , 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0          , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 2 * (1.23 + 4.56), 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * (1.23 + 4.56), 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * (1.23 + 4.56), 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 2 * (1.23 + 4.56), 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0          , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * (1.23 + 4.56), 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 1 * (1.23 + 4.56), 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0          , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1 * (1.23 + 4.56), 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2),     0.0          , 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * (1.23 + 4.56), 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.23);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.23);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.56);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 4.56);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    const auto iV1 = coll.variableIndex(varMap, "V1");
+
+    BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+    const auto v1 = coll.regionVariableValues().values(*iV1);
+
+    BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+    // FIELD
+    BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 6 * (1.23 + 4.56), 1.0e-8);
+
+    // FIPNUM
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0          , 1.0e-8); // FIPNUM == 0
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * (1.23 + 4.56), 1.0e-8); // FIPNUM == 1
+    BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 5 * (1.23 + 4.56), 1.0e-8); // FIPNUM == 2
+
+    // FIPABC
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0          , 1.0e-8); // FIPABC == 0
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 3 * (1.23 + 4.56), 1.0e-8); // FIPABC == 1
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * (1.23 + 4.56), 1.0e-8); // FIPABC == 2
+    BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 2 * (1.23 + 4.56), 1.0e-8); // FIPABC == 3
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Accumulation
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Var
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Multi_Var)
+
+BOOST_AUTO_TEST_SUITE(Single_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    // -----------------------------------------------------------------
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 0.0, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 4.4, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 0.0, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 4.4, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // -----------------------------------------------------------------
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 4 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 4 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2),     0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 2 * 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 1.1, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * 1.1, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 4 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 4 * 2.2, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 2 * 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 1 * 2.2, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 1 * 2.2, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 4 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 4 * 3.3, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 2 * 3.3, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 1 * 3.3, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 1 * 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 4 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 4 * 4.4, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 2 * 4.4, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 1 * 4.4, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 1 * 4.4, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    // -----------------------------------------------------------------
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 2 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 1 * 1.1, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1 * 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * 1.1, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 2 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 1 * 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 1 * 2.2, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 1 * 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 1 * 2.2, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 2 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 1 * 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 1 * 3.3, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 1 * 3.3, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 1 * 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 2 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 1 * 4.4, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 1 * 4.4, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 1 * 4.4, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 1 * 4.4, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 4.4);
+
+    // -----------------------------------------------------------------
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 6 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 5 * 1.1, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 3 * 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 1.1, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 2 * 1.1, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 6 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 1 * 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 5 * 2.2, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 3 * 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 1 * 2.2, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 2 * 2.2, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 6 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 1 * 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 5 * 3.3, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 3 * 3.3, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 1 * 3.3, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 2 * 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 6 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 1 * 4.4, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 5 * 4.4, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 3 * 4.4, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 1 * 4.4, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 2 * 4.4, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Accumulation
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Multi_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 0.11 + 5.5, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0), 0.0       , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 0.11 + 5.5, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 0.0       , 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0), 0.0       , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 0.11 + 5.5, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 0.0       , 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 0.0       , 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 0.22 + 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0), 0.0       , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 0.22 + 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 0.0       , 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0), 0.0       , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 0.22 + 6.6, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 0.0       , 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 0.0       , 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 0.33 + 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0), 0.0       , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 0.33 + 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 0.0       , 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0), 0.0       , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 0.33 + 7.7, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 0.0       , 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 0.0       , 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 0.44 + 8.8, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0), 0.0       , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 0.44 + 8.8, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 0.0       , 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0), 0.0       , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 0.44 + 8.8, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 0.0       , 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 0.0       , 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.11);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.22);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.33);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 4 * (0.11 + 5.5), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 4 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2),     0.0         , 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 2 * (0.11 + 5.5), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * (0.11 + 5.5), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * (0.11 + 5.5), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 4 * (0.22 + 6.6), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 4 * (0.22 + 6.6), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2),     0.0         , 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 2 * (0.22 + 6.6), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 1 * (0.22 + 6.6), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 1 * (0.22 + 6.6), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 4 * (0.33 + 7.7), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 4 * (0.33 + 7.7), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2),     0.0         , 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 2 * (0.33 + 7.7), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 1 * (0.33 + 7.7), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 1 * (0.33 + 7.7), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 4 * (0.44 + 8.8), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 4 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2),     0.0         , 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 2 * (0.44 + 8.8), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 1 * (0.44 + 8.8), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 1 * (0.44 + 8.8), 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.11);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.22);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.33);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 2 * (0.11 + 5.5), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 1 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1 * (0.11 + 5.5), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2),     0.0         , 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * (0.11 + 5.5), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 2 * (0.22 + 6.6), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 1 * (0.22 + 6.6), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 1 * (0.22 + 6.6), 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 1 * (0.22 + 6.6), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2),     0.0         , 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 1 * (0.22 + 6.6), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 2 * (0.33 + 7.7), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 1 * (0.33 + 7.7), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 1 * (0.33 + 7.7), 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 1 * (0.33 + 7.7), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2),     0.0         , 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 1 * (0.33 + 7.7), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 2 * (0.44 + 8.8), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 1 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 1 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 1 * (0.44 + 8.8), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2),     0.0         , 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 1 * (0.44 + 8.8), 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.11);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.22);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.33);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 6 * (0.11 + 5.5), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 5 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 3 * (0.11 + 5.5), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * (0.11 + 5.5), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 2 * (0.11 + 5.5), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 6 * (0.22 + 6.6), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 1 * (0.22 + 6.6), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 5 * (0.22 + 6.6), 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 3 * (0.22 + 6.6), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 1 * (0.22 + 6.6), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 2 * (0.22 + 6.6), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 6 * (0.33 + 7.7), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 1 * (0.33 + 7.7), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 5 * (0.33 + 7.7), 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 3 * (0.33 + 7.7), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 1 * (0.33 + 7.7), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 2 * (0.33 + 7.7), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 6 * (0.44 + 8.8), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 1 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 5 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 3 * (0.44 + 8.8), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 1 * (0.44 + 8.8), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 2 * (0.44 + 8.8), 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Accumulation
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Var
+
+BOOST_AUTO_TEST_SUITE_END()     // Cumulative
+
+// ###########################################################################
+
+BOOST_AUTO_TEST_SUITE(Mix_Var_Type)
+
+BOOST_AUTO_TEST_SUITE(Single_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 0.0, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 4.4, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 0.0, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 4.4, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // -----------------------------------------------------------------
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 4 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 4 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2),     0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 2 * 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 1.1, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * 1.1, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 4 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 4 * 2.2, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 2 * 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 1 * 2.2, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 1 * 2.2, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 4 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 4 * 3.3, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 2 * 3.3, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 1 * 3.3, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 1 * 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 4 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1),     0.0, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 4 * 4.4, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 2 * 4.4, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 1 * 4.4, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 1 * 4.4, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 2 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 1 * 1.1, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1 * 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * 1.1, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 2 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 1 * 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 1 * 2.2, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 1 * 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 1 * 2.2, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 2 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 1 * 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 1 * 3.3, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 1 * 3.3, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 1 * 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 2 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 1 * 4.4, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 1 * 4.4, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 1 * 4.4, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 1 * 4.4, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ false);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 1.1);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 1.1);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 2.2);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 2.2);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 3.3);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 3.3);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 4.4);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 4.4);
+
+    coll.commitValues();
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 6 * 1.1, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * 1.1, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 5 * 1.1, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 3 * 1.1, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * 1.1, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 2 * 1.1, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 6 * 2.2, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 1 * 2.2, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 5 * 2.2, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 3 * 2.2, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 1 * 2.2, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 2 * 2.2, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 6 * 3.3, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 1 * 3.3, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 5 * 3.3, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 3 * 3.3, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 1 * 3.3, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 2 * 3.3, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 6 * 4.4, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 1 * 4.4, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 5 * 4.4, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 3 * 4.4, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 1 * 4.4, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 2 * 4.4, 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Accumulation
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Multi_Accumulation)
+
+BOOST_AUTO_TEST_CASE(Single_Assign)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 0.11 + 5.5, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0), 0.0       , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 0.11 + 5.5, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 0.0       , 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0), 0.0       , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 0.11 + 5.5, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 0.0       , 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 0.0       , 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 6.6, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0), 0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0), 0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 7.7, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 0.0, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 0.44 + 8.8, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0), 0.0       , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 0.44 + 8.8, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 0.0       , 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0), 0.0       , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 0.44 + 8.8, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 0.0       , 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 0.0       , 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Single_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.11);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.22);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.33);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 0),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 4 * (0.11 + 5.5), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 4 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2),     0.0         , 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 2 * (0.11 + 5.5), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * (0.11 + 5.5), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * (0.11 + 5.5), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 4 * 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 4 * 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2),     0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 2 * 6.6, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 1 * 6.6, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 1 * 6.6, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 4 * 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 4 * 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2),     0.0, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 2 * 7.7, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 1 * 7.7, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 1 * 7.7, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 4 * (0.44 + 8.8), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 4 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2),     0.0         , 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 2 * (0.44 + 8.8), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 1 * (0.44 + 8.8), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 1 * (0.44 + 8.8), 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Single_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 2, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.11);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.22);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.33);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 2 * (0.11 + 5.5), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 1 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 1 * (0.11 + 5.5), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2),     0.0         , 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 1 * (0.11 + 5.5), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 2 * 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 1 * 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 1 * 6.6, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 1 * 6.6, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 1 * 6.6, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 2 * 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 1 * 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 1 * 7.7, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 1 * 7.7, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2),     0.0, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 1 * 7.7, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 2 * (0.44 + 8.8), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 1 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 1 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 1 * (0.44 + 8.8), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2),     0.0         , 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 1 * (0.44 + 8.8), 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Multi_Assign_Multi_Reg)
+{
+    // Recall: Lifetime of FieldPropsManager must exceed the "variable collection".
+    const auto es = staticProperties();
+
+    auto coll = Opm::RegionVariableCollection {
+        std::make_unique<Opm::data::RegionsetVariableDescriptor>(),
+        std::make_unique<Opm::data::RegionVariableValues>()
+    };
+
+    auto varMap = mapping();
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V1" }, /* cumulative = */ true);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V2" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V3" }, /* cumulative = */ false);
+    varMap.add(Opm::data::RegionVariableMapping::Variable { "V4" }, /* cumulative = */ true);
+
+    varMap.commitStructure();
+
+    coll.initialise(/* declaredMaxID = */ 0, es.fieldProps(), varMap);
+
+    const auto& grid = es.getInputGrid();
+
+    // -----------------------------------------------------------------
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.11);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.11);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.22);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.22);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.33);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.33);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 0.44);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 0.44);
+
+    coll.commitValues();
+
+    // =================================================================
+
+    coll.prepareValueAccumulation();
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 5.5);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 0,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 5.5);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 6.6);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 1,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 6.6);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 7.7);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 2,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 7.7);
+
+    // -----------------------------------------------------------------
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 0),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 2, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 2
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 4, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 1, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 1
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 0, 1),
+                      /* x       = */ 8.8);
+
+    // FIPABC = 3
+    coll.addCellValue(/* var_ix  = */ 3,
+                      /* cell_ix = */ grid.activeIndex(0, 3, 1),
+                      /* x       = */ 8.8);
+
+    coll.commitValues();
+
+    // -----------------------------------------------------------------
+
+    const auto iFLD = coll.regionSetIndex(varMap, "FIELD");
+    const auto iNUM = coll.regionSetIndex(varMap, "FIPNUM");
+    const auto iABC = coll.regionSetIndex(varMap, "FIPABC");
+
+    BOOST_REQUIRE_MESSAGE(iFLD.has_value(), R"(Pseudo-region set "FIELD" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iNUM.has_value(), R"(Region set "FIPNUM" must have an index)");
+    BOOST_REQUIRE_MESSAGE(iABC.has_value(), R"(Region set "FIPABC" must have an index)");
+
+    {
+        const auto iV1 = coll.variableIndex(varMap, "V1");
+
+        BOOST_REQUIRE_MESSAGE(iV1.has_value(), R"(Variable "V1" must have an index)");
+
+        const auto v1 = coll.regionVariableValues().values(*iV1);
+
+        BOOST_REQUIRE_MESSAGE(v1.has_value(), R"(Variable "V1" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v1->element(*iFLD, 0), 6 * (0.11 + 5.5), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 1), 1 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v1->element(*iNUM, 2), 5 * (0.11 + 5.5), 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 1), 3 * (0.11 + 5.5), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 2), 1 * (0.11 + 5.5), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v1->element(*iABC, 3), 2 * (0.11 + 5.5), 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV2 = coll.variableIndex(varMap, "V2");
+
+        BOOST_REQUIRE_MESSAGE(iV2.has_value(), R"(Variable "V2" must have an index)");
+
+        const auto v2 = coll.regionVariableValues().values(*iV2);
+
+        BOOST_REQUIRE_MESSAGE(v2.has_value(), R"(Variable "V2" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v2->element(*iFLD, 0), 6 * 6.6, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 1), 1 * 6.6, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v2->element(*iNUM, 2), 5 * 6.6, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 1), 3 * 6.6, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 2), 1 * 6.6, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v2->element(*iABC, 3), 2 * 6.6, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV3 = coll.variableIndex(varMap, "V3");
+
+        BOOST_REQUIRE_MESSAGE(iV3.has_value(), R"(Variable "V3" must have an index)");
+
+        const auto v3 = coll.regionVariableValues().values(*iV3);
+
+        BOOST_REQUIRE_MESSAGE(v3.has_value(), R"(Variable "V3" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v3->element(*iFLD, 0), 6 * 7.7, 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 0),     0.0, 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 1), 1 * 7.7, 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v3->element(*iNUM, 2), 5 * 7.7, 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 0),     0.0, 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 1), 3 * 7.7, 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 2), 1 * 7.7, 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v3->element(*iABC, 3), 2 * 7.7, 1.0e-8); // FIPABC == 3
+    }
+
+    {
+        const auto iV4 = coll.variableIndex(varMap, "V4");
+
+        BOOST_REQUIRE_MESSAGE(iV4.has_value(), R"(Variable "V4" must have an index)");
+
+        const auto v4 = coll.regionVariableValues().values(*iV4);
+
+        BOOST_REQUIRE_MESSAGE(v4.has_value(), R"(Variable "V4" must have defined values)");
+
+        // FIELD
+        BOOST_CHECK_CLOSE(v4->element(*iFLD, 0), 6 * (0.44 + 8.8), 1.0e-8);
+
+        // FIPNUM
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 0),     0.0         , 1.0e-8); // FIPNUM == 0
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 1), 1 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 1
+        BOOST_CHECK_CLOSE(v4->element(*iNUM, 2), 5 * (0.44 + 8.8), 1.0e-8); // FIPNUM == 2
+
+        // FIPABC
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 0),     0.0         , 1.0e-8); // FIPABC == 0
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 1), 3 * (0.44 + 8.8), 1.0e-8); // FIPABC == 1
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 2), 1 * (0.44 + 8.8), 1.0e-8); // FIPABC == 2
+        BOOST_CHECK_CLOSE(v4->element(*iABC, 3), 2 * (0.44 + 8.8), 1.0e-8); // FIPABC == 3
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Multi_Accumulation
+
+BOOST_AUTO_TEST_SUITE_END()     // Mix_Var_Type
+
+BOOST_AUTO_TEST_SUITE_END()     // Two_Regsets


### PR DESCRIPTION
This PR introduces a new manager-style class
```
RegionVariableCollection
```
which aggregates region set descriptors and variable values and distributes per-cell variable contributions to all pertinent region sets.  Client code is expected to create a single object of this class and initialise it with a populated region variable mapping. Then as needed, typically at the end of every converged time step, client code is expected to perform a value accumulation as follows:

1. Prepare this object for accumulation (`prepareValueAccumulation()`)
2. For each applicable variable and cell, include the per-cell contribution (`addCellValue()`).
3. Commit those contributions to compute the new variable values (`commitValues()`).

Once `commitValues()` has completed, client code may retrieve those new variable values through the `regionVariableValues()` member function.  The process of committing values may involve cross-rank MPI communication in parallel and will add to or overwrite the current values depending on whether the variable is declared cumulative.

We also include two helper functions,

* `regionSetIndex()`
* `variableIndex()`

which essentially just forward a query to the variable mapping object supplied as an argument.  The one exception is that `regionSetIndex()` knows that "FIELD" is a special region set pertaining to field-level quantities and will act accordingly.