### PR TITLE
Populate Region Variable Mapping From Summary Config

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -146,6 +146,7 @@ list(APPEND MAIN_SOURCE_FILES
   opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.cpp
   opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
   opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+  opm/input/eclipse/EclipseState/SummaryConfig/RegionVariableSupport.cpp
   opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
   opm/input/eclipse/EclipseState/Tables/Aqudims.cpp
   opm/input/eclipse/EclipseState/Tables/ColumnSchema.cpp
@@ -519,6 +520,7 @@ list(APPEND TEST_SOURCE_FILES
   tests/test_data_InterRegFlowMap.cpp
   tests/test_data_regionsetvariabledescriptor.cpp
   tests/test_data_regionvariablemapping.cpp
+  tests/test_data_regionvariablesupport.cpp
   tests/test_data_regionvariablevalues.cpp
   tests/test_data_regionvariableview.cpp
   tests/test_DatumDepth.cpp
@@ -1011,6 +1013,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
   opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
   opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
+  opm/input/eclipse/EclipseState/SummaryConfig/RegionVariableSupport.hpp
   opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
   opm/input/eclipse/EclipseState/Tables/Aqudims.hpp
   opm/input/eclipse/EclipseState/Tables/AqutabTable.hpp

--- a/opm/input/eclipse/EclipseState/SummaryConfig/RegionVariableSupport.cpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/RegionVariableSupport.cpp
@@ -1,0 +1,64 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/EclipseState/SummaryConfig/RegionVariableSupport.hpp>
+
+#include <opm/output/data/RegionVariableMapping.hpp>
+
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+namespace {
+    void populateOilEfficiencyVariables(const Opm::SummaryConfig&         sumcfg,
+                                        Opm::data::RegionVariableMapping& regVarMap)
+    {
+        // FOEW, ROEW, ROEW_<REG>
+        const auto oew_kws = sumcfg.keywords(R"(*OEW*)");
+
+        if (oew_kws.empty()) {
+            // No *OEW* vectors requested.  Nothing to do.
+            return;
+        }
+
+        using RegSet = Opm::data::RegionVariableMapping::RegionSet;
+
+        regVarMap.add(Opm::data::RegionVariableMapping::Variable { "ConnOPT" },
+                      /* is_cumulative = */ true);
+
+        for (const auto& oew_kw : oew_kws) {
+            if (oew_kw.category() == Opm::SummaryConfigNode::Category::Region) {
+                regVarMap.add(RegSet { oew_kw.fip_region() });
+            }
+            else {
+                // Not a region level vector.  Typically FOEW.  Ensure that
+                // we have FIPNUM for this case.
+                regVarMap.add(RegSet { "FIPNUM" });
+            }
+        }
+    }
+} // Anonymous namespace
+
+// ===========================================================================
+// Public interface below separator
+// ===========================================================================
+
+void Opm::populateRegVarMapping(const SummaryConfig&         sumcfg,
+                                data::RegionVariableMapping& regVarMap)
+{
+    populateOilEfficiencyVariables(sumcfg, regVarMap);
+}

--- a/opm/input/eclipse/EclipseState/SummaryConfig/RegionVariableSupport.hpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/RegionVariableSupport.hpp
@@ -1,0 +1,47 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_REGION_VARIABLE_SUPPORT_HPP
+#define OPM_REGION_VARIABLE_SUPPORT_HPP
+
+namespace Opm {
+    class SummaryConfig;
+} // namespace Opm
+
+namespace Opm::data {
+    class RegionVariableMapping;
+} // namespace Opm::data
+
+namespace Opm {
+    /// Register internal region variables and region sets needed by the
+    /// configured SUMMARY vectors in \p sumcfg.
+    ///
+    /// \note This function only registers names in \p regVarMap. Callers are
+    /// responsible for managing the RegionVariableMapping lifecycle (i.e.
+    /// calling prepareRegistration() before registration and commitStructure()
+    /// after all registrations are complete).
+    ///
+    /// \param[in] sumcfg Summary configuration.
+    ///
+    /// \param[in,out] regVarMap Region variable mapping to populate.
+    void populateRegVarMapping(const SummaryConfig&         sumcfg,
+                               data::RegionVariableMapping& regVarMap);
+}
+
+#endif // OPM_REGION_VARIABLE_SUPPORT_HPP

--- a/tests/test_data_regionvariablesupport.cpp
+++ b/tests/test_data_regionvariablesupport.cpp
@@ -1,0 +1,223 @@
+/*
+  Copyright (c) 2026 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE SummaryConfig_RegionVariableSupport
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/input/eclipse/EclipseState/SummaryConfig/RegionVariableSupport.hpp>
+
+#include <opm/output/data/RegionVariableMapping.hpp>
+
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
+#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <fmt/format.h>
+
+#include <memory>
+#include <string_view>
+
+namespace {
+    Opm::SummaryConfig makeSummaryConfig(std::string_view regions, std::string_view summary)
+    {
+        const auto deck = Opm::Parser{}.parseString(fmt::format(R"(RUNSPEC
+DIMENS
+  5 1 2 /
+OIL
+GAS
+WATER
+METRIC
+TABDIMS
+/
+EQLDIMS
+/
+GRID
+DXV
+  5*100 /
+DYV
+  1*100 /
+DZV
+  5 10 /
+DEPTHZ
+  12*2000.0 /
+EQUALS
+  PORO 0.25 /
+  PERMX 100 /
+  PERMY 100 /
+  PERMZ 10 /
+/
+PROPS
+DENSITY
+  850.0 1024.0 1.0 /
+REGIONS
+{regions}
+SOLUTION
+EQUIL
+  2010.0 256.25 2013.0 0.0 2000.0 0.0 /
+SUMMARY
+{summary}
+SCHEDULE
+WELSPECS
+  'I' 'G' 1 1 2002.5 'WATER' /
+  'P' 'G' 5 1 2010.0 'LIQ' /
+/
+COMPDAT
+  'I' 1 1 1 1 'OPEN' 1* 1* 0.5 /
+  'P' 5 1 2 2 'OPEN' 1* 1* 0.5 /
+/
+TSTEP
+  1 2 3 4 5 10 20 5*30 /
+END
+)", fmt::arg("regions", regions), fmt::arg("summary", summary)));
+
+        const auto es = Opm::EclipseState{deck};
+
+        const auto sched = Opm::Schedule{deck, es};
+
+        const auto parseCtx = Opm::ParseContext{};
+        auto errors = Opm::ErrorGuard{};
+
+        auto summaryConfig = Opm::SummaryConfig {
+            deck, sched, es.fieldProps(), es.aquifer(), parseCtx, errors
+        };
+
+        errors.clear();
+
+        return summaryConfig;
+    }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Basic_Operations)
+
+BOOST_AUTO_TEST_CASE(No_Oil_Efficiency_From_Wells)
+{
+    const auto sumCfg = makeSummaryConfig(R"(FIPNUM
+  5*1 5*2 /
+FIPABC
+  5*2 5*1 /
+)", R"(WOPR
+/
+FOPT
+ROPT
+/
+ROPT_ABC
+/
+)");
+
+    auto m = Opm::data::RegionVariableMapping{};
+    m.prepareRegistration();
+
+    Opm::populateRegVarMapping(sumCfg, m);
+
+    m.commitStructure();
+
+    BOOST_CHECK_EQUAL(m.numRegionSets(), std::size_t{0});
+    BOOST_CHECK_EQUAL(m.numVariables(), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Default_Regions)
+{
+    const auto sumCfg = makeSummaryConfig("", R"(ROEW
+1 /
+)");
+
+    auto m = Opm::data::RegionVariableMapping{};
+    m.prepareRegistration();
+
+    Opm::populateRegVarMapping(sumCfg, m);
+
+    m.commitStructure();
+
+    BOOST_CHECK_EQUAL(m.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(m.numVariables(), std::size_t{1});
+
+    BOOST_REQUIRE_MESSAGE(m.index(Opm::data::RegionVariableMapping::RegionSet{"FIPNUM"}).has_value(),
+                          R"(Region set "FIPNUM" must be known to mapping)");
+    BOOST_REQUIRE_MESSAGE(m.index(Opm::data::RegionVariableMapping::Variable{"ConnOPT"}).has_value(),
+                          R"(Variable "ConnOPT" must be known to mapping)");
+
+    BOOST_CHECK_EQUAL(m.index(Opm::data::RegionVariableMapping::RegionSet{"FIPNUM"}).value(), std::size_t{0});
+    BOOST_CHECK_EQUAL(m.index(Opm::data::RegionVariableMapping::Variable{"ConnOPT"}).value(), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Custom_Regions)
+{
+    const auto sumCfg = makeSummaryConfig(R"(FIPNUM
+  5*1 5*2 /
+FIPABC
+  5*2 5*1 /)", R"(ROEW_ABC
+1 /)");
+
+    auto m = Opm::data::RegionVariableMapping{};
+    m.prepareRegistration();
+
+    Opm::populateRegVarMapping(sumCfg, m);
+
+    m.commitStructure();
+
+    BOOST_CHECK_EQUAL(m.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(m.numVariables(), std::size_t{1});
+
+    BOOST_CHECK_MESSAGE(! m.index(Opm::data::RegionVariableMapping::RegionSet{"FIPNUM"}).has_value(),
+                        R"(Region set "FIPNUM" must NOT be known to mapping)");
+    BOOST_REQUIRE_MESSAGE(m.index(Opm::data::RegionVariableMapping::RegionSet{"FIPABC"}).has_value(),
+                          R"(Region set "FIPABC" must be known to mapping)");
+    BOOST_REQUIRE_MESSAGE(m.index(Opm::data::RegionVariableMapping::Variable{"ConnOPT"}).has_value(),
+                          R"(Variable "ConnOPT" must be known to mapping)");
+
+    BOOST_CHECK_EQUAL(m.index(Opm::data::RegionVariableMapping::RegionSet{"FIPABC"}).value(), std::size_t{0});
+    BOOST_CHECK_EQUAL(m.index(Opm::data::RegionVariableMapping::Variable{"ConnOPT"}).value(), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Field_Level)
+{
+    const auto sumCfg = makeSummaryConfig(R"(FIPNUM
+  5*1 5*2 /)", R"(FOEW
+)");
+
+    auto m = Opm::data::RegionVariableMapping{};
+    m.prepareRegistration();
+
+    Opm::populateRegVarMapping(sumCfg, m);
+
+    m.commitStructure();
+
+    BOOST_CHECK_EQUAL(m.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(m.numVariables(), std::size_t{1});
+
+    BOOST_REQUIRE_MESSAGE(m.index(Opm::data::RegionVariableMapping::RegionSet{"FIPNUM"}).has_value(),
+                          R"(Region set "FIPNUM" must be known to mapping)");
+    BOOST_CHECK_MESSAGE(! m.index(Opm::data::RegionVariableMapping::RegionSet{"FIPABC"}).has_value(),
+                          R"(Region set "FIPABC" must NOT be known to mapping)");
+    BOOST_REQUIRE_MESSAGE(m.index(Opm::data::RegionVariableMapping::Variable{"ConnOPT"}).has_value(),
+                          R"(Variable "ConnOPT" must be known to mapping)");
+
+    BOOST_CHECK_EQUAL(m.index(Opm::data::RegionVariableMapping::RegionSet{"FIPNUM"}).value(), std::size_t{0});
+    BOOST_CHECK_EQUAL(m.index(Opm::data::RegionVariableMapping::Variable{"ConnOPT"}).value(), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Basic_Operations


### PR DESCRIPTION
This PR adds a special purpose helper function,
```
populateRegVarMapping()
```
that, based on the run's configured summary vectors, populates an object of type `data::RegionVariableMapping` (#5274).

In this initial implementation, we define a variable named

* `ConnOPT`

if any of the `*OEW*` summary vectors are configured in the run's `SUMMARY` section.  Those OEW vectors require tracking the per-region cumulative oil production from wells and it's easier to have a dedicated variable for this than to introduce extra `COPT` summary vectors that are visible to the user through the result set's summary files (e.g., `.SMSPEC` and `.UNSMRY`).