### PR TITLE
[PH-Flash] Add mixture enthalpy models with cited caloric data and baseline flash tests

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -709,6 +709,7 @@ list(APPEND DUNE_TEST_SOURCE_FILES
   tests/material/test_ncpflash.cpp
   tests/material/test_pengrobinson.cpp
   tests/material/test_tabulation.cpp
+  tests/material/test_mixture_enthalpy.cpp
   tests/material/test_threecomponents_ptflash.cpp
   tests/material/test_twocomponents_ptflash.cpp
 )
@@ -1313,6 +1314,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/material/components/BrineDynamic.hpp
   opm/material/components/C1.hpp
   opm/material/components/C10.hpp
+  opm/material/components/ComponentCp.hpp
   opm/material/components/CO2.hpp
   opm/material/components/CO2Tables.hpp
   opm/material/components/Component.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1337,8 +1337,10 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/material/components/iapws/Region4.hpp
   opm/material/constraintsolvers/CompositionFromFugacities.hpp
   opm/material/constraintsolvers/ComputeFromReferencePhase.hpp
+  opm/material/constraintsolvers/IdealGasCaloricData.hpp
   opm/material/constraintsolvers/ImmiscibleFlash.hpp
   opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp
+  opm/material/constraintsolvers/MixtureEnthalpy.hpp
   opm/material/constraintsolvers/NcpFlash.hpp
   opm/material/constraintsolvers/PTFlash.hpp
   opm/material/densead/DynamicEvaluation.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -710,6 +710,7 @@ list(APPEND DUNE_TEST_SOURCE_FILES
   tests/material/test_pengrobinson.cpp
   tests/material/test_tabulation.cpp
   tests/material/test_threecomponents_ptflash.cpp
+  tests/material/test_twocomponents_ptflash.cpp
 )
 
 if(dune-common_FOUND)

--- a/opm/material/components/C1.hpp
+++ b/opm/material/components/C1.hpp
@@ -28,6 +28,7 @@
 #define OPM_C1_HPP
 
 #include "Component.hpp"
+#include "ComponentCp.hpp"
 
 #include <opm/material/IdealGas.hpp>
 #include <opm/material/common/MathToolbox.hpp>
@@ -42,7 +43,11 @@ namespace Opm
 /*!
  * \ingroup Components
  *
- * \brief Properties of pure molecular methane \f$C_1\f$.
+ * \brief Properties of pure molecular methane \f$C_1\f$
+ *        (CAS 74-82-8, formula CH\f$_4\f$).
+ *
+ * Constants cross-checked against the CoolProp reference fluid "Methane"
+ * (reference EoS: Setzmann & Wagner, J. Phys. Chem. Ref. Data 20 (1991) 1061).
  *
  * \tparam Scalar The type used for scalar values
  */
@@ -53,7 +58,7 @@ class C1 : public Component<Scalar, C1<Scalar> >
 
 public:
     /*!
-     * \brief A human readable name for NDecane.
+     * \brief A human readable name for methane.
      */
     static std::string_view name()
     { return "C1"; }
@@ -86,9 +91,34 @@ public:
      */
     static Scalar acentricFactor() { return 0.011; }
 
+    /*!
+     * \brief Returns the temperature \f$\mathrm{[K]}\f$ at the triple point of methane.
+     */
+    static Scalar tripleTemperature()
+    { return 90.6941; /* [K] — Setzmann & Wagner (1991), via CoolProp 8.0.0 */ }
 
+    /*!
+     * \brief Returns the pressure \f$\mathrm{[Pa]}\f$ at the triple point of methane.
+     */
+    static Scalar triplePressure()
+    { return 1.1696e4; /* [Pa] — Setzmann & Wagner (1991), via CoolProp 8.0.0 */ }
 
-
+    /*!
+     * \brief Cubic ideal-gas heat-capacity polynomial of methane \f$\mathrm{[J/(mol\ K)]}\f$.
+     *
+     * Least-squares fit to the ideal-gas part of the reference EoS
+     * (Setzmann & Wagner 1991), window 250–600 K, RMS 0.024 /
+     * max 0.063 J/(mol K); sampled via CoolProp 8.0.0 (extraction tool
+     * only). Outside the window the cubic extrapolates — refit rather than
+     * trust it there.
+     *
+     * This is the CALORIC (ideal-gas) identity consumed by the compositional
+     * mixture-enthalpy model; it deliberately does NOT implement the
+     * Component<> gasEnthalpy/gasHeatCapacity slots (those are real-fluid
+     * correlations where implemented).
+     */
+    static constexpr ComponentCp<Scalar> idealGasHeatCapacityPolynomial()
+    { return {40.1503, -8.47372e-2, 2.93012e-4, -1.96125e-7}; }
 };
 
 } // namespace Opm

--- a/opm/material/components/C10.hpp
+++ b/opm/material/components/C10.hpp
@@ -28,6 +28,7 @@
 #define OPM_C10_HPP
 
 #include "Component.hpp"
+#include "ComponentCp.hpp"
 
 #include <opm/material/IdealGas.hpp>
 #include <opm/material/common/MathToolbox.hpp>
@@ -41,7 +42,11 @@ namespace Opm
 /*!
  * \ingroup Components
  *
- * \brief Properties of pure molecular n-Decane \f$C_10\f$.
+ * \brief Properties of pure molecular n-Decane \f$C_10\f$
+ *        (CAS 124-18-5, formula C\f$_{10}\f$H\f$_{22}\f$).
+ *
+ * Constants cross-checked against the CoolProp reference fluid "n-Decane"
+ * (reference EoS: Lemmon & Span, J. Chem. Eng. Data 51 (2006) 785).
  *
  * \tparam Scalar The type used for scalar values
  */
@@ -85,7 +90,34 @@ public:
      */
     static Scalar acentricFactor() { return 0.488; }
 
+    /*!
+     * \brief Returns the temperature \f$\mathrm{[K]}\f$ at the triple point of n-Decane.
+     */
+    static Scalar tripleTemperature()
+    { return 243.5; /* [K] — Lemmon & Span (2006), via CoolProp 8.0.0 */ }
 
+    /*!
+     * \brief Returns the pressure \f$\mathrm{[Pa]}\f$ at the triple point of n-Decane.
+     */
+    static Scalar triplePressure()
+    { return 1.404; /* [Pa] — Lemmon & Span (2006), via CoolProp 8.0.0 */ }
+
+    /*!
+     * \brief Cubic ideal-gas heat-capacity polynomial of n-Decane \f$\mathrm{[J/(mol\ K)]}\f$.
+     *
+     * Least-squares fit to the ideal-gas part of the reference EoS
+     * (Lemmon & Span 2006), window 250–600 K, RMS 0.266 /
+     * max 0.792 J/(mol K); sampled via CoolProp 8.0.0 (extraction tool
+     * only). Outside the window the cubic extrapolates — refit rather than
+     * trust it there.
+     *
+     * This is the CALORIC (ideal-gas) identity consumed by the compositional
+     * mixture-enthalpy model; it deliberately does NOT implement the
+     * Component<> gasEnthalpy/gasHeatCapacity slots (those are real-fluid
+     * correlations where implemented).
+     */
+    static constexpr ComponentCp<Scalar> idealGasHeatCapacityPolynomial()
+    { return {79.4791, 3.1066e-1, 9.88317e-4, -1.00245e-6}; }
 };
 
 } // namespace Opm

--- a/opm/material/components/ComponentCp.hpp
+++ b/opm/material/components/ComponentCp.hpp
@@ -1,0 +1,82 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief The cubic ideal-gas heat-capacity polynomial and its closed-form
+ *        enthalpy integral — the caloric EQUATIONS, species-blind.
+ *
+ * The coefficients (a species' caloric identity) live on the component
+ * classes (e.g. C1::idealGasHeatCapacityPolynomial()); the name-keyed lookup
+ * and the enthalpy reference datum live in IdealGasCaloricData. This header
+ * holds only the mathematics shared by all of them.
+ *
+ * Units are SI throughout: temperature [K], molar heat capacity [J/(mol K)],
+ * molar enthalpy [J/mol].
+ */
+#ifndef OPM_COMPONENT_CP_HPP
+#define OPM_COMPONENT_CP_HPP
+
+#include <array>
+
+namespace Opm {
+
+/*!
+ * \brief Cubic ideal-gas heat-capacity polynomial of one component:
+ *        cp(T) = c0 + c1*T + c2*T^2 + c3*T^3   [J/(mol K)]
+ */
+template <class Scalar>
+struct ComponentCp {
+    Scalar c0, c1, c2, c3;
+
+    //! cp(T) [J/(mol K)]. Generic in the evaluation type (double or AD).
+    template <class Eval>
+    Eval heatCapacity(const Eval& T) const
+    {
+        return c0 + c1*T + c2*T*T + c3*T*T*T;
+    }
+
+    /*!
+     * \brief Ideal-gas enthalpy h(T) = int_{T0}^{T} cp dT' [J/mol],
+     *        in closed form. h(T0) = 0 by construction.
+     */
+    template <class Eval>
+    Eval enthalpyIntegral(const Eval& T, const Scalar T0) const
+    {
+        return c0*(T - T0)
+             + c1/2*(T*T - T0*T0)
+             + c2/3*(T*T*T - T0*T0*T0)
+             + c3/4*(T*T*T*T - T0*T0*T0*T0);
+    }
+};
+
+//! Per-component cp table for an N-component fluid system, indexed like the
+//! fluid system's component indices.
+template <class Scalar, int numComponents>
+using CpTable = std::array<ComponentCp<Scalar>, numComponents>;
+
+} // namespace Opm
+
+#endif // OPM_COMPONENT_CP_HPP

--- a/opm/material/components/SimpleCO2.hpp
+++ b/opm/material/components/SimpleCO2.hpp
@@ -32,6 +32,7 @@
 
 #include <opm/material/IdealGas.hpp>
 #include <opm/material/components/Component.hpp>
+#include <opm/material/components/ComponentCp.hpp>
 
 #include <cmath>
 #include <string_view>
@@ -42,6 +43,11 @@ namespace Opm {
  * \ingroup Components
  *
  * \brief A simplistic class representing the \f$CO_2\f$ fluid properties
+ *        (CAS 124-38-9, formula CO\f$_2\f$).
+ *
+ * Constants cross-checked against the CoolProp reference fluid
+ * "CarbonDioxide" (reference EoS: Span & Wagner, J. Phys. Chem. Ref. Data
+ * 25 (1996) 1509).
  *
  * \tparam Scalar The type used for scalar values
  */
@@ -97,6 +103,23 @@ public:
      */
     static Scalar triplePressure()
     { return 5.11e5; /* [N/m^2] */ }
+
+    /*!
+     * \brief Cubic ideal-gas heat-capacity polynomial of \f$CO_2\f$ \f$\mathrm{[J/(mol\ K)]}\f$.
+     *
+     * Least-squares fit to the ideal-gas part of the reference EoS
+     * (Span & Wagner 1996), window 250–600 K, RMS 0.003 /
+     * max 0.014 J/(mol K); sampled via CoolProp 8.0.0 (extraction tool
+     * only). Outside the window the cubic extrapolates — refit rather than
+     * trust it there.
+     *
+     * This is the CALORIC (ideal-gas) identity consumed by the compositional
+     * mixture-enthalpy model; it deliberately does NOT implement the
+     * Component<> gasEnthalpy/gasHeatCapacity slots (those are real-fluid
+     * correlations where implemented).
+     */
+    static constexpr ComponentCp<Scalar> idealGasHeatCapacityPolynomial()
+    { return {18.2687, 8.36359e-2, -7.75148e-5, 3.14088e-8}; }
 
     /*!
      * \copydoc Component::gasIsCompressible

--- a/opm/material/constraintsolvers/IdealGasCaloricData.hpp
+++ b/opm/material/constraintsolvers/IdealGasCaloricData.hpp
@@ -1,0 +1,122 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Name-keyed lookup of the components' ideal-gas heat-capacity
+ *        polynomials and the enthalpy reference state used by the caloric
+ *        mixture-enthalpy model (MixtureEnthalpy).
+ *
+ * The polynomial coefficients live on the component classes (their caloric
+ * identity, next to the EoS constants); the polynomial mathematics lives in
+ * ComponentCp.hpp. This header owns the shared reference datum and the
+ * deck-style name lookup.
+ *
+ * Units are SI throughout: temperature [K], molar heat capacity [J/(mol K)],
+ * molar enthalpy [J/mol]. Enthalpy is zero at the reference temperature.
+ */
+#ifndef OPM_IDEAL_GAS_CALORIC_DATA_HPP
+#define OPM_IDEAL_GAS_CALORIC_DATA_HPP
+
+#include <opm/material/components/C1.hpp>
+#include <opm/material/components/C10.hpp>
+#include <opm/material/components/ComponentCp.hpp>
+#include <opm/material/components/SimpleCO2.hpp>
+
+#include <cctype>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace Opm {
+
+/*!
+ * \brief The enthalpy reference state and component cp presets.
+ *
+ * The reference (datum) is fixed ONCE for the whole caloric stack: any specified
+ * enthalpy H_spec handed to the isenthalpic flash must be expressed against
+ * the same datum, H(referenceTemperature) = 0.
+ */
+template <class Scalar>
+struct IdealGasCaloricData {
+    //! reference temperature T0 [K]; enthalpy is zero here
+    static constexpr Scalar referenceTemperature() { return 298.15; }
+
+    //! reference pressure P0 [Pa] (documentation of the datum; the ideal-gas
+    //! caloric enthalpy itself is pressure-independent)
+    static constexpr Scalar referencePressure() { return 1e5; }
+
+    // The coefficients live on the COMPONENT CLASSES (C1.hpp, C10.hpp,
+    // SimpleCO2.hpp — idealGasHeatCapacityPolynomial()), each next to the
+    // species' other constants and its provenance block: one identity card
+    // per species. The wrappers below are the stable lookup surface; the
+    // fitting recipe (least-squares cubic to the reference-EoS ideal-gas cp,
+    // 250-600 K window, CoolProp 8.0.0 as extraction tool) is documented on
+    // the classes. A unit test pins each preset against tabulated reference
+    // values so a corrupt coefficient row cannot enter silently (an earlier
+    // n-decane row of untraceable origin was ~32% low, which no
+    // self-consistent round-trip test could detect).
+
+    //! methane (C1) ideal-gas cp polynomial [J/(mol K)]
+    static constexpr ComponentCp<Scalar> methane()
+    { return C1<Scalar>::idealGasHeatCapacityPolynomial(); }
+
+    //! n-decane (nC10) ideal-gas cp polynomial [J/(mol K)]
+    static constexpr ComponentCp<Scalar> decane()
+    { return C10<Scalar>::idealGasHeatCapacityPolynomial(); }
+
+    //! carbon dioxide (CO2) ideal-gas cp polynomial [J/(mol K)]
+    static constexpr ComponentCp<Scalar> carbonDioxide()
+    { return SimpleCO2<Scalar>::idealGasHeatCapacityPolynomial(); }
+
+    /*!
+     * \brief Preset lookup by component name (deck-style aliases,
+     *        case-insensitive).
+     *
+     * Throws std::runtime_error naming the component when no preset exists:
+     * there is deliberately NO silent fallback — an unknown component must
+     * fail loudly rather than receive somebody else's heat capacity.
+     */
+    static ComponentCp<Scalar> byName(const std::string_view name)
+    {
+        std::string n(name);
+        for (auto& c : n)
+            c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+
+        if (n == "C1" || n == "CH4" || n == "METHANE")
+            return methane();
+        if (n == "C10" || n == "NC10" || n == "DECANE" || n == "N-DECANE")
+            return decane();
+        if (n == "CO2" || n == "CARBONDIOXIDE" || n == "CARBON-DIOXIDE" || n == "CARBON DIOXIDE")
+            return carbonDioxide();
+        throw std::runtime_error(
+            "IdealGasCaloricData: no ideal-gas heat-capacity preset for component '"
+            + std::string(name) + "' — supply coefficients explicitly");
+    }
+};
+
+} // namespace Opm
+
+#endif // OPM_IDEAL_GAS_CALORIC_DATA_HPP

--- a/opm/material/constraintsolvers/MixtureEnthalpy.hpp
+++ b/opm/material/constraintsolvers/MixtureEnthalpy.hpp
@@ -1,0 +1,326 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Mixture enthalpy for the compositional (flash) path — the property
+ *        an isenthalpic (P-H) flash inverts for temperature.
+ *
+ * Two models behind one seam (EnthalpyModel):
+ *
+ * - caloric (ideal-gas): per-phase enthalpy is the composition-weighted
+ *   ideal-gas enthalpy of the components, and the mixture sums the phases
+ *   weighted by their mole fractions,
+ *
+ *       H = L*H_oil + (1-L)*H_gas,   H_phase = sum_i w_i * int_{T0}^{T} cp_i dT'.
+ *
+ *   With this model the phase split cancels exactly (H = sum_i z_i*h_i(T) by
+ *   material balance), so H is independent of the flash result.
+ *
+ * - eos_departure: adds the residual (departure) enthalpy per phase,
+ *
+ *       H_res = -R * T^2 * sum_i w_i * dln(phi_i)/dT      (fixed P, w),
+ *
+ *   which makes the enthalpy consistent with the same cubic EoS that computes
+ *   the phase split. dln(phi_i)/dT is obtained from the fluid system's own
+ *   fugacityCoefficient evaluated on a densead state with temperature seeded
+ *   as the single AD variable — no hand-derived EoS calculus. The residual
+ *   differs per phase (the liquid's is of vaporization-enthalpy scale), so
+ *   with this model the enthalpy genuinely depends on the flash result.
+ *
+ * Units: SI, molar enthalpy [J/mol]; H(T0) = 0 at the IdealGasCaloricData datum
+ * (the caloric part carries the datum; the residual vanishes as P -> 0).
+ */
+#ifndef OPM_MIXTURE_ENTHALPY_HPP
+#define OPM_MIXTURE_ENTHALPY_HPP
+
+#include <opm/material/constraintsolvers/IdealGasCaloricData.hpp>
+
+#include <opm/material/common/MathToolbox.hpp>
+#include <opm/material/Constants.hpp>
+#include <opm/material/densead/Evaluation.hpp>
+#include <opm/material/fluidstates/CompositionalFluidState.hpp>
+
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
+
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace Opm {
+
+//! Which enthalpy model the P-H stack evaluates.
+enum class EnthalpyModel { caloric, eos_departure };
+
+//! Parse an enthalpy-model name ("caloric" / "eos_departure"); throws
+//! std::runtime_error on anything else. Lives beside the enum so every
+//! runtime-parameter consumer shares one parser.
+inline EnthalpyModel enthalpyModelFromString(const std::string_view name)
+{
+    if (name == "caloric")
+        return EnthalpyModel::caloric;
+    if (name == "eos_departure" || name == "eos-departure")
+        return EnthalpyModel::eos_departure;
+    throw std::runtime_error("unknown enthalpy model '" + std::string(name)
+                             + "' (valid: caloric, eos_departure)");
+}
+
+//! The canonical name of an enthalpy model (inverse of enthalpyModelFromString).
+inline std::string enthalpyModelToString(const EnthalpyModel model)
+{
+    return model == EnthalpyModel::caloric ? "caloric" : "eos_departure";
+}
+
+/*!
+ * \brief Molar mixture enthalpy of a flashed compositional state, under the
+ *        caloric (ideal-gas) or EoS-consistent departure model — the property
+ *        an isenthalpic (P-H) flash inverts for temperature.
+ *
+ * See the file documentation for the model definitions, the caloric
+ * split-cancellation property, and the unit/datum conventions.
+ */
+template <class Scalar, class FluidSystem>
+struct MixtureEnthalpy {
+    static constexpr int numComponents = FluidSystem::numComponents;
+
+    using EOSType = CompositionalConfig::EOSType;
+
+    /*!
+     * \brief Molar enthalpy of one phase [J/mol], caloric model.
+     *
+     * Generic in the fluid state's value type: works on plain doubles and on
+     * DenseAd::Evaluation states alike (the expression is polynomial only).
+     */
+    template <class FluidState>
+    static typename FluidState::ValueType
+    phaseEnthalpy(const FluidState& fluidState,
+                  const unsigned phaseIdx,
+                  const CpTable<Scalar, numComponents>& cpTable,
+                  const Scalar refTemperature)
+    {
+        using ValueType = typename FluidState::ValueType;
+
+        const ValueType& T = fluidState.temperature(phaseIdx);
+        ValueType h = 0.0;
+        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+            h += fluidState.moleFraction(phaseIdx, compIdx)
+                 * cpTable[compIdx].enthalpyIntegral(T, refTemperature);
+        }
+        return h;
+    }
+
+    /*!
+     * \brief Molar enthalpy of the flashed mixture [J/mol]: phase enthalpies
+     *        weighted by the liquid mole fraction L from the fluid state.
+     *
+     * Precondition: fluidState is a FLASHED state — L() set and the per-phase
+     * compositions consistent with it (both phases at the equilibrium
+     * temperature), i.e. the state PTFlash::solve returns.
+     */
+    template <class FluidState>
+    static typename FluidState::ValueType
+    mixtureEnthalpy(const FluidState& fluidState,
+                    const CpTable<Scalar, numComponents>& cpTable,
+                    const Scalar refTemperature)
+    {
+        const auto& L = fluidState.L();
+        return L * phaseEnthalpy(fluidState, FluidSystem::oilPhaseIdx, cpTable, refTemperature)
+             + (1.0 - L) * phaseEnthalpy(fluidState, FluidSystem::gasPhaseIdx, cpTable, refTemperature);
+    }
+
+    /*!
+     * \brief Total molar heat capacity dH/dT [J/(mol K)] of the mixture,
+     *        analytic, CALORIC model only.
+     *
+     * With an EoS-consistent (departure) enthalpy dH/dT gains a residual term
+     * that this function does NOT include — do not wire it into a Newton step
+     * on a departure-mode enthalpy.
+     *
+     * Precondition: same as mixtureEnthalpy — a flashed, L-consistent state.
+     */
+    template <class FluidState>
+    static typename FluidState::ValueType
+    mixtureCp(const FluidState& fluidState,
+              const CpTable<Scalar, numComponents>& cpTable)
+    {
+        using ValueType = typename FluidState::ValueType;
+
+        const auto& L = fluidState.L();
+        ValueType cp = 0.0;
+        for (unsigned phaseIdx : {static_cast<unsigned>(FluidSystem::oilPhaseIdx),
+                                  static_cast<unsigned>(FluidSystem::gasPhaseIdx)}) {
+            const ValueType& T = fluidState.temperature(phaseIdx);
+            ValueType cpPhase = 0.0;
+            for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+                cpPhase += fluidState.moleFraction(phaseIdx, compIdx)
+                           * cpTable[compIdx].heatCapacity(T);
+            }
+            cp += (phaseIdx == static_cast<unsigned>(FluidSystem::oilPhaseIdx) ? L : 1.0 - L) * cpPhase;
+        }
+        return cp;
+    }
+
+    // ── EoS-consistent departure (residual) enthalpy ────────────────────────
+
+    /*!
+     * \brief dln(phi_i)/dT of one component in one phase at fixed pressure
+     *        and phase composition [1/K].
+     *
+     * Evaluates the fluid system's own fugacityCoefficient on a one-variable
+     * densead state (temperature seeded at slot 0; pressure and composition
+     * held constant) and reads the partial: phi.derivative(0)/phi.value().
+     * Exposed separately so tests can verify the AD derivative against a
+     * finite difference of ln(phi).
+     */
+    template <class FluidState>
+    static Scalar phaseDLnPhiDT(const FluidState& fluidState,
+                                const unsigned phaseIdx,
+                                const unsigned compIdx,
+                                const EOSType& eosType)
+    {
+        const auto seeded = temperatureSeededCopy_(fluidState, phaseIdx);
+
+        using Eval1 = DenseAd::Evaluation<Scalar, 1>;
+        using ParamCache = typename FluidSystem::template ParameterCache<Eval1>;
+        ParamCache paramCache(eosType);
+        paramCache.updatePhase(seeded, phaseIdx);
+
+        const Eval1 phi = FluidSystem::fugacityCoefficient(seeded, paramCache, phaseIdx, compIdx);
+        return phi.derivative(0) / phi.value();
+    }
+
+    /*!
+     * \brief Residual (departure) molar enthalpy of one phase [J/mol]:
+     *        H_res = -R * T^2 * sum_i w_i * dln(phi_i)/dT  at fixed (P, w).
+     *
+     * Returns a plain Scalar: the residual's derivatives w.r.t. any outer AD
+     * variables are NOT propagated (values only — propagating them is the
+     * simulator-coupling stage's concern, not this model's).
+     */
+    template <class FluidState>
+    static Scalar phaseResidualEnthalpy(const FluidState& fluidState,
+                                        const unsigned phaseIdx,
+                                        const EOSType& eosType)
+    {
+        const auto seeded = temperatureSeededCopy_(fluidState, phaseIdx);
+
+        using Eval1 = DenseAd::Evaluation<Scalar, 1>;
+        using ParamCache = typename FluidSystem::template ParameterCache<Eval1>;
+        ParamCache paramCache(eosType);
+        paramCache.updatePhase(seeded, phaseIdx);
+
+        Scalar HresOverR = 0.0;
+        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+            const Eval1 phi = FluidSystem::fugacityCoefficient(seeded, paramCache, phaseIdx, compIdx);
+            const Scalar dLnPhiDT = phi.derivative(0) / phi.value();
+            const Scalar w_i = Opm::getValue(fluidState.moleFraction(phaseIdx, compIdx));
+            HresOverR -= w_i * dLnPhiDT;
+        }
+        const Scalar T = Opm::getValue(fluidState.temperature(phaseIdx));
+        return Constants<Scalar>::R * HresOverR * T * T;
+    }
+
+    /*!
+     * \brief Molar enthalpy of one phase [J/mol] under the selected model:
+     *        caloric ideal-gas part, plus the EoS departure when
+     *        model == eos_departure.
+     */
+    template <class FluidState>
+    static typename FluidState::ValueType
+    phaseEnthalpy(const FluidState& fluidState,
+                  const unsigned phaseIdx,
+                  const CpTable<Scalar, numComponents>& cpTable,
+                  const Scalar refTemperature,
+                  const EOSType& eosType,
+                  const EnthalpyModel model)
+    {
+        typename FluidState::ValueType h =
+            phaseEnthalpy(fluidState, phaseIdx, cpTable, refTemperature);
+        if (model == EnthalpyModel::eos_departure)
+            h += phaseResidualEnthalpy(fluidState, phaseIdx, eosType);
+        return h;
+    }
+
+    /*!
+     * \brief Molar enthalpy of the flashed mixture [J/mol] under the selected
+     *        model. Precondition as for the caloric overload: a flashed,
+     *        L-consistent state.
+     *
+     * Absent phases (weight 0) skip the residual evaluation: their
+     * composition is degenerate and their contribution vanishes anyway.
+     */
+    template <class FluidState>
+    static typename FluidState::ValueType
+    mixtureEnthalpy(const FluidState& fluidState,
+                    const CpTable<Scalar, numComponents>& cpTable,
+                    const Scalar refTemperature,
+                    const EOSType& eosType,
+                    const EnthalpyModel model)
+    {
+        using ValueType = typename FluidState::ValueType;
+
+        const auto& L = fluidState.L();
+        const Scalar Lval = Opm::getValue(L);
+
+        ValueType hOil = phaseEnthalpy(fluidState, FluidSystem::oilPhaseIdx, cpTable, refTemperature);
+        ValueType hGas = phaseEnthalpy(fluidState, FluidSystem::gasPhaseIdx, cpTable, refTemperature);
+        if (model == EnthalpyModel::eos_departure) {
+            if (Lval > 0.0)
+                hOil += phaseResidualEnthalpy(fluidState, FluidSystem::oilPhaseIdx, eosType);
+            if (Lval < 1.0)
+                hGas += phaseResidualEnthalpy(fluidState, FluidSystem::gasPhaseIdx, eosType);
+        }
+        return L * hOil + (1.0 - L) * hGas;
+    }
+
+private:
+    /*!
+     * \brief AD-typed copy of one phase with temperature as the single seeded
+     *        variable (slot 0); pressure and composition enter as constants,
+     *        so derivative(0) is a partial at fixed (P, w).
+     */
+    template <class FluidState>
+    static CompositionalFluidState<DenseAd::Evaluation<Scalar, 1>, FluidSystem>
+    temperatureSeededCopy_(const FluidState& fluidState, const unsigned phaseIdx)
+    {
+        using Eval1 = DenseAd::Evaluation<Scalar, 1>;
+
+        CompositionalFluidState<Eval1, FluidSystem> seeded;
+        seeded.setTemperature(
+            Eval1::createVariable(Opm::getValue(fluidState.temperature(phaseIdx)), 0));
+        const Eval1 p = Eval1::createConstant(Opm::getValue(fluidState.pressure(phaseIdx)));
+        seeded.setPressure(FluidSystem::oilPhaseIdx, p);
+        seeded.setPressure(FluidSystem::gasPhaseIdx, p);
+        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+            seeded.setMoleFraction(phaseIdx, compIdx,
+                Eval1::createConstant(Opm::getValue(fluidState.moleFraction(phaseIdx, compIdx))));
+        }
+        return seeded;
+    }
+};
+
+} // namespace Opm
+
+#endif // OPM_MIXTURE_ENTHALPY_HPP

--- a/tests/material/flashTestFixtures.hpp
+++ b/tests/material/flashTestFixtures.hpp
@@ -39,9 +39,11 @@
 #include <opm/material/eos/CubicEOS.hpp>
 #include <opm/material/fluidsystems/BaseFluidSystem.hpp>
 #include <opm/material/fluidsystems/ThreeComponentFluidSystem.hh>
+#include <opm/material/components/SimpleCO2.hpp>
 #include <opm/material/components/C10.hpp>
 #include <opm/material/components/C1.hpp>
 
+#include <opm/material/constraintsolvers/IdealGasCaloricData.hpp>
 #include <opm/material/constraintsolvers/PTFlash.hpp>
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
@@ -54,6 +56,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 namespace Opm {
 namespace FlashTest {
@@ -275,6 +278,38 @@ inline constexpr std::array<double, 2> f1Z = {0.5, 0.5};
 inline constexpr double f2Pressure = 10e5;      // [Pa]
 inline constexpr double f2Temperature = 300.;   // [K]
 inline constexpr std::array<double, 3> f2Z = {0.5, 0.3, 0.2};
+
+/*!
+ * \brief The cp table for the F1 fixture, in the fluid system's component
+ *        order (asserted at compile time).
+ */
+inline CpTable<double, 2> f1CpTable()
+{
+    using FS = TwoComponentFluidSystem<double>;
+    static_assert(std::is_same_v<typename FS::Comp0, C1<double>>,
+                  "F1 cp table assumes Comp0 = C1 (methane)");
+    static_assert(std::is_same_v<typename FS::Comp1, C10<double>>,
+                  "F1 cp table assumes Comp1 = nC10 (decane)");
+    return {IdealGasCaloricData<double>::methane(), IdealGasCaloricData<double>::decane()};
+}
+
+/*!
+ * \brief The cp table for the F2 fixture (ThreeComponentFluidSystem), in the
+ *        fluid system's component order (asserted at compile time).
+ */
+inline CpTable<double, 3> f2CpTable()
+{
+    using FS = Opm::ThreeComponentFluidSystem<double>;
+    static_assert(std::is_same_v<typename FS::Comp0, SimpleCO2<double>>,
+                  "F2 cp table assumes Comp0 = CO2");
+    static_assert(std::is_same_v<typename FS::Comp1, C1<double>>,
+                  "F2 cp table assumes Comp1 = C1 (methane)");
+    static_assert(std::is_same_v<typename FS::Comp2, C10<double>>,
+                  "F2 cp table assumes Comp2 = nC10 (decane)");
+    return {IdealGasCaloricData<double>::carbonDioxide(),
+            IdealGasCaloricData<double>::methane(),
+            IdealGasCaloricData<double>::decane()};
+}
 
 /*!
  * \brief Build a fluid state ready for PTFlash::solve, applying the full input

--- a/tests/material/flashTestFixtures.hpp
+++ b/tests/material/flashTestFixtures.hpp
@@ -87,10 +87,13 @@ public:
     using Comp0 = C1<Scalar>;
     using Comp1 = C10<Scalar>;
 
-    //! C1/nC10 Peng-Robinson binary interaction parameter — the value this
-    //! library's compositional tests use (cf. ThreeComponentFluidSystem). The
-    //! unequal-index shortcut in interactionCoefficient() is valid only
-    //! because the system is binary.
+    //! C1/nC10 Peng-Robinson binary interaction parameter. Pinned fixture
+    //! value within the range of published C1/nC10 PR coefficients (roughly
+    //! 0.04-0.05, source- and temperature-dependent); the two-phase baselines
+    //! built on it were cross-validated against an independent PR
+    //! implementation (CoolProp) using this same value. The unequal-index
+    //! shortcut in interactionCoefficient() is valid only because the system
+    //! is binary.
     static constexpr Scalar bipC1nC10 = 0.0411;
 
     template <class ValueType>

--- a/tests/material/flashTestFixtures.hpp
+++ b/tests/material/flashTestFixtures.hpp
@@ -1,0 +1,416 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Test-local fixtures for the compositional flash test suite:
+ *        a binary C1/nC10 fluid system, the canonical operating points, and
+ *        a case-struct driver (FlashCase -> runFlash -> FlashOutcome) that
+ *        applies the full PTFlash input contract.
+ *
+ * This header is deliberately Boost-free: it holds data and physics only;
+ * assertions live in the test files. Shared, Boost-free helpers go here.
+ */
+#ifndef OPM_FLASH_TEST_FIXTURES_HPP
+#define OPM_FLASH_TEST_FIXTURES_HPP
+
+#include <opm/material/eos/CubicEOS.hpp>
+#include <opm/material/fluidsystems/BaseFluidSystem.hpp>
+#include <opm/material/fluidsystems/ThreeComponentFluidSystem.hh>
+#include <opm/material/components/C10.hpp>
+#include <opm/material/components/C1.hpp>
+
+#include <opm/material/constraintsolvers/PTFlash.hpp>
+#include <opm/material/densead/Evaluation.hpp>
+#include <opm/material/fluidstates/CompositionalFluidState.hpp>
+#include <opm/material/fluidsystems/PTFlashParameterCache.hpp>
+#include <opm/material/viscositymodels/ViscosityModels.hpp>
+
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
+
+#include <array>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace Opm {
+namespace FlashTest {
+
+/*!
+ * \brief A two phase two component fluid system with components
+ *        methane (C1) and n-decane (nC10) — the "F1" synthetic fixture.
+ *
+ * Test-local: lives in the FlashTest namespace on purpose; it is a fixture,
+ * not installable API.
+ */
+template<class Scalar>
+class TwoComponentFluidSystem
+        : public Opm::BaseFluidSystem<Scalar, TwoComponentFluidSystem<Scalar> > {
+public:
+    static constexpr int numPhases = 2;
+    static constexpr int numComponents = 2;
+    static constexpr int numMisciblePhases = 2;
+    static constexpr int numMiscibleComponents = 2;
+    static constexpr bool waterEnabled = false;
+    static constexpr int oilPhaseIdx = 0;
+    static constexpr int gasPhaseIdx = 1;
+    static constexpr int waterPhaseIdx = -1;
+
+    static constexpr int Comp0Idx = 0;
+    static constexpr int Comp1Idx = 1;
+
+    using Comp0 = C1<Scalar>;
+    using Comp1 = C10<Scalar>;
+
+    //! C1/nC10 Peng-Robinson binary interaction parameter — the value this
+    //! library's compositional tests use (cf. ThreeComponentFluidSystem). The
+    //! unequal-index shortcut in interactionCoefficient() is valid only
+    //! because the system is binary.
+    static constexpr Scalar bipC1nC10 = 0.0411;
+
+    template <class ValueType>
+    using ParameterCache = PTFlashParameterCache<ValueType, TwoComponentFluidSystem<Scalar>>;
+    using ViscosityModel = ViscosityModels<Scalar, TwoComponentFluidSystem<Scalar>>;
+    using CubicEOS = ::Opm::CubicEOS<Scalar, TwoComponentFluidSystem<Scalar>>;
+
+    static bool phaseIsActive(unsigned phaseIdx)
+    {
+        return phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx;
+    }
+
+    //! \copydoc BaseFluidSystem::acentricFactor
+    static Scalar acentricFactor(unsigned compIdx)
+    {
+        switch (compIdx) {
+        case Comp0Idx: return Comp0::acentricFactor();
+        case Comp1Idx: return Comp1::acentricFactor();
+        default: throw std::runtime_error("Illegal component index for acentricFactor");
+        }
+    }
+
+    //! \copydoc BaseFluidSystem::criticalTemperature
+    static Scalar criticalTemperature(unsigned compIdx)
+    {
+        switch (compIdx) {
+        case Comp0Idx: return Comp0::criticalTemperature();
+        case Comp1Idx: return Comp1::criticalTemperature();
+        default: throw std::runtime_error("Illegal component index for criticalTemperature");
+        }
+    }
+
+    //! \copydoc BaseFluidSystem::criticalPressure
+    static Scalar criticalPressure(unsigned compIdx)
+    {
+        switch (compIdx) {
+        case Comp0Idx: return Comp0::criticalPressure();
+        case Comp1Idx: return Comp1::criticalPressure();
+        default: throw std::runtime_error("Illegal component index for criticalPressure");
+        }
+    }
+
+    //! \copydoc BaseFluidSystem::criticalVolume
+    static Scalar criticalVolume(unsigned compIdx)
+    {
+        switch (compIdx) {
+        case Comp0Idx: return Comp0::criticalVolume();
+        case Comp1Idx: return Comp1::criticalVolume();
+        default: throw std::runtime_error("Illegal component index for criticalVolume");
+        }
+    }
+
+    //! \copydoc BaseFluidSystem::molarMass
+    static Scalar molarMass(unsigned compIdx)
+    {
+        switch (compIdx) {
+        case Comp0Idx: return Comp0::molarMass();
+        case Comp1Idx: return Comp1::molarMass();
+        default: throw std::runtime_error("Illegal component index for molarMass");
+        }
+    }
+
+    //! \copydoc BaseFluidSystem::interactionCoefficient
+    static Scalar interactionCoefficient(unsigned comp1Idx, unsigned comp2Idx)
+    {
+        if (comp1Idx != comp2Idx)
+            return bipC1nC10;
+        return 0.0;
+    }
+
+    //! \copydoc BaseFluidSystem::phaseName
+    static std::string_view phaseName(unsigned phaseIdx)
+    {
+        static const std::string_view name[] = {"o",   // oleic phase
+                                                "g"};  // gas phase
+
+        assert(phaseIdx < 2);
+        return name[phaseIdx];
+    }
+
+    //! \copydoc BaseFluidSystem::componentName
+    static std::string_view componentName(unsigned compIdx)
+    {
+        static const std::string_view name[] = {
+                Comp0::name(),
+                Comp1::name(),
+        };
+
+        assert(compIdx < 2);
+        return name[compIdx];
+    }
+
+    //! \copydoc BaseFluidSystem::density
+    template <class FluidState, class LhsEval = typename FluidState::ValueType, class ParamCacheEval = LhsEval>
+    static LhsEval density(const FluidState& fluidState,
+                           const ParameterCache<ParamCacheEval>& paramCache,
+                           unsigned phaseIdx)
+    {
+        assert(phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx);
+        return decay<LhsEval>(fluidState.averageMolarMass(phaseIdx) / paramCache.molarVolume(phaseIdx));
+    }
+
+    //! \copydoc BaseFluidSystem::viscosity
+    template <class FluidState, class LhsEval = typename FluidState::ValueType, class ParamCacheEval = LhsEval>
+    static LhsEval viscosity(const FluidState& fluidState,
+                             const ParameterCache<ParamCacheEval>& paramCache,
+                             unsigned phaseIdx)
+    {
+        // Use LBC method to calculate viscosity
+        return decay<LhsEval>(ViscosityModel::LBC(fluidState, paramCache, phaseIdx));
+    }
+
+    //! \copydoc BaseFluidSystem::fugacityCoefficient
+    template <class FluidState, class LhsEval = typename FluidState::ValueType, class ParamCacheEval = LhsEval>
+    static LhsEval fugacityCoefficient(const FluidState& fluidState,
+                                       const ParameterCache<ParamCacheEval>& paramCache,
+                                       unsigned phaseIdx,
+                                       unsigned compIdx)
+    {
+        assert(phaseIdx < numPhases);
+        assert(compIdx < numComponents);
+
+        return decay<LhsEval>(CubicEOS::computeFugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx));
+    }
+
+    //! \copydoc BaseFluidSystem::isCompressible
+    static bool isCompressible([[maybe_unused]] unsigned phaseIdx)
+    {
+        assert(phaseIdx < numPhases);
+
+        return true;
+    }
+
+    //! \copydoc BaseFluidSystem::isIdealMixture
+    static bool isIdealMixture([[maybe_unused]] unsigned phaseIdx)
+    {
+        assert(phaseIdx < numPhases);
+
+        return false;
+    }
+
+    //! \copydoc BaseFluidSystem::isLiquid
+    static bool isLiquid(unsigned phaseIdx)
+    {
+        assert(phaseIdx < numPhases);
+
+        return (phaseIdx == 0);
+    }
+
+    //! \copydoc BaseFluidSystem::isIdealGas
+    static bool isIdealGas(unsigned phaseIdx)
+    {
+        assert(phaseIdx < numPhases);
+
+        return (phaseIdx == 1);
+    }
+};
+
+/*!
+ * \brief The Evaluation type the flash test suite runs PTFlash with.
+ *
+ * Arity = numComponents + 1, bound to the AD variable layout used by
+ * makeInitialState below: slot 0 = pressure, slot 1 = temperature,
+ * slots 2.. = the first numComponents-1 overall mole fractions (the last
+ * mole fraction closes the sum to 1). Deriving the size anywhere else
+ * invites the arity and the slot assignment to drift apart.
+ */
+template <class FluidSystem>
+using FlashEvaluation = Opm::DenseAd::Evaluation<double, FluidSystem::numComponents + 1>;
+
+// ── Canonical operating points ─────────────────────────────────────────────
+// Shared anchors so the physical baselines cannot drift between test stages.
+// Tests remain free to define local probe points; these are the documented
+// reference conditions of the fixtures themselves.
+
+//! F1 (C1/nC10) two-phase anchor: 50 bar, 300 K, equimolar feed — well inside
+//! the two-phase window at this pressure.
+inline constexpr double f1Pressure = 50e5;      // [Pa]
+inline constexpr double f1Temperature = 300.;   // [K]
+inline constexpr std::array<double, 2> f1Z = {0.5, 0.5};
+
+//! F2 ternary anchor — the known two-phase point of the existing
+//! three-component PTFlash test. Component order of ThreeComponentFluidSystem:
+//! Comp0 = CO2, Comp1 = C1 (methane), Comp2 = nC10 (decane).
+inline constexpr double f2Pressure = 10e5;      // [Pa]
+inline constexpr double f2Temperature = 300.;   // [K]
+inline constexpr std::array<double, 3> f2Z = {0.5, 0.3, 0.2};
+
+/*!
+ * \brief Build a fluid state ready for PTFlash::solve, applying the full input
+ *        contract: phase pressures, global mole fractions, temperature, and the
+ *        caller-side Wilson K-value + L seed.
+ *
+ * AD variable layout (see FlashEvaluation): pressure = slot 0, temperature =
+ * slot 1, first numComponents-1 overall mole fractions = slots 2.. (the last
+ * mole fraction closes the sum to 1).
+ */
+template <class FluidSystem, class Evaluation>
+Opm::CompositionalFluidState<Evaluation, FluidSystem>
+makeInitialState(double pressure, double temperature,
+                 const std::array<double, FluidSystem::numComponents>& z)
+{
+    constexpr int numComponents = FluidSystem::numComponents;
+
+    const Evaluation p_init = Evaluation::createVariable(pressure, 0);
+    const Evaluation T_init = Evaluation::createVariable(temperature, 1);
+
+    Opm::CompositionalFluidState<Evaluation, FluidSystem> fluid_state;
+    fluid_state.setPressure(FluidSystem::oilPhaseIdx, p_init);
+    fluid_state.setPressure(FluidSystem::gasPhaseIdx, p_init);
+
+    Evaluation sum = 0.;
+    for (int compIdx = 0; compIdx < numComponents - 1; ++compIdx) {
+        const Evaluation zi = Evaluation::createVariable(z[compIdx], 2 + compIdx);
+        fluid_state.setMoleFraction(compIdx, zi);
+        sum += zi;
+    }
+    fluid_state.setMoleFraction(numComponents - 1, 1. - sum);
+
+    fluid_state.setTemperature(T_init);
+
+    // PTFlash input contract: the caller seeds the initial K-values (Wilson)
+    // and the liquid fraction L before calling solve.
+    for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        const Evaluation Ktmp = fluid_state.wilsonK_(compIdx);
+        fluid_state.setKvalue(compIdx, Ktmp);
+    }
+    const Evaluation Ltmp = 1.;
+    fluid_state.setLvalue(Ltmp);
+
+    return fluid_state;
+}
+
+/*!
+ * \brief What phase state a flash case is expected to produce.
+ *
+ * single_liquid / single_vapor refer to the Li-correlation label PTFlash
+ * assigns to single-phase states (pressure-blind: liquid iff T < Tc_est).
+ */
+enum class ExpectedPhase { any, two_phase, single_liquid, single_vapor };
+
+/*!
+ * \brief A complete flash test case: the full input state of the fluid plus
+ *        the run configuration and the expected phase outcome.
+ *
+ * Aggregate-initializable: FlashCase<2> c{"name", 50e5, 300., {0.5, 0.5}};
+ * (trailing members take their defaults).
+ */
+template <int numComponents>
+struct FlashCase {
+    std::string name;                          // shown in failure messages
+    double pressure;                           // [Pa], both phases
+    double temperature;                        // [K]
+    std::array<double, numComponents> z;       // overall mole fractions
+    std::string method = "ssi";                // "ssi" / "newton" / "ssi+newton"
+    Opm::CompositionalConfig::EOSType eos_type = Opm::CompositionalConfig::EOSType::PR;
+    double tolerance = 1.e-8;                  // PTFlash convergence tolerance on the
+                                               // fugacity-ratio residual (equal-fugacity mismatch)
+    int verbosity = 0;
+    ExpectedPhase expected = ExpectedPhase::any;
+};
+
+/*!
+ * \brief The state of the fluid after the flash, as plain doubles.
+ *
+ * x/y/K are meaningful only when !single_phase — in single-phase states both
+ * phase compositions degenerate to the feed and K carries no information.
+ */
+template <int numComponents>
+struct FlashResult {
+    bool single_phase;                         // PTFlash::solve return value
+    double L;                                  // liquid mole fraction
+    std::array<double, numComponents> x;       // liquid composition
+    std::array<double, numComponents> y;       // vapor composition
+    std::array<double, numComponents> K;       // converged equilibrium ratio y/x
+    std::array<double, numComponents> K_wilson; // the input Wilson seed (fs.K() keeps this)
+};
+
+/*!
+ * \brief Full outcome of running a FlashCase: the plain-double summary plus
+ *        the final consistent fluid state (needed e.g. for fugacity checks).
+ */
+template <class FluidSystem, class Evaluation>
+struct FlashOutcome {
+    FlashResult<FluidSystem::numComponents> summary;
+    Opm::CompositionalFluidState<Evaluation, FluidSystem> state;
+};
+
+/*!
+ * \brief Run one FlashCase through PTFlash and collect the outcome.
+ */
+template <class FluidSystem, class Evaluation>
+FlashOutcome<FluidSystem, Evaluation>
+runFlash(const FlashCase<FluidSystem::numComponents>& testCase)
+{
+    constexpr int numComponents = FluidSystem::numComponents;
+    using Flash = Opm::PTFlash<double, FluidSystem, true>;
+
+    FlashOutcome<FluidSystem, Evaluation> outcome;
+    outcome.state = makeInitialState<FluidSystem, Evaluation>(
+        testCase.pressure, testCase.temperature, testCase.z);
+
+    // record the Wilson seed: fluid_state.K() is an input to solve and still
+    // holds this seed afterwards — the converged ratio is y/x
+    for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        outcome.summary.K_wilson[compIdx] = Opm::getValue(outcome.state.K(compIdx));
+
+    outcome.summary.single_phase = Flash::solve(outcome.state, testCase.method,
+                                                testCase.tolerance, testCase.eos_type,
+                                                testCase.verbosity);
+
+    outcome.summary.L = Opm::getValue(outcome.state.L());
+    for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        const double x_i = Opm::getValue(outcome.state.moleFraction(FluidSystem::oilPhaseIdx, compIdx));
+        const double y_i = Opm::getValue(outcome.state.moleFraction(FluidSystem::gasPhaseIdx, compIdx));
+        outcome.summary.x[compIdx] = x_i;
+        outcome.summary.y[compIdx] = y_i;
+        outcome.summary.K[compIdx] = y_i / x_i;
+    }
+    return outcome;
+}
+
+} // namespace FlashTest
+} // namespace Opm
+
+#endif // OPM_FLASH_TEST_FIXTURES_HPP

--- a/tests/material/test_mixture_enthalpy.cpp
+++ b/tests/material/test_mixture_enthalpy.cpp
@@ -1,0 +1,112 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Tests for the compositional caloric data and enthalpy machinery.
+ *
+ * This file starts with the per-component caloric identity cards (the
+ * ideal-gas heat-capacity polynomials on the component classes) pinned
+ * against external reference values; the mixture-enthalpy model suites
+ * land as siblings in this file.
+ */
+#include "config.h"
+
+#define BOOST_TEST_MODULE MixtureEnthalpy
+#include <boost/test/unit_test.hpp>
+
+#include <opm/material/components/C1.hpp>
+#include <opm/material/components/C10.hpp>
+#include <opm/material/components/ComponentCp.hpp>
+#include <opm/material/components/SimpleCO2.hpp>
+
+#include <array>
+#include <cstddef>
+
+BOOST_AUTO_TEST_SUITE(CaloricData)
+
+// The caloric equations (ComponentCp), species-blind: enthalpy is the exact
+// integral of the heat-capacity polynomial, zero at the reference datum.
+BOOST_AUTO_TEST_CASE(EnthalpyIntegralMatchesHeatCapacity)
+{
+    const Opm::ComponentCp<double> cp = Opm::C1<double>::idealGasHeatCapacityPolynomial();
+    const double T0 = 298.15;
+
+    // h(T0) = 0 by construction
+    BOOST_CHECK_EQUAL(cp.enthalpyIntegral(T0, T0), 0.0);
+
+    // dh/dT == cp(T), checked against a central finite difference
+    const double T = 400.;
+    const double dT = 1e-3;
+    const double dhdT = (cp.enthalpyIntegral(T + dT, T0) - cp.enthalpyIntegral(T - dT, T0)) / (2. * dT);
+    BOOST_CHECK_CLOSE(dhdT, cp.heatCapacity(T), 1e-6); // [%]
+}
+
+// The identity cards against EXTERNAL reference values — the one check no
+// amount of internal consistency can substitute: a self-consistent test
+// manufactures its expectation from the same coefficients it verifies, so a
+// corrupt row passes it. The pinned values are the reference-EoS ideal-gas
+// heat capacities (Setzmann & Wagner 1991 methane; Lemmon & Span 2006
+// n-decane; Span & Wagner 1996 CO2), tabulated at four temperatures spanning
+// the fit window.
+BOOST_AUTO_TEST_CASE(CardsMatchReferenceIdealGasCp)
+{
+    constexpr std::array<double, 4> temps{298.15, 350., 450., 600.};
+    const struct {
+        const char* name;
+        Opm::ComponentCp<double> card;
+        std::array<double, 4> cpRef; // [J/(mol K)] at temps[]
+    } pins[] = {
+        {"methane", Opm::C1<double>::idealGasHeatCapacityPolynomial(),
+         {35.7085, 37.9628, 43.5052, 52.4919}},
+        {"decane", Opm::C10<double>::idealGasHeatCapacityPolynomial(),
+         {233.0250, 266.2081, 328.2699, 405.7329}},
+        {"carbonDioxide", Opm::SimpleCO2<double>::idealGasHeatCapacityPolynomial(),
+         {37.1408, 39.3941, 43.0700, 47.3303}},
+    };
+
+    for (const auto& pin : pins) {
+        for (std::size_t i = 0; i < temps.size(); ++i) {
+            BOOST_TEST_CONTEXT(pin.name << " at T = " << temps[i]) {
+                // 1% relative: an order looser than the fit residuals (max
+                // 0.3%), an order tighter than the defect class it guards
+                BOOST_CHECK_CLOSE(pin.card.heatCapacity(temps[i]),
+                                  pin.cpRef[i], 1.0); // [%]
+            }
+        }
+    }
+}
+
+// The triple points added on the identity cards, against the reference-EoS
+// fluid values (papers cited on the classes).
+BOOST_AUTO_TEST_CASE(TriplePointsMatchReferenceFluids)
+{
+    BOOST_CHECK_CLOSE(Opm::C1<double>::tripleTemperature(), 90.6941, 1e-6);
+    BOOST_CHECK_CLOSE(Opm::C1<double>::triplePressure(), 11696.06, 0.01);
+    BOOST_CHECK_CLOSE(Opm::C10<double>::tripleTemperature(), 243.5, 1e-6);
+    BOOST_CHECK_CLOSE(Opm::C10<double>::triplePressure(), 1.4042, 0.02);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // CaloricData

--- a/tests/material/test_mixture_enthalpy.cpp
+++ b/tests/material/test_mixture_enthalpy.cpp
@@ -27,10 +27,10 @@
  *
  * \brief Tests for the compositional caloric data and enthalpy machinery.
  *
- * This file starts with the per-component caloric identity cards (the
- * ideal-gas heat-capacity polynomials on the component classes) pinned
- * against external reference values; the mixture-enthalpy model suites
- * land as siblings in this file.
+ * CaloricData pins the per-component identity cards (the ideal-gas
+ * heat-capacity polynomials on the component classes) against external
+ * reference values; CaloricModel and DepartureModel test the mixture
+ * enthalpy the compositional path evaluates on top of them.
  */
 #include "config.h"
 
@@ -41,9 +41,47 @@
 #include <opm/material/components/C10.hpp>
 #include <opm/material/components/ComponentCp.hpp>
 #include <opm/material/components/SimpleCO2.hpp>
+#include <opm/material/constraintsolvers/IdealGasCaloricData.hpp>
+#include <opm/material/constraintsolvers/MixtureEnthalpy.hpp>
+
+#include <opm/material/fluidstates/CompositionalFluidState.hpp>
+
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
+
+#include "flashTestFixtures.hpp"
 
 #include <array>
+#include <cmath>
 #include <cstddef>
+#include <stdexcept>
+
+using Scalar = double;
+using Opm::FlashTest::FlashCase;
+using Opm::FlashTest::runFlash;
+using Opm::FlashTest::f1Pressure;
+using Opm::FlashTest::f1Z;
+
+// F1: binary C1/nC10
+using FluidSystemF1 = Opm::FlashTest::TwoComponentFluidSystem<Scalar>;
+constexpr int numComponentsF1 = FluidSystemF1::numComponents;
+using EvaluationF1 = Opm::FlashTest::FlashEvaluation<FluidSystemF1>;
+using EnthalpyF1 = Opm::MixtureEnthalpy<Scalar, FluidSystemF1>;
+
+namespace {
+
+const Scalar T0 = Opm::IdealGasCaloricData<Scalar>::referenceTemperature();
+
+// unchecked probe helper: flash F1 at (P, T) and return the mixture enthalpy
+// of the flashed state. Deliberately assertion-free — the calling test owns
+// its expectations; do not bolt checks in here.
+double mixtureEnthalpyAt(const double pressure, const double temperature)
+{
+    FlashCase<numComponentsF1> testCase{"enthalpy probe", pressure, temperature, f1Z};
+    const auto outcome = runFlash<FluidSystemF1, EvaluationF1>(testCase);
+    return Opm::getValue(EnthalpyF1::mixtureEnthalpy(outcome.state, Opm::FlashTest::f1CpTable(), T0));
+}
+
+} // anonymous namespace
 
 BOOST_AUTO_TEST_SUITE(CaloricData)
 
@@ -110,3 +148,241 @@ BOOST_AUTO_TEST_CASE(TriplePointsMatchReferenceFluids)
 }
 
 BOOST_AUTO_TEST_SUITE_END() // CaloricData
+
+BOOST_AUTO_TEST_SUITE(CaloricModel)
+
+// Enthalpy is strictly increasing in temperature (Cp > 0). The sweep
+// deliberately crosses phase-regime boundaries: with the caloric model H is
+// monotone irrespective of how the split changes along the way.
+BOOST_AUTO_TEST_CASE(MonotoneInTemperature)
+{
+    const std::array<double, 4> temperatures = {250., 300., 350., 400.};
+
+    double previous = mixtureEnthalpyAt(f1Pressure, temperatures[0]);
+    for (std::size_t i = 1; i < temperatures.size(); ++i) {
+        const double current = mixtureEnthalpyAt(f1Pressure, temperatures[i]);
+        BOOST_CHECK_MESSAGE(current > previous,
+                            "H not monotone: H(" << temperatures[i] << ") = " << current
+                                                 << " <= H(" << temperatures[i-1] << ") = " << previous);
+        previous = current;
+    }
+}
+
+// The reference datum: H(T0) = 0, regardless of the phase split
+BOOST_AUTO_TEST_CASE(ReferenceDatum)
+{
+    const double H0 = mixtureEnthalpyAt(f1Pressure, T0);
+    BOOST_CHECK_SMALL(H0, 1e-12);
+}
+
+// Analytic mixtureCp matches a central finite difference of the mixture
+// enthalpy. Note the physics of WHY they may be compared at all: the FD probe
+// re-flashes at T±h (a total derivative, split re-equilibrated) while
+// mixtureCp is a frozen-split partial derivative — they agree only because
+// the caloric H is flash-independent. Do NOT reuse this check unchanged for a
+// departure-mode enthalpy, where the two derivatives legitimately differ.
+BOOST_AUTO_TEST_CASE(CpVersusFiniteDifference)
+{
+    constexpr double T = 300.;
+    constexpr double h = 1e-3; // [K]
+
+    FlashCase<numComponentsF1> testCase{"cp probe", f1Pressure, T, f1Z};
+    const auto outcome = runFlash<FluidSystemF1, EvaluationF1>(testCase);
+    const double cpAnalytic = Opm::getValue(
+        EnthalpyF1::mixtureCp(outcome.state, Opm::FlashTest::f1CpTable()));
+
+    const double cpFD = (mixtureEnthalpyAt(f1Pressure, T + h)
+                         - mixtureEnthalpyAt(f1Pressure, T - h)) / (2.*h);
+
+    BOOST_CHECK_CLOSE(cpAnalytic, cpFD, 1e-6); // [%]
+}
+
+// Phase-decomposed mixture enthalpy equals the feed-direct sum
+// sum_i z_i*h_i(T). With the caloric model the phase split cancels exactly by
+// material balance — this pins the L/x/y weighting (indexing) of the
+// implementation and documents that caloric H is flash-independent.
+BOOST_AUTO_TEST_CASE(PhaseDecompositionMatchesFeedSum)
+{
+    constexpr double T = 340.;
+
+    FlashCase<numComponentsF1> testCase{"decomposition probe", f1Pressure, T, f1Z};
+    const auto outcome = runFlash<FluidSystemF1, EvaluationF1>(testCase);
+    // the cancellation is only non-trivially tested on a genuine two-phase split
+    BOOST_REQUIRE(!outcome.summary.single_phase);
+    BOOST_REQUIRE(outcome.summary.L > 0. && outcome.summary.L < 1.);
+
+    const auto cpTable = Opm::FlashTest::f1CpTable();
+    const double viaPhases = Opm::getValue(EnthalpyF1::mixtureEnthalpy(outcome.state, cpTable, T0));
+
+    double viaFeed = 0.;
+    for (int compIdx = 0; compIdx < numComponentsF1; ++compIdx)
+        viaFeed += f1Z[compIdx] * cpTable[compIdx].enthalpyIntegral(T, T0);
+
+    BOOST_CHECK_CLOSE(viaPhases, viaFeed, 1e-9); // [%]
+}
+
+// The caloric coefficients live on the component classes (the species'
+// identity card, next to its EoS constants); the IdealGasCaloricData presets
+// are delegating wrappers over them. Pin the delegation coefficient-wise so
+// the two surfaces can never drift apart.
+BOOST_AUTO_TEST_CASE(DelegationMatchesCards)
+{
+    using Caloric = Opm::IdealGasCaloricData<double>;
+
+    const auto checkSame = [](const char* name,
+                              const Opm::ComponentCp<double>& wrapper,
+                              const Opm::ComponentCp<double>& owner) {
+        BOOST_TEST_CONTEXT(name) {
+            BOOST_CHECK_EQUAL(wrapper.c0, owner.c0);
+            BOOST_CHECK_EQUAL(wrapper.c1, owner.c1);
+            BOOST_CHECK_EQUAL(wrapper.c2, owner.c2);
+            BOOST_CHECK_EQUAL(wrapper.c3, owner.c3);
+        }
+    };
+    checkSame("methane", Caloric::methane(),
+              Opm::C1<double>::idealGasHeatCapacityPolynomial());
+    checkSame("decane", Caloric::decane(),
+              Opm::C10<double>::idealGasHeatCapacityPolynomial());
+    checkSame("carbonDioxide", Caloric::carbonDioxide(),
+              Opm::SimpleCO2<double>::idealGasHeatCapacityPolynomial());
+}
+
+BOOST_AUTO_TEST_SUITE_END() // CaloricModel
+
+// ────────────────────────────────────────────────────────────────────────────
+// EoS-consistent departure (residual) enthalpy:
+// H_res = -R*T^2 * sum_i w_i * dln(phi_i)/dT per phase, with the temperature
+// derivative of the fugacity coefficient supplied by densead AD through the
+// fluid system's own fugacityCoefficient. This is the model under which the
+// enthalpy genuinely depends on the flash result (the caloric cancellation
+// tested above no longer holds).
+// ────────────────────────────────────────────────────────────────────────────
+BOOST_AUTO_TEST_SUITE(DepartureModel)
+
+namespace {
+using EOSType = Opm::CompositionalConfig::EOSType;
+}
+
+// The AD temperature-derivative of ln(phi) matches a central finite
+// difference of ln(phi(T)) evaluated at fixed pressure and frozen phase
+// composition — per phase, per component.
+BOOST_AUTO_TEST_CASE(AdDerivativeMatchesFiniteDifference)
+{
+    FlashCase<numComponentsF1> testCase{"AD probe", f1Pressure,
+                                        Opm::FlashTest::f1Temperature, f1Z};
+    const auto outcome = runFlash<FluidSystemF1, EvaluationF1>(testCase);
+    BOOST_REQUIRE(!outcome.summary.single_phase);
+
+    constexpr double h = 1e-3; // FD step [K]
+    for (unsigned phaseIdx : {static_cast<unsigned>(FluidSystemF1::oilPhaseIdx),
+                              static_cast<unsigned>(FluidSystemF1::gasPhaseIdx)}) {
+        // freeze this phase's composition from the flashed state
+        std::array<double, numComponentsF1> w;
+        for (int compIdx = 0; compIdx < numComponentsF1; ++compIdx)
+            w[compIdx] = Opm::getValue(outcome.state.moleFraction(phaseIdx, compIdx));
+
+        // independent, scalar evaluation path for ln(phi(T)) at fixed (P, w)
+        auto lnPhi = [&](const double T, const int compIdx) {
+            Opm::CompositionalFluidState<double, FluidSystemF1> fs;
+            fs.setTemperature(T);
+            fs.setPressure(FluidSystemF1::oilPhaseIdx, f1Pressure);
+            fs.setPressure(FluidSystemF1::gasPhaseIdx, f1Pressure);
+            for (int i = 0; i < numComponentsF1; ++i)
+                fs.setMoleFraction(phaseIdx, i, w[i]);
+            FluidSystemF1::ParameterCache<double> paramCache(EOSType::PR);
+            paramCache.updatePhase(fs, phaseIdx);
+            return std::log(FluidSystemF1::fugacityCoefficient(fs, paramCache, phaseIdx, compIdx));
+        };
+
+        const double T = Opm::FlashTest::f1Temperature;
+        for (int compIdx = 0; compIdx < numComponentsF1; ++compIdx) {
+            const double ad = EnthalpyF1::phaseDLnPhiDT(outcome.state, phaseIdx, compIdx, EOSType::PR);
+            const double fd = (lnPhi(T + h, compIdx) - lnPhi(T - h, compIdx)) / (2.*h);
+            BOOST_CHECK_CLOSE(ad, fd, 1e-3); // [%]
+        }
+    }
+}
+
+// Ideal-gas limit: the gas-phase residual vanishes as P -> 0
+BOOST_AUTO_TEST_CASE(IdealGasLimit)
+{
+    FlashCase<numComponentsF1> lowP{"near-vacuum probe", 1e3, Opm::FlashTest::f1Temperature, f1Z};
+    FlashCase<numComponentsF1> anchor{"anchor probe", f1Pressure, Opm::FlashTest::f1Temperature, f1Z};
+
+    const auto lowOutcome = runFlash<FluidSystemF1, EvaluationF1>(lowP);
+    const auto anchorOutcome = runFlash<FluidSystemF1, EvaluationF1>(anchor);
+
+    const double resLow = EnthalpyF1::phaseResidualEnthalpy(
+        lowOutcome.state, FluidSystemF1::gasPhaseIdx, EOSType::PR);
+    const double resAnchor = EnthalpyF1::phaseResidualEnthalpy(
+        anchorOutcome.state, FluidSystemF1::gasPhaseIdx, EOSType::PR);
+
+    BOOST_CHECK_LT(std::abs(resLow), 10.);   // [J/mol] — near-ideal at 10 mbar
+    BOOST_CHECK_LT(std::abs(resLow), 0.05 * std::abs(resAnchor));
+}
+
+// With the departure term the enthalpy couples to the split: the L-weighted
+// phase decomposition still holds, but the caloric feed-sum identity breaks,
+// and the liquid residual is attractive (vaporization-enthalpy scale).
+BOOST_AUTO_TEST_CASE(DepartureCouplesToSplit)
+{
+    FlashCase<numComponentsF1> testCase{"departure anchor", f1Pressure,
+                                        Opm::FlashTest::f1Temperature, f1Z};
+    const auto outcome = runFlash<FluidSystemF1, EvaluationF1>(testCase);
+    BOOST_REQUIRE(!outcome.summary.single_phase);
+    BOOST_REQUIRE(outcome.summary.L > 0. && outcome.summary.L < 1.);
+
+    const auto cpTable = Opm::FlashTest::f1CpTable();
+
+    // (a) decomposition consistency of the model-switch overload
+    const double viaMixture = Opm::getValue(EnthalpyF1::mixtureEnthalpy(
+        outcome.state, cpTable, T0, EOSType::PR, Opm::EnthalpyModel::eos_departure));
+    const double L = outcome.summary.L;
+    const double hOil = Opm::getValue(EnthalpyF1::phaseEnthalpy(
+                            outcome.state, FluidSystemF1::oilPhaseIdx, cpTable, T0))
+        + EnthalpyF1::phaseResidualEnthalpy(outcome.state, FluidSystemF1::oilPhaseIdx, EOSType::PR);
+    const double hGas = Opm::getValue(EnthalpyF1::phaseEnthalpy(
+                            outcome.state, FluidSystemF1::gasPhaseIdx, cpTable, T0))
+        + EnthalpyF1::phaseResidualEnthalpy(outcome.state, FluidSystemF1::gasPhaseIdx, EOSType::PR);
+    BOOST_CHECK_CLOSE(viaMixture, L*hOil + (1. - L)*hGas, 1e-9); // [%]
+
+    // (b) the caloric cancellation is broken: departure H differs from the
+    // feed-direct ideal sum by far more than any tolerance
+    double viaFeedIdeal = 0.;
+    for (int compIdx = 0; compIdx < numComponentsF1; ++compIdx)
+        viaFeedIdeal += f1Z[compIdx] * cpTable[compIdx].enthalpyIntegral(
+            Opm::FlashTest::f1Temperature, T0);
+    BOOST_CHECK_GT(std::abs(viaMixture - viaFeedIdeal), 100.); // [J/mol]
+
+    // (c) the liquid's residual is negative (attractive interactions)
+    BOOST_CHECK_LT(EnthalpyF1::phaseResidualEnthalpy(
+        outcome.state, FluidSystemF1::oilPhaseIdx, EOSType::PR), 0.);
+}
+
+// The caloric seam is untouched: the model-switch overload with
+// EnthalpyModel::caloric reproduces the original caloric overload exactly.
+BOOST_AUTO_TEST_CASE(CaloricSeamUnchanged)
+{
+    FlashCase<numComponentsF1> testCase{"seam probe", f1Pressure,
+                                        Opm::FlashTest::f1Temperature, f1Z};
+    const auto outcome = runFlash<FluidSystemF1, EvaluationF1>(testCase);
+    const auto cpTable = Opm::FlashTest::f1CpTable();
+
+    const double viaCaloric = Opm::getValue(
+        EnthalpyF1::mixtureEnthalpy(outcome.state, cpTable, T0));
+    const double viaSwitch = Opm::getValue(EnthalpyF1::mixtureEnthalpy(
+        outcome.state, cpTable, T0, EOSType::PR, Opm::EnthalpyModel::caloric));
+    BOOST_CHECK_CLOSE(viaCaloric, viaSwitch, 1e-12); // [%]
+}
+
+// the shared enthalpy-model parser: round-trips and loud failure
+BOOST_AUTO_TEST_CASE(EnthalpyModelStrings)
+{
+    BOOST_CHECK(Opm::enthalpyModelFromString("caloric") == Opm::EnthalpyModel::caloric);
+    BOOST_CHECK(Opm::enthalpyModelFromString("eos_departure") == Opm::EnthalpyModel::eos_departure);
+    BOOST_CHECK_EQUAL(Opm::enthalpyModelToString(Opm::EnthalpyModel::caloric), "caloric");
+    BOOST_CHECK_EQUAL(Opm::enthalpyModelToString(Opm::EnthalpyModel::eos_departure), "eos_departure");
+    BOOST_CHECK_THROW(Opm::enthalpyModelFromString("nonsense"), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // DepartureModel

--- a/tests/material/test_mixture_enthalpy.cpp
+++ b/tests/material/test_mixture_enthalpy.cpp
@@ -247,6 +247,47 @@ BOOST_AUTO_TEST_CASE(DelegationMatchesCards)
               Opm::SimpleCO2<double>::idealGasHeatCapacityPolynomial());
 }
 
+// byName() is the safety seam of the preset surface: deck-style aliases must
+// resolve case-insensitively to the intended card, and an unknown component
+// must fail loudly rather than receive somebody else's heat capacity. Pin
+// every documented alias coefficient-wise, plus the throw.
+BOOST_AUTO_TEST_CASE(ByNameAliasesAndUnknownName)
+{
+    using Caloric = Opm::IdealGasCaloricData<double>;
+
+    const struct {
+        const char* alias;
+        Opm::ComponentCp<double> expected;
+    } lookups[] = {
+        {"C1", Caloric::methane()},
+        {"c1", Caloric::methane()},
+        {"CH4", Caloric::methane()},
+        {"Methane", Caloric::methane()},
+        {"C10", Caloric::decane()},
+        {"nC10", Caloric::decane()},
+        {"Decane", Caloric::decane()},
+        {"n-decane", Caloric::decane()},
+        {"CO2", Caloric::carbonDioxide()},
+        {"co2", Caloric::carbonDioxide()},
+        {"CarbonDioxide", Caloric::carbonDioxide()},
+        {"Carbon-Dioxide", Caloric::carbonDioxide()},
+        {"carbon dioxide", Caloric::carbonDioxide()},
+    };
+    for (const auto& lookup : lookups) {
+        BOOST_TEST_CONTEXT(lookup.alias) {
+            const auto card = Caloric::byName(lookup.alias);
+            BOOST_CHECK_EQUAL(card.c0, lookup.expected.c0);
+            BOOST_CHECK_EQUAL(card.c1, lookup.expected.c1);
+            BOOST_CHECK_EQUAL(card.c2, lookup.expected.c2);
+            BOOST_CHECK_EQUAL(card.c3, lookup.expected.c3);
+        }
+    }
+
+    // no silent fallback: unknown names throw, naming the component
+    BOOST_CHECK_THROW(Caloric::byName("unobtainium"), std::runtime_error);
+    BOOST_CHECK_THROW(Caloric::byName(""), std::runtime_error);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // CaloricModel
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -265,7 +306,9 @@ using EOSType = Opm::CompositionalConfig::EOSType;
 
 // The AD temperature-derivative of ln(phi) matches a central finite
 // difference of ln(phi(T)) evaluated at fixed pressure and frozen phase
-// composition — per phase, per component.
+// composition — per phase, per component, per supported cubic EoS (the
+// alpha-function branches in CubicEOSParams differ exactly in this
+// temperature dependence).
 BOOST_AUTO_TEST_CASE(AdDerivativeMatchesFiniteDifference)
 {
     FlashCase<numComponentsF1> testCase{"AD probe", f1Pressure,
@@ -274,31 +317,38 @@ BOOST_AUTO_TEST_CASE(AdDerivativeMatchesFiniteDifference)
     BOOST_REQUIRE(!outcome.summary.single_phase);
 
     constexpr double h = 1e-3; // FD step [K]
-    for (unsigned phaseIdx : {static_cast<unsigned>(FluidSystemF1::oilPhaseIdx),
-                              static_cast<unsigned>(FluidSystemF1::gasPhaseIdx)}) {
-        // freeze this phase's composition from the flashed state
-        std::array<double, numComponentsF1> w;
-        for (int compIdx = 0; compIdx < numComponentsF1; ++compIdx)
-            w[compIdx] = Opm::getValue(outcome.state.moleFraction(phaseIdx, compIdx));
+    // the flashed state is only a probe point: the AD == FD identity holds
+    // at any (P, T, w), so the one flashed composition serves every EoS
+    for (const auto eosType : {EOSType::PR, EOSType::PRCORR,
+                               EOSType::SRK, EOSType::RK}) {
+        BOOST_TEST_CONTEXT("EoS " << Opm::CompositionalConfig::eosTypeToString(eosType)) {
+            for (unsigned phaseIdx : {static_cast<unsigned>(FluidSystemF1::oilPhaseIdx),
+                                      static_cast<unsigned>(FluidSystemF1::gasPhaseIdx)}) {
+                // freeze this phase's composition from the flashed state
+                std::array<double, numComponentsF1> w;
+                for (int compIdx = 0; compIdx < numComponentsF1; ++compIdx)
+                    w[compIdx] = Opm::getValue(outcome.state.moleFraction(phaseIdx, compIdx));
 
-        // independent, scalar evaluation path for ln(phi(T)) at fixed (P, w)
-        auto lnPhi = [&](const double T, const int compIdx) {
-            Opm::CompositionalFluidState<double, FluidSystemF1> fs;
-            fs.setTemperature(T);
-            fs.setPressure(FluidSystemF1::oilPhaseIdx, f1Pressure);
-            fs.setPressure(FluidSystemF1::gasPhaseIdx, f1Pressure);
-            for (int i = 0; i < numComponentsF1; ++i)
-                fs.setMoleFraction(phaseIdx, i, w[i]);
-            FluidSystemF1::ParameterCache<double> paramCache(EOSType::PR);
-            paramCache.updatePhase(fs, phaseIdx);
-            return std::log(FluidSystemF1::fugacityCoefficient(fs, paramCache, phaseIdx, compIdx));
-        };
+                // independent, scalar evaluation path for ln(phi(T)) at fixed (P, w)
+                auto lnPhi = [&](const double T, const int compIdx) {
+                    Opm::CompositionalFluidState<double, FluidSystemF1> fs;
+                    fs.setTemperature(T);
+                    fs.setPressure(FluidSystemF1::oilPhaseIdx, f1Pressure);
+                    fs.setPressure(FluidSystemF1::gasPhaseIdx, f1Pressure);
+                    for (int i = 0; i < numComponentsF1; ++i)
+                        fs.setMoleFraction(phaseIdx, i, w[i]);
+                    FluidSystemF1::ParameterCache<double> paramCache(eosType);
+                    paramCache.updatePhase(fs, phaseIdx);
+                    return std::log(FluidSystemF1::fugacityCoefficient(fs, paramCache, phaseIdx, compIdx));
+                };
 
-        const double T = Opm::FlashTest::f1Temperature;
-        for (int compIdx = 0; compIdx < numComponentsF1; ++compIdx) {
-            const double ad = EnthalpyF1::phaseDLnPhiDT(outcome.state, phaseIdx, compIdx, EOSType::PR);
-            const double fd = (lnPhi(T + h, compIdx) - lnPhi(T - h, compIdx)) / (2.*h);
-            BOOST_CHECK_CLOSE(ad, fd, 1e-3); // [%]
+                const double T = Opm::FlashTest::f1Temperature;
+                for (int compIdx = 0; compIdx < numComponentsF1; ++compIdx) {
+                    const double ad = EnthalpyF1::phaseDLnPhiDT(outcome.state, phaseIdx, compIdx, eosType);
+                    const double fd = (lnPhi(T + h, compIdx) - lnPhi(T - h, compIdx)) / (2.*h);
+                    BOOST_CHECK_CLOSE(ad, fd, 1e-3); // [%]
+                }
+            }
         }
     }
 }

--- a/tests/material/test_twocomponents_ptflash.cpp
+++ b/tests/material/test_twocomponents_ptflash.cpp
@@ -1,0 +1,299 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Isothermal (P-T) baseline tests on synthetic fixtures: the PTFlash
+ *        behaviour that the P-H (isenthalpic) flash builds on.
+ *
+ * Cases are data-driven: a FlashCase struct (flashTestFixtures.hpp) carries the
+ * full input state of the fluid + run configuration + expected phase outcome;
+ * runFlash() executes it and returns a FlashOutcome — a plain-double
+ * FlashResult summary plus the final fluid state. Assertions live here, the
+ * driver stays Boost-free in the header.
+ */
+#include "config.h"
+
+#define BOOST_TEST_MODULE TwoComponentsPtFlash
+#include <boost/test/unit_test.hpp>
+
+#include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
+
+#include <opm/material/fluidsystems/ThreeComponentFluidSystem.hh>
+
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
+
+#include "flashTestFixtures.hpp"
+
+#include <array>
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using Scalar = double;
+using EOSType = Opm::CompositionalConfig::EOSType;
+using Opm::FlashTest::ExpectedPhase;
+using Opm::FlashTest::FlashCase;
+using Opm::FlashTest::FlashResult;
+using Opm::FlashTest::runFlash;
+using Opm::FlashTest::f1Pressure;
+using Opm::FlashTest::f1Temperature;
+using Opm::FlashTest::f1Z;
+using Opm::FlashTest::f2Pressure;
+using Opm::FlashTest::f2Temperature;
+using Opm::FlashTest::f2Z;
+
+// F1: binary C1/nC10 (the workhorse fixture)
+using FluidSystemF1 = Opm::FlashTest::TwoComponentFluidSystem<Scalar>;
+constexpr int numComponentsF1 = FluidSystemF1::numComponents;
+using EvaluationF1 = Opm::FlashTest::FlashEvaluation<FluidSystemF1>;
+
+// F2: ternary CO2/C1/nC10 (reuses the existing three-component system)
+using FluidSystemF2 = Opm::ThreeComponentFluidSystem<Scalar>;
+constexpr int numComponentsF2 = FluidSystemF2::numComponents;
+using EvaluationF2 = Opm::FlashTest::FlashEvaluation<FluidSystemF2>;
+
+namespace {
+
+constexpr double INVARIANT_TOLERANCE = 1.e-8;       // absolute, on mass balance / normalization
+constexpr double PARITY_TOLERANCE = 1.e-6;          // absolute, between solver methods
+constexpr double FUGACITY_TOLERANCE = 1.e-6;        // relative; flash converges the fugacity ratio to 1e-8
+constexpr double SINGLE_PHASE_L_TOLERANCE = 1.e-6;  // on the Li-label L in {0,1}
+
+// assert the case's declared phase expectation against the flash result
+template <int numComponents>
+void checkExpectedPhase(const FlashCase<numComponents>& testCase,
+                        const FlashResult<numComponents>& result)
+{
+    switch (testCase.expected) {
+    case ExpectedPhase::two_phase:
+        BOOST_CHECK_MESSAGE(!result.single_phase && result.L > 0. && result.L < 1.,
+                            testCase.name << ": expected two-phase, got single_phase = "
+                                          << result.single_phase << ", L = " << result.L);
+        break;
+    case ExpectedPhase::single_liquid:
+        BOOST_CHECK_MESSAGE(result.single_phase,
+                            testCase.name << ": expected single phase, got L = " << result.L);
+        // note: BOOST_CHECK_CLOSE tolerance is in percent
+        BOOST_CHECK_CLOSE(result.L, 1., SINGLE_PHASE_L_TOLERANCE);
+        break;
+    case ExpectedPhase::single_vapor:
+        BOOST_CHECK_MESSAGE(result.single_phase,
+                            testCase.name << ": expected single phase, got L = " << result.L);
+        BOOST_CHECK_SMALL(result.L, SINGLE_PHASE_L_TOLERANCE);
+        break;
+    case ExpectedPhase::any:
+        break;
+    }
+}
+
+// two-phase physical invariants: composition normalization, component mass
+// balance against the feed, and equal fugacity across the phases.
+// NOTE: fluid_state.K() is an INPUT seed to PTFlash::solve (the caller-set
+// Wilson estimate) and is not updated to the converged K on this state, so it
+// must not be checked against y/x here. The true equilibrium condition is
+// equal fugacity, evaluated below through the same ParameterCache +
+// fugacityCoefficient path PTFlash itself uses.
+template <class FluidSystem, class FluidState>
+void checkTwoPhaseInvariants(const FluidState& fluid_state,
+                             const std::array<double, FluidSystem::numComponents>& z,
+                             const EOSType eos_type)
+{
+    constexpr int numComponents = FluidSystem::numComponents;
+
+    const double L = Opm::getValue(fluid_state.L());
+    BOOST_CHECK_MESSAGE(L > 0. && L < 1.,
+                        "expected a two-phase split, got L = " << L);
+
+    // The ParameterCache holds ONE phase's EoS state at a time, so the oil
+    // fugacity coefficients must be captured before updatePhase(gas) — do not
+    // interleave the phases in a refactor.
+    using ParamCache = typename FluidSystem::template ParameterCache<typename FluidState::ValueType>;
+    ParamCache paramCache(eos_type);
+    paramCache.updatePhase(fluid_state, FluidSystem::oilPhaseIdx);
+    std::array<double, numComponents> phi_oil;
+    for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        phi_oil[compIdx] = Opm::getValue(
+            FluidSystem::fugacityCoefficient(fluid_state, paramCache, FluidSystem::oilPhaseIdx, compIdx));
+    }
+    paramCache.updatePhase(fluid_state, FluidSystem::gasPhaseIdx);
+
+    double sum_x = 0., sum_y = 0.;
+    for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        const double x_i = Opm::getValue(fluid_state.moleFraction(FluidSystem::oilPhaseIdx, compIdx));
+        const double y_i = Opm::getValue(fluid_state.moleFraction(FluidSystem::gasPhaseIdx, compIdx));
+        sum_x += x_i;
+        sum_y += y_i;
+
+        // mass balance: z_i = L*x_i + (1 - L)*y_i
+        BOOST_CHECK_SMALL(L * x_i + (1. - L) * y_i - z[compIdx], INVARIANT_TOLERANCE);
+
+        // equal fugacity: x_i*phi_i^oil = y_i*phi_i^gas (pressure cancels)
+        const double phi_gas_i = Opm::getValue(
+            FluidSystem::fugacityCoefficient(fluid_state, paramCache, FluidSystem::gasPhaseIdx, compIdx));
+        const double f_oil = x_i * phi_oil[compIdx];
+        const double f_gas = y_i * phi_gas_i;
+        BOOST_CHECK_MESSAGE(std::abs(f_oil / f_gas - 1.) < FUGACITY_TOLERANCE,
+                            "component " << compIdx << ": fugacity mismatch, f_oil = "
+                                         << f_oil << ", f_gas = " << f_gas);
+    }
+    BOOST_CHECK_SMALL(sum_x - 1., INVARIANT_TOLERANCE);
+    BOOST_CHECK_SMALL(sum_y - 1., INVARIANT_TOLERANCE);
+}
+
+} // anonymous namespace
+
+namespace {
+
+// scope the PTFlash debug-output backend to one test case, exception-safely:
+// a leaked backend would make later cases' output order-dependent
+struct DebugLogGuard {
+    DebugLogGuard()
+    {
+        auto debugLog = std::make_shared<Opm::StreamLog>(std::cout, Opm::Log::MessageType::Debug);
+        Opm::OpmLog::addBackend("DEBUGLOG", debugLog);
+    }
+    ~DebugLogGuard() { Opm::OpmLog::removeBackend("DEBUGLOG"); }
+};
+
+} // anonymous namespace
+
+// LEARN case: run one flash verbosely and print the resulting state — an
+// intentional, human-readable record of how the inner flash is operated and
+// behaves.
+BOOST_AUTO_TEST_CASE(LearnPtFlashF1)
+{
+    // route PTFlash's OpmLog::debug() output to stdout for this case only
+    const DebugLogGuard debugLogGuard;
+
+    FlashCase<numComponentsF1> testCase{"LEARN two-phase F1", f1Pressure, f1Temperature, f1Z};
+    testCase.verbosity = 3;
+    testCase.expected = ExpectedPhase::two_phase;
+
+    const auto outcome = runFlash<FluidSystemF1, EvaluationF1>(testCase);
+    const auto& r = outcome.summary;
+
+    std::cout << "LEARN: P = " << testCase.pressure << " Pa, T = " << testCase.temperature
+              << " K, z = (" << testCase.z[0] << ", " << testCase.z[1] << ")\n";
+    std::cout << "LEARN: single_phase = " << r.single_phase << ", L = " << r.L << "\n";
+    for (int compIdx = 0; compIdx < numComponentsF1; ++compIdx) {
+        // fluid_state.K() still holds the caller's Wilson seed after solve;
+        // the converged equilibrium ratio is y/x
+        std::cout << "LEARN: comp " << compIdx
+                  << " (" << FluidSystemF1::componentName(compIdx) << ")"
+                  << ": x = " << r.x[compIdx] << ", y = " << r.y[compIdx]
+                  << ", K = y/x = " << r.K[compIdx]
+                  << " (Wilson seed was " << r.K_wilson[compIdx] << ")\n";
+    }
+
+    checkExpectedPhase(testCase, r);
+    // the light component (C1) concentrates in the vapor; the feed sits in between
+    BOOST_CHECK_MESSAGE(r.x[0] < testCase.z[0] && testCase.z[0] < r.y[0],
+                        "expected x_C1 < z_C1 < y_C1, got x = " << r.x[0] << ", y = " << r.y[0]);
+}
+
+// Baseline pressure, low temperature -> single-phase, labeled liquid (L = 1).
+// Like the vapor case below, the label follows from Li's pressure-blind
+// correlation: T = 200 K < Tc_est = 558.24 K for this feed.
+BOOST_AUTO_TEST_CASE(SinglePhaseLiquidF1)
+{
+    FlashCase<numComponentsF1> testCase{"single-phase liquid F1", f1Pressure, 200., f1Z};
+    testCase.expected = ExpectedPhase::single_liquid;
+
+    const auto outcome = runFlash<FluidSystemF1, EvaluationF1>(testCase);
+    checkExpectedPhase(testCase, outcome.summary);
+}
+
+// Low pressure / high temperature -> single-phase vapor (L = 0).
+// The single-phase L label comes from Li's correlation (PTFlash
+// li_single_phase_label_): liquid iff T < Tc_est = sum(Vc_i*Tc_i*z_i)/sum(Vc_i*z_i),
+// INDEPENDENT of pressure. For the equimolar C1/nC10 feed Tc_est = 558.24 K —
+// e.g. this fixture at 1 bar / 500 K is physically gaseous but still returns
+// the liquid label (L = 1). 600 K sits above the Li threshold and is
+// unambiguously vapor at 1 bar.
+BOOST_AUTO_TEST_CASE(SinglePhaseVaporF1)
+{
+    FlashCase<numComponentsF1> testCase{"single-phase vapor F1", 1e5, 600., f1Z};
+    testCase.expected = ExpectedPhase::single_vapor;
+
+    const auto outcome = runFlash<FluidSystemF1, EvaluationF1>(testCase);
+    checkExpectedPhase(testCase, outcome.summary);
+}
+
+// Two-phase split invariants: normalization, mass balance, equal fugacity
+BOOST_AUTO_TEST_CASE(TwoPhaseInvariantsF1)
+{
+    FlashCase<numComponentsF1> testCase{"two-phase invariants F1", f1Pressure, f1Temperature, f1Z};
+    testCase.expected = ExpectedPhase::two_phase;
+
+    const auto outcome = runFlash<FluidSystemF1, EvaluationF1>(testCase);
+    checkExpectedPhase(testCase, outcome.summary);
+    checkTwoPhaseInvariants<FluidSystemF1>(outcome.state, testCase.z, testCase.eos_type);
+}
+
+// ssi / newton / ssi+newton converge to the same solution
+BOOST_AUTO_TEST_CASE(MethodParityF1)
+{
+    const std::vector<std::string> methods {"ssi", "newton", "ssi+newton"};
+
+    std::vector<FlashResult<numComponentsF1>> results;
+    for (const auto& method : methods) {
+        FlashCase<numComponentsF1> testCase{"parity F1 [" + method + "]",
+                                            f1Pressure, f1Temperature, f1Z};
+        testCase.method = method;
+        testCase.expected = ExpectedPhase::two_phase;
+
+        const auto outcome = runFlash<FluidSystemF1, EvaluationF1>(testCase);
+        checkExpectedPhase(testCase, outcome.summary);
+        results.push_back(outcome.summary);
+    }
+
+    for (std::size_t m = 1; m < methods.size(); ++m) {
+        BOOST_CHECK_MESSAGE(std::abs(results[m].L - results[0].L) < PARITY_TOLERANCE,
+                            methods[m] << " vs " << methods[0] << ": L differs: "
+                                       << results[m].L << " vs " << results[0].L);
+        for (int compIdx = 0; compIdx < numComponentsF1; ++compIdx) {
+            BOOST_CHECK_SMALL(results[m].x[compIdx] - results[0].x[compIdx], PARITY_TOLERANCE);
+            BOOST_CHECK_SMALL(results[m].y[compIdx] - results[0].y[compIdx], PARITY_TOLERANCE);
+        }
+    }
+}
+
+// Ternary (F2) split satisfies the same invariants at the fixture's canonical
+// two-phase point; z ordering follows ThreeComponentFluidSystem
+// (Comp0 = CO2, Comp1 = C1, Comp2 = nC10).
+BOOST_AUTO_TEST_CASE(TernaryInvariantsF2)
+{
+    FlashCase<numComponentsF2> testCase{"two-phase invariants F2", f2Pressure, f2Temperature, f2Z};
+    testCase.expected = ExpectedPhase::two_phase;
+
+    const auto outcome = runFlash<FluidSystemF2, EvaluationF2>(testCase);
+    checkExpectedPhase(testCase, outcome.summary);
+    checkTwoPhaseInvariants<FluidSystemF2>(outcome.state, testCase.z, testCase.eos_type);
+}


### PR DESCRIPTION
The compositional path in opm-common cannot evaluate the enthalpy of a flashed mixture. This PR adds that capability — the groundwork for an isenthalpic (P–H) compositional flash, which follows in a separate PR.

### What this adds

- **`ComponentCp`** — cubic ideal-gas heat-capacity polynomial and its closed-form enthalpy integral. The coefficients live on the component classes (`C1`, `C10`, `SimpleCO2`) as cited identity cards, each fitted to the species' reference EoS (Setzmann & Wagner 1991; Lemmon & Span 2006; Span & Wagner 1996) over 250–600 K, with cross-checked triple points.
- **`IdealGasCaloricData`** — the shared enthalpy datum (H = 0 at 298.15 K) and a name-keyed lookup of the cards. Unknown components throw instead of silently receiving another species' data.
- **`MixtureEnthalpy`** — molar enthalpy of a flashed state under two models: `caloric` (ideal-gas; independent of the phase split by material balance) and `eos_departure` (adds the per-phase residual `H_res = -R T² Σ w_i ∂lnφ_i/∂T`). The temperature derivative is computed by automatic differentiation: temperature is seeded as a one-variable `DenseAd::Evaluation` and `∂lnφ_i/∂T` is read from the fluid system's own `fugacityCoefficient` — no hand-derived EoS calculus, so every EoS variant the fluid system supports is covered. The AD is internal to this evaluation; results are plain values.
- **Baseline tests for the existing isothermal flash** on a new synthetic two-component (C1/nC10) fixture: phase labels, material balance, equal fugacity, K-consistency, and `ssi`/`newton`/`ssi+newton` parity.

### Testing

About 65% of the diff is tests:

- every heat-capacity card is pinned against tabulated reference-EoS values, so a corrupt coefficient row fails loudly instead of passing self-consistent checks;
- the AD derivative is verified against an independent finite difference of lnφ, per phase and per component (the seam `phaseDLnPhiDT` exists for exactly this);
- ideal-gas limit of the residual, split-cancellation and monotonicity of the caloric model, the reference datum, and the model-name parser.

Additive only — no existing behavior changes.
