### PR TITLE
Reject RAT guide-rate target for non-injection wells

### DIFF
--- a/opm/input/eclipse/Schedule/Group/GuideRateKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRateKeywordHandlers.cpp
@@ -19,6 +19,8 @@
 
 #include "GuideRateKeywordHandlers.hpp"
 
+#include <opm/common/utility/OpmInputError.hpp>
+
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
@@ -31,6 +33,8 @@
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 #include "../HandlerContext.hpp"
+
+#include <fmt/format.h>
 
 namespace Opm {
 
@@ -93,6 +97,15 @@ void handleWGRUPCON(HandlerContext& handlerContext)
             }
 
             auto well = handlerContext.state().wells.get(well_name);
+            if ((phase == Well::GuideRateTarget::RAT) && !well.isInjector()) {
+                const auto msg = fmt::format(
+                    "Surface flow guide rate (RAT) is not permissible for non-injection well '{}'.\n"
+                    "This should only be used if the well has been declared an injection well via WCONINJE.",
+                    well_name);
+
+                throw OpmInputError(msg, handlerContext.keyword.location());
+            }
+
             if (well.updateWellGuideRate(availableForGroupControl, guide_rate, phase, scaling_factor)) {
                 auto new_config = handlerContext.state().guide_rate();
                 new_config.update_well(well);

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1175,8 +1175,16 @@ Well::GuideRateTarget Well::getGuideRatePhase() const
 {
     const auto target = this->getRawGuideRatePhase();
 
-    if (this->isInjector() && (target == GuideRateTarget::RAT)) {
-        return this->preferredPhaseAsGuideRatePhase();
+    if (target == GuideRateTarget::RAT) {
+        if (this->isInjector()) {
+            return this->preferredPhaseAsGuideRatePhase();
+        }
+
+        throw std::logic_error {
+            fmt::format("Guide rate target RAT is invalid for non-injection well '{}'. "
+                        "This should only be used if the well has been declared an injection well via the WCONINJE keyword in the SCHEDULE section.",
+                        this->name())
+        };
     }
 
     return target;

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -509,14 +509,30 @@ BOOST_AUTO_TEST_CASE(WellHaveInjectionControlLimit) {
 /*********************************************************************/
 
 BOOST_AUTO_TEST_CASE(WellGuideRatePhase_GuideRatePhaseSet) {
-    Opm::Well well("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false, 0, Opm::Well::GasInflowEquation::STD);
+    {
+        Opm::Well producer("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false, 0, Opm::Well::GasInflowEquation::STD);
 
-    BOOST_CHECK(Opm::Well::GuideRateTarget::UNDEFINED == well.getGuideRatePhase());
+        BOOST_CHECK(Opm::Well::GuideRateTarget::UNDEFINED == producer.getRawGuideRatePhase());
 
-    BOOST_CHECK(well.updateWellGuideRate(true, 100, Opm::Well::GuideRateTarget::RAT, 66.0));
-    BOOST_CHECK(Opm::Well::GuideRateTarget::RAT == well.getGuideRatePhase());
-    BOOST_CHECK_EQUAL(100, well.getGuideRate());
-    BOOST_CHECK_EQUAL(66.0, well.getGuideRateScalingFactor());
+        BOOST_CHECK(producer.updateWellGuideRate(true, 100, Opm::Well::GuideRateTarget::RAT, 66.0));
+        BOOST_CHECK(Opm::Well::GuideRateTarget::RAT == producer.getRawGuideRatePhase());
+        BOOST_CHECK_THROW(producer.getGuideRatePhase(), std::logic_error);
+        BOOST_CHECK_EQUAL(100, producer.getGuideRate());
+        BOOST_CHECK_EQUAL(66.0, producer.getGuideRateScalingFactor());
+    }
+
+    {
+        Opm::Well injector("WELL2" , "GROUP", 0, 1, 0, 0, 0.0, Opm::WellType(Opm::Phase::WATER), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false, 0, Opm::Well::GasInflowEquation::STD);
+
+        auto injection_props = std::make_shared<Opm::Well::WellInjectionProperties>(injector.getInjectionProperties());
+        injection_props->surfaceInjectionRate.update(1.0);
+        injector.updateInjection(injection_props);
+
+        BOOST_CHECK(injector.updateWellGuideRate(true, 200, Opm::Well::GuideRateTarget::RAT, 77.0));
+        BOOST_CHECK(Opm::Well::GuideRateTarget::WAT == injector.getGuideRatePhase());
+        BOOST_CHECK_EQUAL(200, injector.getGuideRate());
+        BOOST_CHECK_EQUAL(77.0, injector.getGuideRateScalingFactor());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(WellEfficiencyFactorSet) {

--- a/tests/parser/data/integration_tests/SCHEDULE/SCHEDULE_WGRUPCON
+++ b/tests/parser/data/integration_tests/SCHEDULE/SCHEDULE_WGRUPCON
@@ -26,6 +26,10 @@ WELSPECS
 
 /
 
+WCONINJE
+  'W_3' WATER OPEN RATE 100 /
+/
+
 WGRUPCON
    'W_1' 2* OIL /
 -- the spaces around the name are intentional!

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -674,7 +674,7 @@ BOOST_AUTO_TEST_CASE(WellTestWGRUPCONWellPropertiesSet) {
     const auto& well3 = sched.getWell("W_3", 0);
     BOOST_CHECK(well3.isAvailableForGroupControl( ));
     BOOST_CHECK_EQUAL(100, well3.getGuideRate( ));
-    BOOST_CHECK(Well::GuideRateTarget::RAT == well3.getGuideRatePhase( ));
+    BOOST_CHECK(Well::GuideRateTarget::WAT == well3.getGuideRatePhase( ));
     BOOST_CHECK_EQUAL(0.5, well3.getGuideRateScalingFactor( ));
 }
 


### PR DESCRIPTION
Reject RAT guide-rate target for non-injection wells and add an error message.

Related to https://github.com/OPM/opm-common/pull/5267, but can be merged independently. 