### PR TITLE
adding WELL_THP_UPDATE event. 

### DIFF
--- a/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
+++ b/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
@@ -72,7 +72,7 @@ struct SimulatorUpdate
     /// its internal notion of the connection transmissibility factors.
     std::unordered_set<std::string> welpi_wells{};
 
-    /// Wells whose THP limit and/or VFP table has been (re)specified by
+    /// Wells whose THP limit and/or VFP table have been (re)specified by
     /// WCONPROD, WCONHIST, WCONINJE or WCONINJH for the named wells, by
     /// WELTARG with THP or VFP control, or by WTMULT with THP control.
     /// Producers and injectors alike are included. Unlike affected_wells,

--- a/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
+++ b/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
@@ -73,12 +73,13 @@ struct SimulatorUpdate
     std::unordered_set<std::string> welpi_wells{};
 
     /// Wells whose THP limit and/or VFP table has been (re)specified by
-    /// WCONPROD or WCONHIST for the named wells, by WELTARG with THP or VFP
-    /// control, or by WTMULT with THP control. Unlike affected_wells, this
-    /// set also includes wells for which the entered values are unchanged,
-    /// since re-specifying either input cancels a THP limit imposed
-    /// dynamically by the simulator (e.g. by network balancing). See also
-    /// the WELL_THP_UPDATE schedule event.
+    /// WCONPROD, WCONHIST, WCONINJE or WCONINJH for the named wells, by
+    /// WELTARG with THP or VFP control, or by WTMULT with THP control.
+    /// Producers and injectors alike are included. Unlike affected_wells,
+    /// this set also includes wells for which the entered values are
+    /// unchanged, since re-specifying either input cancels a THP limit
+    /// imposed dynamically by the simulator (e.g. by network balancing).
+    /// See also the WELL_THP_UPDATE schedule event.
     std::unordered_set<std::string> thp_respecified_wells{};
 
     /// New well connections created as a result of a geomechanical

--- a/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
+++ b/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
@@ -44,6 +44,7 @@ struct SimulatorUpdate
         simulatorUpdate.well_structure_changed = true;
         simulatorUpdate.affected_wells = {"test"};
         simulatorUpdate.welpi_wells.insert("I-45");
+        simulatorUpdate.thp_respecified_wells.insert("P-3");
         simulatorUpdate.new_frac_wconns.assign({
                 std::pair { "I-45"s, std::vector { std::size_t{11}, std::size_t{22}, std::size_t{33} } },
                 std::pair { "RA-MAN"s, std::vector { std::size_t{1}, std::size_t{7}, std::size_t{29} } },
@@ -57,6 +58,7 @@ struct SimulatorUpdate
     {
         serializer(affected_wells);
         serializer(welpi_wells);
+        serializer(thp_respecified_wells);
         serializer(new_frac_wconns);
         serializer(tran_update);
         serializer(well_structure_changed);
@@ -69,6 +71,15 @@ struct SimulatorUpdate
     /// Wells affected only by WELPI for which the simulator needs to update
     /// its internal notion of the connection transmissibility factors.
     std::unordered_set<std::string> welpi_wells{};
+
+    /// Wells whose THP limit and/or VFP table has been (re)specified by
+    /// WCONPROD or WCONHIST for the named wells, by WELTARG with THP or VFP
+    /// control, or by WTMULT with THP control. Unlike affected_wells, this
+    /// set also includes wells for which the entered values are unchanged,
+    /// since re-specifying either input cancels a THP limit imposed
+    /// dynamically by the simulator (e.g. by network balancing). See also
+    /// the WELL_THP_UPDATE schedule event.
+    std::unordered_set<std::string> thp_respecified_wells{};
 
     /// New well connections created as a result of a geomechanical
     /// fracturing process.
@@ -116,6 +127,9 @@ struct SimulatorUpdate
         this->welpi_wells.insert(otherSimUpdate.welpi_wells.begin(),
                                  otherSimUpdate.welpi_wells.end());
 
+        this->thp_respecified_wells.insert(otherSimUpdate.thp_respecified_wells.begin(),
+                                      otherSimUpdate.thp_respecified_wells.end());
+
         this->new_frac_wconns.insert(this->new_frac_wconns.end(),
                                      otherSimUpdate.new_frac_wconns.begin(),
                                      otherSimUpdate.new_frac_wconns.end());
@@ -128,6 +142,7 @@ struct SimulatorUpdate
         this->well_structure_changed = false;
         this->affected_wells.clear();
         this->welpi_wells.clear();
+        this->thp_respecified_wells.clear();
         this->new_frac_wconns.clear();
     }
 
@@ -137,6 +152,7 @@ struct SimulatorUpdate
             && (this->well_structure_changed == that.well_structure_changed)
             && (this->affected_wells == that.affected_wells)
             && (this->welpi_wells == that.welpi_wells)
+            && (this->thp_respecified_wells == that.thp_respecified_wells)
             && (this->new_frac_wconns == that.new_frac_wconns)
             ;
     }

--- a/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
+++ b/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
@@ -73,12 +73,13 @@ struct SimulatorUpdate
     std::unordered_set<std::string> welpi_wells{};
 
     /// Wells whose THP limit and/or VFP table has been (re)specified by
-    /// WCONPROD or WCONHIST for the named wells, by WELTARG with THP or VFP
-    /// control, or by WTMULT with THP control. Unlike affected_wells, this
-    /// set also includes wells for which the entered values are unchanged,
-    /// since re-specifying either input cancels a THP limit imposed
-    /// dynamically by the simulator (e.g. by network balancing). See also
-    /// the WELL_THP_UPDATE schedule event.
+    /// WCONPROD, WCONHIST, WCONINJE or WCONINJH for the named wells, by
+    /// WELTARG with THP or VFP control, or by WTMULT with THP control.
+    /// Producers and injectors alike are included. Unlike affected_wells,
+    /// this set also includes wells for which the entered values are
+    /// unchanged, since re-specifying either input cancels a THP limit
+    /// imposed dynamically by the simulator (e.g. by network balancing).
+    /// See also the WELL_THP_UPDATE schedule event.
     std::unordered_set<std::string> thp_respec_wells{};
 
     /// New well connections created as a result of a geomechanical

--- a/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
+++ b/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
@@ -44,6 +44,7 @@ struct SimulatorUpdate
         simulatorUpdate.well_structure_changed = true;
         simulatorUpdate.affected_wells = {"test"};
         simulatorUpdate.welpi_wells.insert("I-45");
+        simulatorUpdate.thp_respec_wells.insert("P-3");
         simulatorUpdate.new_frac_wconns.assign({
                 std::pair { "I-45"s, std::vector { std::size_t{11}, std::size_t{22}, std::size_t{33} } },
                 std::pair { "RA-MAN"s, std::vector { std::size_t{1}, std::size_t{7}, std::size_t{29} } },
@@ -57,6 +58,7 @@ struct SimulatorUpdate
     {
         serializer(affected_wells);
         serializer(welpi_wells);
+        serializer(thp_respec_wells);
         serializer(new_frac_wconns);
         serializer(tran_update);
         serializer(well_structure_changed);
@@ -69,6 +71,15 @@ struct SimulatorUpdate
     /// Wells affected only by WELPI for which the simulator needs to update
     /// its internal notion of the connection transmissibility factors.
     std::unordered_set<std::string> welpi_wells{};
+
+    /// Wells whose THP limit and/or VFP table has been (re)specified by
+    /// WCONPROD or WCONHIST for the named wells, by WELTARG with THP or VFP
+    /// control, or by WTMULT with THP control. Unlike affected_wells, this
+    /// set also includes wells for which the entered values are unchanged,
+    /// since re-specifying either input cancels a THP limit imposed
+    /// dynamically by the simulator (e.g. by network balancing). See also
+    /// the WELL_THP_UPDATE schedule event.
+    std::unordered_set<std::string> thp_respec_wells{};
 
     /// New well connections created as a result of a geomechanical
     /// fracturing process.
@@ -116,6 +127,9 @@ struct SimulatorUpdate
         this->welpi_wells.insert(otherSimUpdate.welpi_wells.begin(),
                                  otherSimUpdate.welpi_wells.end());
 
+        this->thp_respec_wells.insert(otherSimUpdate.thp_respec_wells.begin(),
+                                      otherSimUpdate.thp_respec_wells.end());
+
         this->new_frac_wconns.insert(this->new_frac_wconns.end(),
                                      otherSimUpdate.new_frac_wconns.begin(),
                                      otherSimUpdate.new_frac_wconns.end());
@@ -128,6 +142,7 @@ struct SimulatorUpdate
         this->well_structure_changed = false;
         this->affected_wells.clear();
         this->welpi_wells.clear();
+        this->thp_respec_wells.clear();
         this->new_frac_wconns.clear();
     }
 
@@ -137,6 +152,7 @@ struct SimulatorUpdate
             && (this->well_structure_changed == that.well_structure_changed)
             && (this->affected_wells == that.affected_wells)
             && (this->welpi_wells == that.welpi_wells)
+            && (this->thp_respec_wells == that.thp_respec_wells)
             && (this->new_frac_wconns == that.new_frac_wconns)
             ;
     }

--- a/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
+++ b/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
@@ -72,7 +72,7 @@ struct SimulatorUpdate
     /// its internal notion of the connection transmissibility factors.
     std::unordered_set<std::string> welpi_wells{};
 
-    /// Wells whose THP limit and/or VFP table has been (re)specified by
+    /// Wells whose THP limit and/or VFP table have been (re)specified by
     /// WCONPROD, WCONHIST, WCONINJE or WCONINJH for the named wells, by
     /// WELTARG with THP or VFP control, or by WTMULT with THP control.
     /// Producers and injectors alike are included. Unlike affected_wells,
@@ -129,7 +129,7 @@ struct SimulatorUpdate
                                  otherSimUpdate.welpi_wells.end());
 
         this->thp_respecified_wells.insert(otherSimUpdate.thp_respecified_wells.begin(),
-                                      otherSimUpdate.thp_respecified_wells.end());
+                                           otherSimUpdate.thp_respecified_wells.end());
 
         this->new_frac_wconns.insert(this->new_frac_wconns.end(),
                                      otherSimUpdate.new_frac_wconns.begin(),

--- a/opm/input/eclipse/Schedule/Events.hpp
+++ b/opm/input/eclipse/Schedule/Events.hpp
@@ -115,12 +115,14 @@ namespace Opm
             REQUEST_OPEN_COMPLETION = (UINT64_C(1) << 24),
 
             /// The well THP limit and/or VFP table has been (re)specified
-            /// by WCONPROD or WCONHIST for the named wells, by WELTARG with
-            /// THP or VFP control, or by WTMULT with THP control.  Unlike
-            /// PRODUCTION_UPDATE, the event is also triggered when the
-            /// entered values are unchanged, since re-specifying either
-            /// input cancels a THP limit imposed dynamically by the
-            /// simulator (e.g. by network balancing).
+            /// by WCONPROD, WCONHIST, WCONINJE or WCONINJH for the named
+            /// wells, by WELTARG with THP or VFP control, or by WTMULT with
+            /// THP control.  The event applies to producers and injectors
+            /// alike; consumers must check the well type where it matters.
+            /// Unlike PRODUCTION_UPDATE and INJECTION_UPDATE, the event is
+            /// also triggered when the entered values are unchanged, since
+            /// re-specifying either input cancels a THP limit imposed
+            /// dynamically by the simulator (e.g. by network balancing).
             WELL_THP_UPDATE = (UINT64_C(1) << 25),
         };
     } // namespace ScheduleEvents

--- a/opm/input/eclipse/Schedule/Events.hpp
+++ b/opm/input/eclipse/Schedule/Events.hpp
@@ -114,7 +114,7 @@ namespace Opm
             /// the recorded schedule state).
             REQUEST_OPEN_COMPLETION = (UINT64_C(1) << 24),
 
-            /// The well THP limit and/or VFP table has been (re)specified
+            /// The well THP limit and/or VFP table have been (re)specified
             /// by WCONPROD, WCONHIST, WCONINJE or WCONINJH for the named
             /// wells, by WELTARG with THP or VFP control, or by WTMULT with
             /// THP control.  The event applies to producers and injectors

--- a/opm/input/eclipse/Schedule/Events.hpp
+++ b/opm/input/eclipse/Schedule/Events.hpp
@@ -47,9 +47,9 @@ namespace Opm
             NEW_GROUP = (UINT64_C(1) << 3),
 
             /// The PRODUCTION_UPDATE event is triggered by the WCONPROD,
-            /// WCONHIST, WELTARG, WTMULT keywords.  The event will be
-            /// triggered if *any* of the elements in one of keywords is
-            /// changed. Quite simlar for INJECTION_UPDATE and
+            /// WCONHIST and WELTARG keywords when any element of the keyword
+            /// changes, and by WTMULT whether or not the multiplier changes
+            /// anything. The same applies to INJECTION_UPDATE and
             /// POLYMER_UPDATE.
             PRODUCTION_UPDATE = (UINT64_C(1) << 4),
             INJECTION_UPDATE = (UINT64_C(1) << 5),
@@ -114,7 +114,7 @@ namespace Opm
             /// the recorded schedule state).
             REQUEST_OPEN_COMPLETION = (UINT64_C(1) << 24),
 
-            /// The well THP limit and/or VFP table has been (re)specified
+            /// The well THP limit and/or VFP table have been (re)specified
             /// by WCONPROD, WCONHIST, WCONINJE or WCONINJH for the named
             /// wells, by WELTARG with THP or VFP control, or by WTMULT with
             /// THP control.  The event applies to producers and injectors

--- a/opm/input/eclipse/Schedule/Events.hpp
+++ b/opm/input/eclipse/Schedule/Events.hpp
@@ -47,7 +47,7 @@ namespace Opm
             NEW_GROUP = (UINT64_C(1) << 3),
 
             /// The PRODUCTION_UPDATE event is triggered by the WCONPROD,
-            /// WCONHIST, WELTARG, WEFAC keywords.  The event will be
+            /// WCONHIST, WELTARG, WTMULT keywords.  The event will be
             /// triggered if *any* of the elements in one of keywords is
             /// changed. Quite simlar for INJECTION_UPDATE and
             /// POLYMER_UPDATE.
@@ -113,6 +113,15 @@ namespace Opm
             /// request OPEN for an existing connection/completion (regardless of
             /// the recorded schedule state).
             REQUEST_OPEN_COMPLETION = (UINT64_C(1) << 24),
+
+            /// The well THP limit and/or VFP table has been (re)specified
+            /// by WCONPROD or WCONHIST for the named wells, by WELTARG with
+            /// THP or VFP control, or by WTMULT with THP control.  Unlike
+            /// PRODUCTION_UPDATE, the event is also triggered when the
+            /// entered values are unchanged, since re-specifying either
+            /// input cancels a THP limit imposed dynamically by the
+            /// simulator (e.g. by network balancing).
+            WELL_THP_UPDATE = (UINT64_C(1) << 25),
         };
     } // namespace ScheduleEvents
 

--- a/opm/input/eclipse/Schedule/HandlerContext.cpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.cpp
@@ -48,6 +48,13 @@ void HandlerContext::affected_well(const std::string& well_name)
     }
 }
 
+void HandlerContext::thp_respecified_well(const std::string& well_name)
+{
+    if (sim_update != nullptr) {
+        sim_update->thp_respecified_wells.insert(well_name);
+    }
+}
+
 void HandlerContext::welpi_well(const std::string& well_name)
 {
     if (sim_update != nullptr) {

--- a/opm/input/eclipse/Schedule/HandlerContext.cpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.cpp
@@ -50,7 +50,7 @@ void HandlerContext::affected_well(const std::string& well_name)
 
 void HandlerContext::thp_respecified_well(const std::string& well_name)
 {
-    if (sim_update != nullptr) {
+    if (sim_update) {
         sim_update->thp_respecified_wells.insert(well_name);
     }
 }

--- a/opm/input/eclipse/Schedule/HandlerContext.cpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.cpp
@@ -48,6 +48,13 @@ void HandlerContext::affected_well(const std::string& well_name)
     }
 }
 
+void HandlerContext::thp_respec_well(const std::string& well_name)
+{
+    if (sim_update != nullptr) {
+        sim_update->thp_respec_wells.insert(well_name);
+    }
+}
+
 void HandlerContext::welpi_well(const std::string& well_name)
 {
     if (sim_update != nullptr) {

--- a/opm/input/eclipse/Schedule/HandlerContext.cpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.cpp
@@ -50,7 +50,7 @@ void HandlerContext::affected_well(const std::string& well_name)
 
 void HandlerContext::thp_respec_well(const std::string& well_name)
 {
-    if (sim_update != nullptr) {
+    if (sim_update) {
         sim_update->thp_respec_wells.insert(well_name);
     }
 }

--- a/opm/input/eclipse/Schedule/HandlerContext.hpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.hpp
@@ -107,6 +107,10 @@ public:
     //! \brief Mark that a well is affected by WELPI.
     void welpi_well(const std::string& well_name);
 
+    //! \brief Mark that the THP limit and/or VFP table of a well has been
+    //! (re)specified, also when the entered values are unchanged.
+    void thp_respec_well(const std::string& well_name);
+
     //! \brief Mark that transmissibilities must be recalculated.
     void record_tran_change();
 

--- a/opm/input/eclipse/Schedule/HandlerContext.hpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.hpp
@@ -107,7 +107,7 @@ public:
     //! \brief Mark that a well is affected by WELPI.
     void welpi_well(const std::string& well_name);
 
-    //! \brief Mark that the THP limit and/or VFP table of a well has been
+    //! \brief Mark that the THP limit and/or VFP table of a well have been
     //! (re)specified, also when the entered values are unchanged.
     void thp_respecified_well(const std::string& well_name);
 

--- a/opm/input/eclipse/Schedule/HandlerContext.hpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.hpp
@@ -107,7 +107,7 @@ public:
     //! \brief Mark that a well is affected by WELPI.
     void welpi_well(const std::string& well_name);
 
-    //! \brief Mark that the THP limit and/or VFP table of a well has been
+    //! \brief Mark that the THP limit and/or VFP table of a well have been
     //! (re)specified, also when the entered values are unchanged.
     void thp_respec_well(const std::string& well_name);
 

--- a/opm/input/eclipse/Schedule/HandlerContext.hpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.hpp
@@ -107,6 +107,10 @@ public:
     //! \brief Mark that a well is affected by WELPI.
     void welpi_well(const std::string& well_name);
 
+    //! \brief Mark that the THP limit and/or VFP table of a well has been
+    //! (re)specified, also when the entered values are unchanged.
+    void thp_respecified_well(const std::string& well_name);
+
     //! \brief Mark that transmissibilities must be recalculated.
     void record_tran_change();
 

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -267,6 +267,12 @@ void handleWCONINJE(HandlerContext& handlerContext)
                 update_well = true;
             }
 
+            // The THP limit and VFP table (items 8 and 9) are re-specified
+            // by every WCONINJE, whether or not any value changed.
+            handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
+            handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::WELL_THP_UPDATE);
+            handlerContext.thp_respec_well(well_name);
+
             if (update_well) {
                 handlerContext.state().events().addEvent(ScheduleEvents::INJECTION_UPDATE);
                 handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::INJECTION_UPDATE);
@@ -341,6 +347,12 @@ void handleWCONINJH(HandlerContext& handlerContext)
             if (well2.updateHasInjected()) {
                 update_well = true;
             }
+
+            // The VFP table (item 7) is re-specified by every WCONINJH,
+            // whether or not any value changed.
+            handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
+            handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::WELL_THP_UPDATE);
+            handlerContext.thp_respec_well(well_name);
 
             if (update_well) {
                 handlerContext.state().events().addEvent( ScheduleEvents::INJECTION_UPDATE );
@@ -848,9 +860,7 @@ void handleWELTARG(HandlerContext& handlerContext)
 
             // The THP limit or VFP table is re-specified, whether or not
             // the value changed.
-            if (well2.isProducer() &&
-                (cmode == Well::WELTARGCMode::THP || cmode == Well::WELTARGCMode::VFP))
-            {
+            if (cmode == Well::WELTARGCMode::THP || cmode == Well::WELTARGCMode::VFP) {
                 handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
                 handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::WELL_THP_UPDATE);
                 handlerContext.thp_respec_well(well_name);

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -193,6 +193,7 @@ void handleWCONHIST(HandlerContext& handlerContext)
             // whether or not any value changed.
             handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
             handlerContext.state().wellgroup_events().addEvent( well2.name(), ScheduleEvents::WELL_THP_UPDATE);
+            handlerContext.thp_respecified_well(well2.name());
 
             if (update_well) {
                 handlerContext.state().events().addEvent( ScheduleEvents::PRODUCTION_UPDATE );
@@ -447,6 +448,7 @@ void handleWCONPROD(HandlerContext& handlerContext)
             // by every WCONPROD, whether or not any value changed.
             handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
             handlerContext.state().wellgroup_events().addEvent( well2.name(), ScheduleEvents::WELL_THP_UPDATE);
+            handlerContext.thp_respecified_well(well2.name());
 
             if (update_well) {
                 handlerContext.state().events().addEvent( ScheduleEvents::PRODUCTION_UPDATE );
@@ -853,6 +855,7 @@ void handleWELTARG(HandlerContext& handlerContext)
             {
                 handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
                 handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::WELL_THP_UPDATE);
+                handlerContext.thp_respecified_well(well_name);
             }
 
             if (update) {

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -189,6 +189,11 @@ void handleWCONHIST(HandlerContext& handlerContext)
                 update_well = true;
             }
 
+            // The VFP table (item 7) is re-specified by every WCONHIST,
+            // whether or not any value changed.
+            handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
+            handlerContext.state().wellgroup_events().addEvent( well2.name(), ScheduleEvents::WELL_THP_UPDATE);
+
             if (update_well) {
                 handlerContext.state().events().addEvent( ScheduleEvents::PRODUCTION_UPDATE );
                 handlerContext.state().wellgroup_events().addEvent( well2.name(), ScheduleEvents::PRODUCTION_UPDATE);
@@ -437,6 +442,11 @@ void handleWCONPROD(HandlerContext& handlerContext)
             if (well2.updateHasProduced()) {
                 update_well = true;
             }
+
+            // The THP limit and VFP table (items 10 and 11) are re-specified
+            // by every WCONPROD, whether or not any value changed.
+            handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
+            handlerContext.state().wellgroup_events().addEvent( well2.name(), ScheduleEvents::WELL_THP_UPDATE);
 
             if (update_well) {
                 handlerContext.state().events().addEvent( ScheduleEvents::PRODUCTION_UPDATE );
@@ -834,6 +844,15 @@ void handleWELTARG(HandlerContext& handlerContext)
                 if (inj->updateUDQActive(handlerContext.state().udq.get(), cmode, udq_active)) {
                     handlerContext.state().udq_active.update(std::move(udq_active));
                 }
+            }
+
+            // The THP limit or VFP table is re-specified, whether or not
+            // the value changed.
+            if (well2.isProducer() &&
+                (cmode == Well::WELTARGCMode::THP || cmode == Well::WELTARGCMode::VFP))
+            {
+                handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
+                handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::WELL_THP_UPDATE);
             }
 
             if (update) {

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -268,6 +268,12 @@ void handleWCONINJE(HandlerContext& handlerContext)
                 update_well = true;
             }
 
+            // The THP limit and VFP table (items 8 and 9) are re-specified
+            // by every WCONINJE, whether or not any value changed.
+            handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
+            handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::WELL_THP_UPDATE);
+            handlerContext.thp_respecified_well(well_name);
+
             if (update_well) {
                 handlerContext.state().events().addEvent(ScheduleEvents::INJECTION_UPDATE);
                 handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::INJECTION_UPDATE);
@@ -342,6 +348,12 @@ void handleWCONINJH(HandlerContext& handlerContext)
             if (well2.updateHasInjected()) {
                 update_well = true;
             }
+
+            // The VFP table (item 7) is re-specified by every WCONINJH,
+            // whether or not any value changed.
+            handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
+            handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::WELL_THP_UPDATE);
+            handlerContext.thp_respecified_well(well_name);
 
             if (update_well) {
                 handlerContext.state().events().addEvent( ScheduleEvents::INJECTION_UPDATE );
@@ -850,9 +862,7 @@ void handleWELTARG(HandlerContext& handlerContext)
 
             // The THP limit or VFP table is re-specified, whether or not
             // the value changed.
-            if (well2.isProducer() &&
-                (cmode == Well::WELTARGCMode::THP || cmode == Well::WELTARGCMode::VFP))
-            {
+            if (cmode == Well::WELTARGCMode::THP || cmode == Well::WELTARGCMode::VFP) {
                 handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
                 handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::WELL_THP_UPDATE);
                 handlerContext.thp_respecified_well(well_name);

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -192,6 +192,7 @@ void handleWCONHIST(HandlerContext& handlerContext)
             // whether or not any value changed.
             handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
             handlerContext.state().wellgroup_events().addEvent( well2.name(), ScheduleEvents::WELL_THP_UPDATE);
+            handlerContext.thp_respec_well(well2.name());
 
             if (update_well) {
                 handlerContext.state().events().addEvent( ScheduleEvents::PRODUCTION_UPDATE );
@@ -446,6 +447,7 @@ void handleWCONPROD(HandlerContext& handlerContext)
             // by every WCONPROD, whether or not any value changed.
             handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
             handlerContext.state().wellgroup_events().addEvent( well2.name(), ScheduleEvents::WELL_THP_UPDATE);
+            handlerContext.thp_respec_well(well2.name());
 
             if (update_well) {
                 handlerContext.state().events().addEvent( ScheduleEvents::PRODUCTION_UPDATE );
@@ -851,6 +853,7 @@ void handleWELTARG(HandlerContext& handlerContext)
             {
                 handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
                 handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::WELL_THP_UPDATE);
+                handlerContext.thp_respec_well(well_name);
             }
 
             if (update) {

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -188,6 +188,11 @@ void handleWCONHIST(HandlerContext& handlerContext)
                 update_well = true;
             }
 
+            // The VFP table (item 7) is re-specified by every WCONHIST,
+            // whether or not any value changed.
+            handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
+            handlerContext.state().wellgroup_events().addEvent( well2.name(), ScheduleEvents::WELL_THP_UPDATE);
+
             if (update_well) {
                 handlerContext.state().events().addEvent( ScheduleEvents::PRODUCTION_UPDATE );
                 handlerContext.state().wellgroup_events().addEvent( well2.name(), ScheduleEvents::PRODUCTION_UPDATE);
@@ -436,6 +441,11 @@ void handleWCONPROD(HandlerContext& handlerContext)
             if (well2.updateHasProduced()) {
                 update_well = true;
             }
+
+            // The THP limit and VFP table (items 10 and 11) are re-specified
+            // by every WCONPROD, whether or not any value changed.
+            handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
+            handlerContext.state().wellgroup_events().addEvent( well2.name(), ScheduleEvents::WELL_THP_UPDATE);
 
             if (update_well) {
                 handlerContext.state().events().addEvent( ScheduleEvents::PRODUCTION_UPDATE );
@@ -832,6 +842,15 @@ void handleWELTARG(HandlerContext& handlerContext)
                 if (inj->updateUDQActive(handlerContext.state().udq.get(), cmode, udq_active)) {
                     handlerContext.state().udq_active.update(std::move(udq_active));
                 }
+            }
+
+            // The THP limit or VFP table is re-specified, whether or not
+            // the value changed.
+            if (well2.isProducer() &&
+                (cmode == Well::WELTARGCMode::THP || cmode == Well::WELTARGCMode::VFP))
+            {
+                handlerContext.state().events().addEvent( ScheduleEvents::WELL_THP_UPDATE );
+                handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::WELL_THP_UPDATE);
             }
 
             if (update) {

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -132,8 +132,11 @@ void handleWCONHIST(HandlerContext& handlerContext)
             auto properties = std::make_shared<Well::WellProductionProperties>(well2.getProductionProperties());
             bool update_well = false;
 
-            auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
-            if (record.getItem("VFP_TABLE").defaultApplied(0)) { // Default 1* use the privious set vfp table
+            const auto& vfp_table_item = record.getItem("VFP_TABLE");
+            const bool vfp_table_respecified = !vfp_table_item.defaultApplied(0);
+            auto table_nr = vfp_table_item.get<int>(0);
+            if (!vfp_table_respecified) {
+                // A defaulted item retains the previously selected VFP table.
                 table_nr = properties->VFPTableNumber;
             }
 
@@ -316,8 +319,11 @@ void handleWCONINJH(HandlerContext& handlerContext)
                                                                   6891.2);
             }
 
-            auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
-            if (record.getItem("VFP_TABLE").defaultApplied(0)) { // Default 1* use the privious set vfp table
+            const auto& vfp_table_item = record.getItem("VFP_TABLE");
+            const bool vfp_table_respecified = !vfp_table_item.defaultApplied(0);
+            auto table_nr = vfp_table_item.get<int>(0);
+            if (!vfp_table_respecified) {
+                // A defaulted item retains the previously selected VFP table.
                 table_nr = injection->VFPTableNumber;
             }
             if (table_nr != 0) {

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -667,6 +667,17 @@ void handleWTMULT(HandlerContext& handlerContext)
                 properties->handleWTMULT(cmode, factor.get<double>());
 
                 well.updateProduction(properties);
+
+                // The THP limit is re-specified (multiplied).
+                if (cmode == Well::WELTARGCMode::THP) {
+                    handlerContext.state().events()
+                        .addEvent(ScheduleEvents::WELL_THP_UPDATE);
+
+                    handlerContext.state().wellgroup_events()
+                        .addEvent(well_name, ScheduleEvents::WELL_THP_UPDATE);
+
+                }
+
                 if (update_well) {
                     handlerContext.state().events()
                         .addEvent(ScheduleEvents::PRODUCTION_UPDATE);

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -643,6 +643,17 @@ void handleWTMULT(HandlerContext& handlerContext)
         for (const auto& well_name : well_names) {
             auto well = handlerContext.state().wells.get(well_name);
 
+            // The THP limit is re-specified (multiplied).
+            if (cmode == Well::WELTARGCMode::THP) {
+                handlerContext.state().events()
+                    .addEvent(ScheduleEvents::WELL_THP_UPDATE);
+
+                handlerContext.state().wellgroup_events()
+                    .addEvent(well_name, ScheduleEvents::WELL_THP_UPDATE);
+
+                handlerContext.thp_respecified_well(well_name);
+            }
+
             if (well.isInjector()) {
                 const bool update_well = true;
 
@@ -667,17 +678,6 @@ void handleWTMULT(HandlerContext& handlerContext)
                 properties->handleWTMULT(cmode, factor.get<double>());
 
                 well.updateProduction(properties);
-
-                // The THP limit is re-specified (multiplied).
-                if (cmode == Well::WELTARGCMode::THP) {
-                    handlerContext.state().events()
-                        .addEvent(ScheduleEvents::WELL_THP_UPDATE);
-
-                    handlerContext.state().wellgroup_events()
-                        .addEvent(well_name, ScheduleEvents::WELL_THP_UPDATE);
-
-                    handlerContext.thp_respecified_well(well_name);
-                }
 
                 if (update_well) {
                     handlerContext.state().events()

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -633,6 +633,17 @@ void handleWTMULT(HandlerContext& handlerContext)
                 properties->handleWTMULT(cmode, factor.get<double>());
 
                 well.updateProduction(properties);
+
+                // The THP limit is re-specified (multiplied).
+                if (cmode == Well::WELTARGCMode::THP) {
+                    handlerContext.state().events()
+                        .addEvent(ScheduleEvents::WELL_THP_UPDATE);
+
+                    handlerContext.state().wellgroup_events()
+                        .addEvent(well_name, ScheduleEvents::WELL_THP_UPDATE);
+
+                }
+
                 if (update_well) {
                     handlerContext.state().events()
                         .addEvent(ScheduleEvents::PRODUCTION_UPDATE);

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -609,6 +609,17 @@ void handleWTMULT(HandlerContext& handlerContext)
         for (const auto& well_name : well_names) {
             auto well = handlerContext.state().wells.get(well_name);
 
+            // The THP limit is re-specified (multiplied).
+            if (cmode == Well::WELTARGCMode::THP) {
+                handlerContext.state().events()
+                    .addEvent(ScheduleEvents::WELL_THP_UPDATE);
+
+                handlerContext.state().wellgroup_events()
+                    .addEvent(well_name, ScheduleEvents::WELL_THP_UPDATE);
+
+                handlerContext.thp_respec_well(well_name);
+            }
+
             if (well.isInjector()) {
                 const bool update_well = true;
 
@@ -633,17 +644,6 @@ void handleWTMULT(HandlerContext& handlerContext)
                 properties->handleWTMULT(cmode, factor.get<double>());
 
                 well.updateProduction(properties);
-
-                // The THP limit is re-specified (multiplied).
-                if (cmode == Well::WELTARGCMode::THP) {
-                    handlerContext.state().events()
-                        .addEvent(ScheduleEvents::WELL_THP_UPDATE);
-
-                    handlerContext.state().wellgroup_events()
-                        .addEvent(well_name, ScheduleEvents::WELL_THP_UPDATE);
-
-                    handlerContext.thp_respec_well(well_name);
-                }
 
                 if (update_well) {
                     handlerContext.state().events()

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -676,6 +676,7 @@ void handleWTMULT(HandlerContext& handlerContext)
                     handlerContext.state().wellgroup_events()
                         .addEvent(well_name, ScheduleEvents::WELL_THP_UPDATE);
 
+                    handlerContext.thp_respecified_well(well_name);
                 }
 
                 if (update_well) {

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -642,6 +642,7 @@ void handleWTMULT(HandlerContext& handlerContext)
                     handlerContext.state().wellgroup_events()
                         .addEvent(well_name, ScheduleEvents::WELL_THP_UPDATE);
 
+                    handlerContext.thp_respec_well(well_name);
                 }
 
                 if (update_well) {

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -2188,3 +2188,96 @@ BOOST_AUTO_TEST_CASE(Eval_RegionVector_In_Condition_Default_RegSet_2)
                             "Condition must be satisfied");
     }
 }
+
+BOOST_AUTO_TEST_CASE(Action_THP_RESPECIFIED)
+{
+    const auto deck_string = std::string{ R"(
+RUNSPEC
+OIL
+WATER
+GAS
+GRID
+PORO
+    1000*0.1 /
+PERMX
+    1000*1 /
+PERMY
+    1000*0.1 /
+PERMZ
+    1000*0.01 /
+SCHEDULE
+
+VFPPROD
+-- table, datum, flo, wfr, gfr, pressure, alq, unit, table_vals
+  1 7.0E+03 LIQ WCT GOR THP ' ' METRIC BHP /
+  1.0 /
+  0.0 1.0 /
+  0.0 /
+  0.0 /
+  0.0 /
+  1 1 1 1 0.0 /
+  2 1 1 1 1.0 /
+
+WELSPECS
+    'PROD1' 'G1'  1 1 10 'OIL' /
+/
+
+COMPDAT
+ 'PROD1'  1  1   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+/
+
+WCONPROD
+    'PROD1' 'OPEN' 'ORAT' 1000 4* 100.0 25.0 1 /
+/
+
+-- Re-specifies the THP limit with the value it already has
+ACTIONX
+'UNCHANGED_THP' /
+FPR < 100 /
+/
+WELTARG
+    'PROD1' THP 25.0 /
+/
+ENDACTIO
+
+-- Sets a target that is not the THP limit or the VFP table
+ACTIONX
+'ORAT_ONLY' /
+FPR < 100 /
+/
+WELTARG
+    'PROD1' ORAT 900 /
+/
+ENDACTIO
+
+TSTEP
+10 /
+END
+)"};
+
+    Schedule sched = make_schedule(deck_string);
+    const Action::Result action_result(true);
+
+    auto apply = [&sched, &action_result](const std::string& action_name)
+    {
+        return sched.applyAction(0, sched[0].actions.get()[action_name],
+                                 action_result.matches(),
+                                 std::unordered_map<std::string,double>{}, true);
+    };
+
+    // Re-specifying the THP limit with the value it already has cancels a
+    // dynamically imposed limit. Nothing changed, so the well is absent from
+    // affected_wells and this set is the only report of it.
+    {
+        const auto sim_update = apply("UNCHANGED_THP");
+        BOOST_CHECK_EQUAL(sim_update.thp_respecified_wells.count("PROD1"), 1);
+        BOOST_CHECK_EQUAL(sim_update.affected_wells.count("PROD1"), 0);
+    }
+
+    // A target that leaves the THP limit and the VFP table alone does not.
+    {
+        const auto sim_update = apply("ORAT_ONLY");
+        BOOST_CHECK_EQUAL(sim_update.thp_respecified_wells.count("PROD1"), 0);
+        BOOST_CHECK_EQUAL(sim_update.affected_wells.count("PROD1"), 1);
+    }
+}

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -7232,3 +7232,91 @@ END
         BOOST_CHECK_CLOSE(s->width(), 1819.202122, 1.0e-8);
     }
 }
+
+BOOST_AUTO_TEST_CASE(WellTHPUpdateEvent) {
+    const auto schedule = make_schedule(R"(
+RUNSPEC
+OIL
+WATER
+GAS
+
+START
+8 MAR 1998 /
+
+SCHEDULE
+
+WELSPECS
+    'P1' 'G1'  1 1 2500 'OIL' /
+/
+WCONPROD
+    'P1' 'OPEN' 'ORAT' 1000 4* 50.0 /
+/
+
+DATES        -- 1
+ 10 JUN 1998 /
+/
+
+WCONPROD     -- identical to the current well controls
+    'P1' 'OPEN' 'ORAT' 1000 4* 50.0 /
+/
+
+DATES        -- 2
+ 10 JUL 1998 /
+/
+
+WELTARG
+    'P1' 'ORAT' 500 /
+/
+
+DATES        -- 3
+ 10 AUG 1998 /
+/
+
+WELTARG
+    'P1' 'THP' 60 /
+/
+
+DATES        -- 4
+ 10 SEP 1998 /
+/
+
+WELTARG      -- unchanged VFP table number
+    'P1' 'VFP' 0 /
+/
+
+DATES        -- 5
+ 10 OKT 1998 /
+/
+
+WTMULT
+    'P1' 'THP' 2.0 /
+/
+
+DATES        -- 6
+ 10 NOV 1998 /
+/
+
+WCONHIST
+    'P1' 'OPEN' 'ORAT' 100 0 0 /
+/
+)");
+
+    // Initial WCONPROD specifies the THP limit and VFP table
+    BOOST_CHECK( schedule[0].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+    // A WCONPROD with unchanged values re-specifies the THP limit and VFP
+    // table without triggering PRODUCTION_UPDATE
+    BOOST_CHECK( schedule[1].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+    BOOST_CHECK(!schedule[1].wellgroup_events().hasEvent("P1", ScheduleEvents::PRODUCTION_UPDATE));
+    // WELTARG ORAT does not touch the THP limit or VFP table
+    BOOST_CHECK(!schedule[2].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+    BOOST_CHECK( schedule[2].wellgroup_events().hasEvent("P1", ScheduleEvents::PRODUCTION_UPDATE));
+    // WELTARG THP re-specifies the THP limit
+    BOOST_CHECK( schedule[3].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+    // WELTARG VFP re-specifies the VFP table, also for an unchanged value
+    BOOST_CHECK( schedule[4].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+    BOOST_CHECK(!schedule[4].wellgroup_events().hasEvent("P1", ScheduleEvents::PRODUCTION_UPDATE));
+    // WTMULT with THP control re-specifies (multiplies) the THP limit
+    BOOST_CHECK( schedule[5].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+    // WCONHIST re-specifies the VFP table
+    BOOST_CHECK( schedule[6].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+}

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -7247,9 +7247,13 @@ SCHEDULE
 
 WELSPECS
     'P1' 'G1'  1 1 2500 'OIL' /
+    'I1' 'G1'  2 2 2500 'WAT' /
 /
 WCONPROD
     'P1' 'OPEN' 'ORAT' 1000 4* 50.0 /
+/
+WCONINJE
+    'I1' 'WATER' 'OPEN' 'RATE' 1000 /
 /
 
 DATES        -- 1
@@ -7299,6 +7303,38 @@ DATES        -- 6
 WCONHIST
     'P1' 'OPEN' 'ORAT' 100 0 0 /
 /
+
+DATES        -- 7
+ 10 DES 1998 /
+/
+
+WELTARG
+    'I1' 'THP' 30 /
+/
+
+DATES        -- 8
+ 10 JAN 1999 /
+/
+
+WELTARG
+    'I1' 'WRAT' 800 /
+/
+
+DATES        -- 9
+ 10 FEB 1999 /
+/
+
+WTMULT
+    'I1' 'THP' 2.0 /
+/
+
+DATES        -- 10
+ 10 MAR 1999 /
+/
+
+WCONINJH
+    'I1' 'WATER' 'OPEN' 100 /
+/
 )");
 
     // Initial WCONPROD specifies the THP limit and VFP table
@@ -7319,4 +7355,17 @@ WCONHIST
     BOOST_CHECK( schedule[5].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
     // WCONHIST re-specifies the VFP table
     BOOST_CHECK( schedule[6].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+
+    // The event also applies to injectors:
+    // WCONINJE re-specifies the THP limit and VFP table
+    BOOST_CHECK( schedule[0].wellgroup_events().hasEvent("I1", ScheduleEvents::WELL_THP_UPDATE));
+    // WELTARG THP re-specifies the THP limit
+    BOOST_CHECK( schedule[7].wellgroup_events().hasEvent("I1", ScheduleEvents::WELL_THP_UPDATE));
+    // WELTARG WRAT does not touch the THP limit or VFP table
+    BOOST_CHECK(!schedule[8].wellgroup_events().hasEvent("I1", ScheduleEvents::WELL_THP_UPDATE));
+    BOOST_CHECK( schedule[8].wellgroup_events().hasEvent("I1", ScheduleEvents::INJECTION_UPDATE));
+    // WTMULT with THP control re-specifies (multiplies) the THP limit
+    BOOST_CHECK( schedule[9].wellgroup_events().hasEvent("I1", ScheduleEvents::WELL_THP_UPDATE));
+    // WCONINJH re-specifies the VFP table
+    BOOST_CHECK( schedule[10].wellgroup_events().hasEvent("I1", ScheduleEvents::WELL_THP_UPDATE));
 }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -7461,3 +7461,91 @@ END
         BOOST_CHECK_CLOSE(s->width(), 1819.202122, 1.0e-8);
     }
 }
+
+BOOST_AUTO_TEST_CASE(WellTHPUpdateEvent) {
+    const auto schedule = make_schedule(R"(
+RUNSPEC
+OIL
+WATER
+GAS
+
+START
+8 MAR 1998 /
+
+SCHEDULE
+
+WELSPECS
+    'P1' 'G1'  1 1 2500 'OIL' /
+/
+WCONPROD
+    'P1' 'OPEN' 'ORAT' 1000 4* 50.0 /
+/
+
+DATES        -- 1
+ 10 JUN 1998 /
+/
+
+WCONPROD     -- identical to the current well controls
+    'P1' 'OPEN' 'ORAT' 1000 4* 50.0 /
+/
+
+DATES        -- 2
+ 10 JUL 1998 /
+/
+
+WELTARG
+    'P1' 'ORAT' 500 /
+/
+
+DATES        -- 3
+ 10 AUG 1998 /
+/
+
+WELTARG
+    'P1' 'THP' 60 /
+/
+
+DATES        -- 4
+ 10 SEP 1998 /
+/
+
+WELTARG      -- unchanged VFP table number
+    'P1' 'VFP' 0 /
+/
+
+DATES        -- 5
+ 10 OKT 1998 /
+/
+
+WTMULT
+    'P1' 'THP' 2.0 /
+/
+
+DATES        -- 6
+ 10 NOV 1998 /
+/
+
+WCONHIST
+    'P1' 'OPEN' 'ORAT' 100 0 0 /
+/
+)");
+
+    // Initial WCONPROD specifies the THP limit and VFP table
+    BOOST_CHECK( schedule[0].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+    // A WCONPROD with unchanged values re-specifies the THP limit and VFP
+    // table without triggering PRODUCTION_UPDATE
+    BOOST_CHECK( schedule[1].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+    BOOST_CHECK(!schedule[1].wellgroup_events().hasEvent("P1", ScheduleEvents::PRODUCTION_UPDATE));
+    // WELTARG ORAT does not touch the THP limit or VFP table
+    BOOST_CHECK(!schedule[2].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+    BOOST_CHECK( schedule[2].wellgroup_events().hasEvent("P1", ScheduleEvents::PRODUCTION_UPDATE));
+    // WELTARG THP re-specifies the THP limit
+    BOOST_CHECK( schedule[3].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+    // WELTARG VFP re-specifies the VFP table, also for an unchanged value
+    BOOST_CHECK( schedule[4].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+    BOOST_CHECK(!schedule[4].wellgroup_events().hasEvent("P1", ScheduleEvents::PRODUCTION_UPDATE));
+    // WTMULT with THP control re-specifies (multiplies) the THP limit
+    BOOST_CHECK( schedule[5].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+    // WCONHIST re-specifies the VFP table
+    BOOST_CHECK( schedule[6].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+}

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -7476,9 +7476,13 @@ SCHEDULE
 
 WELSPECS
     'P1' 'G1'  1 1 2500 'OIL' /
+    'I1' 'G1'  2 2 2500 'WAT' /
 /
 WCONPROD
     'P1' 'OPEN' 'ORAT' 1000 4* 50.0 /
+/
+WCONINJE
+    'I1' 'WATER' 'OPEN' 'RATE' 1000 /
 /
 
 DATES        -- 1
@@ -7528,6 +7532,38 @@ DATES        -- 6
 WCONHIST
     'P1' 'OPEN' 'ORAT' 100 0 0 /
 /
+
+DATES        -- 7
+ 10 DES 1998 /
+/
+
+WELTARG
+    'I1' 'THP' 30 /
+/
+
+DATES        -- 8
+ 10 JAN 1999 /
+/
+
+WELTARG
+    'I1' 'WRAT' 800 /
+/
+
+DATES        -- 9
+ 10 FEB 1999 /
+/
+
+WTMULT
+    'I1' 'THP' 2.0 /
+/
+
+DATES        -- 10
+ 10 MAR 1999 /
+/
+
+WCONINJH
+    'I1' 'WATER' 'OPEN' 100 /
+/
 )");
 
     // Initial WCONPROD specifies the THP limit and VFP table
@@ -7548,4 +7584,17 @@ WCONHIST
     BOOST_CHECK( schedule[5].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
     // WCONHIST re-specifies the VFP table
     BOOST_CHECK( schedule[6].wellgroup_events().hasEvent("P1", ScheduleEvents::WELL_THP_UPDATE));
+
+    // The event also applies to injectors:
+    // WCONINJE re-specifies the THP limit and VFP table
+    BOOST_CHECK( schedule[0].wellgroup_events().hasEvent("I1", ScheduleEvents::WELL_THP_UPDATE));
+    // WELTARG THP re-specifies the THP limit
+    BOOST_CHECK( schedule[7].wellgroup_events().hasEvent("I1", ScheduleEvents::WELL_THP_UPDATE));
+    // WELTARG WRAT does not touch the THP limit or VFP table
+    BOOST_CHECK(!schedule[8].wellgroup_events().hasEvent("I1", ScheduleEvents::WELL_THP_UPDATE));
+    BOOST_CHECK( schedule[8].wellgroup_events().hasEvent("I1", ScheduleEvents::INJECTION_UPDATE));
+    // WTMULT with THP control re-specifies (multiplies) the THP limit
+    BOOST_CHECK( schedule[9].wellgroup_events().hasEvent("I1", ScheduleEvents::WELL_THP_UPDATE));
+    // WCONINJH re-specifies the VFP table
+    BOOST_CHECK( schedule[10].wellgroup_events().hasEvent("I1", ScheduleEvents::WELL_THP_UPDATE));
 }


### PR DESCRIPTION
Adds a WELL_THP_UPDATE schedule event and a SimulatorUpdate::thp_respecified_wells set, raised whenever WCONPROD, WCONHIST, WELTARG THP/VFP or WTMULT THP (re)specifies a well THP limit or VFP table — also when the entered values are unchanged, which PRODUCTION_UPDATE does not cover.