### PR TITLE
Let callers reuse the saturated factor and its table segment in PVT

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -213,6 +213,24 @@ public:
     }
 
     /*!
+     * \brief Returns the saturated gas dissolution factor together with the
+     *        index of the table segment it was evaluated on.
+     *
+     * The segment index can be handed to the corresponding
+     * inverseFormationVolumeFactorAndViscosity() overload so that the search
+     * and the table evaluation are not repeated by that call.
+     */
+    template <class LhsEval>
+    std::pair<LhsEval, SegmentIndex>
+    saturatedGasDissolutionFactorAndSegment(unsigned regionIdx, const LhsEval& pressure) const
+    {
+        const auto segIdx =
+            this->saturatedGasDissolutionFactorTable_[regionIdx].findSegmentIndex(pressure, /*extrapolate=*/ true);
+        return { this->saturatedGasDissolutionFactorTable_[regionIdx].eval(pressure, SegmentIndex{segIdx}),
+                 SegmentIndex{segIdx} };
+    }
+
+    /*!
      * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
      */
     template <class FluidState, class LhsEval = typename FluidState::ValueType>
@@ -220,10 +238,27 @@ public:
     inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx)
     {
         const LhsEval& p = decay<LhsEval>(fluidState.pressure(FluidState::oilPhaseIdx));
+        const auto [RsSat, satSegIdx] = saturatedGasDissolutionFactorAndSegment<LhsEval>(regionIdx, p);
+        return inverseFormationVolumeFactorAndViscosity<FluidState, LhsEval>(fluidState, regionIdx,
+                                                                             RsSat, satSegIdx);
+    }
+
+    /*!
+     * \brief Formation volume factor and viscosity, reusing an already
+     *        computed saturated dissolution factor and its table segment.
+     *
+     * Equivalent to the overload above; the caller must pass the values
+     * returned by saturatedGasDissolutionFactorAndSegment() for the same
+     * region and pressure.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::ValueType>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx,
+                                             const LhsEval& RsSat, SegmentIndex satSegIdx)
+    {
+        const LhsEval& p = decay<LhsEval>(fluidState.pressure(FluidState::oilPhaseIdx));
         const LhsEval& Rs = decay<LhsEval>(fluidState.Rs());
 
-        const auto satSegIdx = this->saturatedGasDissolutionFactorTable_[regionIdx].findSegmentIndex(p, /*extrapolate=*/ true);
-        const auto RsSat = this->saturatedGasDissolutionFactorTable_[regionIdx].eval(p, SegmentIndex{satSegIdx});
         const bool useSaturatedTables = (fluidState.saturation(FluidState::gasPhaseIdx) > 0.0) && (Rs >= (1.0 - 1e-10) * RsSat);
 
         if (useSaturatedTables) {

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -213,6 +213,24 @@ public:
     { return inverseGasB_[regionIdx].eval(pressure, Rv, /*extrapolate=*/true); }
 
     /*!
+     * \brief Returns the saturated oil vaporization factor together with the
+     *        index of the table segment it was evaluated on.
+     *
+     * The segment index can be handed to the corresponding
+     * inverseFormationVolumeFactorAndViscosity() overload so that the search
+     * and the table evaluation are not repeated by that call.
+     */
+    template <class LhsEval>
+    std::pair<LhsEval, SegmentIndex>
+    saturatedOilVaporizationFactorAndSegment(unsigned regionIdx, const LhsEval& pressure) const
+    {
+        const auto segIdx =
+            this->saturatedOilVaporizationFactorTable_[regionIdx].findSegmentIndex(pressure, /*extrapolate=*/ true);
+        return { this->saturatedOilVaporizationFactorTable_[regionIdx].eval(pressure, SegmentIndex{segIdx}),
+                 SegmentIndex{segIdx} };
+    }
+
+    /*!
      * \brief Returns the formation volume factor [-] and viscosity [Pa s] of the fluid phase.
      */
     template <class FluidState, class LhsEval = typename FluidState::ValueType>
@@ -220,10 +238,27 @@ public:
     inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx)
     {
         const LhsEval& p = decay<LhsEval>(fluidState.pressure(FluidState::gasPhaseIdx));
+        const auto [RvSat, satSegIdx] = saturatedOilVaporizationFactorAndSegment<LhsEval>(regionIdx, p);
+        return inverseFormationVolumeFactorAndViscosity<FluidState, LhsEval>(fluidState, regionIdx,
+                                                                             RvSat, satSegIdx);
+    }
+
+    /*!
+     * \brief Formation volume factor and viscosity, reusing an already
+     *        computed saturated vaporization factor and its table segment.
+     *
+     * Equivalent to the overload above; the caller must pass the values
+     * returned by saturatedOilVaporizationFactorAndSegment() for the same
+     * region and pressure.
+     */
+    template <class FluidState, class LhsEval = typename FluidState::ValueType>
+    std::pair<LhsEval, LhsEval>
+    inverseFormationVolumeFactorAndViscosity(const FluidState& fluidState, unsigned regionIdx,
+                                             const LhsEval& RvSat, SegmentIndex satSegIdx)
+    {
+        const LhsEval& p = decay<LhsEval>(fluidState.pressure(FluidState::gasPhaseIdx));
         const LhsEval& Rv = decay<LhsEval>(fluidState.Rv());
 
-        const auto satSegIdx = this->saturatedOilVaporizationFactorTable_[regionIdx].findSegmentIndex(p, /*extrapolate=*/ true);
-        const auto RvSat = this->saturatedOilVaporizationFactorTable_[regionIdx].eval(p, SegmentIndex{satSegIdx});
         const bool useSaturatedTables = (fluidState.saturation(FluidState::oilPhaseIdx) > 0.0) && (Rv >= (1.0 - 1e-10) * RvSat);
 
         if (useSaturatedTables) {

--- a/tests/material/test_eclblackoilpvt.cpp
+++ b/tests/material/test_eclblackoilpvt.cpp
@@ -55,6 +55,7 @@
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Units/Units.hpp>
 
+#include <array>
 #include <tuple>
 
 // values of strings based on the first SPE1 test case of opm-data.  note that in the
@@ -404,6 +405,125 @@ BOOST_AUTO_TEST_CASE(RSCONST_ThrowsBelowBubblePoint)
     BOOST_CHECK_NO_THROW(
         oilPvt.saturatedGasDissolutionFactor(0, 300.0, pressureAbovePb)
     );
+}
+
+// The saturated-factor-and-segment accessors let a caller hand the already
+// computed saturated value and its table segment to the b/mu evaluation.
+// That overload must reproduce the self-contained one bit for bit.
+
+// Minimal live-oil deck: the fixture deck carries PVTG but no PVTO, so the
+// oil branch of the shared-segment test needs its own.
+static constexpr const char* liveOilDeckString =
+    "RUNSPEC\n"
+    "OIL\n"
+    "GAS\n"
+    "WATER\n"
+    "DISGAS\n"
+    "VAPOIL\n"
+    "METRIC\n"
+    "DIMENS\n"
+    "  1 1 1 /\n"
+    "TABDIMS\n"
+    "/\n"
+    "GRID\n"
+    "DX\n"
+    "  1*100 /\n"
+    "DY\n"
+    "  1*100 /\n"
+    "DZ\n"
+    "  1*10 /\n"
+    "TOPS\n"
+    "  1*2000 /\n"
+    "PORO\n"
+    "  1*0.2 /\n"
+    "PROPS\n"
+    "DENSITY\n"
+    "  859.5  1033.0  0.854 /\n"
+    "PVTW\n"
+    "  277.0  1.038  4.67E-5  0.318  0.0 /\n"
+    "PVTO\n"
+    "  0.165  50.0  1.20  1.02 /\n"
+    "  0.335 100.0  1.26  0.90 /\n"
+    "  0.500 150.0  1.32  0.80 /\n"
+    "  0.665 200.0  1.38  0.72\n"
+    "         300.0  1.35  0.79 /\n"
+    "/\n"
+    "PVTG\n"
+    "   50.0  0.00006  0.0250  0.0130\n"
+    "         0.00000  0.0252  0.0132 /\n"
+    "  100.0  0.00014  0.0130  0.0150\n"
+    "         0.00000  0.0132  0.0152 /\n"
+    "  150.0  0.00030  0.0090  0.0170\n"
+    "         0.00000  0.0091  0.0172 /\n"
+    "  200.0  0.00060  0.0070  0.0190\n"
+    "         0.00000  0.0071  0.0192 /\n"
+    "/\n";
+
+// Minimal state carrying exactly what the PVT classes read.
+template <class Scalar>
+struct PvtProbeState
+{
+    using ValueType = Scalar;
+    static constexpr unsigned oilPhaseIdx = 0;
+    static constexpr unsigned gasPhaseIdx = 1;
+    static constexpr unsigned waterPhaseIdx = 2;
+
+    Scalar p{};
+    std::array<Scalar, 3> sat{};
+    Scalar rs{};
+    Scalar rv{};
+
+    Scalar pressure(unsigned) const { return p; }
+    Scalar saturation(unsigned phaseIdx) const { return sat[phaseIdx]; }
+    Scalar temperature(unsigned) const { return Scalar(300.0); }
+    Scalar Rs() const { return rs; }
+    Scalar Rv() const { return rv; }
+};
+
+// The saturated-factor-and-segment accessors let a caller hand the already
+// computed saturated value and its table segment to the b/mu evaluation.
+// That overload must reproduce the self-contained one bit for bit.
+BOOST_AUTO_TEST_CASE_TEMPLATE(SharedSegmentIndexMatchesSelfContained, Scalar, Types)
+{
+    using FluidState = PvtProbeState<Scalar>;
+
+    const auto liveOilDeck = Opm::Parser().parseString(liveOilDeckString);
+    const Opm::EclipseState liveOilState(liveOilDeck);
+    const Opm::Schedule liveOilSchedule(liveOilDeck, liveOilState, std::make_shared<Opm::Python>());
+
+    Opm::LiveOilPvt<Scalar> oilPvt;
+    Opm::WetGasPvt<Scalar> gasPvt;
+    oilPvt.initFromState(liveOilState, liveOilSchedule);
+    gasPvt.initFromState(liveOilState, liveOilSchedule);
+
+    for (int ip = 0; ip <= 20; ++ip) {
+        const Scalar p = Scalar(6.0e6) + Scalar(ip) * Scalar(1.2e6);
+        const Scalar rsSat = oilPvt.saturatedGasDissolutionFactor(0, Scalar(300.0), p);
+        const Scalar rvSat = gasPvt.saturatedOilVaporizationFactor(0, Scalar(300.0), p);
+
+        // both branches: at the saturated value, and well below it
+        for (int isat = 0; isat < 2; ++isat) {
+            FluidState fs;
+            fs.p = p;
+            fs.sat = { Scalar(0.5), Scalar(0.3), Scalar(0.2) };
+            fs.rs = (isat == 0) ? rsSat : Scalar(0.3) * rsSat;
+            fs.rv = (isat == 0) ? rvSat : Scalar(0.3) * rvSat;
+
+            const auto oilRef = oilPvt.template inverseFormationVolumeFactorAndViscosity<FluidState, Scalar>(fs, 0);
+            const auto oilSatSeg = oilPvt.template saturatedGasDissolutionFactorAndSegment<Scalar>(0, p);
+            const auto oilShared = oilPvt.template inverseFormationVolumeFactorAndViscosity<FluidState, Scalar>(
+                fs, 0, oilSatSeg.first, oilSatSeg.second);
+            BOOST_CHECK_EQUAL(oilRef.first, oilShared.first);
+            BOOST_CHECK_EQUAL(oilRef.second, oilShared.second);
+
+            const auto gasRef = gasPvt.template inverseFormationVolumeFactorAndViscosity<FluidState, Scalar>(fs, 0);
+            const auto gasSatSeg = gasPvt.template saturatedOilVaporizationFactorAndSegment<Scalar>(0, p);
+            const auto gasShared = gasPvt.template inverseFormationVolumeFactorAndViscosity<FluidState, Scalar>(
+                fs, 0, gasSatSeg.first, gasSatSeg.second);
+            BOOST_CHECK_EQUAL(gasRef.first, gasShared.first);
+            BOOST_CHECK_EQUAL(gasRef.second, gasShared.second);
+        }
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
`LiveOilPvt`/`WetGasPvt` compute the saturated dissolution/vaporization factor inside `inverseFormationVolumeFactorAndViscosity()` to choose between the saturated and undersaturated tables. When the caller already has that factor — the intensive quantities compute it to set Rs/Rv immediately before, whenever the gas meaning is Sg — the segment search and the table evaluation are done twice per cell.

This adds `saturated{GasDissolution,OilVaporization}FactorAndSegment()` plus an overload taking the factor and segment; the existing signature delegates to it, so behaviour is unchanged. New unit test checks the two paths agree bit for bit on both branches, float and double.

**Correction to an earlier version of this description.** It first claimed −14% (Norne) / −29% (SPE9) on the composition + b/mu sequence. That came from a benchmark that had *every* cell evaluate the saturated factor in the composition step; in reality cells with `GasMeaning::Rs` read Rs from the primary variables and never do. With that fixed, the measurement is:

| | master | with this change |
|---|---|---|
| Norne | 71.6 ns/cell | 68.1 (−4.9%) |
| SPE9 | 20.6 | 20.7 (±0) |

So this is a small win on a deck with much dissolved gas and neutral otherwise — a cleanup that removes duplicated work rather than a significant speedup. Posting it because the API costs nothing and composes with the consumer-side change, but it should be judged on that basis.

Draft: the consumer side still needs a way to carry the pair from the composition step to the mobility step (the two are separate methods in the intensive quantities, and the call goes through the PVT multiplexer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)