### PR TITLE
default-initialise MMPCAuxConstraint members

### DIFF
--- a/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
+++ b/opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
@@ -49,8 +49,7 @@ template <class Scalar>
 class MMPCAuxConstraint
 {
 public:
-    MMPCAuxConstraint()
-    {}
+    MMPCAuxConstraint() = default;
 
     MMPCAuxConstraint(unsigned phaseIndex, unsigned compIndex, Scalar val)
         : phaseIdx_(phaseIndex)
@@ -90,9 +89,9 @@ public:
     { return value_; }
 
 private:
-    unsigned phaseIdx_;
-    unsigned compIdx_;
-    Scalar value_;
+    unsigned phaseIdx_{};
+    unsigned compIdx_{};
+    Scalar value_{};
 };
 
 /*!


### PR DESCRIPTION
GCC -Wmaybe-uninitialized fires when the full numComponents-sized auxConstraints array is passed to MiscibleMultiPhaseComposition::solve() even though only numAuxConstraints entries are read.  Adding in-class default member initialisers gives every element a defined value and removes the false positive.

the warning doesn't trigger as-is, but with upcoming changes in opm-simulators to fix warnings there, it will.