### PR TITLE
TableManager: default PVTW and DENSITY for compositional runs with water

### DIFF
--- a/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
@@ -127,6 +127,9 @@ struct DensityTable : public FlatTableWithCopy<DENSITYRecord>
     explicit DensityTable(const GravityTable& gravity);
     explicit DensityTable(std::initializer_list<DENSITYRecord> records);
 
+    /// Construct \p num_tables identical table records.
+    DensityTable(const DENSITYRecord& record, std::size_t num_tables);
+
     static DensityTable serializationTestObject()
     {
         return DensityTable({{1.0, 2.0, 3.0}});
@@ -269,6 +272,9 @@ struct PvtwTable : public FlatTableWithCopy<PVTWRecord>
     PvtwTable() = default;
     explicit PvtwTable(const DeckKeyword& kw);
     explicit PvtwTable(std::initializer_list<PVTWRecord> records);
+
+    /// Construct \p num_tables identical table records.
+    PvtwTable(const PVTWRecord& record, std::size_t num_tables);
 
     static PvtwTable serializationTestObject()
     {

--- a/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -102,6 +102,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/D.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/H.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/J.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/M.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/O.hpp>
@@ -179,6 +180,13 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         else if( deck.hasKeyword( "GRAVITY" ) )
             this->m_densityTable = DensityTable( GravityTable ( deck["GRAVITY"].back() ) );
+
+        else
+            this->initDefaultDensity( deck );
+
+        // Initialize DENSITY first so a generated PVTW table can use the same
+        // number of PVT regions.
+        this->initDefaultPvtw( deck );
 
         if( deck.hasKeyword( "DIFFC" ) )
             this->m_diffCoeffTable = DiffCoeffTable( deck["DIFFC"].back() );
@@ -431,6 +439,76 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
     const TableContainer& TableManager::operator[](const std::string& tableName) const {
         return getTables(tableName);
+    }
+
+    namespace {
+        // The CO2/H2 storage and solution options take the water properties from
+        // the built-in brine models and ignore PVTW and DENSITY.
+        bool brineWaterProps(const Deck& deck)
+        {
+            return deck.hasKeyword<ParserKeywords::CO2STORE>()
+                || deck.hasKeyword<ParserKeywords::CO2STOR>()
+                || deck.hasKeyword<ParserKeywords::CO2SOL>()
+                || deck.hasKeyword<ParserKeywords::H2STORE>()
+                || deck.hasKeyword<ParserKeywords::H2SOL>();
+        }
+
+        bool defaultCompositionalWaterProps(const Deck& deck)
+        {
+            // GASWAT activates both gas and water; mirror Runspec phase detection.
+            const bool water = deck.hasKeyword<ParserKeywords::WATER>()
+                            || deck.hasKeyword<ParserKeywords::GASWAT>();
+
+            return deck.hasKeyword<ParserKeywords::COMPS>()
+                && water
+                && !brineWaterProps(deck);
+        }
+    } // anonymous namespace
+
+    void TableManager::initDefaultPvtw(const Deck& deck)
+    {
+        if (!this->m_pvtwTable.empty() || !defaultCompositionalWaterProps(deck)) {
+            return;
+        }
+
+        // Default water properties for a compositional run that omits PVTW.
+        constexpr auto pref = unit::atm;
+        constexpr auto bw = 1.0;
+        constexpr auto cw = 4.0e-5 / unit::atm;
+        constexpr auto viscosity = 0.3 * prefix::centi * unit::Poise;
+        constexpr auto viscosibility = 0.0;
+
+        const PVTWRecord rec { pref, bw, cw, viscosity, viscosibility };
+        // Water PVT requires the same number of regions as DENSITY.
+        const auto regions = this->m_densityTable.empty()
+            ? this->m_tabdims.getNumPVTTables()
+            : this->m_densityTable.size();
+        this->m_pvtwTable = PvtwTable(rec, regions);
+
+        OpmLog::info("PVTW is not specified for a compositional run with water. "
+                     "Defaulting to Pref = 1 atm, Bw = 1, Cw = 4.0E-5/atm, "
+                     "water viscosity 0.3 cP.");
+    }
+
+    void TableManager::initDefaultDensity(const Deck& deck)
+    {
+        if (!defaultCompositionalWaterProps(deck)) {
+            return;
+        }
+
+        // Only the water density is used; oil and gas come from the equation of
+        // state and reach no further than the INIT file's table output.
+        const DENSITYRecord rec { ParserKeywords::DENSITY::OIL::defaultValue,
+                                  ParserKeywords::DENSITY::WATER::defaultValue,
+                                  ParserKeywords::DENSITY::GAS::defaultValue };
+        const auto regions = this->m_pvtwTable.empty()
+            ? this->m_tabdims.getNumPVTTables()
+            : this->m_pvtwTable.size();
+        this->m_densityTable = DensityTable(rec, regions);
+
+        OpmLog::info("DENSITY is not specified for a compositional run with water. "
+                     "Defaulting the surface water density to 999.014 kg/m3 "
+                     "(oil and gas surface properties come from the equation of state).");
     }
 
     void TableManager::initSimpleTables(const Deck& deck) {

--- a/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
@@ -303,6 +303,8 @@ namespace Opm {
 
         void addTables( const std::string& tableName , std::size_t numTables);
         void initSimpleTables(const Deck& deck);
+        void initDefaultPvtw(const Deck& deck);
+        void initDefaultDensity(const Deck& deck);
         void initRTempTables(const Deck& deck);
         void initZmfvdTables(const Deck& deck);
         void initCompvdTables(const Deck& deck);

--- a/opm/input/eclipse/EclipseState/Tables/Tables.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Tables.cpp
@@ -2808,6 +2808,11 @@ DensityTable::DensityTable(std::initializer_list<DENSITYRecord> records)
     : FlatTableWithCopy(records)
 {}
 
+DensityTable::DensityTable(const DENSITYRecord& record, const std::size_t num_tables)
+{
+    this->table_.assign(num_tables, record);
+}
+
 DensityTable::DensityTable(const GravityTable& gravity)
 {
     this->table_.reserve(gravity.size());
@@ -2844,6 +2849,11 @@ PvtwTable::PvtwTable(const DeckKeyword& kw)
 PvtwTable::PvtwTable(std::initializer_list<PVTWRecord> records)
     : FlatTableWithCopy(records)
 {}
+
+PvtwTable::PvtwTable(const PVTWRecord& record, const std::size_t num_tables)
+{
+    this->table_.assign(num_tables, record);
+}
 
 // ------------------------------------------------------------------------
 

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -1512,6 +1512,27 @@ END
     }
 }
 
+BOOST_AUTO_TEST_CASE(NoDefaultWaterPvtWithCo2Store) {
+    // The CO2 storage option with the water and gas phases spelled out instead
+    // of through GASWAT.  The brine models supply the water properties, so this
+    // deck needs neither PVTW nor DENSITY and must not be given defaults.
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+WATER
+GAS
+CO2STORE
+COMPS
+3 /
+TABDIMS
+1 1 /
+PROPS
+END
+)");
+
+    const auto tm = Opm::TableManager { deck };
+    BOOST_CHECK(tm.getPvtwTable().empty());
+    BOOST_CHECK(tm.getDensityTable().empty());
+}
+
 BOOST_AUTO_TEST_CASE(PvtwTable_Tests) {
     // PVT tables from opm-tests/model5/include/pvt_live_oil_dgas.ecl .
     const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -1415,6 +1415,103 @@ END
     }
 }
 
+BOOST_AUTO_TEST_CASE(CompositionalDefaultWaterPvt) {
+    // Compositional runs default omitted water properties.
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+GAS
+WATER
+COMPS
+3 /
+TABDIMS
+1 1 /
+PROPS
+END
+)");
+
+    const auto tmgr = Opm::TableManager { deck };
+
+    const auto& pvtw = tmgr.getPvtwTable();
+    BOOST_REQUIRE_EQUAL(pvtw.size(), std::size_t{1});
+    BOOST_CHECK_CLOSE(pvtw[0].reference_pressure, 101325.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(pvtw[0].volume_factor, 1.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(pvtw[0].compressibility, 4.0e-5 / 101325.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(pvtw[0].viscosity, 0.3e-3, 1.0e-10);
+    BOOST_CHECK_SMALL(pvtw[0].viscosibility, 1.0e-20);
+
+    const auto& dens = tmgr.getDensityTable();
+    BOOST_REQUIRE_EQUAL(dens.size(), std::size_t{1});
+    BOOST_CHECK_CLOSE(dens[0].oil, 600.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(dens[0].water, 999.014, 1.0e-10);
+    BOOST_CHECK_CLOSE(dens[0].gas, 1.0, 1.0e-10);
+}
+
+BOOST_AUTO_TEST_CASE(NoDefaultWaterPvtOutsideCompositional) {
+    // Black-oil runs must still supply their water properties explicitly.
+    const auto blackoil = Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+WATER
+TABDIMS
+1 1 /
+PROPS
+END
+)");
+    const auto tm1 = Opm::TableManager { blackoil };
+    BOOST_CHECK(tm1.getPvtwTable().empty());
+    BOOST_CHECK(tm1.getDensityTable().empty());
+
+    // GASWAT activates a water phase and therefore receives defaults.
+    const auto gaswat = Opm::Parser{}.parseString(R"(RUNSPEC
+GASWAT
+COMPS
+3 /
+TABDIMS
+1 1 /
+PROPS
+END
+)");
+    const auto tmGasWat = Opm::TableManager { gaswat };
+    BOOST_REQUIRE_EQUAL(tmGasWat.getPvtwTable().size(), std::size_t{1});
+    BOOST_CHECK_CLOSE(tmGasWat.getPvtwTable()[0].viscosity, 0.3e-3, 1.0e-10);
+    BOOST_REQUIRE_EQUAL(tmGasWat.getDensityTable().size(), std::size_t{1});
+    BOOST_CHECK_CLOSE(tmGasWat.getDensityTable()[0].water, 999.014, 1.0e-10);
+
+    // No water phase means no water-property defaults.
+    const auto nowater = Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+GAS
+COMPS
+3 /
+TABDIMS
+1 1 /
+PROPS
+END
+)");
+    const auto tm2 = Opm::TableManager { nowater };
+    BOOST_CHECK(tm2.getPvtwTable().empty());
+    BOOST_CHECK(tm2.getDensityTable().empty());
+
+    // The CO2/H2 storage and solution options bring their own water
+    // properties, so a deck using them is left alone as well.
+    for (const std::string option : { "CO2STORE", "CO2STOR", "H2STORE" }) {
+        const auto deck = Opm::Parser{}.parseString("RUNSPEC\n"
+                                                    "GASWAT\n"
+                                                    + option + "\n"
+                                                    "COMPS\n"
+                                                    "3 /\n"
+                                                    "TABDIMS\n"
+                                                    "1 1 /\n"
+                                                    "PROPS\n"
+                                                    "END\n");
+
+        const auto tm = Opm::TableManager { deck };
+        BOOST_TEST_CONTEXT(option) {
+            BOOST_CHECK(tm.getPvtwTable().empty());
+            BOOST_CHECK(tm.getDensityTable().empty());
+        }
+    }
+}
+
 BOOST_AUTO_TEST_CASE(PvtwTable_Tests) {
     // PVT tables from opm-tests/model5/include/pvt_live_oil_dgas.ecl .
     const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC


### PR DESCRIPTION
A compositional run with a water phase might not provide the PVTW and DENSITY keywords, and default values are used in that situation. Without them the water PVT setup finds the tables empty and the deck is refused.

PVTW is defaulted to reference pressure 1 atm, Bw = 1, Cw = 4.0E-5/atm, water viscosity 0.3 cP and zero viscosibility, which differ from this parser's item defaults for the keyword; DENSITY is defaulted to the parser's own item defaults, so that an absent keyword behaves like a wholly defaulted one. A defaulted table is sized to match its counterpart when that came from the deck, since the water PVT requires the two to have the same number of regions. Both substitutions are logged.

Decks without a water phase are left alone: nothing reads these tables there, and defaulting them would add a density table to INIT output that has none today. Black-oil decks are likewise unaffected, so a missing PVTW remains an error there.