### PR TITLE
Restore writing of ICON/SCON for RPTRST NORST=1

### DIFF
--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -478,14 +478,11 @@ namespace {
         auto connectionData = Helpers::AggregateConnectionData(ih);
         connectionData.captureDeclaredConnDataLGR(schedule, grid, schedule.getUnits(),
                                                      wells, sumState, sim_step, lgr_tag);
-        if (norst_value == 0)
-        {
-            rstFile.write("ICON", connectionData.getIConn());
-            rstFile.write("SCON", connectionData.getSConn());
-        }
 
         if (norst_value <= 1)
         {
+            rstFile.write("ICON", connectionData.getIConn());
+            rstFile.write("SCON", connectionData.getSConn());
             rstFile.write("XCON", connectionData.getXConn());
         }
     }

--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -424,12 +424,9 @@ namespace {
         connectionData.captureDeclaredConnData(schedule, grid, schedule.getUnits(),
                                                wells, sumState, sim_step);
 
-        if (norst_value == 0) {
+        if (norst_value <= 1) {
             rstFile.write("ICON", connectionData.getIConn());
             rstFile.write("SCON", connectionData.getSConn());
-        }
-
-        if (norst_value <= 1) {
             rstFile.write("XCON", connectionData.getXConn());
         }
     }


### PR DESCRIPTION
In the implementation of the NORST mnemonic in RPTRST (https://github.com/OPM/opm-common/pull/5122) it appears that ICON and SCON, two arrays required for proper visualization, are skipped for NORST=1. In particular, this prevents the ResInsight viewer from properly loading well connections (demonstrated on the Drogon case from opm-tests, for example). 