### PR TITLE
Allocate the per-cell material law parameters from an arena

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawInitParams.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawInitParams.cpp
@@ -85,6 +85,16 @@ run(const IntLookupFunction& fieldPropIntOnLeafAssigner,
     std::vector<std::vector<MaterialLawParams>*> mlpArray;
     initArrays_(satnumArray, imbnumArray, mlpArray);
     const auto num_arrays = mlpArray.size();
+    // One contiguous arena per parameter array. Without this each cell's
+    // nested parameter object is a separate heap allocation reached through
+    // its own shared_ptr control block, so the evaluation loop walks the
+    // parameter set in allocation order rather than in cell order.
+    const auto approach = this->parent_.threePhaseApproach();
+    params_.materialLawParamArenas.resize(num_arrays);
+    for (unsigned i = 0; i < num_arrays; i++) {
+        params_.materialLawParamArenas[i] =
+            MaterialLawParams::makeArena(approach, this->numCompressedElems_);
+    }
     for (unsigned i = 0; i < num_arrays; i++) {
 #ifdef _OPENMP
 #pragma omp parallel for
@@ -111,7 +121,9 @@ run(const IntLookupFunction& fieldPropIntOnLeafAssigner,
                 hystParams.setImbibitionParamsGasWater(elemIdx, imbRegionIdx, lookupIdxOnLevelZeroAssigner);
             }
             hystParams.finalize();
-            initThreePhaseParams_(hystParams, (*mlpArray[i])[elemIdx], satRegionIdx, elemIdx);
+            initThreePhaseParams_(hystParams, (*mlpArray[i])[elemIdx], satRegionIdx, elemIdx,
+                                  MaterialLawParams::arenaSlot(params_.materialLawParamArenas[i],
+                                                               approach, elemIdx));
         }
     }
 }
@@ -229,14 +241,15 @@ InitParams<Traits>::
 initThreePhaseParams_(HystParams<Traits>& hystParams,
                       MaterialLawParams& materialParams,
                       unsigned satRegionIdx,
-                      unsigned elemIdx)
+                      unsigned elemIdx,
+                      std::shared_ptr<void> pooledParams)
 {
     const auto& epsInfo = this->params_.oilWaterScaledEpsInfoDrainage[elemIdx];
 
     auto oilWaterParams = hystParams.getOilWaterParams();
     auto gasOilParams = hystParams.getGasOilParams();
     auto gasWaterParams = hystParams.getGasWaterParams();
-    materialParams.setApproach(this->parent_.threePhaseApproach());
+    materialParams.setApproach(this->parent_.threePhaseApproach(), std::move(pooledParams));
     switch (materialParams.approach()) {
         case EclMultiplexerApproach::Stone1: {
             auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Stone1>();

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawInitParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawInitParams.hpp
@@ -33,6 +33,7 @@
 
 #include <cstddef>
 #include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -99,7 +100,8 @@ private:
     void initThreePhaseParams_(HystParams<Traits>& hystParams,
                                MaterialLawParams& materialParams,
                                unsigned satRegionIdx,
-                               unsigned elemIdx);
+                               unsigned elemIdx,
+                               std::shared_ptr<void> pooledParams);
 
     void readEffectiveParameters_();
 

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -122,6 +122,10 @@ public:
         std::vector<int> imbnumRegionArray{};
         std::vector<MaterialLawParams> materialLawParams{};
         DirectionalMaterialLawParamsPtr dirMaterialLawParams{};
+        // Contiguous backing storage for the nested parameter objects the
+        // entries above point at: one arena per parameter array instead of
+        // one heap allocation per cell.
+        std::vector<std::shared_ptr<void>> materialLawParamArenas{};
         bool onlyPiecewiseLinear = true;
 
         bool hasDirectionalRelperms() const

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
@@ -33,8 +33,11 @@
 #include "EclTwoPhaseMaterial.hpp"
 
 #include <cassert>
+#include <cstddef>
 #include <memory>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 #include <opm/material/common/EnsureFinalized.hpp>
 
@@ -118,6 +121,67 @@ public:
         realParams_.reset();
         setApproach( other.approach() );
         return *this;
+    }
+
+    /*!
+     * \brief Contiguous storage for \a n parameter objects of one approach.
+     *
+     * Hand the slots out with arenaSlot(). Keep the returned pointer alive for
+     * as long as any of them is in use.
+     */
+    static ParamPointerType makeArena(EclMultiplexerApproach approach, std::size_t n)
+    {
+        switch (approach) {
+        case EclMultiplexerApproach::Stone1:
+            return std::make_shared<std::vector<Stone1Params>>(n);
+        case EclMultiplexerApproach::Stone2:
+            return std::make_shared<std::vector<Stone2Params>>(n);
+        case EclMultiplexerApproach::Default:
+            return std::make_shared<std::vector<DefaultParams>>(n);
+        case EclMultiplexerApproach::TwoPhase:
+            return std::make_shared<std::vector<TwoPhaseParams>>(n);
+        case EclMultiplexerApproach::OnePhase:
+            break;  // no parameters
+        }
+        return {};
+    }
+
+    /*!
+     * \brief Slot \a i of an arena, as an aliasing pointer sharing the arena's
+     *        single control block.
+     */
+    static ParamPointerType arenaSlot(const ParamPointerType& arena,
+                                      EclMultiplexerApproach approach,
+                                      std::size_t i)
+    {
+        const auto at = [&arena, i](auto* tag) {
+            using V = std::vector<std::remove_pointer_t<decltype(tag)>>;
+            return ParamPointerType{arena, &(*std::static_pointer_cast<V>(arena))[i]};
+        };
+        switch (approach) {
+        case EclMultiplexerApproach::Stone1:   return at(static_cast<Stone1Params*>(nullptr));
+        case EclMultiplexerApproach::Stone2:   return at(static_cast<Stone2Params*>(nullptr));
+        case EclMultiplexerApproach::Default:  return at(static_cast<DefaultParams*>(nullptr));
+        case EclMultiplexerApproach::TwoPhase: return at(static_cast<TwoPhaseParams*>(nullptr));
+        case EclMultiplexerApproach::OnePhase: break;
+        }
+        return {};
+    }
+
+    /*!
+     * \brief Point this object at storage owned by someone else.
+     *
+     * The caller keeps ownership; \a pooled is expected to be an aliasing
+     * shared_ptr into an arena, so a whole grid's worth of parameter objects
+     * costs one allocation and one control block instead of one of each per
+     * cell. Type and lifetime are the caller's responsibility, exactly as for
+     * the self-allocating overload.
+     */
+    void setApproach(EclMultiplexerApproach newApproach, ParamPointerType pooled)
+    {
+        assert(realParams_ == nullptr);
+        approach_ = newApproach;
+        realParams_ = std::move(pooled);
     }
 
     void setApproach(EclMultiplexerApproach newApproach)


### PR DESCRIPTION
Each cell's nested material-law parameter object is a separate `new` behind its own `shared_ptr` control block. On Norne that is 44927 allocations of 304 B spread over 105.7 MB of address space for 13.7 MB of data. This adds `makeArena()`/`arenaSlot()` and a `setApproach()` overload taking externally owned storage, so the manager hands out aliasing pointers into one vector per parameter array — one allocation, one control block, fixed 304 B stride.

Draft because **it is not a measured speedup**. Norne relperm+pc, best of 5 alternating runs: 91.5 → 91.3 ns/cell in cell order, 112.4 → 111.7 shuffled. The allocator already returns long contiguous runs when the objects are built back to back, so only the allocation count and the address span change. Posting it because the layout is a precondition for anything that wants these objects as an array (SoA/GPU), not because it makes Norne faster today.

What does move the number on Norne is the *size* of these objects: padding them from 304 B to 1440 B — the size they reach once `EHYSTR` is active — costs +45 ns/cell in the same loop. That suggests splitting the Killough/WAG scalars out of `EclHysteresisTwoPhaseLawParams` is the change worth making; happy to drop this one if you would rather see only that.

All 228 opm-common tests pass.