### PR TITLE
Separate out geomechanical items from BCPROP to new keyword BCMECH

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -186,7 +186,7 @@ list(APPEND MAIN_SOURCE_FILES
   opm/input/eclipse/Parser/raw/StarToken.cpp
   opm/input/eclipse/Python/Python.cpp
   opm/input/eclipse/Schedule/ArrayDimChecker.cpp
-  opm/input/eclipse/Schedule/BCProp.cpp
+  opm/input/eclipse/Schedule/BCState.cpp
   opm/input/eclipse/Schedule/CompletedCells.cpp
   opm/input/eclipse/Schedule/eval_uda.cpp
   opm/input/eclipse/Schedule/Events.cpp
@@ -1133,7 +1133,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/input/eclipse/Schedule/Action/State.hpp
   opm/input/eclipse/Schedule/Action/WGNames.hpp
   opm/input/eclipse/Schedule/ArrayDimChecker.hpp
-  opm/input/eclipse/Schedule/BCProp.hpp
+  opm/input/eclipse/Schedule/BCState.hpp
   opm/input/eclipse/Schedule/CompletedCells.hpp
   opm/input/eclipse/Schedule/Events.hpp
   opm/input/eclipse/Schedule/GasLiftOpt.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -188,7 +188,7 @@ list(APPEND MAIN_SOURCE_FILES
   opm/input/eclipse/Parser/raw/StarToken.cpp
   opm/input/eclipse/Python/Python.cpp
   opm/input/eclipse/Schedule/ArrayDimChecker.cpp
-  opm/input/eclipse/Schedule/BCProp.cpp
+  opm/input/eclipse/Schedule/BCState.cpp
   opm/input/eclipse/Schedule/CompletedCells.cpp
   opm/input/eclipse/Schedule/eval_uda.cpp
   opm/input/eclipse/Schedule/Events.cpp
@@ -1145,7 +1145,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/input/eclipse/Schedule/Action/State.hpp
   opm/input/eclipse/Schedule/Action/WGNames.hpp
   opm/input/eclipse/Schedule/ArrayDimChecker.hpp
-  opm/input/eclipse/Schedule/BCProp.hpp
+  opm/input/eclipse/Schedule/BCState.hpp
   opm/input/eclipse/Schedule/CompletedCells.hpp
   opm/input/eclipse/Schedule/Events.hpp
   opm/input/eclipse/Schedule/GasLiftOpt.hpp

--- a/opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.cpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.cpp
@@ -92,7 +92,7 @@ BCConfig::BCConfig(const Deck& deck) {
         for (const auto* keyword : deck.getKeywordList<ParserKeywords::BC>()) {
             const std::string reason = "ERROR: The BC keyword is obsolete. \n "
                             "Instead use BCCON in the GRID section to specify the connections. \n "
-                            "And BCPROP in the SCHEDULE section to specify the type and values. \n"
+                            "And BCPROP/BCMECH in the SCHEDULE section to specify the type and values. \n"
                             "Check the OPM manual for details.";
             throw OpmInputError { reason, keyword->location()};
         }

--- a/opm/input/eclipse/Schedule/BCState.cpp
+++ b/opm/input/eclipse/Schedule/BCState.cpp
@@ -20,7 +20,7 @@
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/B.hpp>
-#include <opm/input/eclipse/Schedule/BCProp.hpp>
+#include <opm/input/eclipse/Schedule/BCState.hpp>
 
 #include <algorithm>
 #include <string>
@@ -100,67 +100,61 @@ BCComponent component(const std::string& s) {
 }
 
 using BCKEY = ParserKeywords::BCPROP;
-BCProp::BCFace::BCFace(const DeckRecord& record) :
-    index(record.getItem<BCKEY::INDEX>().get<int>(0)),
-    bctype(fromstring::bctype(record.getItem<BCKEY::TYPE>().get<std::string>(0))),
-    bcmechtype(fromstring::bcmechtype(record.getItem<BCKEY::MECHTYPE>().get<std::string>(0))),
-    component(fromstring::component(record.getItem<BCKEY::COMPONENT>().get<std::string>(0))),
-    rate(record.getItem<BCKEY::RATE>().getSIDouble(0))
+BCState::BCFace BCState::BCFace::fromBCProp(const DeckRecord& record)
 {
+    BCFace bcpropface;
+    bcpropface.index = record.getItem<BCKEY::INDEX>().get<int>(0);
+    bcpropface.bctype = fromstring::bctype(record.getItem<BCKEY::TYPE>().get<std::string>(0));
+    bcpropface.component = fromstring::component(record.getItem<BCKEY::COMPONENT>().get<std::string>(0));
+    bcpropface.rate = record.getItem<BCKEY::RATE>().getSIDouble(0);
     if (const auto& P = record.getItem<BCKEY::PRESSURE>(); ! P.defaultApplied(0)) {
-        pressure = P.getSIDouble(0);
+        bcpropface.pressure = P.getSIDouble(0);
     }
     if (const auto& T = record.getItem<BCKEY::TEMPERATURE>(); ! T.defaultApplied(0)) {
-        temperature = T.getSIDouble(0);
+        bcpropface.temperature = T.getSIDouble(0);
     }
+    return bcpropface;
+}
+
+using BCMECHKEY = ParserKeywords::BCMECH;
+BCState::BCFace BCState::BCFace::fromBCMech(const DeckRecord& record)
+{
+    BCFace bcmechface;
+    bcmechface.index = record.getItem<BCMECHKEY::INDEX>().get<int>(0);
+    bcmechface.bcmechtype =
+        fromstring::bcmechtype(record.getItem<BCMECHKEY::MECHTYPE>().get<std::string>(0));
 
     MechBCValue mechbcvaluetmp;
-    bool allDefault = true;
-    if (const auto& P = record.getItem<BCKEY::STRESSXX>(); ! P.defaultApplied(0)) {
+    if (const auto& P = record.getItem<BCMECHKEY::STRESSXX>(); ! P.defaultApplied(0)) {
         mechbcvaluetmp.stress[0] = P.getSIDouble(0);
-        allDefault = false;
     }
-    if (const auto& P = record.getItem<BCKEY::STRESSYY>(); ! P.defaultApplied(0)) {
+    if (const auto& P = record.getItem<BCMECHKEY::STRESSYY>(); ! P.defaultApplied(0)) {
         mechbcvaluetmp.stress[1] = P.getSIDouble(0);
-        allDefault = false;
     }
-    if (const auto& P = record.getItem<BCKEY::STRESSZZ>(); ! P.defaultApplied(0)) {
+    if (const auto& P = record.getItem<BCMECHKEY::STRESSZZ>(); ! P.defaultApplied(0)) {
         mechbcvaluetmp.stress[2] = P.getSIDouble(0);
-        allDefault = false;
     }
     mechbcvaluetmp.stress[3] = 0;
     mechbcvaluetmp.stress[4] = 0;
     mechbcvaluetmp.stress[5] = 0;
-    if (const auto& P = record.getItem<BCKEY::DISPX>(); ! P.defaultApplied(0)) {
+    if (const auto& P = record.getItem<BCMECHKEY::DISPX>(); ! P.defaultApplied(0)) {
         mechbcvaluetmp.disp[0] = P.getSIDouble(0);
-        allDefault = false;
     }
-    if (const auto& P = record.getItem<BCKEY::DISPY>(); ! P.defaultApplied(0)) {
+    if (const auto& P = record.getItem<BCMECHKEY::DISPY>(); ! P.defaultApplied(0)) {
         mechbcvaluetmp.disp[1] = P.getSIDouble(0);
-        allDefault = false;
     }
-    if (const auto& P = record.getItem<BCKEY::DISPZ>(); ! P.defaultApplied(0)) {
+    if (const auto& P = record.getItem<BCMECHKEY::DISPZ>(); ! P.defaultApplied(0)) {
         mechbcvaluetmp.disp[2] = P.getSIDouble(0);
-        allDefault = false;
     }
-    if (const auto& P = record.getItem<BCKEY::FIXEDX>(); ! P.defaultApplied(0)) {
-        mechbcvaluetmp.fixeddir[0] = P.get<int>(0);
-        allDefault = false;
-    }
-    if (const auto& P = record.getItem<BCKEY::FIXEDY>(); ! P.defaultApplied(0)) {
-        mechbcvaluetmp.fixeddir[1] = P.get<int>(0);
-        allDefault = false;
-    }
-    if (const auto& P = record.getItem<BCKEY::FIXEDZ>(); ! P.defaultApplied(0)) {
-        mechbcvaluetmp.fixeddir[2] = P.get<int>(0);
-        allDefault = false;
-    }
-    if (!allDefault) {
-        mechbcvalue = mechbcvaluetmp;
-    }
+    mechbcvaluetmp.fixeddir[0] = record.getItem<BCMECHKEY::FIXEDX>().get<int>(0);
+    mechbcvaluetmp.fixeddir[1] = record.getItem<BCMECHKEY::FIXEDY>().get<int>(0);
+    mechbcvaluetmp.fixeddir[2] = record.getItem<BCMECHKEY::FIXEDZ>().get<int>(0);
+    bcmechface.mechbcvalue = mechbcvaluetmp;
+
+    return bcmechface;
 }
 
-BCProp::BCFace BCProp::BCFace::serializationTestObject()
+BCState::BCFace BCState::BCFace::serializationTestObject()
 {
     BCFace result;
     result.index = 100;
@@ -175,7 +169,7 @@ BCProp::BCFace BCProp::BCFace::serializationTestObject()
 }
 
 
-bool BCProp::BCFace::operator==(const BCProp::BCFace& other) const {
+bool BCState::BCFace::operator==(const BCState::BCFace& other) const {
     return this->index == other.index &&
            this->bctype == other.bctype &&
            this->bcmechtype == other.bcmechtype &&
@@ -188,46 +182,82 @@ bool BCProp::BCFace::operator==(const BCProp::BCFace& other) const {
 
 
 
-void BCProp::updateBCProp(const DeckRecord& record)
+void BCState::updateBCProp(const DeckRecord& record)
 {
-    const BCProp::BCFace bcnew(record);
+    const BCFace bcnew = BCFace::fromBCProp(record);
     auto it = std::ranges::find_if(m_faces,
                                    [&bcnew](const auto& bc)
                                    {
                                        return bc.index == bcnew.index &&
                                               bc.component == bcnew.component;
                                    });
+    if (it == m_faces.end()) {
+        // If a BCMECH record already created a face for this index that has no flow data of
+        // its own, claim it instead of forking a duplicate face for the same index.
+        static constexpr BCFace defaultFace{};
+        auto isUnclaimedByBCProp = [](const BCFace& bc) {
+            return bc.bctype == defaultFace.bctype &&
+                bc.component == defaultFace.component &&
+                bc.rate == defaultFace.rate &&
+                bc.pressure == defaultFace.pressure &&
+                bc.temperature == defaultFace.temperature;
+        };
+        it = std::ranges::find_if(m_faces,
+                                  [&bcnew, &isUnclaimedByBCProp](const auto& bc) {
+                                      return bc.index == bcnew.index &&
+                                          isUnclaimedByBCProp(bc);
+                                  });
+    }
     if (it != m_faces.end()) {
-        *it = bcnew;
+        it->bctype = bcnew.bctype;
+        it->component = bcnew.component;
+        it->rate = bcnew.rate;
+        it->pressure = bcnew.pressure;
+        it->temperature = bcnew.temperature;
+    } else {
+        this->m_faces.emplace_back(bcnew);
+    }
+}
+
+void BCState::updateBCMech(const DeckRecord& record)
+{
+    const BCFace bcnew = BCFace::fromBCMech(record);
+    auto it = std::ranges::find_if(m_faces,
+                                   [&bcnew](const auto& bc)
+                                   {
+                                       return bc.index == bcnew.index;
+                                   });
+    if (it != m_faces.end()) {
+        it->bcmechtype = bcnew.bcmechtype;
+        it->mechbcvalue = bcnew.mechbcvalue;
     } else {
         this->m_faces.emplace_back(bcnew);
     }
 }
 
 
-
-BCProp BCProp::serializationTestObject()
+BCState BCState::serializationTestObject()
 {
-    BCProp result;
+    BCState result;
     result.m_faces = {BCFace::serializationTestObject()};
 
     return result;
 }
 
 
-std::size_t BCProp::size() const {
+std::size_t BCState::size() const {
     return this->m_faces.size();
 }
 
-std::vector<BCProp::BCFace>::const_iterator BCProp::begin() const {
+std::vector<BCState::BCFace>::const_iterator BCState::begin() const {
     return this->m_faces.begin();
 }
 
-std::vector<BCProp::BCFace>::const_iterator BCProp::end() const {
+std::vector<BCState::BCFace>::const_iterator BCState::end() const {
     return this->m_faces.end();
 }
 
-const BCProp::BCFace& BCProp::operator[](int index) const
+const BCState::BCFace& BCState::operator[](int index) const
 {
     const auto it = std::ranges::find_if(m_faces,
                                          [index](const auto& bc)
@@ -241,7 +271,7 @@ const BCProp::BCFace& BCProp::operator[](int index) const
     return this->m_faces[0];
 }
 
-bool BCProp::operator==(const BCProp& other) const {
+bool BCState::operator==(const BCState& other) const {
     return this->m_faces == other.m_faces;
 }
 

--- a/opm/input/eclipse/Schedule/BCState.cpp
+++ b/opm/input/eclipse/Schedule/BCState.cpp
@@ -20,7 +20,7 @@
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/B.hpp>
-#include <opm/input/eclipse/Schedule/BCProp.hpp>
+#include <opm/input/eclipse/Schedule/BCState.hpp>
 
 #include <algorithm>
 #include <string>
@@ -100,67 +100,61 @@ BCComponent component(const std::string& s) {
 }
 
 using BCKEY = ParserKeywords::BCPROP;
-BCProp::BCFace::BCFace(const DeckRecord& record) :
-    index(record.getItem<BCKEY::INDEX>().get<int>(0)),
-    bctype(fromstring::bctype(record.getItem<BCKEY::TYPE>().get<std::string>(0))),
-    bcmechtype(fromstring::bcmechtype(record.getItem<BCKEY::MECHTYPE>().get<std::string>(0))),
-    component(fromstring::component(record.getItem<BCKEY::COMPONENT>().get<std::string>(0))),
-    rate(record.getItem<BCKEY::RATE>().getSIDouble(0))
+BCState::BCFace BCState::BCFace::fromBCProp(const DeckRecord& record)
 {
+    BCFace bcpropface;
+    bcpropface.index = record.getItem<BCKEY::INDEX>().get<int>(0);
+    bcpropface.bctype = fromstring::bctype(record.getItem<BCKEY::TYPE>().get<std::string>(0));
+    bcpropface.component = fromstring::component(record.getItem<BCKEY::COMPONENT>().get<std::string>(0));
+    bcpropface.rate = record.getItem<BCKEY::RATE>().getSIDouble(0);
     if (const auto& P = record.getItem<BCKEY::PRESSURE>(); ! P.defaultApplied(0)) {
-        pressure = P.getSIDouble(0);
+        bcpropface.pressure = P.getSIDouble(0);
     }
     if (const auto& T = record.getItem<BCKEY::TEMPERATURE>(); ! T.defaultApplied(0)) {
-        temperature = T.getSIDouble(0);
+        bcpropface.temperature = T.getSIDouble(0);
     }
+    return bcpropface;
+}
+
+using BCMECHKEY = ParserKeywords::BCMECH;
+BCState::BCFace BCState::BCFace::fromBCMech(const DeckRecord& record)
+{
+    BCFace bcmechface;
+    bcmechface.index = record.getItem<BCMECHKEY::INDEX>().get<int>(0);
+    bcmechface.bcmechtype =
+        fromstring::bcmechtype(record.getItem<BCMECHKEY::MECHTYPE>().get<std::string>(0));
 
     MechBCValue mechbcvaluetmp;
-    bool allDefault = true;
-    if (const auto& P = record.getItem<BCKEY::STRESSXX>(); ! P.defaultApplied(0)) {
+    if (const auto& P = record.getItem<BCMECHKEY::STRESSXX>(); ! P.defaultApplied(0)) {
         mechbcvaluetmp.stress[0] = P.getSIDouble(0);
-        allDefault = false;
     }
-    if (const auto& P = record.getItem<BCKEY::STRESSYY>(); ! P.defaultApplied(0)) {
+    if (const auto& P = record.getItem<BCMECHKEY::STRESSYY>(); ! P.defaultApplied(0)) {
         mechbcvaluetmp.stress[1] = P.getSIDouble(0);
-        allDefault = false;
     }
-    if (const auto& P = record.getItem<BCKEY::STRESSZZ>(); ! P.defaultApplied(0)) {
+    if (const auto& P = record.getItem<BCMECHKEY::STRESSZZ>(); ! P.defaultApplied(0)) {
         mechbcvaluetmp.stress[2] = P.getSIDouble(0);
-        allDefault = false;
     }
     mechbcvaluetmp.stress[3] = 0;
     mechbcvaluetmp.stress[4] = 0;
     mechbcvaluetmp.stress[5] = 0;
-    if (const auto& P = record.getItem<BCKEY::DISPX>(); ! P.defaultApplied(0)) {
+    if (const auto& P = record.getItem<BCMECHKEY::DISPX>(); ! P.defaultApplied(0)) {
         mechbcvaluetmp.disp[0] = P.getSIDouble(0);
-        allDefault = false;
     }
-    if (const auto& P = record.getItem<BCKEY::DISPY>(); ! P.defaultApplied(0)) {
+    if (const auto& P = record.getItem<BCMECHKEY::DISPY>(); ! P.defaultApplied(0)) {
         mechbcvaluetmp.disp[1] = P.getSIDouble(0);
-        allDefault = false;
     }
-    if (const auto& P = record.getItem<BCKEY::DISPZ>(); ! P.defaultApplied(0)) {
+    if (const auto& P = record.getItem<BCMECHKEY::DISPZ>(); ! P.defaultApplied(0)) {
         mechbcvaluetmp.disp[2] = P.getSIDouble(0);
-        allDefault = false;
     }
-    if (const auto& P = record.getItem<BCKEY::FIXEDX>(); ! P.defaultApplied(0)) {
-        mechbcvaluetmp.fixeddir[0] = P.get<int>(0);
-        allDefault = false;
-    }
-    if (const auto& P = record.getItem<BCKEY::FIXEDY>(); ! P.defaultApplied(0)) {
-        mechbcvaluetmp.fixeddir[1] = P.get<int>(0);
-        allDefault = false;
-    }
-    if (const auto& P = record.getItem<BCKEY::FIXEDZ>(); ! P.defaultApplied(0)) {
-        mechbcvaluetmp.fixeddir[2] = P.get<int>(0);
-        allDefault = false;
-    }
-    if (!allDefault) {
-        mechbcvalue = mechbcvaluetmp;
-    }
+    mechbcvaluetmp.fixeddir[0] = record.getItem<BCMECHKEY::FIXEDX>().get<int>(0);
+    mechbcvaluetmp.fixeddir[1] = record.getItem<BCMECHKEY::FIXEDY>().get<int>(0);
+    mechbcvaluetmp.fixeddir[2] = record.getItem<BCMECHKEY::FIXEDZ>().get<int>(0);
+    bcmechface.mechbcvalue = mechbcvaluetmp;
+
+    return bcmechface;
 }
 
-BCProp::BCFace BCProp::BCFace::serializationTestObject()
+BCState::BCFace BCState::BCFace::serializationTestObject()
 {
     BCFace result;
     result.index = 100;
@@ -175,7 +169,7 @@ BCProp::BCFace BCProp::BCFace::serializationTestObject()
 }
 
 
-bool BCProp::BCFace::operator==(const BCProp::BCFace& other) const {
+bool BCState::BCFace::operator==(const BCState::BCFace& other) const {
     return this->index == other.index &&
            this->bctype == other.bctype &&
            this->bcmechtype == other.bcmechtype &&
@@ -188,9 +182,9 @@ bool BCProp::BCFace::operator==(const BCProp::BCFace& other) const {
 
 
 
-void BCProp::updateBCProp(const DeckRecord& record)
+void BCState::updateBCProp(const DeckRecord& record)
 {
-    const BCProp::BCFace bcnew(record);
+    const BCFace bcnew = BCFace::fromBCProp(record);
     auto it = std::ranges::find_if(m_faces,
                                    [&bcnew](const auto& bc)
                                    {
@@ -198,36 +192,55 @@ void BCProp::updateBCProp(const DeckRecord& record)
                                               bc.component == bcnew.component;
                                    });
     if (it != m_faces.end()) {
-        *it = bcnew;
+        it->bctype = bcnew.bctype;
+        it->component = bcnew.component;
+        it->rate = bcnew.rate;
+        it->pressure = bcnew.pressure;
+        it->temperature = bcnew.temperature;
+    } else {
+        this->m_faces.emplace_back(bcnew);
+    }
+}
+
+void BCState::updateBCMech(const DeckRecord& record)
+{
+    const BCFace bcnew = BCFace::fromBCMech(record);
+    auto it = std::ranges::find_if(m_faces,
+                                   [&bcnew](const auto& bc)
+                                   {
+                                       return bc.index == bcnew.index;
+                                   });
+    if (it != m_faces.end()) {
+        it->bcmechtype = bcnew.bcmechtype;
+        it->mechbcvalue = bcnew.mechbcvalue;
     } else {
         this->m_faces.emplace_back(bcnew);
     }
 }
 
 
-
-BCProp BCProp::serializationTestObject()
+BCState BCState::serializationTestObject()
 {
-    BCProp result;
+    BCState result;
     result.m_faces = {BCFace::serializationTestObject()};
 
     return result;
 }
 
 
-std::size_t BCProp::size() const {
+std::size_t BCState::size() const {
     return this->m_faces.size();
 }
 
-std::vector<BCProp::BCFace>::const_iterator BCProp::begin() const {
+std::vector<BCState::BCFace>::const_iterator BCState::begin() const {
     return this->m_faces.begin();
 }
 
-std::vector<BCProp::BCFace>::const_iterator BCProp::end() const {
+std::vector<BCState::BCFace>::const_iterator BCState::end() const {
     return this->m_faces.end();
 }
 
-const BCProp::BCFace& BCProp::operator[](int index) const
+const BCState::BCFace& BCState::operator[](int index) const
 {
     const auto it = std::ranges::find_if(m_faces,
                                          [index](const auto& bc)
@@ -241,7 +254,7 @@ const BCProp::BCFace& BCProp::operator[](int index) const
     return this->m_faces[0];
 }
 
-bool BCProp::operator==(const BCProp& other) const {
+bool BCState::operator==(const BCState& other) const {
     return this->m_faces == other.m_faces;
 }
 

--- a/opm/input/eclipse/Schedule/BCState.hpp
+++ b/opm/input/eclipse/Schedule/BCState.hpp
@@ -18,8 +18,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OPM_BC_PROP_HPP
-#define OPM_BC_PROP_HPP
+#ifndef OPM_BC_STATE_HPP
+#define OPM_BC_STATE_HPP
 
 #include <vector>
 #include <cstddef>
@@ -88,7 +88,7 @@ struct MechBCValue {
     }
 };
 
-class BCProp
+class BCState
 {
 public:
     struct BCFace
@@ -101,12 +101,13 @@ public:
         std::optional<double> pressure{};
         std::optional<double> temperature{};
 
-        std::optional<MechBCValue> mechbcvalue{};
+        MechBCValue mechbcvalue{};
 
         BCFace() = default;
-        explicit BCFace(const DeckRecord& record);
 
         static BCFace serializationTestObject();
+        static BCFace fromBCProp(const DeckRecord& record);
+        static BCFace fromBCMech(const DeckRecord& record);
 
         bool operator==(const BCFace& other) const;
 
@@ -124,17 +125,18 @@ public:
         }
     };
 
-    BCProp() = default;
+    BCState() = default;
 
-    static BCProp serializationTestObject();
+    static BCState serializationTestObject();
 
     std::size_t size() const;
     std::vector<BCFace>::const_iterator begin() const;
     std::vector<BCFace>::const_iterator end() const;
-    bool operator==(const BCProp& other) const;
+    bool operator==(const BCState& other) const;
     const BCFace& operator[](int index) const;
 
     void updateBCProp(const DeckRecord& record);
+    void updateBCMech(const DeckRecord& record);
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)

--- a/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -95,9 +95,17 @@ void handleAQUFLUX(HandlerContext& handlerContext)
 
 void handleBCProp(HandlerContext& handlerContext)
 {
-    auto& bcprop = handlerContext.state().bcprop;
+    auto& bcstate = handlerContext.state().bcstate;
     for (const auto& record : handlerContext.keyword) {
-        bcprop.updateBCProp(record);
+        bcstate.updateBCProp(record);
+    }
+}
+
+void handleBCMech(HandlerContext& handlerContext)
+{
+    auto& bcstate = handlerContext.state().bcstate;
+    for (const auto& record : handlerContext.keyword) {
+        bcstate.updateBCMech(record);
     }
 }
 
@@ -476,6 +484,7 @@ KeywordHandlers::KeywordHandlers()
         { "AQUCT",    &handleAQUCT      },
         { "AQUFETP",  &handleAQUFETP    },
         { "AQUFLUX",  &handleAQUFLUX    },
+        { "BCMECH",   &handleBCMech     },
         { "BCPROP",   &handleBCProp     },
         { "BOX",      &handleGEOKeyword },
         { "ENDBOX"  , &handleGEOKeyword },

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -27,7 +27,7 @@
 #include <opm/input/eclipse/EclipseState/Phase.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 
-#include <opm/input/eclipse/Schedule/BCProp.hpp>
+#include <opm/input/eclipse/Schedule/BCState.hpp>
 #include <opm/input/eclipse/Schedule/Events.hpp>
 #include <opm/input/eclipse/Schedule/GasPlantTable.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
@@ -656,7 +656,7 @@ namespace Opm {
 
         // constant flux aquifers
         std::unordered_map<int, SingleAquiferFlux> aqufluxs;
-        BCProp bcprop;
+        BCState bcstate;
         // injection streams for compostional STREAM injection using WINJGAS
         map_member<std::string, std::vector<double>> inj_streams;
 
@@ -700,7 +700,7 @@ namespace Opm {
             serializer(this->injectionNetwork);
             serializer(wseed);
             serializer(aqufluxs);
-            serializer(bcprop);
+            serializer(bcstate);
             serializer(inj_streams);
             serializer(target_wellpi);
             serializer(this->next_tstep);

--- a/opm/input/eclipse/share/keywords/900_OPM/B/BCMECH
+++ b/opm/input/eclipse/share/keywords/900_OPM/B/BCMECH
@@ -1,0 +1,68 @@
+{
+  "name": "BCMECH",
+  "sections": [
+    "SCHEDULE"
+  ],
+  "items": [
+    {
+      "name": "INDEX",
+      "value_type": "INT"
+    },
+    {
+      "name": "MECHTYPE",
+      "value_type": "STRING",
+      "default": "NONE"
+    },
+    {
+      "name": "FIXEDX",
+      "value_type": "INT",
+      "default": 1
+    },
+    {
+      "name": "FIXEDY",
+      "value_type": "INT",
+      "default": 1
+    },
+    {
+      "name": "FIXEDZ",
+      "value_type": "INT",
+      "default": 1
+    },
+    {
+      "name": "STRESSXX",
+      "value_type": "DOUBLE",
+      "default": 0,
+      "dimension": "Pressure"
+    },
+    {
+      "name": "STRESSYY",
+      "value_type": "DOUBLE",
+      "default": 0,
+      "dimension": "Pressure"
+    },
+    {
+      "name": "STRESSZZ",
+      "value_type": "DOUBLE",
+      "default": 0,
+      "dimension": "Pressure"
+    },
+    {
+      "name": "DISPX",
+      "value_type": "DOUBLE",
+      "default": 0,
+      "dimension": "Length"
+    },
+    {
+      "name": "DISPY",
+      "value_type": "DOUBLE",
+      "default": 0,
+      "dimension": "Length"
+    },
+    {
+      "name": "DISPZ",
+      "value_type": "DOUBLE",
+      "default": 0,
+      "dimension": "Length"
+    }
+  ]
+}

--- a/opm/input/eclipse/share/keywords/900_OPM/B/BCPROP
+++ b/opm/input/eclipse/share/keywords/900_OPM/B/BCPROP
@@ -33,62 +33,6 @@
       "name": "TEMPERATURE",
       "value_type": "DOUBLE",
       "dimension": "Temperature"
-    },
-    {
-      "name": "MECHTYPE",
-      "value_type": "STRING",
-      "default": "NONE"
-    },
-    {
-      "name": "FIXEDX",
-      "value_type": "INT",
-      "default": 1
-    },
-    {
-      "name": "FIXEDY",
-      "value_type": "INT",
-      "default": 1
-    },
-    {
-      "name": "FIXEDZ",
-      "value_type": "INT",
-      "default": 1
-    },
-    {
-      "name": "STRESSXX",
-      "value_type": "DOUBLE",
-      "default": 0,
-      "dimension": "Pressure"
-    },
-    {
-      "name": "STRESSYY",
-      "value_type": "DOUBLE",
-      "default": 0,
-      "dimension": "Pressure"
-    },
-    {
-      "name": "STRESSZZ",
-      "value_type": "DOUBLE",
-      "default": 0,
-      "dimension": "Pressure"
-    },
-    {
-      "name": "DISPX",
-      "value_type": "DOUBLE",
-      "default": 0,
-      "dimension": "Length"
-    },
-    {
-      "name": "DISPY",
-      "value_type": "DOUBLE",
-      "default": 0,
-      "dimension": "Length"
-    },
-    {
-      "name": "DISPZ",
-      "value_type": "DOUBLE",
-      "default": 0,
-      "dimension": "Length"
     }
   ]
 }

--- a/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1145,6 +1145,7 @@ set( keywords
 
      900_OPM/B/BC
      900_OPM/B/BCCON
+     900_OPM/B/BCMECH
      900_OPM/B/BCPROP
      900_OPM/B/BIOFILM
      900_OPM/B/BIOFPARA

--- a/tests/parser/BCConfigTests.cpp
+++ b/tests/parser/BCConfigTests.cpp
@@ -22,7 +22,7 @@
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/B.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
-#include <opm/input/eclipse/Schedule/BCProp.hpp>
+#include <opm/input/eclipse/Schedule/BCState.hpp>
 
 #include <string>
 
@@ -73,7 +73,7 @@ BCPROP
     auto deck = createDeck(input);
     Opm::BCConfig config(deck);
     const auto& kw = deck.get<Opm::ParserKeywords::BCPROP>();
-    Opm::BCProp prop;
+    Opm::BCState prop;
     for (const auto& record : kw.back()) {
         prop.updateBCProp(record);
     }
@@ -146,7 +146,7 @@ BCPROP
     auto deck = createDeck(input);
     Opm::BCConfig config(deck);
     const auto& kw = deck.get<Opm::ParserKeywords::BCPROP>();
-    Opm::BCProp prop;
+    Opm::BCState prop;
     for (const auto& record : kw.back()) {
         prop.updateBCProp(record);
     }
@@ -190,7 +190,7 @@ BCPROP
                       *prop[2].pressure);
 }
 
-BOOST_AUTO_TEST_CASE(Mech)
+BOOST_AUTO_TEST_CASE(MechOnly)
 {
     const std::string input = R"(
 RUNSPEC
@@ -218,92 +218,198 @@ BCCON
   3 10 15 1 10 4 7 Z /
 /
 SCHEDULE
-BCPROP
- 1 NONE * * * * FIXED 1 0 0 1.0 * * 2.0 * * /
- 2 NONE * * * * FIXED 0 1 0 * 3.0 * /
- 3 NONE * * * * FREE 0 0 1 * * 4.0 * * 5.0 /
+BCMECH
+ 1 FIXED 1 0 0 1.0 * * 2.0 * * /
+ 2 FIXED 0 1 0 * 3.0 * /
+ 3 FREE 0 0 1 * * 4.0 * * 5.0 /
 /
 )";
 
     auto deck = createDeck(input);
     Opm::BCConfig config(deck);
-    const auto& kw = deck.get<Opm::ParserKeywords::BCPROP>();
-    Opm::BCProp prop;
-    for (const auto& record : kw.back()) {
-        prop.updateBCProp(record);
+    Opm::BCState prop;
+    for (const auto& record : deck.get<Opm::ParserKeywords::BCMECH>().back()) {
+        prop.updateBCMech(record);
     }
 
     BOOST_CHECK_EQUAL(config.size(), 3U);
 
     BOOST_CHECK_EQUAL(prop.size(), 3U);
-    BOOST_CHECK(prop[1].bctype == Opm::BCType::NONE);
-    BOOST_CHECK(prop[1].component == Opm::BCComponent::NONE);
+
     using measure = Opm::UnitSystem::measure;
-    BOOST_CHECK_EQUAL(0.0,
+    constexpr Opm::BCState::BCFace defaultFace{};
+
+    // No BCPROP record was ever issued, so the flow fields on every face
+    // must stay at their defaults.
+    BOOST_CHECK(prop[1].bctype == defaultFace.bctype);
+    BOOST_CHECK(prop[1].component == defaultFace.component);
+    BOOST_CHECK_EQUAL(prop[1].rate, defaultFace.rate);
+    BOOST_CHECK(prop[1].pressure == defaultFace.pressure);
+    BOOST_CHECK(prop[1].temperature == defaultFace.temperature);
+
+    BOOST_CHECK(prop[1].bcmechtype == Opm::BCMECHType::FIXED);
+    BOOST_CHECK_EQUAL(prop[1].mechbcvalue.fixeddir[0], 1);
+    BOOST_CHECK_EQUAL(prop[1].mechbcvalue.fixeddir[1], 0);
+    BOOST_CHECK_EQUAL(prop[1].mechbcvalue.fixeddir[2], 0);
+    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::pressure, 1.0),
+                      prop[1].mechbcvalue.stress[0]);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.stress[1], 1e-12);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.stress[2], 1e-12);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.stress[3], 1e-12);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.stress[4], 1e-12);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.stress[5], 1e-12);
+    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::length, 2.0),
+                      prop[1].mechbcvalue.disp[0]);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.disp[1], 1e-12);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.disp[2], 1e-12);
+
+    BOOST_CHECK(prop[2].bctype == defaultFace.bctype);
+    BOOST_CHECK(prop[2].component == defaultFace.component);
+    BOOST_CHECK_EQUAL(prop[2].rate, defaultFace.rate);
+    BOOST_CHECK(prop[2].pressure == defaultFace.pressure);
+    BOOST_CHECK(prop[2].temperature == defaultFace.temperature);
+
+    BOOST_CHECK(prop[2].bcmechtype == Opm::BCMECHType::FIXED);
+    BOOST_CHECK_EQUAL(prop[2].mechbcvalue.fixeddir[0], 0);
+    BOOST_CHECK_EQUAL(prop[2].mechbcvalue.fixeddir[1], 1);
+    BOOST_CHECK_EQUAL(prop[2].mechbcvalue.fixeddir[2], 0);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.stress[0], 1e-12);
+    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::pressure, 3.0),
+                      prop[2].mechbcvalue.stress[1]);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.stress[2], 1e-12);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.stress[3], 1e-12);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.stress[4], 1e-12);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.stress[5], 1e-12);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.disp[0], 1e-12);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.disp[1], 1e-12);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.disp[2], 1e-12);
+
+    BOOST_CHECK(prop[3].bctype == defaultFace.bctype);
+    BOOST_CHECK(prop[3].component == defaultFace.component);
+    BOOST_CHECK_EQUAL(prop[3].rate, defaultFace.rate);
+    BOOST_CHECK(prop[3].pressure == defaultFace.pressure);
+    BOOST_CHECK(prop[3].temperature == defaultFace.temperature);
+
+    BOOST_CHECK(prop[3].bcmechtype == Opm::BCMECHType::FREE);
+    BOOST_CHECK_EQUAL(prop[3].mechbcvalue.fixeddir[0], 0);
+    BOOST_CHECK_EQUAL(prop[3].mechbcvalue.fixeddir[1], 0);
+    BOOST_CHECK_EQUAL(prop[3].mechbcvalue.fixeddir[2], 1);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.stress[0], 1e-12);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.stress[1], 1e-12);
+    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::pressure, 4.0),
+                      prop[3].mechbcvalue.stress[2]);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.stress[3], 1e-12);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.stress[4], 1e-12);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.stress[5], 1e-12);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.disp[0], 1e-12);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.disp[1], 1e-12);
+    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::length, 5.0),
+                      prop[3].mechbcvalue.disp[2]);
+}
+
+BOOST_AUTO_TEST_CASE(BcPropAndBcMech)
+{
+    const std::string input = R"(
+RUNSPEC
+
+DIMENS
+  10 10 3 /
+OIL
+GAS
+WATER
+LAB
+START
+  1 'JAN' 2015 /
+GRID
+DX
+  300*1000 /
+DY
+  300*1000 /
+DZ
+  300*1000 /
+TOPS
+  100*8325 /
+BCCON
+  1 1* * 1 5 1 10 Y- /
+  2 20 20 4* Y /
+  3 10 15 1 10 4 7 Z /
+/
+SCHEDULE
+BCMECH
+ 1 FIXED 1 0 0 1.0 * * 2.0 * * /
+ 3 FREE 0 0 1 * * 4.0 * * 5.0 /
+/
+BCPROP
+ 1 RATE GAS -0.01 /
+ 2 THERMAL WATER -0.05 * 50.0 /
+/
+)";
+
+    auto deck = createDeck(input);
+    Opm::BCConfig config(deck);
+    Opm::BCState prop;
+    for (const auto& record : deck.get<Opm::ParserKeywords::BCMECH>().back()) {
+        prop.updateBCMech(record);
+    }
+    for (const auto& record : deck.get<Opm::ParserKeywords::BCPROP>().back()) {
+        prop.updateBCProp(record);
+    }
+
+    BOOST_CHECK_EQUAL(config.size(), 3U);
+    BOOST_CHECK_EQUAL(prop.size(), 3U);
+
+    using measure = Opm::UnitSystem::measure;
+
+    // Index 1: BCMECH data must survive the later BCPROP record for the
+    // same index, and vice versa
+    BOOST_CHECK(prop[1].bctype == Opm::BCType::RATE);
+    BOOST_CHECK(prop[1].component == Opm::BCComponent::GAS);
+    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si("Mass/Time*Length*Length", -0.01),
                       prop[1].rate);
     BOOST_CHECK(!prop[1].pressure.has_value());
     BOOST_CHECK(!prop[1].temperature.has_value());
-    BOOST_CHECK(prop[1].bcmechtype == Opm::BCMECHType::FIXED);
-    BOOST_CHECK(prop[1].mechbcvalue.has_value());
-    BOOST_CHECK_EQUAL(prop[1].mechbcvalue->fixeddir[0], 1);
-    BOOST_CHECK_EQUAL(prop[1].mechbcvalue->fixeddir[1], 0);
-    BOOST_CHECK_EQUAL(prop[1].mechbcvalue->fixeddir[2], 0);
-    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::pressure, 1.0),
-                      prop[1].mechbcvalue->stress[0]);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->stress[1], 1e-12);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->stress[2], 1e-12);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->stress[3], 1e-12);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->stress[4], 1e-12);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->stress[5], 1e-12);
-    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::length, 2.0),
-                      prop[1].mechbcvalue->disp[0]);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->disp[1], 1e-12);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->disp[2], 1e-12);
 
-    BOOST_CHECK(prop[2].bctype == Opm::BCType::NONE);
-    BOOST_CHECK(prop[2].component == Opm::BCComponent::NONE);
-    using measure = Opm::UnitSystem::measure;
-    BOOST_CHECK_EQUAL(0.0,
+    BOOST_CHECK(prop[1].bcmechtype == Opm::BCMECHType::FIXED);
+    BOOST_CHECK_EQUAL(prop[1].mechbcvalue.fixeddir[0], 1);
+    BOOST_CHECK_EQUAL(prop[1].mechbcvalue.fixeddir[1], 0);
+    BOOST_CHECK_EQUAL(prop[1].mechbcvalue.fixeddir[2], 0);
+    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::pressure, 1.0),
+                      prop[1].mechbcvalue.stress[0]);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.stress[1], 1e-12);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.stress[2], 1e-12);
+    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::length, 2.0),
+                      prop[1].mechbcvalue.disp[0]);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.disp[1], 1e-12);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.disp[2], 1e-12);
+
+    // Default values for BCPROP and BCMECH to check against
+    constexpr Opm::BCState::BCFace defaultFace{};
+
+    // Index 2: only BCPROP for this face; the mechanical fields must be default values.
+    BOOST_CHECK(prop[2].bctype == Opm::BCType::THERMAL);
+    BOOST_CHECK(prop[2].component == Opm::BCComponent::WATER);
+    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si("Mass/Time*Length*Length", -0.05),
                       prop[2].rate);
     BOOST_CHECK(!prop[2].pressure.has_value());
-    BOOST_CHECK(!prop[2].temperature.has_value());
-    BOOST_CHECK(prop[2].bcmechtype == Opm::BCMECHType::FIXED);
-    BOOST_CHECK(prop[2].mechbcvalue.has_value());
-    BOOST_CHECK_EQUAL(prop[2].mechbcvalue->fixeddir[0], 0);
-    BOOST_CHECK_EQUAL(prop[2].mechbcvalue->fixeddir[1], 1);
-    BOOST_CHECK_EQUAL(prop[2].mechbcvalue->fixeddir[2], 0);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->stress[0], 1e-12);
-    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::pressure, 3.0),
-                      prop[2].mechbcvalue->stress[1]);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->stress[2], 1e-12);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->stress[3], 1e-12);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->stress[4], 1e-12);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->stress[5], 1e-12);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->disp[0], 1e-12);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->disp[1], 1e-12);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->disp[2], 1e-12);
+    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::temperature, 50.0),
+                      *prop[2].temperature);
 
-    BOOST_CHECK(prop[3].bctype == Opm::BCType::NONE);
-    BOOST_CHECK(prop[3].component == Opm::BCComponent::NONE);
-    using measure = Opm::UnitSystem::measure;
-    BOOST_CHECK_EQUAL(0.0,
-                      prop[3].rate);
-    BOOST_CHECK(!prop[3].pressure.has_value());
-    BOOST_CHECK(!prop[3].temperature.has_value());
+    BOOST_CHECK(prop[2].bcmechtype == defaultFace.bcmechtype);
+    BOOST_CHECK(prop[2].mechbcvalue == defaultFace.mechbcvalue);
+
+    // Index 3: only BCMECH for this face; the flow fields must be  default values.
+    BOOST_CHECK(prop[3].bctype == defaultFace.bctype);
+    BOOST_CHECK(prop[3].component == defaultFace.component);
+    BOOST_CHECK_EQUAL(prop[3].rate, defaultFace.rate);
+    BOOST_CHECK(prop[3].pressure == defaultFace.pressure);
+    BOOST_CHECK(prop[3].temperature == defaultFace.temperature);
+
     BOOST_CHECK(prop[3].bcmechtype == Opm::BCMECHType::FREE);
-    BOOST_CHECK(prop[3].mechbcvalue.has_value());
-    BOOST_CHECK_EQUAL(prop[3].mechbcvalue->fixeddir[0], 0);
-    BOOST_CHECK_EQUAL(prop[3].mechbcvalue->fixeddir[1], 0);
-    BOOST_CHECK_EQUAL(prop[3].mechbcvalue->fixeddir[2], 1);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->stress[0], 1e-12);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->stress[1], 1e-12);
+    BOOST_CHECK_EQUAL(prop[3].mechbcvalue.fixeddir[0], 0);
+    BOOST_CHECK_EQUAL(prop[3].mechbcvalue.fixeddir[1], 0);
+    BOOST_CHECK_EQUAL(prop[3].mechbcvalue.fixeddir[2], 1);
     BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::pressure, 4.0),
-                      prop[3].mechbcvalue->stress[2]);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->stress[3], 1e-12);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->stress[4], 1e-12);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->stress[5], 1e-12);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->disp[0], 1e-12);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->disp[1], 1e-12);
+                      prop[3].mechbcvalue.stress[2]);
     BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::length, 5.0),
-                      prop[3].mechbcvalue->disp[2]);
+                      prop[3].mechbcvalue.disp[2]);
 }

--- a/tests/parser/BCConfigTests.cpp
+++ b/tests/parser/BCConfigTests.cpp
@@ -22,7 +22,7 @@
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/B.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
-#include <opm/input/eclipse/Schedule/BCProp.hpp>
+#include <opm/input/eclipse/Schedule/BCState.hpp>
 
 #include <string>
 
@@ -73,7 +73,7 @@ BCPROP
     auto deck = createDeck(input);
     Opm::BCConfig config(deck);
     const auto& kw = deck.get<Opm::ParserKeywords::BCPROP>();
-    Opm::BCProp prop;
+    Opm::BCState prop;
     for (const auto& record : kw.back()) {
         prop.updateBCProp(record);
     }
@@ -146,7 +146,7 @@ BCPROP
     auto deck = createDeck(input);
     Opm::BCConfig config(deck);
     const auto& kw = deck.get<Opm::ParserKeywords::BCPROP>();
-    Opm::BCProp prop;
+    Opm::BCState prop;
     for (const auto& record : kw.back()) {
         prop.updateBCProp(record);
     }
@@ -218,92 +218,71 @@ BCCON
   3 10 15 1 10 4 7 Z /
 /
 SCHEDULE
-BCPROP
- 1 NONE * * * * FIXED 1 0 0 1.0 * * 2.0 * * /
- 2 NONE * * * * FIXED 0 1 0 * 3.0 * /
- 3 NONE * * * * FREE 0 0 1 * * 4.0 * * 5.0 /
+BCMECH
+ 1 FIXED 1 0 0 1.0 * * 2.0 * * /
+ 2 FIXED 0 1 0 * 3.0 * /
+ 3 FREE 0 0 1 * * 4.0 * * 5.0 /
 /
 )";
 
     auto deck = createDeck(input);
     Opm::BCConfig config(deck);
-    const auto& kw = deck.get<Opm::ParserKeywords::BCPROP>();
-    Opm::BCProp prop;
-    for (const auto& record : kw.back()) {
-        prop.updateBCProp(record);
+    Opm::BCState prop;
+    for (const auto& record : deck.get<Opm::ParserKeywords::BCMECH>().back()) {
+        prop.updateBCMech(record);
     }
 
     BOOST_CHECK_EQUAL(config.size(), 3U);
 
     BOOST_CHECK_EQUAL(prop.size(), 3U);
-    BOOST_CHECK(prop[1].bctype == Opm::BCType::NONE);
-    BOOST_CHECK(prop[1].component == Opm::BCComponent::NONE);
+
     using measure = Opm::UnitSystem::measure;
-    BOOST_CHECK_EQUAL(0.0,
-                      prop[1].rate);
-    BOOST_CHECK(!prop[1].pressure.has_value());
-    BOOST_CHECK(!prop[1].temperature.has_value());
     BOOST_CHECK(prop[1].bcmechtype == Opm::BCMECHType::FIXED);
-    BOOST_CHECK(prop[1].mechbcvalue.has_value());
-    BOOST_CHECK_EQUAL(prop[1].mechbcvalue->fixeddir[0], 1);
-    BOOST_CHECK_EQUAL(prop[1].mechbcvalue->fixeddir[1], 0);
-    BOOST_CHECK_EQUAL(prop[1].mechbcvalue->fixeddir[2], 0);
+    BOOST_CHECK_EQUAL(prop[1].mechbcvalue.fixeddir[0], 1);
+    BOOST_CHECK_EQUAL(prop[1].mechbcvalue.fixeddir[1], 0);
+    BOOST_CHECK_EQUAL(prop[1].mechbcvalue.fixeddir[2], 0);
     BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::pressure, 1.0),
-                      prop[1].mechbcvalue->stress[0]);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->stress[1], 1e-12);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->stress[2], 1e-12);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->stress[3], 1e-12);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->stress[4], 1e-12);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->stress[5], 1e-12);
+                      prop[1].mechbcvalue.stress[0]);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.stress[1], 1e-12);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.stress[2], 1e-12);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.stress[3], 1e-12);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.stress[4], 1e-12);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.stress[5], 1e-12);
     BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::length, 2.0),
-                      prop[1].mechbcvalue->disp[0]);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->disp[1], 1e-12);
-    BOOST_CHECK_SMALL(prop[1].mechbcvalue->disp[2], 1e-12);
+                      prop[1].mechbcvalue.disp[0]);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.disp[1], 1e-12);
+    BOOST_CHECK_SMALL(prop[1].mechbcvalue.disp[2], 1e-12);
 
-    BOOST_CHECK(prop[2].bctype == Opm::BCType::NONE);
-    BOOST_CHECK(prop[2].component == Opm::BCComponent::NONE);
-    using measure = Opm::UnitSystem::measure;
-    BOOST_CHECK_EQUAL(0.0,
-                      prop[2].rate);
-    BOOST_CHECK(!prop[2].pressure.has_value());
-    BOOST_CHECK(!prop[2].temperature.has_value());
     BOOST_CHECK(prop[2].bcmechtype == Opm::BCMECHType::FIXED);
-    BOOST_CHECK(prop[2].mechbcvalue.has_value());
-    BOOST_CHECK_EQUAL(prop[2].mechbcvalue->fixeddir[0], 0);
-    BOOST_CHECK_EQUAL(prop[2].mechbcvalue->fixeddir[1], 1);
-    BOOST_CHECK_EQUAL(prop[2].mechbcvalue->fixeddir[2], 0);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->stress[0], 1e-12);
+    BOOST_CHECK_EQUAL(prop[2].mechbcvalue.fixeddir[0], 0);
+    BOOST_CHECK_EQUAL(prop[2].mechbcvalue.fixeddir[1], 1);
+    BOOST_CHECK_EQUAL(prop[2].mechbcvalue.fixeddir[2], 0);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.stress[0], 1e-12);
     BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::pressure, 3.0),
-                      prop[2].mechbcvalue->stress[1]);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->stress[2], 1e-12);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->stress[3], 1e-12);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->stress[4], 1e-12);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->stress[5], 1e-12);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->disp[0], 1e-12);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->disp[1], 1e-12);
-    BOOST_CHECK_SMALL(prop[2].mechbcvalue->disp[2], 1e-12);
+                      prop[2].mechbcvalue.stress[1]);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.stress[2], 1e-12);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.stress[3], 1e-12);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.stress[4], 1e-12);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.stress[5], 1e-12);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.disp[0], 1e-12);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.disp[1], 1e-12);
+    BOOST_CHECK_SMALL(prop[2].mechbcvalue.disp[2], 1e-12);
 
-    BOOST_CHECK(prop[3].bctype == Opm::BCType::NONE);
-    BOOST_CHECK(prop[3].component == Opm::BCComponent::NONE);
-    using measure = Opm::UnitSystem::measure;
-    BOOST_CHECK_EQUAL(0.0,
-                      prop[3].rate);
     BOOST_CHECK(!prop[3].pressure.has_value());
     BOOST_CHECK(!prop[3].temperature.has_value());
     BOOST_CHECK(prop[3].bcmechtype == Opm::BCMECHType::FREE);
-    BOOST_CHECK(prop[3].mechbcvalue.has_value());
-    BOOST_CHECK_EQUAL(prop[3].mechbcvalue->fixeddir[0], 0);
-    BOOST_CHECK_EQUAL(prop[3].mechbcvalue->fixeddir[1], 0);
-    BOOST_CHECK_EQUAL(prop[3].mechbcvalue->fixeddir[2], 1);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->stress[0], 1e-12);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->stress[1], 1e-12);
+    BOOST_CHECK_EQUAL(prop[3].mechbcvalue.fixeddir[0], 0);
+    BOOST_CHECK_EQUAL(prop[3].mechbcvalue.fixeddir[1], 0);
+    BOOST_CHECK_EQUAL(prop[3].mechbcvalue.fixeddir[2], 1);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.stress[0], 1e-12);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.stress[1], 1e-12);
     BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::pressure, 4.0),
-                      prop[3].mechbcvalue->stress[2]);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->stress[3], 1e-12);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->stress[4], 1e-12);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->stress[5], 1e-12);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->disp[0], 1e-12);
-    BOOST_CHECK_SMALL(prop[3].mechbcvalue->disp[1], 1e-12);
+                      prop[3].mechbcvalue.stress[2]);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.stress[3], 1e-12);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.stress[4], 1e-12);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.stress[5], 1e-12);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.disp[0], 1e-12);
+    BOOST_CHECK_SMALL(prop[3].mechbcvalue.disp[1], 1e-12);
     BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::length, 5.0),
-                      prop[3].mechbcvalue->disp[2]);
+                      prop[3].mechbcvalue.disp[2]);
 }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -7084,7 +7084,7 @@ BCPROP
     const auto& schedule = make_schedule(input);
     {
         std::size_t currentStep = 0;
-        const auto& bc = schedule[currentStep].bcprop;
+        const auto& bc = schedule[currentStep].bcstate;
         BOOST_CHECK_EQUAL(bc.size(), 2);
         const auto& bcface0 = bc[0];
         BOOST_CHECK_CLOSE(bcface0.rate * Opm::unit::day, 100, 1e-8 );
@@ -7092,7 +7092,7 @@ BCPROP
 
     {
         std::size_t currentStep = 1;
-        const auto& bc = schedule[currentStep].bcprop;
+        const auto& bc = schedule[currentStep].bcstate;
         BOOST_CHECK_EQUAL(bc.size(), 2);
         const auto& bcface0 = bc[0];
         BOOST_CHECK_CLOSE(bcface0.rate * Opm::unit::day, 200, 1e-8 );

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -6855,7 +6855,7 @@ BCPROP
     const auto& schedule = make_schedule(input);
     {
         std::size_t currentStep = 0;
-        const auto& bc = schedule[currentStep].bcprop;
+        const auto& bc = schedule[currentStep].bcstate;
         BOOST_CHECK_EQUAL(bc.size(), 2);
         const auto& bcface0 = bc[0];
         BOOST_CHECK_CLOSE(bcface0.rate * Opm::unit::day, 100, 1e-8 );
@@ -6863,7 +6863,7 @@ BCPROP
 
     {
         std::size_t currentStep = 1;
-        const auto& bc = schedule[currentStep].bcprop;
+        const auto& bc = schedule[currentStep].bcstate;
         BOOST_CHECK_EQUAL(bc.size(), 2);
         const auto& bcface0 = bc[0];
         BOOST_CHECK_CLOSE(bcface0.rate * Opm::unit::day, 200, 1e-8 );


### PR DESCRIPTION
This PR separates out the items for defining geomechanics boundary condition from BCPROP to a new keyword BCMECH. This allows for both keywords to be used together in a deck, or defining one without the other. 
Note that the class where both keywords are parsed is renamed from BCProp to BCState to avoid confusion, since it now parses two keywords, BCPROP and BCMECH.