### PR TITLE
Fix upper limit index check for LGR input param.

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/Carfin.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/Carfin.cpp
@@ -86,6 +86,25 @@ namespace Opm
         this->reset();
     }
 
+    /// @brief Construct a Carfin object with local grid refinement parameters.
+    /// @param gridDims The dimensions of the global grid.
+    /// @param isActive A functor to determine if a cell is active.
+    /// @param activeIdx A functor to get the active index of a cell.
+    /// @param name The name of the local grid refinement.
+    /// @param i1 The starting index in the i-direction.
+    /// @param i2 The ending index in the i-direction.
+    /// @param j1 The starting index in the j-direction.
+    /// @param j2 The ending index in the j-direction.
+    /// @param k1 The starting index in the k-direction.
+    /// @param k2 The ending index in the k-direction.
+    /// @param nx The number of refined cells in the i-direction.
+    /// @param ny The number of refined cells in the j-direction.
+    /// @param nz The number of refined cells in the k-direction.
+    ///
+    /// Note that the indices i1, i2, j1, j2, k1, k2 are 0-based and inclusive.
+    /// For example for a global grid with dimensions (1, 3, 1) the (j1, j2) indices
+    /// need to be in the range [0, 2]. The ending indices give the index of the last
+    /// cell to be refined, and not one-beyond last as typical of C++ iterator ranges.
     Carfin::Carfin(const GridDims& gridDims,
                    IsActive        isActive,
                    ActiveIdx       activeIdx,

--- a/opm/input/eclipse/EclipseState/Grid/Carfin.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/Carfin.cpp
@@ -32,7 +32,7 @@ namespace {
         if ((l1 < 0) || (l2 < 0) || (l1 > l2))
             throw std::invalid_argument(name + ": Invalid index values for lgr");
 
-        if (l2 > nglobal)
+        if (l2 >= nglobal)
             throw std::invalid_argument(name + ": Index values for lgr greater than global grid size");
 
         if (nlgr % (l2-l1+1) != 0)

--- a/tests/parser/CarfinTests.cpp
+++ b/tests/parser/CarfinTests.cpp
@@ -46,6 +46,9 @@ BOOST_AUTO_TEST_CASE(TestKeywordCarfin) {
     // J2 > nyglobal
     BOOST_CHECK_THROW( Opm::Carfin(gridDims, allActive(), identityMapping(), "LGR",1,1,3,8,2,2,2,12,2), std::invalid_argument);
 
+    // J2 == nyglobal
+    BOOST_CHECK_THROW( Opm::Carfin(gridDims, allActive(), identityMapping(), "LGR",1,1,3,7,2,2,2,10,2), std::invalid_argument);
+
     //nlgr % (l2-l1+1) != 0
     BOOST_CHECK_THROW( Opm::Carfin(gridDims, allActive(), identityMapping(), "LGR",1,1,3,4,2,2,2,5,2), std::invalid_argument);
 


### PR DESCRIPTION
Existing code fails to catch off-by-one limit errors in the CARFIN specification.