### PR TITLE
Numerical aquifers: option to keep them out of the grid

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -955,6 +955,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.hpp
   opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
   opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
+  opm/input/eclipse/EclipseState/Aquifer/NumericalAquiferMode.hpp
   opm/input/eclipse/EclipseState/Co2StoreConfig.hpp
   opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
   opm/input/eclipse/EclipseState/EclipseConfig.hpp

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.cpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.cpp
@@ -39,17 +39,20 @@ namespace Opm {
         , length ( record.getItem<AQUNUM::LENGTH>().getSIDouble(0) )
         , permeability( record.getItem<AQUNUM::PERM>().getSIDouble(0) )
     {
-        const auto& poro = field_props.get_double("PORO");
-        const auto& pvtnum = field_props.get_int("PVTNUM");
-        const auto& satnum = field_props.get_int("SATNUM");
+        // Read through the global arrays rather than the active-cell ones.  For an active
+        // cell the two carry the same value, but the cell an AQUNUM record names is not
+        // necessarily active: when the aquifer is represented outside the grid, the cell
+        // it names is deactivated precisely so that nothing else occupies it.
+        const auto& poro = field_props.get_global_double("PORO");
+        const auto& pvtnum = field_props.get_global_int("PVTNUM");
+        const auto& satnum = field_props.get_global_int("SATNUM");
 
         this->global_index = grid.getGlobalIndex(I, J, K);
-        const std::size_t active_index = grid.activeIndex(this->global_index);
 
         if ( !record.getItem<AQUNUM::PORO>().defaultApplied(0) ) {
             this->porosity = record.getItem<AQUNUM::PORO>().getSIDouble(0);
         } else {
-            this->porosity = poro[active_index];
+            this->porosity = poro[this->global_index];
         }
 
         if ( !record.getItem<AQUNUM::DEPTH>().defaultApplied(0) ) {
@@ -65,13 +68,13 @@ namespace Opm {
         if ( !record.getItem<AQUNUM::PVT_TABLE_NUM>().defaultApplied(0) ) {
             this->pvttable = record.getItem<AQUNUM::PVT_TABLE_NUM>().get<int>(0);
         } else {
-            this->pvttable = pvtnum[active_index];
+            this->pvttable = pvtnum[this->global_index];
         }
 
         if ( !record.getItem<AQUNUM::SAT_TABLE_NUM>().defaultApplied(0) ) {
             this->sattable = record.getItem<AQUNUM::SAT_TABLE_NUM>().get<int>(0);
         } else {
-            this->sattable = satnum[active_index];
+            this->sattable = satnum[this->global_index];
         }
 
         this->record_id = record_id_;

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquiferMode.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquiferMode.hpp
@@ -1,0 +1,57 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_NUMERICAL_AQUIFER_MODE_HPP
+#define OPM_NUMERICAL_AQUIFER_MODE_HPP
+
+namespace Opm {
+
+/*!
+ * \brief How the numerical aquifers of a deck (AQUNUM/AQUCON) are represented.
+ *
+ * A numerical aquifer is pure flow bookkeeping: a pore volume and a list of
+ * connections.  It has no geometry.  ECLIPSE nevertheless expresses it by taking over a
+ * grid cell, which is cheap and restart-compatible, and this remains the default so that
+ * existing decks are unaffected.
+ *
+ * That representation costs something, though, for anything that reads the grid as
+ * geometry rather than as bookkeeping.  The taken-over cell is forced active and carries
+ * an authored depth and pore volume, and its connections become non-neighbour
+ * connections, which have no face and therefore no geometry either.  Mechanics is the
+ * clearest case: such a cell is not rock, and a connection which is not a face cannot
+ * carry a traction.
+ *
+ * \c AuxiliaryCells asks for the opposite: leave the grid alone entirely, and let the
+ * simulator represent the aquifer as degrees of freedom of its own.  The keywords are
+ * still parsed and the aquifer data is still available; what changes is that no grid cell
+ * is taken over, no field property is overridden and no non-neighbour connection is
+ * generated.  A simulator which selects this mode is responsible for representing the
+ * aquifers itself -- nothing else will.
+ */
+enum class NumericalAquiferMode {
+    //! Take over a grid cell per aquifer cell (the historical behaviour).
+    GridCells,
+
+    //! Leave the grid untouched; the simulator represents the aquifer itself.
+    AuxiliaryCells,
+};
+
+} // namespace Opm
+
+#endif // OPM_NUMERICAL_AQUIFER_MODE_HPP

--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -445,6 +445,14 @@ namespace Opm {
             return;
         }
 
+        auto& numerical_aquifer = this->aquifer_config.mutableNumericalAquifers();
+
+        // Tell the MULTREGT scanner which cells belong to an aquifer.  This shapes
+        // nothing; it is what lets a MULTREGT record distinguish an aquifer connection
+        // from any other non-neighbour connection (the NOAQUNNC behaviour), and that
+        // distinction has to be drawn the same way however the aquifer is represented.
+        this->m_transMult.applyNumericalAquifer(numerical_aquifer.allAquiferCellIds());
+
         // Everything below reshapes the grid and the field properties so that a grid
         // cell can stand in for an aquifer cell.  In AuxiliaryCells mode nothing stands
         // in for it -- the simulator represents the aquifer as degrees of freedom of its
@@ -453,8 +461,6 @@ namespace Opm {
         if (this->numerical_aquifer_mode == NumericalAquiferMode::AuxiliaryCells) {
             return;
         }
-
-        auto& numerical_aquifer = this->aquifer_config.mutableNumericalAquifers();
 
         numerical_aquifer.applyMinPV(this->m_inputGrid);
 
@@ -465,8 +471,6 @@ namespace Opm {
         // Add NNCs between aquifer cells and first aquifer cell and aquifer
         // connections.
         this->appendInputNNC(numerical_aquifer.aquiferCellNNCs());
-
-        this->m_transMult.applyNumericalAquifer(numerical_aquifer.allAquiferCellIds());
     }
 
     void EclipseState::applyMULTXYZ()

--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -129,13 +129,14 @@ namespace Opm {
 // process is done twice, first after the initial field_props processing and
 // subsequently after the processing of numerical aquifers.
 
-    EclipseState::EclipseState(const Deck& deck)
+    EclipseState::EclipseState(const Deck& deck, NumericalAquiferMode aquiferMode)
     try
-        : m_tables(            deck )
+        : numerical_aquifer_mode( aquiferMode )
+        , m_tables(            deck )
         , m_runspec(           deck )
         , m_eclipseConfig(     deck, m_runspec )
         , m_deckUnitSystem(    deck.getActiveUnitSystem() )
-        , m_inputGrid(         deck, nullptr )
+        , m_inputGrid(         deck, nullptr, aquiferMode )
         , m_inputNnc(          m_inputGrid, deck)
         , m_gridDims(          deck )
         , field_props(         deck, m_runspec.phases(), m_inputGrid, m_tables, m_runspec.numComps())
@@ -441,6 +442,15 @@ namespace Opm {
     void EclipseState::conveyNumericalAquiferEffects()
     {
         if (! this->aquifer_config.hasNumericalAquifer()) {
+            return;
+        }
+
+        // Everything below reshapes the grid and the field properties so that a grid
+        // cell can stand in for an aquifer cell.  In AuxiliaryCells mode nothing stands
+        // in for it -- the simulator represents the aquifer as degrees of freedom of its
+        // own -- so the grid, the field properties and the non-neighbour connections are
+        // left exactly as the deck describes them.
+        if (this->numerical_aquifer_mode == NumericalAquiferMode::AuxiliaryCells) {
             return;
         }
 

--- a/opm/input/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.hpp
@@ -21,6 +21,7 @@
 #define OPM_ECLIPSE_STATE_HPP
 
 #include <opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.hpp>
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquiferMode.hpp>
 #include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseConfig.hpp>
 #include <opm/input/eclipse/EclipseState/Geochemistry/SpeciesConfig.hpp>
@@ -73,8 +74,23 @@ namespace Opm {
         };
 
         EclipseState() = default;
-        explicit EclipseState(const Deck& deck);
+
+        /// Construct from a deck.
+        ///
+        /// \param[in] aquiferMode How numerical aquifers are represented.  The default
+        ///    reproduces the historical behaviour, in which an AQUNUM cell takes over
+        ///    the grid cell it names.  See NumericalAquiferMode.
+        explicit EclipseState(const Deck& deck,
+                              NumericalAquiferMode aquiferMode = NumericalAquiferMode::GridCells);
         virtual ~EclipseState() = default;
+
+        /// How numerical aquifers are represented in this state.
+        ///
+        /// Consumers which would otherwise infer it from the presence of AQUNUM should
+        /// ask here instead, so that a restart or an embedded caller cannot end up
+        /// disagreeing with how the state was actually built.
+        NumericalAquiferMode numericalAquiferMode() const
+        { return this->numerical_aquifer_mode; }
 
         const IOConfig& getIOConfig() const;
         IOConfig& getIOConfig();
@@ -157,6 +173,7 @@ namespace Opm {
         {
             // FieldPropsManager is handled through a different mechanism.
             // Do not add the member (i.e., field_props) to this list.
+            serializer(numerical_aquifer_mode);
             serializer(m_tables);
             serializer(m_runspec);
             serializer(m_eclipseConfig);
@@ -198,6 +215,8 @@ namespace Opm {
                                            const std::string& keywordName);
 
      protected:
+        // Declared before the members whose construction depends on it (m_inputGrid).
+        NumericalAquiferMode numerical_aquifer_mode{NumericalAquiferMode::GridCells};
         TableManager m_tables;
         Runspec m_runspec;
         EclipseConfig m_eclipseConfig;

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -296,12 +296,8 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum, NumericalAquiferM
 
     }
 
-    // In AuxiliaryCells mode the aquifers are represented outside the grid, so the
-    // AQUNUM records must not take over the cells they name: the cells keep the deck's
-    // own ACTNUM and their geometric depth.
-    if (aquiferMode == NumericalAquiferMode::GridCells) {
-        updateNumericalAquiferCells(deck);
-    }
+    this->m_numerical_aquifer_mode = aquiferMode;
+    updateNumericalAquiferCells(deck);
 
     initGrid(deck, actnum);
 
@@ -2675,9 +2671,17 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
 
             for (std::size_t n = 0; n < global_size; n++) {
                 this->m_actnum[n] = actnum[n];
-                // numerical aquifer cells need to be active
                 if (this->m_aquifer_cells.count(n) > 0) {
-                    this->m_actnum[n] = 1;
+                    // A cell named by an AQUNUM record does not belong to the reservoir
+                    // either way.  When the aquifer takes the cell over it has to be
+                    // active in order to host it; when the aquifer is represented outside
+                    // the grid the cell is deactivated instead, so that nothing occupies
+                    // the space the deck reserved for it.  Its geometric neighbours lose
+                    // a neighbour in both cases -- the take-over kills those
+                    // transmissibilities.
+                    this->m_actnum[n] =
+                        (this->m_numerical_aquifer_mode == NumericalAquiferMode::GridCells)
+                        ? 1 : 0;
                 }
                 if (this->m_actnum[n] > 0) {
                     this->m_global_to_active.push_back(this->m_nactive);
@@ -2736,6 +2740,16 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
                 const std::size_t k = record.getItem<AQUNUM::K>().get<int>(0) - 1;
                 const std::size_t global_index = this->getGlobalIndex(i, j, k);
                 this->m_aquifer_cells.insert(global_index);
+
+                // The two maps below describe a cell that *hosts* an aquifer: an
+                // authored depth to report in place of the geometric one, and region
+                // numbers to fold into the host cell's field properties.  Neither
+                // applies when the aquifer lives outside the grid -- the cell is
+                // deactivated then, and the depth and regions belong to the aquifer
+                // itself.
+                if (this->m_numerical_aquifer_mode != NumericalAquiferMode::GridCells) {
+                    continue;
+                }
 
                 if (! record.getItem<AQUNUM::DEPTH>().defaultApplied(0))
                     this->m_aquifer_cell_depths.insert_or_assign(global_index, record.getItem<AQUNUM::DEPTH>().getSIDouble(0));

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -276,7 +276,7 @@ EclipseGrid::EclipseGrid(const EclipseGrid& src, const std::vector<int>& actnum)
 
 
 
-EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
+EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum, NumericalAquiferMode aquiferMode)
     : GridDims(deck),
       m_minpvMode(MinpvMode::Inactive),
       m_pinchoutMode(PinchMode::TOPBOT),
@@ -296,7 +296,12 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
 
     }
 
-    updateNumericalAquiferCells(deck);
+    // In AuxiliaryCells mode the aquifers are represented outside the grid, so the
+    // AQUNUM records must not take over the cells they name: the cells keep the deck's
+    // own ACTNUM and their geometric depth.
+    if (aquiferMode == NumericalAquiferMode::GridCells) {
+        updateNumericalAquiferCells(deck);
+    }
 
     initGrid(deck, actnum);
 

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_PARSER_ECLIPSE_GRID_HPP
 #define OPM_PARSER_ECLIPSE_GRID_HPP
 
+#include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquiferMode.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/MapAxes.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/MinpvMode.hpp>
@@ -86,7 +87,16 @@ namespace Opm {
 
         /// EclipseGrid ignores ACTNUM in Deck, and therefore needs ACTNUM
         /// explicitly.  If a null pointer is passed, every cell is active.
-        explicit EclipseGrid(const Deck& deck, const int * actnum = nullptr);
+        /// Construct from a deck.
+        ///
+        /// \param[in] aquiferMode How numerical aquifers are represented.  In the
+        ///    default \c GridCells mode an AQUNUM cell takes over the grid cell it names
+        ///    -- the cell is forced active and reports the authored depth.  In
+        ///    \c AuxiliaryCells mode the grid is left exactly as the deck describes it
+        ///    and the AQUNUM records have no effect on it at all.
+        explicit EclipseGrid(const Deck& deck,
+                             const int * actnum = nullptr,
+                             NumericalAquiferMode aquiferMode = NumericalAquiferMode::GridCells);
 
         static bool hasGDFILE(const Deck& deck);
         static bool hasRadialKeywords(const Deck& deck);

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -90,10 +90,11 @@ namespace Opm {
         /// Construct from a deck.
         ///
         /// \param[in] aquiferMode How numerical aquifers are represented.  In the
-        ///    default \c GridCells mode an AQUNUM cell takes over the grid cell it names
-        ///    -- the cell is forced active and reports the authored depth.  In
-        ///    \c AuxiliaryCells mode the grid is left exactly as the deck describes it
-        ///    and the AQUNUM records have no effect on it at all.
+        ///    default \c GridCells mode an AQUNUM cell takes over the grid cell it names:
+        ///    the cell is forced active and reports the authored depth.  In
+        ///    \c AuxiliaryCells mode that cell is deactivated instead, so that nothing
+        ///    occupies the space the deck reserved for the aquifer, and the aquifer
+        ///    itself is represented outside the grid.
         explicit EclipseGrid(const Deck& deck,
                              const int * actnum = nullptr,
                              NumericalAquiferMode aquiferMode = NumericalAquiferMode::GridCells);
@@ -391,6 +392,7 @@ namespace Opm {
         std::vector<int> m_active_to_global;
         std::vector<int> m_global_to_active;
         // Numerical aquifer cells, needs to be active
+        NumericalAquiferMode m_numerical_aquifer_mode{NumericalAquiferMode::GridCells};
         std::unordered_set<std::size_t> m_aquifer_cells;
         // Keep track of aquifer cell depths and (pvtnum,satnum)
         std::map<std::size_t, double> m_aquifer_cell_depths;

--- a/opm/output/eclipse/WriteInit.cpp
+++ b/opm/output/eclipse/WriteInit.cpp
@@ -822,9 +822,18 @@ namespace {
                                 ::Opm::EclIO::OutputStream::Init&  initFile)
     {
         std::vector<int> aquifern(grid.getNumActive(), 0);
-        // aquifer cells
+
+        // Aquifer cells.  AQUIFERN is an active-cell array, so it can only name an
+        // aquifer cell that is one -- which it is when the aquifer takes a grid cell
+        // over, and deliberately is not when the aquifer is represented outside the
+        // grid.  In the latter case only the connections below are recorded; the
+        // aquifer cells themselves have no place in a per-grid-cell array.
         const auto& aquifer_cells = num_aquifers.allAquiferCells();
         for ([[maybe_unused]] const auto& [cell_idx, cell] : aquifer_cells) {
+            if (!grid.cellActive(cell->global_index)) {
+                continue;
+            }
+
             const std::size_t active_index = grid.activeIndex(cell->global_index);
             aquifern[active_index] = -(1 << (cell->aquifer_id - 1));
         }


### PR DESCRIPTION
Adds `NumericalAquiferMode` (`grid` | `aux`). In `aux` mode an AQUNUM cell is left
inactive instead of being resurrected and taken over, so the grid keeps only physical
rock; the aquifer volume is carried elsewhere.

Default is unchanged and the existing path is untouched.

Companion PRs: OPM/opm-grid (honour the mode when processing the deck) and
OPM/opm-simulators (the aquifer cells themselves). Draft — CI not yet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)