### PR TITLE
Reduce Complexity of Internal Aggregate* Function Signatures

### DIFF
--- a/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/opm/output/eclipse/AggregateConnectionData.cpp
@@ -25,6 +25,7 @@
 #include <opm/output/data/Wells.hpp>
 
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
@@ -429,12 +430,11 @@ void
 Opm::RestartIO::Helpers::AggregateConnectionData::
 captureDeclaredConnData(const Schedule&     sched,
                         const EclipseGrid&  grid,
-                        const UnitSystem&   units,
                         const data::Wells&  xw,
                         const SummaryState& summary_state,
                         const std::size_t   sim_step)
 {
-    wellConnectionLoop(sched, sim_step, grid, xw, [&units, &summary_state, &grid, this]
+    wellConnectionLoop(sched, sim_step, grid, xw, [&units = sched.getUnits(), &summary_state, &grid, this]
         (const std::string&      wellName,
          const std::size_t       wellID,
          const bool              is_producer,
@@ -466,13 +466,12 @@ void
 Opm::RestartIO::Helpers::AggregateConnectionData::
 captureDeclaredConnDataLGR(const Schedule&     sched,
                            const EclipseGrid&  grid,
-                           const UnitSystem&   units,
                            const data::Wells&  xw,
                            const SummaryState& summary_state,
                            const std::size_t   sim_step,
                            const std::string&  lgr_tag)
 {
-    wellConnectionLoop(sched, sim_step, grid, xw, lgr_tag, [&units, &summary_state, &grid, this]
+    wellConnectionLoop(sched, sim_step, grid, xw, lgr_tag, [&units = sched.getUnits(), &summary_state, &grid, this]
         (const std::string&      wellName,
          const std::size_t       wellID,
          const bool              is_producer,

--- a/opm/output/eclipse/AggregateConnectionData.hpp
+++ b/opm/output/eclipse/AggregateConnectionData.hpp
@@ -28,34 +28,32 @@
 namespace Opm {
     class EclipseGrid;
     class Schedule;
-    class UnitSystem;
     class SummaryState;
 } // Opm
 
-namespace Opm { namespace data {
+namespace Opm::data {
     class Wells;
-}}
+} // Opm::data
 
-namespace Opm { namespace RestartIO { namespace Helpers {
+namespace Opm::RestartIO::Helpers {
 
     class AggregateConnectionData
     {
     public:
         explicit AggregateConnectionData(const std::vector<int>& inteHead);
 
-        void captureDeclaredConnData(const Opm::Schedule&        sched,
-                                     const Opm::EclipseGrid&     grid,
-                                     const Opm::UnitSystem&      units,
-                                     const Opm::data::Wells&     xw,
-                                     const Opm::SummaryState&    summary_state,
-                                     const std::size_t           sim_step);
-        void captureDeclaredConnDataLGR(const Opm::Schedule&        sched,
-                                        const Opm::EclipseGrid&     grid,
-                                        const Opm::UnitSystem&      units,
-                                        const Opm::data::Wells&     xw,
-                                        const Opm::SummaryState&    summary_state,
-                                        const std::size_t           sim_step,
-                                        const std::string&          lgr_tag);
+        void captureDeclaredConnData(const Schedule&     sched,
+                                     const EclipseGrid&  grid,
+                                     const data::Wells&  xw,
+                                     const SummaryState& summary_state,
+                                     const std::size_t   sim_step);
+
+        void captureDeclaredConnDataLGR(const Schedule&     sched,
+                                        const EclipseGrid&  grid,
+                                        const data::Wells&  xw,
+                                        const SummaryState& summary_state,
+                                        const std::size_t   sim_step,
+                                        const std::string&  lgr_tag);
 
         const std::vector<int>& getIConn() const
         {
@@ -78,6 +76,6 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         WindowedMatrix<double> xConn_;
     };
 
-}}} // Opm::RestartIO::Helpers
+} // Opm::RestartIO::Helpers
 
 #endif // OPM_AGGREGATE_CONNECTION_DATA_HPP

--- a/opm/output/eclipse/AggregateGroupData.cpp
+++ b/opm/output/eclipse/AggregateGroupData.cpp
@@ -21,10 +21,12 @@
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 
-#include <opm/output/eclipse/WriteRestartHelpers.hpp>
+#include <opm/output/data/Wells.hpp>
+
 #include <opm/output/eclipse/VectorItems/group.hpp>
-#include <opm/output/eclipse/VectorItems/well.hpp>
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
+#include <opm/output/eclipse/VectorItems/well.hpp>
+#include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
 #include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
@@ -36,7 +38,6 @@
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
-#include <opm/output/data/Wells.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -44,7 +45,7 @@
 #include <cstring>
 #include <exception>
 #include <initializer_list>
-#include <map>
+#include <numeric>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -81,38 +82,52 @@ int nwgmax(const std::vector<int>& inteHead)
 }
 
 namespace value = ::Opm::RestartIO::Helpers::VectorItems::IGroup::Value;
+
 value::GuideRateMode
-GuideRateModeFromGuideRateProdTarget(Opm::Group::GuideRateProdTarget grpt)
+GuideRateModeFromGuideRateProdTarget(const Opm::Group::GuideRateProdTarget grpt)
 {
     switch (grpt) {
-        case Opm::Group::GuideRateProdTarget::OIL:
-            return value::GuideRateMode::Oil;
-        case Opm::Group::GuideRateProdTarget::WAT:
-            return value::GuideRateMode::Water;
-        case Opm::Group::GuideRateProdTarget::GAS:
-            return value::GuideRateMode::Gas;
-        case Opm::Group::GuideRateProdTarget::LIQ:
-            return value::GuideRateMode::Liquid;
-        case Opm::Group::GuideRateProdTarget::RES:
-            return value::GuideRateMode::Resv;
-        case Opm::Group::GuideRateProdTarget::COMB:
-            return value::GuideRateMode::Comb;
-        case Opm::Group::GuideRateProdTarget::WGA:
-            return value::GuideRateMode::None;
-        case Opm::Group::GuideRateProdTarget::CVAL:
-            return value::GuideRateMode::None;
-        case Opm::Group::GuideRateProdTarget::INJV:
-            return value::GuideRateMode::None;
-        case Opm::Group::GuideRateProdTarget::POTN:
-            return value::GuideRateMode::Potn;
-        case Opm::Group::GuideRateProdTarget::FORM:
-            return value::GuideRateMode::Form;
-        case Opm::Group::GuideRateProdTarget::NO_GUIDE_RATE:
-            return value::GuideRateMode::None;
+    case Opm::Group::GuideRateProdTarget::OIL:
+        return value::GuideRateMode::Oil;
 
-        default:
-            throw std::logic_error(fmt::format("Not recognized value: {} for GuideRateProdTarget",
-                                               static_cast<int>(grpt)));
+    case Opm::Group::GuideRateProdTarget::WAT:
+        return value::GuideRateMode::Water;
+
+    case Opm::Group::GuideRateProdTarget::GAS:
+        return value::GuideRateMode::Gas;
+
+    case Opm::Group::GuideRateProdTarget::LIQ:
+        return value::GuideRateMode::Liquid;
+
+    case Opm::Group::GuideRateProdTarget::RES:
+        return value::GuideRateMode::Resv;
+
+    case Opm::Group::GuideRateProdTarget::COMB:
+        return value::GuideRateMode::Comb;
+
+    case Opm::Group::GuideRateProdTarget::WGA:
+        return value::GuideRateMode::None;
+
+    case Opm::Group::GuideRateProdTarget::CVAL:
+        return value::GuideRateMode::None;
+
+    case Opm::Group::GuideRateProdTarget::INJV:
+        return value::GuideRateMode::None;
+
+    case Opm::Group::GuideRateProdTarget::POTN:
+        return value::GuideRateMode::Potn;
+
+    case Opm::Group::GuideRateProdTarget::FORM:
+        return value::GuideRateMode::Form;
+
+    case Opm::Group::GuideRateProdTarget::NO_GUIDE_RATE:
+        return value::GuideRateMode::None;
+
+    default:
+        throw std::logic_error {
+            fmt::format("Unrecognized value '{}' for GuideRateProdTarget",
+                        static_cast<int>(grpt))
+        };
     }
 }
 
@@ -142,13 +157,13 @@ void groupLoop(const std::vector<const Opm::Group*>& groups,
 
     for (std::size_t i = 0; i < groups.size(); ++i) {
         const auto* group = groups[i];
-    // for (const auto* group : groups) {
-        //groupID must be furthered studied to be sure it is correct
+
         groupID += 1;
         if (group == nullptr) {
             groupID -= 1;
             continue;
         }
+
         if (group->wellgroup() &&
             !sched_state.well_group_contains_lgr(*group, lgr_tag)) {
             groupID -= 1;
@@ -165,6 +180,7 @@ int currentGroupLevel(const Opm::Schedule& sched,
 {
     auto current = group;
     int level = 0;
+
     while (current.name() != "FIELD") {
         level += 1;
         current = sched.getGroup(current.parent(), simStep);
@@ -179,14 +195,19 @@ void groupCurrentlyProductionControllable(const Opm::Schedule& sched,
                                           const std::size_t simStep,
                                           bool& controllable)
 {
-    using wellCtrlMode   = ::Opm::RestartIO::Helpers::VectorItems::IWell::Value::WellCtrlMode;
-    if (controllable)
+    using wellCtrlMode = ::Opm::RestartIO::Helpers::VectorItems::IWell::Value::WellCtrlMode;
+
+    if (controllable) {
         return;
+    }
 
     for (const auto& group_name : group.groups()) {
         const auto& sub_group = sched.getGroup(group_name, simStep);
-        auto cur_prod_ctrl = (sub_group.name() == "FIELD") ? static_cast<int>(sumState.get("FMCTP", -1)) :
-                             static_cast<int>(sumState.get_group_var(sub_group.name(), "GMCTP", -1));
+
+        auto cur_prod_ctrl = (sub_group.name() == "FIELD")
+            ? static_cast<int>(sumState.get("FMCTP", -1))
+            : static_cast<int>(sumState.get_group_var(sub_group.name(), "GMCTP", -1));
+
         if (cur_prod_ctrl <= 0) {
             //come here if group is controlled by higher level
             groupCurrentlyProductionControllable(sched, sumState, sched.getGroup(group_name, simStep), simStep, controllable);
@@ -195,6 +216,7 @@ void groupCurrentlyProductionControllable(const Opm::Schedule& sched,
 
     for (const auto& well_name : group.wells()) {
         const auto& well = sched.getWell(well_name, simStep);
+
         if (well.isProducer()) {
             int cur_prod_ctrl = 0;
             // Find control mode for well
@@ -932,18 +954,18 @@ void staticContrib(const Opm::Schedule&     sched,
     }
 }
 
-
 template <class IGrpArray>
-void staticContrib_pseudo_well_group_LGR(std::vector<std::reference_wrapper<const Opm::Well>>& filtered_wells,
-                                         const int                nwgmax,
-                                         IGrpArray&               iGrp)
+void staticContrib_pseudo_well_group_LGR(std::vector<const Opm::Well*>& filtered_wells,
+                                         const int                      nwgmax,
+                                         IGrpArray&                     iGrp)
 {
     using IGroup = ::Opm::RestartIO::Helpers::VectorItems::IGroup::index;
     namespace Value = ::Opm::RestartIO::Helpers::VectorItems::IGroup::Value;
+
     int igrpCount = 0;
 
-    for (const auto& well : filtered_wells) {
-        iGrp[igrpCount] = well.get().seqIndexLGR() + 1;
+    for (const auto* well : filtered_wells) {
+        iGrp[igrpCount] = well->seqIndexLGR() + 1;
         igrpCount += 1;
     }
 
@@ -953,17 +975,16 @@ void staticContrib_pseudo_well_group_LGR(std::vector<std::reference_wrapper<cons
     iGrp[nwgmax + IGroup::ParentGroup] = 2; // Pseudo well group always has FIELD as parent group
 }
 
-
 template <class IGrpArray>
-void staticContrib_field_group_LGR(const int                nwgmax,
-                                   IGrpArray&               iGrp)
+void staticContrib_field_group_LGR(const int  nwgmax,
+                                   IGrpArray& iGrp)
 {
     using IGroup = ::Opm::RestartIO::Helpers::VectorItems::IGroup::index;
+
     iGrp[0] = 1; // Pseudo well group for LGRs alls belong to FIELD LGR
     iGrp[nwgmax + IGroup::NoOfChildGroupsWells] = 1; // FIELD always has one child group - the pseudo well group for LGRs
     iGrp[nwgmax + IGroup::GroupType] = 1; // NodeGroup is default for lgr field group
 }
-
 
 template <class IGrpArray>
 void staticContrib_empty_field_group_LGR(const int          nwgmax,
@@ -1464,142 +1485,127 @@ void staticContrib_empty_field_group_LGR(SGrpArray& sGrp)
 } // SGrp
 
 namespace XGrp {
-std::size_t entriesPerGroup(const std::vector<int>& inteHead)
-{
-    return inteHead[Opm::RestartIO::Helpers::VectorItems::NXGRPZ];
-}
-
-Opm::RestartIO::Helpers::WindowedArray<double>
-allocate(const std::vector<int>& inteHead)
-{
-    using WV = Opm::RestartIO::Helpers::WindowedArray<double>;
-
-    return WV {
-        WV::NumWindows{ ngmaxz(inteHead) },
-        WV::WindowSize{ entriesPerGroup(inteHead) }
+    static const auto fieldKeyToIndex = std::vector<std::pair<std::string_view, std::size_t>> {
+        {"FOPR", 0},    {"FWPR", 1},    {"FGPR", 2},    {"FVPR", 3},    {"FWIR", 5},   {"FGIR", 6},
+        {"FWCT", 8},    {"FGOR", 9},    {"FOPT", 10},   {"FWPT", 11},   {"FGPT", 12},  {"FVPT", 13},
+        {"FWIT", 15},   {"FGIT", 16},   {"FVIT", 17},   {"FGCR", 19},   {"FGCT", 21},  {"FOPP", 22},
+        {"FWPP", 23},   {"FGIMR", 51},  {"FGIMT", 52},  {"FOPTS", 73},  {"FGPTS", 74}, {"FOPTH", 135},
+        {"FWPTH", 139}, {"FWITH", 140}, {"FGPTH", 143}, {"FGITH", 144},
     };
-}
 
-// here define the dynamic group quantities to be written to the restart file
-template <class XGrpArray>
-void dynamicContrib(const std::vector<std::string>&      restart_group_keys,
-                    const std::vector<std::string>&      restart_field_keys,
-                    const std::map<std::string, std::size_t>& groupKeyToIndex,
-                    const std::map<std::string, std::size_t>& fieldKeyToIndex,
-                    const Opm::Group&                    group,
-                    const Opm::SummaryState&             sumState,
-                    XGrpArray&                           xGrp)
-{
-    using Ix = ::Opm::RestartIO::Helpers::VectorItems::XGroup::index;
+    static const auto groupKeyToIndex = std::vector<std::pair<std::string_view, std::size_t>> {
+        {"GOPR", 0},    {"GWPR", 1},    {"GGPR", 2},    {"GVPR", 3},    {"GWIR", 5},    {"GGIR", 6},
+        {"GWCT", 8},    {"GGOR", 9},    {"GOPT", 10},   {"GWPT", 11},   {"GGPT", 12},   {"GVPT", 13},
+        {"GWIT", 15},   {"GGIT", 16},   {"GVIT", 17},   {"GGCR", 19},   {"GGCT", 21},   {"GOPP", 22},
+        {"GWPP", 23},   {"GGIMR", 51},  {"GGIMT", 52},  {"GOPTS", 73},  {"GGPTS", 74},  {"GOPGR", 85},
+        {"GWPGR", 86},  {"GGPGR", 87},  {"GVPGR", 88},  {"GOIGR", 89},  {"GWIGR", 91},  {"GGIGR", 93},
+        {"GOPTH", 135}, {"GWPTH", 139}, {"GWITH", 140}, {"GGPTH", 143}, {"GGITH", 144},
+    };
 
-    std::string groupName = group.name();
-    const std::vector<std::string>& keys = (groupName == "FIELD")
-                                           ? restart_field_keys : restart_group_keys;
-    const std::map<std::string, std::size_t>& keyToIndex = (groupName == "FIELD")
-            ? fieldKeyToIndex : groupKeyToIndex;
+    static const auto wellKeyToIndex = std::vector<std::pair<std::string_view, std::size_t>> {
+        {"WOPR", 0},    {"WWPR", 1},    {"WGPR", 2},    {"WVPR", 3},    {"WWIR", 5},
+        {"WGIR", 6},    {"WWCT", 8},    {"WGOR", 9},    {"WOPT", 10},   {"WWPT", 11},
+        {"WGPT", 12},   {"WVPT", 13},   {"WWIT", 15},   {"WGIT", 16},   {"WVIT", 17},
+        //{"WGCR", 19},
+        {"WGCT", 21},   {"WOPP", 22},   {"WWPP", 23},   {"WOPTS", 73},  {"WGPTS", 74},
+        {"WOPTH", 135}, {"WWPTH", 139}, {"WWITH", 140}, {"WGPTH", 143}, {"WGITH", 144},
+    };
 
-    for (const auto& key : keys) {
-        std::string compKey = (groupName == "FIELD")
-                              ? key : key + ":" + groupName;
-
-        if (sumState.has(compKey)) {
-            const double keyValue = sumState.get(compKey);
-            const auto itr = keyToIndex.find(key);
-            xGrp[itr->second] = keyValue;
-        }
+    std::size_t entriesPerGroup(const std::vector<int>& inteHead)
+    {
+        return inteHead[Opm::RestartIO::Helpers::VectorItems::NXGRPZ];
     }
 
-    xGrp[Ix::OilPrGuideRate_2]  = xGrp[Ix::OilPrGuideRate];
-    xGrp[Ix::WatPrGuideRate_2]  = xGrp[Ix::WatPrGuideRate];
-    xGrp[Ix::GasPrGuideRate_2]  = xGrp[Ix::GasPrGuideRate];
-    xGrp[Ix::VoidPrGuideRate_2] = xGrp[Ix::VoidPrGuideRate];
+    Opm::RestartIO::Helpers::WindowedArray<double>
+    allocate(const std::vector<int>& inteHead)
+    {
+        using WV = Opm::RestartIO::Helpers::WindowedArray<double>;
 
-    xGrp[Ix::WatInjGuideRate_2] = xGrp[Ix::WatInjGuideRate];
+        return WV {
+            WV::NumWindows { ngmaxz(inteHead) },
+            WV::WindowSize { entriesPerGroup(inteHead) }
+        };
+    }
 
-    std::fill(xGrp.begin() + Ix::TracerOffset, xGrp.end(), 0);
-}
+    // Populate restart file's XGRP array for this group.
+    template <class XGrpArray>
+    void dynamicContrib(const Opm::Group&        group,
+                        const Opm::SummaryState& sumState,
+                        XGrpArray&               xGrp)
+    {
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::XGroup::index;
 
-
-template <class XGrpArray>
-void dynamicContribLGR(const std::vector<std::reference_wrapper<const Opm::Well>>& filtered_wells,
-                       const std::vector<std::string>&                      restart_well_keys,
-                       const std::map<std::string, std::size_t>&                 wellKeyToIndex,
-                       const Opm::SummaryState&                             sumState,
-                       XGrpArray&                                           xGrp)
-{
-
-    auto key_list = [&filtered_wells](const std::string& local_key) {
-                        std::vector<std::string> all_well_keys;
-                        all_well_keys.reserve(filtered_wells.size());
-                        std::ranges::transform(filtered_wells, std::back_inserter(all_well_keys),
-                                               [&local_key](const auto& well)
-                                               { return local_key + ":" + well.get().name(); });
-                        return all_well_keys;
-                    };
-    using Ix = ::Opm::RestartIO::Helpers::VectorItems::XGroup::index;
-
-    for (const auto& key : restart_well_keys) {
-        const auto keyPos = wellKeyToIndex.find(key);
-        if (keyPos == wellKeyToIndex.end()) {
-            // Shouldn't really happen...
-            continue;
-        }
-        auto& xGrpValue = xGrp[keyPos->second];
-        for (const auto& compKey : key_list(key)) {
-            if (!sumState.has(compKey)) {
-                continue;
+        if (const auto& groupName = group.name(); groupName == "FIELD") {
+            for (const auto& [key, idx] : fieldKeyToIndex) {
+                xGrp[idx] = sumState.get(std::string{ key }, 0.0);
             }
-            xGrpValue += sumState.get(compKey);
         }
+        else {
+            for (const auto& [key, idx] : groupKeyToIndex) {
+                xGrp[idx] = sumState.get(fmt::format("{}:{}", key, groupName), 0.0);
+            }
+        }
+
+        xGrp[Ix::OilPrGuideRate_2] = xGrp[Ix::OilPrGuideRate];
+        xGrp[Ix::WatPrGuideRate_2] = xGrp[Ix::WatPrGuideRate];
+        xGrp[Ix::GasPrGuideRate_2] = xGrp[Ix::GasPrGuideRate];
+        xGrp[Ix::VoidPrGuideRate_2] = xGrp[Ix::VoidPrGuideRate];
+        xGrp[Ix::WatInjGuideRate_2] = xGrp[Ix::WatInjGuideRate];
+
+        std::fill(xGrp.begin() + Ix::TracerOffset, xGrp.end(), 0);
     }
 
-    xGrp[Ix::OilPrGuideRate_2]  = xGrp[Ix::OilPrGuideRate];
-    xGrp[Ix::WatPrGuideRate_2]  = xGrp[Ix::WatPrGuideRate];
-    xGrp[Ix::GasPrGuideRate_2]  = xGrp[Ix::GasPrGuideRate];
-    xGrp[Ix::VoidPrGuideRate_2] = xGrp[Ix::VoidPrGuideRate];
+    template <class XGrpArray>
+    void
+    dynamicContribLGR(const std::vector<const Opm::Well*>& filtered_wells,
+                      const Opm::SummaryState&             sumState,
+                      XGrpArray&                           xGrp)
+    {
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::XGroup::index;
 
-    xGrp[Ix::WatInjGuideRate_2] = xGrp[Ix::WatInjGuideRate];
+        for (const auto& [key, idx] : wellKeyToIndex) {
+            xGrp[idx] += std::accumulate(filtered_wells.begin(), filtered_wells.end(), 0.0,
+                [&sumState, &key](double acc, const Opm::Well* well) {
+                    return acc + sumState.get(fmt::format("{}:{}", key, well->name()), 0.0);
+                });
+        }
 
-    std::fill(xGrp.begin() + Ix::TracerOffset, xGrp.end(), 0);
-}
+        xGrp[Ix::OilPrGuideRate_2] = xGrp[Ix::OilPrGuideRate];
+        xGrp[Ix::WatPrGuideRate_2] = xGrp[Ix::WatPrGuideRate];
+        xGrp[Ix::GasPrGuideRate_2] = xGrp[Ix::GasPrGuideRate];
+        xGrp[Ix::VoidPrGuideRate_2] = xGrp[Ix::VoidPrGuideRate];
+        xGrp[Ix::WatInjGuideRate_2] = xGrp[Ix::WatInjGuideRate];
 
-
+        std::fill(xGrp.begin() + Ix::TracerOffset, xGrp.end(), 0);
+    }
 
 } // XGrp
 
 namespace ZGrp {
-std::size_t entriesPerGroup(const std::vector<int>& inteHead)
-{
-    return inteHead[Opm::RestartIO::Helpers::VectorItems::NZGRPZ];
-}
+    std::size_t entriesPerGroup(const std::vector<int>& inteHead)
+    {
+        return inteHead[Opm::RestartIO::Helpers::VectorItems::NZGRPZ];
+    }
 
-Opm::RestartIO::Helpers::WindowedArray<
-    Opm::EclIO::PaddedOutputString<8>
-    >
-allocate(const std::vector<int>& inteHead)
-{
-    using WV = Opm::RestartIO::Helpers::WindowedArray<
-        Opm::EclIO::PaddedOutputString<8>
-        >;
+    Opm::RestartIO::Helpers::WindowedArray<Opm::EclIO::PaddedOutputString<8>>
+    allocate(const std::vector<int>& inteHead)
+    {
+        using WV = Opm::RestartIO::Helpers::WindowedArray<Opm::EclIO::PaddedOutputString<8>>;
 
-    return WV {
-        WV::NumWindows{ ngmaxz(inteHead) },
-        WV::WindowSize{ entriesPerGroup(inteHead) }
-    };
-}
+        return WV {WV::NumWindows {ngmaxz(inteHead)}, WV::WindowSize {entriesPerGroup(inteHead)}};
+    }
 
-template <class ZGroupArray>
-void staticContrib(const Opm::Group& group, ZGroupArray& zGroup)
-{
-    zGroup[0] = group.name();
-}
+    template <class ZGroupArray>
+    void staticContrib(const Opm::Group& group, ZGroupArray& zGroup)
+    {
+        zGroup[0] = group.name();
+    }
 
-template <class ZGroupArray>
-void staticContribLGR(const std::string& group_name, ZGroupArray& zGroup)
-{
-    zGroup[0] = group_name;
-}
-
+    template <class ZGroupArray>
+    void staticContribLGR(const std::string& group_name, ZGroupArray& zGroup)
+    {
+        zGroup[0] = group_name;
+    }
 
 } // ZGrp
 
@@ -1621,16 +1627,15 @@ AggregateGroupData(const std::vector<int>& inteHead)
 
 void
 Opm::RestartIO::Helpers::AggregateGroupData::
-captureDeclaredGroupData(const Opm::Schedule&     sched,
-                         const Opm::UnitSystem&   units,
-                         const std::size_t        simStep,
-                         const Opm::SummaryState& sumState,
-                         const std::vector<int>&  inteHead)
+captureDeclaredGroupData(const Schedule&         sched,
+                         const std::size_t       simStep,
+                         const SummaryState&     sumState,
+                         const std::vector<int>& inteHead)
 {
     const auto& curGroups = sched.restart_groups(simStep);
     const auto& sched_state = sched[simStep];
 
-    groupLoop(curGroups, [&sched, simStep, sumState, this]
+    groupLoop(curGroups, [&sched, simStep, &sumState, this]
               (const Group& group, const std::size_t groupID) -> void
     {
         auto ig = this->iGroup_[groupID];
@@ -1641,7 +1646,7 @@ captureDeclaredGroupData(const Opm::Schedule&     sched,
 
     // Define Static Contributions to SGrp Array.
     groupLoop(curGroups,
-              [&sumState, &units, &sched_state, this]
+              [&units = sched.getUnits(), &sumState, &sched_state, this]
               (const Group& group, const std::size_t groupID) -> void
     {
         auto sg = this->sGroup_[groupID];
@@ -1655,19 +1660,15 @@ captureDeclaredGroupData(const Opm::Schedule&     sched,
     {
         auto xg = this->xGroup_[groupID];
 
-        XGrp::dynamicContrib(this->restart_group_keys, this->restart_field_keys,
-                             this->groupKeyToIndex, this->fieldKeyToIndex, group,
-                             sumState, xg);
+        XGrp::dynamicContrib(group, sumState, xg);
     });
 
     // Define Static Contributions to ZGrp Array.
-    groupLoop(curGroups, [this, &inteHead]
+    groupLoop(curGroups, [this, fieldIx = ngmaxz(inteHead) - 1]
               (const Group& group, const std::size_t /* groupID */) -> void
     {
-        std::size_t group_index = group.insert_index() - 1;
-        if (group.name() == "FIELD") {
-            group_index = ngmaxz(inteHead) - 1;
-        }
+        const auto group_index = (group.name() == "FIELD")
+            ? fieldIx : group.insert_index() - 1;
 
         auto zg = this->zGroup_[ group_index ];
 
@@ -1677,65 +1678,41 @@ captureDeclaredGroupData(const Opm::Schedule&     sched,
 
 void
 Opm::RestartIO::Helpers::AggregateGroupData::
-captureDeclaredGroupDataLGR(const Opm::Schedule&     sched,
-                            [[maybe_unused]] const Opm::UnitSystem&   units,
-                            const std::size_t        simStep,
-                            const Opm::SummaryState& sumState,
-                            const std::string&       lgr_tag)
+captureDeclaredGroupDataLGR(const Schedule&     sched,
+                            const std::size_t   simStep,
+                            const SummaryState& sumState,
+                            const std::string&  lgr_tag)
 {
-    const auto& curGroups = sched.restart_groups(simStep);
     const auto& sched_state = sched[simStep];
 
-    const auto all_wells = sched.getWells(simStep);
-    std::vector<std::reference_wrapper<const Opm::Well>> filtered_wells;
-    std::vector<std::reference_wrapper<const Opm::Group>> filtered_groups;
-
     // Filter wells that belong to the specified LGR tag
-    for (const auto& well : all_wells) {
-        auto well_lgr_tag = well.get_lgr_well_tag().value_or("");
-        if ((!well.is_lgr_well()) || (well_lgr_tag != lgr_tag)){
-            continue; // Skip wells that are not tagged with the specified LGR tag
+    auto filtered_wells = std::vector<const Well*>{};
+    for (const auto& wellPtrPair : sched_state.wells) {
+        if (!wellPtrPair.second->is_lgr_well()) {
+            continue; // Skip wells that are not LGR wells
         }
-        filtered_wells.push_back(std::cref(well));
+
+        if (wellPtrPair.second->get_lgr_well_tag().value_or("") != lgr_tag) {
+            continue; // Skip wells that do not have an LGR tag
+        }
+
+        filtered_wells.push_back(wellPtrPair.second.get());
     }
 
-    std::ranges::sort(filtered_wells,
-                      [](const auto& a, const auto& b)
-                      { return a.get().seqIndex() < b.get().seqIndex(); });
+    if (!filtered_wells.empty()) {
+        std::ranges::sort(filtered_wells,
+                          [](const Well* a, const Well* b)
+                          { return a->seqIndex() < b->seqIndex(); });
 
-    const bool has_lgr_well = !filtered_wells.empty();
-
-    // Filter groups that belong to the specified LGR tag but not FIELD
-    for (std::size_t i = 0; i < curGroups.size() - 1 ; ++i) {
-        const auto* group = curGroups[i];
-        if (group == nullptr)  {
-            continue;
-        }
-        if (sched_state.group_contains_lgr(*group, lgr_tag))
-        {
-            filtered_groups.push_back(std::cref(*group));
-        }
-    }
-
-    // Filling IGRP arrays
-    if (has_lgr_well){
         {
             auto ig = this->iGroup_[0];
-            IGrp::staticContrib_pseudo_well_group_LGR( filtered_wells, this->nWGMax_, ig);
+            IGrp::staticContrib_pseudo_well_group_LGR(filtered_wells, this->nWGMax_, ig);
         }
         {
             auto ig = this->iGroup_[1];
-            IGrp::staticContrib_field_group_LGR( this->nWGMax_, ig);
+            IGrp::staticContrib_field_group_LGR(this->nWGMax_, ig);
         }
-    }
-    else {
-        auto ig = this->iGroup_[1];
-        IGrp::staticContrib_empty_field_group_LGR( this->nWGMax_, ig);
-    }
 
-
-    // Filling SGRP array
-    if (has_lgr_well){
         {
             auto sg = this->sGroup_[0]; // Pseudo-well group
             SGrp::staticContrib_pseudo_well_group_LGR(sg);
@@ -1744,34 +1721,46 @@ captureDeclaredGroupDataLGR(const Opm::Schedule&     sched,
             auto sg = this->sGroup_[1]; // Field Group
             SGrp::staticContrib_field_group_LGR(sg);
         }
+
+        {
+            auto xg = this->xGroup_[0];
+            XGrp::dynamicContribLGR(filtered_wells, sumState, xg);
+        }
+        {
+            auto xg = this->xGroup_[1];
+            XGrp::dynamicContribLGR(filtered_wells, sumState, xg);
+        }
     }
     else {
+        auto ig = this->iGroup_[1];
+        IGrp::staticContrib_empty_field_group_LGR(this->nWGMax_, ig);
+
         auto sg = this->sGroup_[1]; // Empty Field Group
         SGrp::staticContrib_empty_field_group_LGR(sg);
     }
 
-    // Filling XGRP array
-    if (has_lgr_well){
-        {
-            auto xg = this->xGroup_[0];
-            XGrp::dynamicContribLGR(filtered_wells, this->restart_well_keys, this->wellKeyToIndex,
-                                          sumState, xg);
+    // Filter groups that belong to the specified LGR tag but not FIELD
+    const auto curGroups = sched.restart_groups(simStep);
+    auto filtered_groups = std::vector<const Group*>{};
+    for (std::size_t i = 0; i < curGroups.size() - 1 ; ++i) {
+        if (curGroups[i] == nullptr) {
+            continue;
         }
-        {
-            auto xg = this->xGroup_[1];
-            XGrp::dynamicContribLGR(filtered_wells, this->restart_well_keys, this->wellKeyToIndex,
-                                          sumState, xg);
+
+        if (sched_state.group_contains_lgr(*curGroups[i], lgr_tag)) {
+            filtered_groups.push_back(curGroups[i]);
         }
     }
 
-    // Filling ZGRP array
-    const std::string group_name =
-                                 has_lgr_well ? filtered_groups.back().get().name() : "";
-
     {
+        const auto& group_name = !filtered_wells.empty() && !filtered_groups.empty()
+            ? filtered_groups.back()->name()
+            : std::string{};
+
         auto zg = this->zGroup_[0];
         ZGrp::staticContribLGR(group_name, zg);
     }
+
     {
         auto zg = this->zGroup_[1];
         ZGrp::staticContribLGR("FIELD", zg);

--- a/opm/output/eclipse/AggregateGroupData.hpp
+++ b/opm/output/eclipse/AggregateGroupData.hpp
@@ -32,28 +32,24 @@
 namespace Opm {
 class Schedule;
 class SummaryState;
-class UnitSystem;
-} // Opm
+} // namespace Opm
 
-namespace Opm { namespace RestartIO { namespace Helpers {
+namespace Opm::RestartIO::Helpers {
 
 class AggregateGroupData
 {
 public:
     explicit AggregateGroupData(const std::vector<int>& inteHead);
 
-    void captureDeclaredGroupData(const Opm::Schedule&        sched,
-                         const Opm::UnitSystem&               units,
-                         const std::size_t                    simStep,
-                         const Opm::SummaryState&             sumState,
-                         const std::vector<int>&              inteHead);
+    void captureDeclaredGroupData(const Schedule&         sched,
+                                  const std::size_t       simStep,
+                                  const SummaryState&     sumState,
+                                  const std::vector<int>& inteHead);
 
-
-    void captureDeclaredGroupDataLGR(const Opm::Schedule&        sched,
-                                     const Opm::UnitSystem&      units,
-                                     const std::size_t           simStep,
-                                     const Opm::SummaryState&    sumState,
-                                     const std::string&          lgr_tag);
+    void captureDeclaredGroupDataLGR(const Schedule&     sched,
+                                     const std::size_t   simStep,
+                                     const SummaryState& sumState,
+                                     const std::string&  lgr_tag);
 
     const std::vector<int>& getIGroup() const
     {
@@ -75,145 +71,6 @@ public:
         return this->zGroup_.data();
     }
 
-    const std::vector<std::string> restart_group_keys = {"GOPP", "GWPP", "GOPR", "GWPR", "GGPR",
-                                                         "GVPR", "GWIR", "GGIR", "GWCT", "GGOR",
-                                                         "GOPT", "GWPT", "GGPT", "GVPT",
-                                                         "GOPTS", "GGPTS",
-                                                         "GWIT" , "GGIT" , "GVIT",
-                                                         "GOPTH", "GWPTH", "GGPTH",
-                                                         "GWITH", "GGITH",
-                                                         "GOPGR", "GWPGR", "GGPGR", "GVPGR",
-                                                         "GOIGR", "GWIGR", "GGIGR",
-                                                         "GGCR", "GGIMR", "GGCT", "GGIMT",
-                                                        };
-
-    // Note: guide rates don't exist at the FIELD level.
-    const std::vector<std::string> restart_field_keys = {"FOPP", "FWPP", "FOPR", "FWPR", "FGPR",
-                                                         "FVPR", "FWIR", "FGIR", "FWCT", "FGOR",
-                                                         "FOPT", "FWPT", "FGPT", "FVPT",
-                                                         "FOPTS", "FGPTS",
-                                                         "FWIT" , "FGIT" , "FVIT",
-                                                         "FOPTH", "FWPTH", "FGPTH",
-                                                         "FGCR", "FGCT", "FGIMR", "FGIMT",
-
-                                                         "FWITH", "FGITH"};
-
-    const std::vector<std::string> restart_well_keys = {"WOPP",  "WWPP", "WOPR", "WWPR", "WGPR",
-                                                        "WVPR",  "WWIR", "WGIR", "WWCT", "WGOR",
-                                                        "WOPT",  "WWPT", "WGPT", "WVPT",
-                                                        "WOPTS", "WGPTS",
-                                                        "WWIT" , "WGIT", "WVIT",
-                                                        "WOPTH", "WWPTH", "WGPTH",
-                                                        /*"WGCR",*/  /*"WGCT",*/ /*"WGIMR",*/ /*"WGIMT",*/
-                                                        "WWITH", "WGITH"};
-
-    const std::map<std::string, std::size_t> groupKeyToIndex = {
-                                                           {"GOPR",  0},
-                                                           {"GWPR",  1},
-                                                           {"GGPR",  2},
-                                                           {"GVPR",  3},
-                                                           {"GWIR",  5},
-                                                           {"GGIR",  6},
-                                                           {"GWCT",  8},
-                                                           {"GGOR",  9},
-                                                           {"GOPT", 10},
-                                                           {"GWPT", 11},
-                                                           {"GGPT", 12},
-                                                           {"GVPT", 13},
-                                                           {"GWIT", 15},
-                                                           {"GGIT", 16},
-                                                           {"GVIT", 17},
-                                                           {"GGCR", 19},
-                                                           {"GGCT", 21},
-                                                           {"GOPP", 22},
-                                                           {"GWPP", 23},
-                                                           {"GGIMR", 51},
-                                                           {"GGIMT", 52},
-                                                           {"GOPTS", 73},
-                                                           {"GGPTS", 74},
-                                                           {"GOPGR", 85},
-                                                           {"GWPGR", 86},
-                                                           {"GGPGR", 87},
-                                                           {"GVPGR", 88},
-                                                           {"GOIGR", 89},
-                                                           {"GWIGR", 91},
-                                                           {"GGIGR", 93},
-                                                           {"GOPTH", 135},
-                                                           {"GWPTH", 139},
-                                                           {"GWITH", 140},
-                                                           {"GGPTH", 143},
-                                                           {"GGITH", 144},
-    };
-
-    const std::map<std::string, std::size_t> fieldKeyToIndex = {
-                                                           {"FOPR",  0},
-                                                           {"FWPR",  1},
-                                                           {"FGPR",  2},
-                                                           {"FVPR",  3},
-                                                           {"FWIR",  5},
-                                                           {"FGIR",  6},
-                                                           {"FWCT",  8},
-                                                           {"FGOR",  9},
-                                                           {"FOPT", 10},
-                                                           {"FWPT", 11},
-                                                           {"FGPT", 12},
-                                                           {"FVPT", 13},
-                                                           {"FWIT", 15},
-                                                           {"FGIT", 16},
-                                                           {"FVIT", 17},
-                                                           {"FGCR", 19},
-                                                           {"FGCT", 21},
-                                                           {"FOPP", 22},
-                                                           {"FWPP", 23},
-                                                           {"FGIMR", 51},
-                                                           {"FGIMT", 52},
-                                                           {"FOPTS", 73},
-                                                           {"FGPTS", 74},
-                                                           {"FOPTH", 135},
-                                                           {"FWPTH", 139},
-                                                           {"FWITH", 140},
-                                                           {"FGPTH", 143},
-                                                           {"FGITH", 144},
-    };
-
-        const std::map<std::string, std::size_t> wellKeyToIndex = {
-                                                           {"WOPR",  0},
-                                                           {"WWPR",  1},
-                                                           {"WGPR",  2},
-                                                           {"WVPR",  3},
-                                                           {"WWIR",  5},
-                                                           {"WGIR",  6},
-                                                           {"WWCT",  8},
-                                                           {"WGOR",  9},
-                                                           {"WOPT", 10},
-                                                           {"WWPT", 11},
-                                                           {"WGPT", 12},
-                                                           {"WVPT", 13},
-                                                           {"WWIT", 15},
-                                                           {"WGIT", 16},
-                                                           {"WVIT", 17},
-                                                           //{"WGCR", 19},
-                                                           {"WGCT", 21},
-                                                           {"WOPP", 22},
-                                                           {"WWPP", 23},
-                                                           {"WGIMR", 51},
-                                                           {"WGIMT", 52},
-                                                           {"WOPTS", 73},
-                                                           {"WGPTS", 74},
-                                                           {"WOPGR", 85},
-                                                           {"WWPGR", 86},
-                                                           {"WGPGR", 87},
-                                                           {"WVPGR", 88},
-                                                           {"WOIGR", 89},
-                                                           {"WWIGR", 91},
-                                                           {"WGIGR", 93},
-                                                           {"WOPTH", 135},
-                                                           {"WWPTH", 139},
-                                                           {"WWITH", 140},
-                                                           {"WGPTH", 143},
-                                                           {"WGITH", 144},
-    };
-
 private:
     /// Aggregate 'IWEL' array (Integer) for all wells.
     WindowedArray<int> iGroup_;
@@ -234,6 +91,6 @@ private:
     int nGMaxz_;
 };
 
-}}} // Opm::RestartIO::Helpers
+} // Opm::RestartIO::Helpers
 
-#endif // OPM_AGGREGATE_WELL_DATA_HPP
+#endif // OPM_AGGREGATE_GROUP_DATA_HPP

--- a/opm/output/eclipse/AggregateMSWData.cpp
+++ b/opm/output/eclipse/AggregateMSWData.cpp
@@ -1322,13 +1322,12 @@ void
 Opm::RestartIO::Helpers::AggregateMSWData::
 captureDeclaredMSWData(const Schedule&          sched,
                        const std::size_t        rptStep,
-                       const Opm::UnitSystem&   units,
                        const std::vector<int>&  inteHead,
                        const Opm::EclipseGrid&  grid,
                        const Opm::SummaryState& smry,
                        const Opm::data::Wells&  wr)
 {
-    const auto& wells = sched.getWells(rptStep);
+    const auto wells = sched.getWells(rptStep);
     auto msw = std::vector<const Opm::Well*>{};
 
     for (const auto& well : wells) {
@@ -1338,7 +1337,7 @@ captureDeclaredMSWData(const Schedule&          sched,
     }
 
     // Extract contributions to the ISEG and RSEG arrays.
-    MSWLoop(msw, [&units, &inteHead, &sched, &grid, &smry, &wr, this]
+    MSWLoop(msw, [&inteHead, &sched, &grid, &smry, &wr, this]
         (const Well& well, const std::size_t mswID)
     {
         auto iseg = this->iSeg_[mswID];
@@ -1346,7 +1345,7 @@ captureDeclaredMSWData(const Schedule&          sched,
 
         ISeg::staticContrib(well, inteHead, iseg);
         RSeg::staticContrib(sched.runspec(), well, inteHead,
-                            grid, units, smry, wr, rseg);
+                            grid, sched.getUnits(), smry, wr, rseg);
     });
 
     // Extract contributions to the ILBS and ILBR arrays.

--- a/opm/output/eclipse/AggregateMSWData.hpp
+++ b/opm/output/eclipse/AggregateMSWData.hpp
@@ -29,11 +29,10 @@ namespace Opm {
     class Phases;
     class Schedule;
     class EclipseGrid;
-    class UnitSystem;
     class SummaryState;
 } // Opm
 
-namespace Opm { namespace RestartIO { namespace Helpers {
+namespace Opm::RestartIO::Helpers {
 
     class AggregateMSWData
     {
@@ -42,7 +41,6 @@ namespace Opm { namespace RestartIO { namespace Helpers {
 
         void captureDeclaredMSWData(const Opm::Schedule&     sched,
                                     const std::size_t        rptStep,
-                                    const Opm::UnitSystem&   units,
                                     const std::vector<int>&  inteHead,
                                     const Opm::EclipseGrid&  grid,
                                     const Opm::SummaryState& smry,
@@ -86,6 +84,6 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         WindowedMatrix<int> iLBR_;
     };
 
-}}} // Opm::RestartIO::Helpers
+} // Opm::RestartIO::Helpers
 
-#endif // OPM_AGGREGATE_WELL_DATA_HPP
+#endif // OPM_AGGREGATE_MSW_DATA_HPP

--- a/opm/output/eclipse/AggregateNetworkData.cpp
+++ b/opm/output/eclipse/AggregateNetworkData.cpp
@@ -147,9 +147,8 @@ int next_branch(int node_no, const std::vector<int>& inlets, const std::vector<i
 }
 
 
-std::vector<int> inobrFunc( const Opm::Schedule&    sched,
-                            const std::size_t       lookup_step
-                 )
+std::vector<int> inobrFunc(const Opm::Schedule& sched,
+                           const std::size_t    lookup_step)
 {
     const auto& ntwNdNm = sched[lookup_step].network().node_names();
     const auto& branchPtrs = sched[lookup_step].network().branches();
@@ -185,22 +184,17 @@ std::vector<int> inobrFunc( const Opm::Schedule&    sched,
     return newInobr;
 }
 
-bool fixedPressureNode(const Opm::Schedule&         sched,
-                       const std::string&           nodeName,
-                       const std::size_t                 lookup_step
-                      )
+bool fixedPressureNode(const Opm::Schedule& sched,
+                       const std::string&   nodeName,
+                       const std::size_t    lookup_step)
 {
-    auto& network = sched[lookup_step].network();
-    bool fpn = (network.node(nodeName).terminal_pressure().has_value()) ? true  : false;
-    return fpn;
+    return sched[lookup_step].network().node(nodeName).terminal_pressure().has_value();
 }
 
-double nodePressure(const Opm::Schedule&               sched,
-                    const ::Opm::SummaryState&         smry,
-                    const std::string&                 nodeName,
-                    const Opm::UnitSystem&             units,
-                    const std::size_t                       lookup_step
-                   )
+double nodePressure(const Opm::Schedule&     sched,
+                    const Opm::SummaryState& smry,
+                    const std::string&       nodeName,
+                    const std::size_t        lookup_step)
 {
     using M = ::Opm::UnitSystem::measure;
     double node_pres = 1.;
@@ -215,7 +209,7 @@ double nodePressure(const Opm::Schedule&               sched,
             if (well.isProducer()) {
                 const auto& pc = well.productionControls(smry);
                 if (pc.thp_limit >= node_pres) {
-                    node_pres = units.from_si(M::pressure, pc.thp_limit);
+                    node_pres = sched.getUnits().from_si(M::pressure, pc.thp_limit);
                     node_wgroup = true;
                 }
             }
@@ -226,7 +220,7 @@ double nodePressure(const Opm::Schedule&               sched,
     if (!node_wgroup) {
         if (fixedPressureNode(sched, nodeName, lookup_step)) {
             // node is a fixed pressure node
-            node_pres = units.from_si(M::pressure, network.node(nodeName).terminal_pressure().value());
+            node_pres = sched.getUnits().from_si(M::pressure, network.node(nodeName).terminal_pressure().value());
         }
         else {
             // find fixed pressure higher in the node tree
@@ -238,7 +232,7 @@ double nodePressure(const Opm::Schedule&               sched,
             auto upt_br = network.uptree_branch(node_name).value();
             while (!fp_flag) {
                 if (fixedPressureNode(sched, upt_br.uptree_node(), lookup_step)) {
-                    node_pres = units.from_si(M::pressure, network.node(upt_br.uptree_node()).terminal_pressure().value());
+                    node_pres = sched.getUnits().from_si(M::pressure, network.node(upt_br.uptree_node()).terminal_pressure().value());
                     fp_flag = true;
                 } else {
                     node_name = upt_br.uptree_node();
@@ -268,12 +262,11 @@ struct nodeProps
     double ndGpr;
 };
 
-nodeProps wellGroupRateDensity(const Opm::EclipseState&                  es,
-                               const Opm::Schedule&                      sched,
-                               const ::Opm::SummaryState&                smry,
-                               const std::string&                        groupName,
-                               const std::size_t                              lookup_step
-                              )
+nodeProps wellGroupRateDensity(const Opm::EclipseState& es,
+                               const Opm::Schedule&     sched,
+                               const Opm::SummaryState& smry,
+                               const std::string&       groupName,
+                               const std::size_t        lookup_step)
 {
     const auto& stdDensityTable = es.getTableManager().getDensityTable();
 
@@ -302,6 +295,7 @@ nodeProps wellGroupRateDensity(const Opm::EclipseState&                  es,
             gpr  += t_gpr;
         }
     }
+
     deno = (opr > 0.) ? deno / opr : 0.;
     denw = (wpr > 0.) ? denw / wpr : 0.;
     deng = (gpr > 0.) ? deng / gpr : 0.;
@@ -310,13 +304,11 @@ nodeProps wellGroupRateDensity(const Opm::EclipseState&                  es,
 
 }
 
-nodeProps nodeRateDensity(const Opm::EclipseState&                  es,
-                          const Opm::Schedule&                      sched,
-                          const ::Opm::SummaryState&                smry,
-                          const std::string&                        nodeName,
-                          const Opm::UnitSystem&                    units,
-                          const std::size_t                              lookup_step
-                         )
+nodeProps nodeRateDensity(const Opm::EclipseState& es,
+                          const Opm::Schedule&     sched,
+                          const Opm::SummaryState& smry,
+                          const std::string&       nodeName,
+                          const std::size_t        lookup_step)
 {
     const auto& network = sched[lookup_step].network();
 
@@ -341,7 +333,7 @@ nodeProps nodeRateDensity(const Opm::EclipseState&                  es,
                 nd_prop_vec.push_back(nd_prop);
             } else {
                 // Network node (not group) - calculate the node rate avg. density for the relevant group
-                nd_prop = nodeRateDensity(es, sched, smry, node_nm, units, lookup_step);
+                nd_prop = nodeRateDensity(es, sched, smry, node_nm, lookup_step);
                 nd_prop_vec.push_back(nd_prop);
             }
         }
@@ -571,7 +563,6 @@ void dynamicContrib(const Opm::Schedule&      sched,
                     const Opm::SummaryState&  sumState,
                     const std::string&        nodeName,
                     const std::size_t         lookup_step,
-                    const Opm::UnitSystem&    units,
                     RNodeArray&               rNode)
 {
     using Ix = ::Opm::RestartIO::Helpers::VectorItems::RNode::index;
@@ -582,12 +573,12 @@ void dynamicContrib(const Opm::Schedule&      sched,
     rNode[Ix::FixedPresNode] = (fixedPressureNode(sched, nodeName, lookup_step)) ? 0. : 1.;
 
     // equal to i) highest well p_thp if wellgroup and ii) pressure of uptree node with fixed pressure
-    rNode[Ix::PressureLimit] = nodePressure(sched, sumState, nodeName, units, lookup_step);
+    rNode[Ix::PressureLimit] = nodePressure(sched, sumState, nodeName, lookup_step);
 
     //the meaning of item [15] is not known at the moment, so far a constant value covers all cases studied
     rNode[15] = 1.;
-
 }
+
 } // Rnode
 
 
@@ -609,19 +600,19 @@ allocate(const std::vector<int>& inteHead)
 }
 
 template <class RBranArray>
-void dynamicContrib(const Opm::EclipseState&         es,
-                    const Opm::Schedule&             sched,
-                    const Opm::Network::Branch&      branch,
-                    const std::size_t                lookup_step,
-                    const Opm::SummaryState&         sumState,
-                    const Opm::UnitSystem&           units,
-                    RBranArray&                      rBran
-                   )
+void dynamicContrib(const Opm::EclipseState&    es,
+                    const Opm::Schedule&        sched,
+                    const Opm::Network::Branch& branch,
+                    const std::size_t           lookup_step,
+                    const Opm::SummaryState&    sumState,
+                    RBranArray&                 rBran)
 {
     using Ix = ::Opm::RestartIO::Helpers::VectorItems::RBran::index;
+
     // branch (downtree node) rates
     const auto& dwntr_node = branch.downtree_node();
-    auto nodePrp = nodeRateDensity(es, sched, sumState, dwntr_node, units, lookup_step);
+    auto nodePrp = nodeRateDensity(es, sched, sumState, dwntr_node, lookup_step);
+
     rBran[Ix::OilProdRate] = nodePrp.ndOpr;
     rBran[Ix::WaterProdRate] = nodePrp.ndWpr;
     rBran[Ix::GasProdRate] = nodePrp.ndGpr;
@@ -630,13 +621,7 @@ void dynamicContrib(const Opm::EclipseState&         es,
 }
 } // Rbran
 
-
-
-
-
 } // namespace
-
-
 
 // =====================================================================
 
@@ -652,18 +637,16 @@ AggregateNetworkData(const std::vector<int>& inteHead)
 
 // ---------------------------------------------------------------------
 
-
 void
 Opm::RestartIO::Helpers::AggregateNetworkData::
-captureDeclaredNetworkData(const Opm::EclipseState&             es,
-                           const Opm::Schedule&                 sched,
-                           const Opm::UnitSystem&               units,
-                           const std::size_t                    lookup_step,
-                           const Opm::SummaryState&             sumState,
-                           const std::vector<int>&              inteHead)
+captureDeclaredNetworkData(const EclipseState&     es,
+                           const Schedule&         sched,
+                           const std::size_t       lookup_step,
+                           const SummaryState&     sumState,
+                           const std::vector<int>& inteHead)
 {
-
     auto ntwNdNm = sched[lookup_step].network().node_names();
+
     std::size_t wdmax = ntwNdNm.size();
     std::vector<const std::string*> ndNmPt(wdmax + 1 , nullptr );
     std::size_t ind_nm = 0;
@@ -699,9 +682,13 @@ captureDeclaredNetworkData(const Opm::EclipseState&             es,
 
     // Define Static Contributions to INobr Array
     if (inobr.size() > entriesPerInobr(inteHead)) {
-        auto msg = fmt::format("Actual size of inobr: {} is larger than maximum size: {} ", inobr.size(), entriesPerInobr(inteHead));
+        auto msg = fmt::format("Actual size of inobr: {} "
+                               "is larger than maximum size: {} ",
+                               inobr.size(), entriesPerInobr(inteHead));
+
         throw std::logic_error(msg);
     }
+
     auto i_nobr = this->iNobr_[0];
     INobr::staticContrib(inobr, i_nobr);
 
@@ -715,21 +702,20 @@ captureDeclaredNetworkData(const Opm::EclipseState&             es,
     });
 
     // Define Static/Dynamic Contributions to RNode Array
-    nodeLoop(networkNodePtrs, [&sched, sumState, units, lookup_step, this]
+    nodeLoop(networkNodePtrs, [&sched, sumState, lookup_step, this]
              (const std::string& nodeName, const std::size_t nodeID) -> void
     {
         auto ind = this->rNode_[nodeID];
 
-        RNode::dynamicContrib(sched, sumState, nodeName, lookup_step, units, ind);
+        RNode::dynamicContrib(sched, sumState, nodeName, lookup_step, ind);
     });
 
     // Define Dynamic Contributions to RBran Array.
-    branchLoop(branchPtrs, [&es, &sched, sumState, units, lookup_step, this]
+    branchLoop(branchPtrs, [&es, &sched, sumState, lookup_step, this]
                (const Opm::Network::Branch& branch, const std::size_t branchID) -> void
     {
         auto ib = this->rBran_[branchID];
 
-        RBran::dynamicContrib(es, sched, branch, lookup_step, sumState, units, ib);
+        RBran::dynamicContrib(es, sched, branch, lookup_step, sumState, ib);
     });
-
 }

--- a/opm/output/eclipse/AggregateNetworkData.hpp
+++ b/opm/output/eclipse/AggregateNetworkData.hpp
@@ -31,7 +31,6 @@ namespace Opm {
     class EclipseState;
     class Schedule;
     class SummaryState;
-    class UnitSystem;
 } // Opm
 
 namespace Opm { namespace RestartIO { namespace Helpers {
@@ -41,12 +40,11 @@ class AggregateNetworkData
 public:
     explicit AggregateNetworkData(const std::vector<int>& inteHead);
 
-    void captureDeclaredNetworkData(const Opm::EclipseState&             es,
-                                    const Opm::Schedule&                 sched,
-                                    const Opm::UnitSystem&               units,
-                                    const std::size_t                    lookup_step,
-                                    const Opm::SummaryState&             sumState,
-                                    const std::vector<int>&              inteHead);
+    void captureDeclaredNetworkData(const EclipseState&     es,
+                                    const Schedule&         sched,
+                                    const std::size_t       lookup_step,
+                                    const SummaryState&     sumState,
+                                    const std::vector<int>& inteHead);
 
     const std::vector<int>& getINode() const
     {

--- a/opm/output/eclipse/AggregateWellData.hpp
+++ b/opm/output/eclipse/AggregateWellData.hpp
@@ -35,62 +35,62 @@ namespace Opm {
     class UnitSystem;
     class WellTestState;
     class TracerConfig;
-    namespace Action {
-        class State;
-    }
 } // Opm
 
-namespace Opm { namespace data {
-    class Wells;
-}} // Opm::data
+namespace Opm::Action {
+    class State;
+}
 
-namespace Opm { namespace RestartIO { namespace Helpers {
+namespace Opm::data {
+    class Wells;
+} // Opm::data
+
+namespace Opm::RestartIO::Helpers {
 
     class AggregateWellData
     {
     public:
         explicit AggregateWellData(const std::vector<int>& inteHead);
 
-        void captureDeclaredWellData(const Schedule&   	          sched,
-                                     const TracerConfig&          tracer,
-                                     const std::size_t 		      sim_step,
-                                     const Opm::Action::State&    action_state,
-                                     const Opm::WellTestState&    wtest_state,
-                                     const Opm::SummaryState&     smry,
-                                     const std::vector<int>&      inteHead);
+        void captureDeclaredWellData(const Schedule&         sched,
+                                     const TracerConfig&     tracer,
+                                     const std::size_t       sim_step,
+                                     const Action::State&    action_state,
+                                     const WellTestState&    wtest_state,
+                                     const SummaryState&     smry,
+                                     const std::vector<int>& inteHead);
 
-        void captureDeclaredWellData(const Schedule&   	          sched,
-                                     const EclipseGrid&           grid,
-                                     const TracerConfig&          tracer,
-                                     const std::size_t 		      sim_step,
-                                     const Opm::Action::State&    action_state,
-                                     const Opm::WellTestState&    wtest_state,
-                                     const Opm::SummaryState&     smry,
-                                     const std::vector<int>&      inteHead);
+        void captureDeclaredWellData(const Schedule&         sched,
+                                     const EclipseGrid&      grid,
+                                     const TracerConfig&     tracer,
+                                     const std::size_t       sim_step,
+                                     const Action::State&    action_state,
+                                     const WellTestState&    wtest_state,
+                                     const SummaryState&     smry,
+                                     const std::vector<int>& inteHead);
 
-        void captureDeclaredWellDataLGR(const Schedule&   	      sched,
-                                        const EclipseGrid&        grid,
-                                        const TracerConfig&       tracer,
-                                        const std::size_t 		  sim_step,
-                                        const Opm::Action::State& action_state,
-                                        const Opm::WellTestState& wtest_state,
-                                        const Opm::SummaryState&  smry,
-                                        const std::vector<int>&   inteHead,
-                                        const std::string&        lgr_tag);
+        void captureDeclaredWellDataLGR(const Schedule&         sched,
+                                        const EclipseGrid&      grid,
+                                        const TracerConfig&     tracer,
+                                        const std::size_t       sim_step,
+                                        const Action::State&    action_state,
+                                        const WellTestState&    wtest_state,
+                                        const SummaryState&     smry,
+                                        const std::vector<int>& inteHead,
+                                        const std::string&      lgr_tag);
 
-        void captureDynamicWellData(const Opm::Schedule&          sched,
-                                    const TracerConfig&           tracer,
-                                    const std::size_t             sim_step,
-                                    const Opm::data::Wells&       xw,
-                                    const Opm::SummaryState&      smry);
+        void captureDynamicWellData(const Schedule&     sched,
+                                    const TracerConfig& tracer,
+                                    const std::size_t   sim_step,
+                                    const data::Wells&  xw,
+                                    const SummaryState& smry);
 
-        void captureDynamicWellDataLGR(const Opm::Schedule&          sched,
-                                       const TracerConfig&           tracer,
-                                       const std::size_t             sim_step,
-                                       const Opm::data::Wells&       xw,
-                                       const Opm::SummaryState&      smry,
-                                       const std::string&            lgr_tag);
-
+        void captureDynamicWellDataLGR(const Schedule&     sched,
+                                       const TracerConfig& tracer,
+                                       const std::size_t   sim_step,
+                                       const data::Wells&  xw,
+                                       const SummaryState& smry,
+                                       const std::string&  lgr_tag);
 
         /// Retrieve Integer Well Data Array.
         const std::vector<int>& getIWell() const
@@ -122,8 +122,6 @@ namespace Opm { namespace RestartIO { namespace Helpers {
             return this->lgWell_.data();
         }
 
-
-
     private:
         /// Aggregate 'IWEL' array (Integer) for all wells.
         WindowedArray<int> iWell_;
@@ -144,6 +142,6 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         int nWGMax_;
     };
 
-}}} // Opm::RestartIO::Helpers
+} // Opm::RestartIO::Helpers
 
 #endif // OPM_AGGREGATE_WELL_DATA_HPP

--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -215,7 +215,6 @@ namespace {
     }
 
     void writeGroup(int                           sim_step,
-                    const UnitSystem&             units,
                     const Schedule&               schedule,
                     const Opm::SummaryState&      sumState,
                     const std::vector<int>&       ih,
@@ -226,7 +225,7 @@ namespace {
 
         auto  groupData = Helpers::AggregateGroupData(ih);
 
-        groupData.captureDeclaredGroupData(schedule, units, simStep, sumState, ih);
+        groupData.captureDeclaredGroupData(schedule, simStep, sumState, ih);
 
         rstFile.write("IGRP", groupData.getIGroup());
         rstFile.write("SGRP", groupData.getSGroup());
@@ -235,7 +234,6 @@ namespace {
     }
 
     void writeGroupLGR(int                           sim_step,
-                       const UnitSystem&             units,
                        const Schedule&               schedule,
                        const Opm::SummaryState&      sumState,
                        const std::vector<int>&       ih,
@@ -245,7 +243,7 @@ namespace {
         const std::size_t simStep = static_cast<std::size_t> (sim_step);
         auto  groupData = Helpers::AggregateGroupData(ih);
 
-        groupData.captureDeclaredGroupDataLGR(schedule, units, simStep, sumState, lgr_tag);
+        groupData.captureDeclaredGroupDataLGR(schedule, simStep, sumState, lgr_tag);
 
         rstFile.write("IGRP", groupData.getIGroup());
         rstFile.write("SGRP", groupData.getSGroup());
@@ -255,7 +253,6 @@ namespace {
 
     void writeNetwork(const Opm::EclipseState&      es,
                       int                           sim_step,
-                      const UnitSystem&             units,
                       const Schedule&               schedule,
                       const Opm::SummaryState&      sumState,
                       const std::vector<int>&       ih,
@@ -266,7 +263,7 @@ namespace {
 
         auto  networkData = Helpers::AggregateNetworkData(ih);
 
-        networkData.captureDeclaredNetworkData(es, schedule, units, simStep, sumState, ih);
+        networkData.captureDeclaredNetworkData(es, schedule, simStep, sumState, ih);
 
         rstFile.write("INODE", networkData.getINode());
         rstFile.write("IBRAN", networkData.getIBran());
@@ -277,7 +274,6 @@ namespace {
     }
 
     void writeMSWData(int                           sim_step,
-                      const UnitSystem&             units,
                       const Schedule&               schedule,
                       const EclipseGrid&            grid,
                       const Opm::SummaryState&      sumState,
@@ -288,9 +284,9 @@ namespace {
         // write ISEG, RSEG, ILBS and ILBR to restart file
         const auto simStep = static_cast<std::size_t> (sim_step);
 
-        auto  MSWData = Helpers::AggregateMSWData(ih);
-        MSWData.captureDeclaredMSWData(schedule, simStep, units,
-                                       ih, grid, sumState, wells);
+        auto MSWData = Helpers::AggregateMSWData(ih);
+        MSWData.captureDeclaredMSWData(schedule, simStep, ih,
+                                       grid, sumState, wells);
 
         rstFile.write("ISEG", MSWData.getISeg());
         rstFile.write("ILBS", MSWData.getILBs());
@@ -365,9 +361,9 @@ namespace {
 
         const auto simStep = static_cast<std::size_t>(sim_step);
 
-        const auto actionxData = RestartIO::Helpers::createAggregateActionxData(
-            schedule, action_state, sum_state, simStep
-        );
+        const auto actionxData = RestartIO::Helpers::
+            createAggregateActionxData(schedule, action_state,
+                                       sum_state, simStep);
 
         rstFile.write("IACT", actionxData.getIACT());
         rstFile.write("SACT", actionxData.getSACT());
@@ -405,26 +401,24 @@ namespace {
             rstFile.write("SWEL", wellData.getSWell());
         }
 
-        if (norst_value <= 1)
-        {
+        if (norst_value <= 1) {
             rstFile.write("XWEL", wellData.getXWell());
         }
 
         rstFile.write("ZWEL", wellData.getZWell());
 
-        if (norst_value == 0)
-        {
+        if (norst_value == 0) {
             auto wListData = Helpers::AggregateWListData(ih);
             wListData.captureDeclaredWListData(schedule, sim_step, ih);
+
             rstFile.write("ZWLS", wListData.getZWls());
             rstFile.write("IWLS", wListData.getIWls());
         }
 
-        auto connectionData = Helpers::AggregateConnectionData(ih);
-        connectionData.captureDeclaredConnData(schedule, grid, schedule.getUnits(),
-                                               wells, sumState, sim_step);
-
         if (norst_value <= 1) {
+            auto connectionData = Helpers::AggregateConnectionData(ih);
+            connectionData.captureDeclaredConnData(schedule, grid, wells, sumState, sim_step);
+
             rstFile.write("ICON", connectionData.getIConn());
             rstFile.write("SCON", connectionData.getSConn());
             rstFile.write("XCON", connectionData.getXConn());
@@ -450,23 +444,21 @@ namespace {
 
         rstFile.write("IWEL", wellData.getIWell());
 
-        if (norst_value == 0)
-        {
+        if (norst_value == 0) {
             rstFile.write("SWEL", wellData.getSWell());
         }
 
-        if (norst_value <= 1)
-        {
+        if (norst_value <= 1) {
             rstFile.write("XWEL", wellData.getXWell());
         }
 
         rstFile.write("ZWEL", wellData.getZWell());
 
-        if (norst_value == 0)
-        {
+        if (norst_value == 0) {
             // write LGWEL
             rstFile.write("LGWEL", wellData.getLGWell());
         }
+
         // wListData for LGR is currently not supported.
         // the following code is left here for future reference.
         // auto wListData = Helpers::AggregateWListData(ih);
@@ -475,12 +467,11 @@ namespace {
         // rstFile.write("ZWLS", wListData.getZWls());
         // rstFile.write("IWLS", wListData.getIWls());
 
-        auto connectionData = Helpers::AggregateConnectionData(ih);
-        connectionData.captureDeclaredConnDataLGR(schedule, grid, schedule.getUnits(),
-                                                     wells, sumState, sim_step, lgr_tag);
+        if (norst_value <= 1) {
+            auto connectionData = Helpers::AggregateConnectionData(ih);
+            connectionData.captureDeclaredConnDataLGR(schedule, grid, wells,
+                                                      sumState, sim_step, lgr_tag);
 
-        if (norst_value <= 1)
-        {
             rstFile.write("ICON", connectionData.getIConn());
             rstFile.write("SCON", connectionData.getSConn());
             rstFile.write("XCON", connectionData.getXConn());
@@ -557,22 +548,20 @@ namespace {
                           EclIO::OutputStream::Restart&                 rstFile)
     {
         const int norst_value = schedule[sim_step].rst_config().norst.value_or(0);
-        if (norst_value == 0)
-        {
-            writeGroup(sim_step, schedule.getUnits(), schedule, sumState, inteHD, rstFile);
+
+        if (norst_value == 0) {
+            writeGroup(sim_step, schedule, sumState, inteHD, rstFile);
         }
 
         // Write network data if the network option is used and network defined
-        const auto& network = schedule[sim_step].network();
-        if (network.active() && norst_value == 0)
+        if (const auto& network = schedule[sim_step].network();
+            network.active() && (norst_value == 0))
         {
-            writeNetwork(es, sim_step, schedule.getUnits(), schedule, sumState, inteHD, rstFile);
+            writeNetwork(es, sim_step, schedule, sumState, inteHD, rstFile);
         }
 
         // Write well and MSW data only when applicable (i.e., when present)
-        if (const auto& wells = schedule.wellNames(sim_step);
-            ! wells.empty())
-        {
+        if (const auto& wells = schedule.wellNames(sim_step); ! wells.empty()) {
             const auto haveMSW =
                 std::ranges::any_of(wells,
                                     [&schedule, sim_step](const std::string& well)
@@ -580,8 +569,8 @@ namespace {
 
             // MSW data is well-structure specific and not written for
             // reduced (NORST=1) or graphics-only (NORST=2) restarts.
-            if (haveMSW && norst_value == 0) {
-                writeMSWData(sim_step, schedule.getUnits(), schedule, grid,
+            if (haveMSW && (norst_value == 0)) {
+                writeMSWData(sim_step, schedule, grid,
                              sumState, wellSol, inteHD, rstFile);
             }
 
@@ -589,8 +578,7 @@ namespace {
                       action_state, wtest_state, sumState, inteHD, norst_value, rstFile);
         }
 
-        if (norst_value == 0)
-        {
+        if (norst_value == 0) {
             if (const auto& aqCfg = es.aquifer();
                 aqCfg.active() && aquiferData.has_value())
             {
@@ -619,46 +607,54 @@ namespace {
     {
         const int norst_value = schedule[sim_step].rst_config().norst.value_or(0);
 
-        if (norst_value == 0)
-        {
-            writeGroupLGR(sim_step, schedule.getUnits(), schedule, sumState, inteHD, rstFile, lgr_tag);
+        if (norst_value == 0) {
+            writeGroupLGR(sim_step, schedule, sumState, inteHD, rstFile, lgr_tag);
         }
+
         // Write network data if the network option is used and network defined
-        const auto& network = schedule[sim_step].network();
-        if (network.active() && norst_value == 0)
+        if (const auto& network = schedule[sim_step].network();
+            network.active() && (norst_value == 0))
         {
-            writeNetwork(es, sim_step, schedule.getUnits(), schedule, sumState, inteHD, rstFile);
+            writeNetwork(es, sim_step, schedule, sumState, inteHD, rstFile);
         }
-        const auto& wells = schedule.wellNames(sim_step);
-        const bool has_lgrwells =
-            std::ranges::any_of(wells,
-                                [&schedule, &lgr_tag, sim_step](const std::string& well)
-                                {
-                                    const auto& lwell = schedule.getWell(well, sim_step);
-                                    return lwell.get_lgr_well_tag().value_or("") == lgr_tag;
-                                });
+
+        const auto wells = schedule.wellNames(sim_step);
+
+        const bool has_lgrwells = std::ranges::any_of
+            (wells, [&schedule, &lgr_tag, sim_step](const std::string& well) {
+                const auto& lwell = schedule.getWell(well, sim_step);
+                return lwell.get_lgr_well_tag().value_or("") == lgr_tag;
+            });
+
         // Write well and MSW data only when applicable (i.e., when present)
-        if (!wells.empty() and has_lgrwells)
-        {
-            const auto haveMSW =
-                std::ranges::any_of(wells,
-                                    [&schedule, sim_step](const std::string& well)
-                                    {
-                                        const auto& lwell = schedule.getWell(well, sim_step);
-                                        return lwell.isMultiSegment() && (lwell.is_lgr_well() );
-                                    });
+        if (!wells.empty() && has_lgrwells) {
+            const auto haveMSW = std::ranges::any_of
+                (wells, [&schedule, sim_step](const std::string& well) {
+                    const auto& lwell = schedule.getWell(well, sim_step);
+                    return lwell.isMultiSegment() && lwell.is_lgr_well();
+                });
 
             if (haveMSW) {
                 throw std::logic_error("MSW not supported for LGR");
             }
 
-            writeWellLGR(sim_step, grid, schedule, es.tracer(), wellSol,
-                         action_state, wtest_state, sumState, inteHD, norst_value, rstFile, lgr_tag);
+            writeWellLGR(sim_step,
+                         grid,
+                         schedule,
+                         es.tracer(),
+                         wellSol,
+                         action_state,
+                         wtest_state,
+                         sumState,
+                         inteHD,
+                         norst_value,
+                         rstFile,
+                         lgr_tag);
         }
+
         // Write aquifer data if the aquifer option for LGR.
         // At the moment LGR and Aquifers are not supported.
         // To be done.
-
     }
 
     std::vector<std::string>
@@ -1006,8 +1002,6 @@ namespace {
         rstFile.message("ENDSOL");
     }
 
-
-
     void writeExtraData(const RestartValue::ExtraVector& extra_data,
                         EclIO::OutputStream::Restart&    rstFile)
     {
@@ -1057,24 +1051,47 @@ namespace {
                                                 std::optional<Helpers::AggregateAquiferData>& aquiferData)
     {
         const int norst_value = schedule[sim_step].rst_config().norst.value_or(0);
-        const auto inteHD =
-        writeHeader(report_step, sim_step, nextStepSize(values[0]),
-                    seconds_elapsed, schedule, grid, es, rstFile);
+
+        const auto inteHD = writeHeader(report_step,
+                                        sim_step,
+                                        nextStepSize(values[0]),
+                                        seconds_elapsed,
+                                        schedule,
+                                        grid,
+                                        es,
+                                        rstFile);
 
         if (report_step > 0) {
-        writeDynamicData(sim_step, grid, es, schedule, values[0].wells,
-                        action_state, wtest_state, sumState, inteHD,
-                        values[0].aquifer, aquiferData, rstFile);
+            writeDynamicData(sim_step,
+                             grid,
+                             es,
+                             schedule,
+                             values[0].wells,
+                             action_state,
+                             wtest_state,
+                             sumState,
+                             inteHD,
+                             values[0].aquifer,
+                             aquiferData,
+                             rstFile);
         }
 
-        if (norst_value == 0)
-        {
+        if (norst_value == 0) {
             writeActionx(report_step, sim_step, schedule, action_state, sumState, rstFile);
         }
-        writeSolution(values[0], es, schedule, udqState, report_step, sim_step,
-                    ecl_compatible_rst, write_double, inteHD, rstFile);
 
-        if (! ecl_compatible_rst && norst_value == 0) {
+        writeSolution(values[0],
+                      es,
+                      schedule,
+                      udqState,
+                      report_step,
+                      sim_step,
+                      ecl_compatible_rst,
+                      write_double,
+                      inteHD,
+                      rstFile);
+
+        if (!ecl_compatible_rst && norst_value == 0) {
             writeExtraData(values[0].extra, rstFile);
         }
 

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -234,7 +234,8 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
             rstFile.write("LOGIHEAD", lh);
             {
                 auto group_aggregator = Opm::RestartIO::Helpers::AggregateGroupData(ih);
-                group_aggregator.captureDeclaredGroupData(sched, es.getUnits(), rptStep-1, st, ih);
+                group_aggregator.captureDeclaredGroupData(sched, rptStep-1, st, ih);
+
                 rstFile.write("IGRP", group_aggregator.getIGroup());
                 rstFile.write("SGRP", group_aggregator.getSGroup());
                 rstFile.write("XGRP", group_aggregator.getXGroup());
@@ -243,6 +244,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
             {
                 auto well_aggregator = Opm::RestartIO::Helpers::AggregateWellData(ih);
                 well_aggregator.captureDeclaredWellData(sched, es.tracer(), rptStep-1, {}, {}, st, ih);
+
                 rstFile.write("IWEL", well_aggregator.getIWell());
                 rstFile.write("SWEL", well_aggregator.getSWell());
                 rstFile.write("XWEL", well_aggregator.getXWell());
@@ -251,7 +253,8 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
             {
                 auto conn_aggregator = Opm::RestartIO::Helpers::AggregateConnectionData(ih);
                 auto xw = Opm::data::Wells {};
-                conn_aggregator.captureDeclaredConnData(sched, grid, es.getUnits(), xw, st, rptStep-1);
+                conn_aggregator.captureDeclaredConnData(sched, grid, xw, st, rptStep-1);
+
                 rstFile.write("ICON", conn_aggregator.getIConn());
                 rstFile.write("SCON", conn_aggregator.getSConn());
                 rstFile.write("XCON", conn_aggregator.getXConn());

--- a/tests/test_AggregateConnectionData.cpp
+++ b/tests/test_AggregateConnectionData.cpp
@@ -622,7 +622,7 @@ BOOST_AUTO_TEST_CASE(Declared_Connection_Data)
 
     const auto& [wrc, sum_state] = wr(simCase.sched);
     auto amconn = Opm::RestartIO::Helpers::AggregateConnectionData {ih.value};
-    amconn.captureDeclaredConnData(simCase.sched, simCase.grid, simCase.es.getUnits(), wrc, sum_state, rptStep);
+    amconn.captureDeclaredConnData(simCase.sched, simCase.grid, wrc, sum_state, rptStep);
 
     // ICONN (PROD)
     {
@@ -840,7 +840,6 @@ BOOST_AUTO_TEST_CASE(InactiveCell)
     auto conn0 = Opm::RestartIO::Helpers::AggregateConnectionData{ih.value};
     conn0.captureDeclaredConnData(simCase.sched,
                                   simCase.grid,
-                                  simCase.es.getUnits(),
                                   wrc,
                                   sum_state,
                                   rptStep);
@@ -853,7 +852,6 @@ BOOST_AUTO_TEST_CASE(InactiveCell)
     auto conn1 = Opm::RestartIO::Helpers::AggregateConnectionData{ih.value};
     conn1.captureDeclaredConnData(simCase.sched,
                                   simCase.grid,
-                                  simCase.es.getUnits(),
                                   wrc,
                                   sum_state,
                                   rptStep);
@@ -1122,9 +1120,7 @@ BOOST_AUTO_TEST_CASE(Basic)
     {
         const auto rptStep = std::size_t {0};
 
-        amconn.captureDeclaredConnData(cse.sched,
-                                       cse.grid,
-                                       cse.es.getUnits(),
+        amconn.captureDeclaredConnData(cse.sched, cse.grid,
                                        wrc, sum_state, rptStep);
 
         // W1 (injector)
@@ -1157,9 +1153,7 @@ BOOST_AUTO_TEST_CASE(Basic)
     {
         const auto rptStep = std::size_t {1};
 
-        amconn.captureDeclaredConnData(cse.sched,
-                                       cse.grid,
-                                       cse.es.getUnits(),
+        amconn.captureDeclaredConnData(cse.sched, cse.grid,
                                        wrc, sum_state, rptStep);
 
         // W1 (injector)

--- a/tests/test_AggregateGroupData.cpp
+++ b/tests/test_AggregateGroupData.cpp
@@ -56,10 +56,9 @@ namespace {
 struct MockIH
 {
     MockIH(const int numWells,
-
-           const int igrpPerGrp	 = 101,  // no of data elements per group in IGRP array
-           const int sgrpPerGrp  = 112,  // number of data elements per group in SGRP array
-           const int xgrpPerGrp  = 180,  // number of data elements per group in XGRP array
+           const int igrpPerGrp	 = 101,   // number of data elements per group in IGRP array
+           const int sgrpPerGrp  = 112,   // number of data elements per group in SGRP array
+           const int xgrpPerGrp  = 181,   // number of data elements per group in XGRP array
            const int zgrpPerGrp  =   5);  // number of data elements per group in XGRP array
 
 
@@ -67,13 +66,13 @@ struct MockIH
 
     using Sz = std::vector<int>::size_type;
 
-    Sz nwells;
-    Sz nwgmax;
-    Sz ngmaxz;
-    Sz nigrpz;
-    Sz nsgrpz;
-    Sz nxgrpz;
-    Sz nzgrpz;
+    Sz nwells{};
+    Sz nwgmax{};
+    Sz ngmaxz{};
+    Sz nigrpz{};
+    Sz nsgrpz{};
+    Sz nxgrpz{};
+    Sz nzgrpz{};
 };
 
 MockIH::MockIH(const int numWells,
@@ -89,6 +88,7 @@ MockIH::MockIH(const int numWells,
 
     this->ngmaxz = this->value[Ix::NGMAXZ] = 5;
     this->nwgmax = this->value[Ix::NWGMAX] = 4;
+
     this->nigrpz = this->value[Ix::NIGRPZ] = igrpPerGrp;
     this->nsgrpz = this->value[Ix::NSGRPZ] = sgrpPerGrp;
     this->nxgrpz = this->value[Ix::NXGRPZ] = xgrpPerGrp;
@@ -102,352 +102,326 @@ Opm::Deck second_sim(std::string fname) {
 Opm::Deck first_sim()
 {
     // Mostly copy of tests/FIRST_SIM.DATA
-    const std::string input = std::string {
-        R"~(
-        RUNSPEC
-
-        TITLE
-        2 PRODUCERS  AND INJECTORS, 2 WELL GROUPS AND ONE INTERMEDIATE GROUP LEVEL  BELOW THE FIELD LEVEL
-
-        DIMENS
-        10  5  10  /
-
-
-        OIL
-
-        WATER
-
-        GAS
-
-        DISGAS
-
-        FIELD
-
-        TABDIMS
-        1  1  15  15  2  15  /
-
-        EQLDIMS
-        2  /
-
-        WELLDIMS
-        4  20  4  2  /
-
-        UNIFIN
-        UNIFOUT
-
-        --FMTIN
-        --FMTOUT
-
-        START
-        1 'JAN' 2015 /
-
-        -- RPTRUNSP
-
-        GRID        =========================================================
-
-        --NOGGF
-        BOX
-        1 10 1 5 1 1 /
-
-        TOPS
-        50*7000 /
-
-        BOX
-        1 10  1 5 1 10 /
-
-        DXV
-        10*100 /
-        DYV
-        5*100  /
-        DZV
-        2*20 100 7*20 /
-
-        EQUALS
-        -- 'DX'     100  /
-        -- 'DY'     100  /
-        'PERMX'  50   /
-        'PERMZ'  5   /
-        -- 'DZ'     20   /
-        'PORO'   0.2  /
-        -- 'TOPS'   7000   1 10  1 5  1 1  /
-        -- 'DZ'     100    1 10  1 5  3 3  /
-        -- 'PORO'   0.0    1 10  1 5  3 3  /
-        /
-
-        COPY
-        PERMX PERMY /
-        /
-
-        RPTGRID
-        -- Report Levels for Grid Section Data
-        --
-        /
-
-        PROPS       ==========================================================
-
-        -- WATER RELATIVE PERMEABILITY AND CAPILLARY PRESSURE ARE TABULATED AS
-        -- A FUNCTION OF WATER SATURATION.
-        --
-        --  SWAT   KRW   PCOW
-        SWFN
-
-        0.12  0       0
-        1.0   0.00001 0  /
-
-        -- SIMILARLY FOR GAS
-        --
-        --  SGAS   KRG   PCOG
-        SGFN
-
-        0     0       0
-        0.02  0       0
-        0.05  0.005   0
-        0.12  0.025   0
-        0.2   0.075   0
-        0.25  0.125   0
-        0.3   0.19    0
-        0.4   0.41    0
-        0.45  0.6     0
-        0.5   0.72    0
-        0.6   0.87    0
-        0.7   0.94    0
-        0.85  0.98    0
-        1.0   1.0     0
-        /
-
-        -- OIL RELATIVE PERMEABILITY IS TABULATED AGAINST OIL SATURATION
-        -- FOR OIL-WATER AND OIL-GAS-CONNATE WATER CASES
-        --
-        --  SOIL     KROW     KROG
-        SOF3
-
-        0        0        0
-        0.18     0        0
-        0.28     0.0001   0.0001
-        0.38     0.001    0.001
-        0.43     0.01     0.01
-        0.48     0.021    0.021
-        0.58     0.09     0.09
-        0.63     0.2      0.2
-        0.68     0.35     0.35
-        0.76     0.7      0.7
-        0.83     0.98     0.98
-        0.86     0.997    0.997
-        0.879    1        1
-        0.88     1        1    /
-
-
-        -- PVT PROPERTIES OF WATER
-        --
-        --    REF. PRES. REF. FVF  COMPRESSIBILITY  REF VISCOSITY  VISCOSIBILITY
-        PVTW
-        4014.7     1.029        3.13D-6           0.31            0 /
-
-        -- ROCK COMPRESSIBILITY
-        --
-        --    REF. PRES   COMPRESSIBILITY
-        ROCK
-        14.7          3.0D-6          /
-
-        -- SURFACE DENSITIES OF RESERVOIR FLUIDS
-        --
-        --        OIL   WATER   GAS
-        DENSITY
-        49.1   64.79  0.06054  /
-
-        -- PVT PROPERTIES OF DRY GAS (NO VAPOURISED OIL)
-        -- WE WOULD USE PVTG TO SPECIFY THE PROPERTIES OF WET GAS
-        --
-        --   PGAS   BGAS   VISGAS
-        PVDG
-        14.7 166.666   0.008
-        264.7  12.093   0.0096
-        514.7   6.274   0.0112
-        1014.7   3.197   0.014
-        2014.7   1.614   0.0189
-        2514.7   1.294   0.0208
-        3014.7   1.080   0.0228
-        4014.7   0.811   0.0268
-        5014.7   0.649   0.0309
-        9014.7   0.386   0.047   /
-
-        -- PVT PROPERTIES OF LIVE OIL (WITH DISSOLVED GAS)
-        -- WE WOULD USE PVDO TO SPECIFY THE PROPERTIES OF DEAD OIL
-        --
-        -- FOR EACH VALUE OF RS THE SATURATION PRESSURE, FVF AND VISCOSITY
-        -- ARE SPECIFIED. FOR RS=1.27 AND 1.618, THE FVF AND VISCOSITY OF
-        -- UNDERSATURATED OIL ARE DEFINED AS A FUNCTION OF PRESSURE. DATA
-        -- FOR UNDERSATURATED OIL MAY BE SUPPLIED FOR ANY RS, BUT MUST BE
-        -- SUPPLIED FOR THE HIGHEST RS (1.618).
-        --
-        --   RS      POIL  FVFO  VISO
-        PVTO
-        0.001    14.7 1.062  1.04    /
-        0.0905  264.7 1.15   0.975   /
-        0.18    514.7 1.207  0.91    /
-        0.371  1014.7 1.295  0.83    /
-        0.636  2014.7 1.435  0.695   /
-        0.775  2514.7 1.5    0.641   /
-        0.93   3014.7 1.565  0.594   /
-        1.270  4014.7 1.695  0.51
-        5014.7 1.671  0.549
-        9014.7 1.579  0.74    /
-        1.618  5014.7 1.827  0.449
-        9014.7 1.726  0.605   /
-        /
-
-
-        RPTPROPS
-        -- PROPS Reporting Options
-        --
-        /
-
-        REGIONS    ===========================================================
-
-
-        FIPNUM
-
-        100*1
-        400*2
-        /
-
-        EQLNUM
-
-        100*1
-        400*2
-        /
-
-        RPTREGS
-
-        /
-
-        SOLUTION    ============================================================
-
-        EQUIL
-        7020.00 2700.00 7990.00  .00000 7020.00  .00000     0      0       5 /
-        7200.00 3700.00 7300.00  .00000 7000.00  .00000     1      0       5 /
-
-        RSVD       2 TABLES    3 NODES IN EACH           FIELD   12:00 17 AUG 83
-        7000.0  1.0000
-        7990.0  1.0000
-        /
-        7000.0  1.0000
-        7400.0  1.0000
-        /
-
-        RPTRST
-        -- Restart File Output Control
-        --
-        'BASIC=2' 'FLOWS' 'POT' 'PRES' /
-
-
-        SUMMARY      ===========================================================
-
-        FOPR
-
-        WOPR
-        /
-
-        FGPR
-
-        FWPR
-
-        FWIR
-
-        FWCT
-
-        FGOR
-
-        --RUNSUM
-
-        ALL
-
-        MSUMLINS
-
-        MSUMNEWT
-
-        SEPARATE
-
-        SCHEDULE     ===========================================================
-
-        DEBUG
-        1 3   /
-
-        DRSDT
-        1.0E20  /
-
-        RPTSCHED
-        'PRES'  'SWAT'  'SGAS'  'RESTART=1'  'RS'  'WELLS=2'  'SUMMARY=2'
-        'CPU=2' 'WELSPECS'   'NEWTON=2' /
-
-        NOECHO
-
-
-        ECHO
-
-        GRUPTREE
-        'GRP1' 'FIELD' /
-        'WGRP1' 'GRP1' /
-        'WGRP2' 'GRP1' /
-        /
-
-        WELSPECS
-        'PROD1' 'WGRP1' 1 5 7030 'OIL' 0.0  'STD'  'STOP'  /
-        'PROD2' 'WGRP2' 1 5 7030 'OIL' 0.0  'STD'  'STOP'  /
-        'WINJ1'  'WGRP1' 10 1 7030 'WAT' 0.0  'STD'  'STOP'   /
-        'WINJ2'  'WGRP2' 10 1 7030 'WAT' 0.0  'STD'  'STOP'   /
-        /
-
-        COMPDAT
-
-        'PROD1' 1 5 2 2   3*  0.2   3*  'X' /
-        'PROD1' 2 5 2 2   3*  0.2   3*  'X' /
-        'PROD1' 3 5 2 2   3*  0.2   3*  'X' /
-        'PROD2' 4 5 2 2   3*  0.2   3*  'X' /
-        'PROD2' 5 5 2 2   3*  0.2   3*  'X' /
-
-        'WINJ1' 10 1  9 9   3*  0.2   3*  'X' /
-        'WINJ1'   9 1  9 9   3*  0.2   3*  'X' /
-        'WINJ1'   8 1  9 9   3*  0.2   3*  'X' /
-        'WINJ2'   7 1  9 9   3*  0.2   3*  'X' /
-        'WINJ2'   6 1  9 9   3*  0.2   3*  'X' /
-        /
-
-
-        WCONPROD
-        'PROD1' 'OPEN' 'LRAT'  3*  1200  1*  2500  1*  /
-        'PROD2' 'OPEN' 'LRAT'  3*    800  1*  2500  1*  /
-        /
-
-        WCONINJE
-        'WINJ1' 'WAT' 'OPEN' 'BHP'  1*  1200  3500  1*  /
-        'WINJ2' 'WAT' 'OPEN' 'BHP'  1*    800  3500  1*  /
-        /
-
-
-        TUNING
-        /
-        /
-        /
-
-        LIFTOPT
-          1 2 /
-
-        GLIFTOPT
-           'WGRP1'  100 200 /
-        /
-
-        TSTEP
-        4
-        /
-
-
-        END
-
-        )~"
-    };
-
-    return Opm::Parser {} .parseString(input);
+    const std::string input = std::string {R"~(RUNSPEC
+TITLE
+2 PRODUCERS  AND INJECTORS, 2 WELL GROUPS AND ONE INTERMEDIATE GROUP LEVEL  BELOW THE FIELD LEVEL
+
+DIMENS
+  10  5  10  /
+
+OIL
+WATER
+GAS
+DISGAS
+
+FIELD
+
+TABDIMS
+  1  1  15  15  2  15  /
+
+EQLDIMS
+  2  /
+
+WELLDIMS
+  4  20  4  2  /
+
+UNIFIN
+UNIFOUT
+
+--FMTIN
+--FMTOUT
+
+START
+1 'JAN' 2015 /
+
+-- RPTRUNSP
+
+GRID        =========================================================
+
+--NOGGF
+BOX
+1 10 1 5 1 1 /
+
+TOPS
+50*7000 /
+
+BOX
+1 10  1 5 1 10 /
+
+DXV
+10*100 /
+DYV
+5*100  /
+DZV
+2*20 100 7*20 /
+
+EQUALS
+-- 'DX'     100  /
+-- 'DY'     100  /
+'PERMX'  50   /
+'PERMZ'  5   /
+-- 'DZ'     20   /
+'PORO'   0.2  /
+-- 'TOPS'   7000   1 10  1 5  1 1  /
+-- 'DZ'     100    1 10  1 5  3 3  /
+-- 'PORO'   0.0    1 10  1 5  3 3  /
+/
+
+COPY
+PERMX PERMY /
+/
+
+RPTGRID
+-- Report Levels for Grid Section Data
+--
+/
+
+PROPS       ==========================================================
+
+-- WATER RELATIVE PERMEABILITY AND CAPILLARY PRESSURE ARE TABULATED AS
+-- A FUNCTION OF WATER SATURATION.
+--
+SWFN
+--  SWAT   KRW   PCOW
+0.12  0       0
+1.0   0.00001 0  /
+
+-- SIMILARLY FOR GAS
+--
+SGFN
+--  SGAS   KRG   PCOG
+0     0       0
+0.02  0       0
+0.05  0.005   0
+0.12  0.025   0
+0.2   0.075   0
+0.25  0.125   0
+0.3   0.19    0
+0.4   0.41    0
+0.45  0.6     0
+0.5   0.72    0
+0.6   0.87    0
+0.7   0.94    0
+0.85  0.98    0
+1.0   1.0     0
+/
+
+-- OIL RELATIVE PERMEABILITY IS TABULATED AGAINST OIL SATURATION
+-- FOR OIL-WATER AND OIL-GAS-CONNATE WATER CASES
+--
+SOF3
+--  SOIL     KROW     KROG
+0        0        0
+0.18     0        0
+0.28     0.0001   0.0001
+0.38     0.001    0.001
+0.43     0.01     0.01
+0.48     0.021    0.021
+0.58     0.09     0.09
+0.63     0.2      0.2
+0.68     0.35     0.35
+0.76     0.7      0.7
+0.83     0.98     0.98
+0.86     0.997    0.997
+0.879    1        1
+0.88     1        1    /
+
+
+-- PVT PROPERTIES OF WATER
+--
+--    REF. PRES. REF. FVF  COMPRESSIBILITY  REF VISCOSITY  VISCOSIBILITY
+PVTW
+4014.7     1.029        3.13D-6           0.31            0 /
+
+-- ROCK COMPRESSIBILITY
+--
+--    REF. PRES   COMPRESSIBILITY
+ROCK
+14.7          3.0D-6          /
+
+-- SURFACE DENSITIES OF RESERVOIR FLUIDS
+--
+--        OIL   WATER   GAS
+DENSITY
+49.1   64.79  0.06054  /
+
+-- PVT PROPERTIES OF DRY GAS (NO VAPOURISED OIL)
+-- WE WOULD USE PVTG TO SPECIFY THE PROPERTIES OF WET GAS
+--
+--   PGAS   BGAS   VISGAS
+PVDG
+14.7 166.666   0.008
+264.7  12.093   0.0096
+514.7   6.274   0.0112
+1014.7   3.197   0.014
+2014.7   1.614   0.0189
+2514.7   1.294   0.0208
+3014.7   1.080   0.0228
+4014.7   0.811   0.0268
+5014.7   0.649   0.0309
+9014.7   0.386   0.047   /
+
+-- PVT PROPERTIES OF LIVE OIL (WITH DISSOLVED GAS)
+-- WE WOULD USE PVDO TO SPECIFY THE PROPERTIES OF DEAD OIL
+--
+-- FOR EACH VALUE OF RS THE SATURATION PRESSURE, FVF AND VISCOSITY
+-- ARE SPECIFIED. FOR RS=1.27 AND 1.618, THE FVF AND VISCOSITY OF
+-- UNDERSATURATED OIL ARE DEFINED AS A FUNCTION OF PRESSURE. DATA
+-- FOR UNDERSATURATED OIL MAY BE SUPPLIED FOR ANY RS, BUT MUST BE
+-- SUPPLIED FOR THE HIGHEST RS (1.618).
+--
+--   RS      POIL  FVFO  VISO
+PVTO
+0.001    14.7 1.062  1.04    /
+0.0905  264.7 1.15   0.975   /
+0.18    514.7 1.207  0.91    /
+0.371  1014.7 1.295  0.83    /
+0.636  2014.7 1.435  0.695   /
+0.775  2514.7 1.5    0.641   /
+0.93   3014.7 1.565  0.594   /
+1.270  4014.7 1.695  0.51
+5014.7 1.671  0.549
+9014.7 1.579  0.74    /
+1.618  5014.7 1.827  0.449
+9014.7 1.726  0.605   /
+/
+
+
+RPTPROPS
+-- PROPS Reporting Options
+--
+/
+
+REGIONS    ===========================================================
+
+
+FIPNUM
+100*1
+400*2
+/
+
+EQLNUM
+100*1
+400*2
+/
+
+RPTREGS
+/
+
+SOLUTION    ============================================================
+
+EQUIL
+7020.00 2700.00 7990.00  .00000 7020.00  .00000     0      0       5 /
+7200.00 3700.00 7300.00  .00000 7000.00  .00000     1      0       5 /
+
+RSVD       2 TABLES    3 NODES IN EACH           FIELD   12:00 17 AUG 83
+7000.0  1.0000
+7990.0  1.0000
+/
+7000.0  1.0000
+7400.0  1.0000
+/
+
+RPTRST
+-- Restart File Output Control
+--
+'BASIC=2' 'FLOWS' 'POT' 'PRES' /
+
+
+SUMMARY      ===========================================================
+
+FOPR
+WOPR
+/
+
+FGPR
+FWPR
+FWIR
+FWCT
+FGOR
+
+--RUNSUM
+
+ALL
+
+MSUMLINS
+MSUMNEWT
+SEPARATE
+
+SCHEDULE     ===========================================================
+
+DEBUG
+1 3   /
+
+DRSDT
+1.0E20  /
+
+RPTSCHED
+'PRES'  'SWAT'  'SGAS'  'RESTART=1'  'RS'  'WELLS=2'  'SUMMARY=2'
+'CPU=2' 'WELSPECS'   'NEWTON=2' /
+
+NOECHO
+
+
+ECHO
+
+GRUPTREE
+'GRP1' 'FIELD' /
+'WGRP1' 'GRP1' /
+'WGRP2' 'GRP1' /
+/
+
+WELSPECS
+'PROD1' 'WGRP1' 1 5 7030 'OIL' 0.0  'STD'  'STOP'  /
+'PROD2' 'WGRP2' 1 5 7030 'OIL' 0.0  'STD'  'STOP'  /
+'WINJ1'  'WGRP1' 10 1 7030 'WAT' 0.0  'STD'  'STOP'   /
+'WINJ2'  'WGRP2' 10 1 7030 'WAT' 0.0  'STD'  'STOP'   /
+/
+
+COMPDAT
+'PROD1' 1 5 2 2   3*  0.2   3*  'X' /
+'PROD1' 2 5 2 2   3*  0.2   3*  'X' /
+'PROD1' 3 5 2 2   3*  0.2   3*  'X' /
+'PROD2' 4 5 2 2   3*  0.2   3*  'X' /
+'PROD2' 5 5 2 2   3*  0.2   3*  'X' /
+
+'WINJ1' 10 1  9 9   3*  0.2   3*  'X' /
+'WINJ1'   9 1  9 9   3*  0.2   3*  'X' /
+'WINJ1'   8 1  9 9   3*  0.2   3*  'X' /
+'WINJ2'   7 1  9 9   3*  0.2   3*  'X' /
+'WINJ2'   6 1  9 9   3*  0.2   3*  'X' /
+/
+
+WCONPROD
+'PROD1' 'OPEN' 'LRAT'  3*  1200  1*  2500  1*  /
+'PROD2' 'OPEN' 'LRAT'  3*    800  1*  2500  1*  /
+/
+
+WCONINJE
+'WINJ1' 'WAT' 'OPEN' 'BHP'  1*  1200  3500  1*  /
+'WINJ2' 'WAT' 'OPEN' 'BHP'  1*    800  3500  1*  /
+/
+
+TUNING
+/
+/
+/
+
+LIFTOPT
+  1 2 /
+
+GLIFTOPT
+   'WGRP1'  100 200 /
+/
+
+TSTEP
+4
+/
+
+END
+)~" };
+
+    return Opm::Parser{}.parseString(input);
 }
 
 Opm::SummaryState sim_state()
@@ -651,11 +625,10 @@ BOOST_AUTO_TEST_CASE (Declared_Group_Data)
 
     BOOST_CHECK_EQUAL(ih.nwells, MockIH::Sz {4});
 
-    const auto& smry = sim_state();
-    const auto& units    = simCase.es.getUnits();
+    const auto smry = sim_state();
+
     auto agrpd = Opm::RestartIO::Helpers::AggregateGroupData {ih.value};
-    agrpd.captureDeclaredGroupData(simCase.sched, units, rptStep, smry,
-                                   ih.value);
+    agrpd.captureDeclaredGroupData(simCase.sched, rptStep, smry, ih.value);
 
     // IGRP (PROD)
     {
@@ -693,7 +666,6 @@ BOOST_AUTO_TEST_CASE (Declared_Group_Data)
         BOOST_CHECK_CLOSE(sGrp[start + Ix::GLOMaxSupply], 100, 1e-6);
         BOOST_CHECK_CLOSE(sGrp[start + Ix::GLOMaxRate],   200, 1e-6);
     }
-
 
     // XGRP (PROD)
     {
@@ -798,14 +770,13 @@ BOOST_AUTO_TEST_CASE (Declared_Group_Data_2)
     const auto& sched = simCase.sched;
     const auto& grid  = simCase.grid;
 
-    const auto& units = es.getUnits();
-    const auto& st    = sim_state_2();
+    const auto st = sim_state_2();
 
     const auto ih = Opm::RestartIO::Helpers::createInteHead(es, grid, sched, secs_elapsed,
                                                             rptStep, rptStep + 1, rptStep);
 
     auto agrpd = Opm::RestartIO::Helpers::AggregateGroupData(ih);
-    agrpd.captureDeclaredGroupData(sched, units, rptStep, st, ih);
+    agrpd.captureDeclaredGroupData(sched, rptStep, st, ih);
 
     // IGRP (PROD)
     {
@@ -1075,14 +1046,13 @@ END
     const auto& sched = cse.sched;
     const auto& grid  = cse.grid;
 
-    const auto& units = es.getUnits();
-    const auto  st    = sim_state_3();
+    const auto st = sim_state_3();
 
     const auto ih = Opm::RestartIO::Helpers::createInteHead(es, grid, sched, secs_elapsed,
                                                             rptStep, rptStep + 1, rptStep);
 
     auto agrpd = Opm::RestartIO::Helpers::AggregateGroupData(ih);
-    agrpd.captureDeclaredGroupData(sched, units, rptStep, st, ih);
+    agrpd.captureDeclaredGroupData(sched, rptStep, st, ih);
 
     const auto& sgrp = agrpd.getSGroup();
     const auto& zgrp = agrpd.getZGroup();

--- a/tests/test_AggregateMSWData.cpp
+++ b/tests/test_AggregateMSWData.cpp
@@ -410,7 +410,6 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
     const auto& es    = simCase.es;
     const auto& grid  = simCase.grid;
     const auto& sched = simCase.sched;
-    const auto& units = es.getUnits();
     const auto  smry  = sim_state(es.runspec().udqParams().undefinedValue());
 
     // Report Step 1: 2008-10-10 --> 2011-01-20
@@ -424,8 +423,7 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
     const Opm::data::Wells wrc = wr();
 
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
-    amswd.captureDeclaredMSWData(sched, rptStep, units,
-                                 ih, grid, smry, wrc);
+    amswd.captureDeclaredMSWData(sched, rptStep, ih, grid, smry, wrc);
 
     // ISEG (PROD)
     {
@@ -492,7 +490,7 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
         std::string stringSegNo = std::to_string(segNo);
 
         const auto  i0 = (segNo-1)*ih[VI::intehead::NRSEGZ];
-        const auto gfactor = (units.getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_FIELD)
+        const auto gfactor = (es.getUnits().getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_FIELD)
                              ? 0.1781076 : 0.001;
         const auto& rseg = amswd.getRSeg();
 
@@ -525,7 +523,7 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
 
         const auto  i0 = ih[VI::intehead::NRSEGZ]*ih[VI::intehead::NSEGMX] + (segNo-1)*ih[VI::intehead::NRSEGZ];
         using M = ::Opm::UnitSystem::measure;
-        const auto gfactor = (units.getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_FIELD)
+        const auto gfactor = (es.getUnits().getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_FIELD)
                              ? 0.1781076 : 0.001;
         const auto& rseg = amswd.getRSeg();
 
@@ -536,7 +534,7 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
         BOOST_CHECK_CLOSE(rseg[i0 +  7], 7010.  , 1.0e-10);
 
         const double temp_o = 0.;
-        const double temp_w = -units.from_si(M::liquid_surface_rate,105.)*0.1;
+        const double temp_w = -es.getUnits().from_si(M::liquid_surface_rate,105.)*0.1;
         const double temp_g = 0.0*gfactor;
 
         auto t0 = temp_o + temp_w + temp_g;
@@ -547,7 +545,6 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
         BOOST_CHECK_CLOSE(rseg[i0 +  9],  t1, 1.0e-10);
         BOOST_CHECK_CLOSE(rseg[i0 + 10],  t2, 1.0e-10);
         BOOST_CHECK_CLOSE(rseg[i0 + 11], 234., 1.0e-10);
-
     }
 
     // ILBR
@@ -585,8 +582,6 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
         BOOST_CHECK_EQUAL(iLBr[start + 2] , 14); // WINJ-branch   2, first segment
         BOOST_CHECK_EQUAL(iLBr[start + 3] , 18); // WINJ-branch   2, last segment
         BOOST_CHECK_EQUAL(iLBr[start + 4] ,  1); // WINJ-branch   2, branch no - 1
-
-
     }
 
     // ILBS
@@ -600,7 +595,6 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
         start = ih[VI::intehead::NLBRMX] + 0*ih[VI::intehead::NLBRMX];
         //WINJ
         BOOST_CHECK_EQUAL(iLBs[start + 0] ,  14); // WINJ-branch   2, first segment in branch
-
     }
 }
 
@@ -621,7 +615,6 @@ BOOST_AUTO_TEST_CASE(Multilateral_Branches)
     const auto& es    = cse.es;
     const auto& grid  = cse.grid;
     const auto& sched = cse.sched;
-    const auto& units = es.getUnits();
     const auto  smry  = Opm::SummaryState {
         Opm::TimeService::now(),
         es.runspec().udqParams().undefinedValue()
@@ -638,8 +631,7 @@ BOOST_AUTO_TEST_CASE(Multilateral_Branches)
     const auto xw = Opm::data::Wells {};
 
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
-    amswd.captureDeclaredMSWData(sched, rptStep, units,
-                                 ih, grid, smry, xw);
+    amswd.captureDeclaredMSWData(sched, rptStep, ih, grid, smry, xw);
 
     // ILBS--First segment on each branch other than branch 1.  Ordered by
     // discovery.
@@ -748,7 +740,6 @@ BOOST_AUTO_TEST_CASE(Multilateral_Segments_ISEG_0)
     const auto& es    = cse.es;
     const auto& grid  = cse.grid;
     const auto& sched = cse.sched;
-    const auto& units = es.getUnits();
     const auto  smry  = Opm::SummaryState {
         Opm::TimeService::now(),
         es.runspec().udqParams().undefinedValue()
@@ -765,8 +756,7 @@ BOOST_AUTO_TEST_CASE(Multilateral_Segments_ISEG_0)
     const auto xw = Opm::data::Wells {};
 
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
-    amswd.captureDeclaredMSWData(sched, rptStep, units,
-                                 ih, grid, smry, xw);
+    amswd.captureDeclaredMSWData(sched, rptStep, ih, grid, smry, xw);
 
     auto isegOffset = [&ih](const int ix)
     {
@@ -832,8 +822,7 @@ BOOST_AUTO_TEST_CASE(Multilateral_Branches_ICD_Valve)
     const auto xw   = Opm::data::Wells {};
 
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
-    amswd.captureDeclaredMSWData(sched, rptStep, es.getUnits(),
-                                 ih, grid, smry, xw);
+    amswd.captureDeclaredMSWData(sched, rptStep, ih, grid, smry, xw);
 
     // ILBS--First segment on each branch other than branch 1.  Ordered by
     // discovery.
@@ -1008,8 +997,7 @@ BOOST_AUTO_TEST_CASE(Multilateral_ICD_Valve_ISEG_0)
     const auto xw   = Opm::data::Wells {};
 
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
-    amswd.captureDeclaredMSWData(sched, rptStep, es.getUnits(),
-                                 ih, grid, smry, xw);
+    amswd.captureDeclaredMSWData(sched, rptStep, ih, grid, smry, xw);
 
     auto isegOffset = [&ih](const int ix)
     {
@@ -1047,7 +1035,6 @@ BOOST_AUTO_TEST_CASE(MSW_AICD)
     const auto& es    = simCase.es;
     const auto& grid  = simCase.grid;
     const auto& sched = simCase.sched;
-    const auto& units = es.getUnits();
     const auto  smry  = sim_state(es.runspec().udqParams().undefinedValue());
 
     // Report Step 1: 2008-10-10 --> 2011-01-20
@@ -1061,8 +1048,7 @@ BOOST_AUTO_TEST_CASE(MSW_AICD)
     const Opm::data::Wells wrc = wr();
 
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
-    amswd.captureDeclaredMSWData(sched, rptStep, units,
-                                 ih, grid, smry, wrc);
+    amswd.captureDeclaredMSWData(sched, rptStep, ih, grid, smry, wrc);
 
     // ISEG (PROD)
     {
@@ -1139,7 +1125,6 @@ BOOST_AUTO_TEST_CASE(MSW_RST)
     const auto& es    = simCase.es;
     const auto& grid  = simCase.grid;
     const auto& sched = simCase.sched;
-    const auto& units = es.getUnits();
     const auto  smry  = sim_state(es.runspec().udqParams().undefinedValue());
 
     // Report Step 1: 2008-10-10 --> 2011-01-20
@@ -1153,8 +1138,7 @@ BOOST_AUTO_TEST_CASE(MSW_RST)
     const Opm::data::Wells wrc = wr();
 
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
-    amswd.captureDeclaredMSWData(sched, rptStep, units,
-                                 ih, grid, smry, wrc);
+    amswd.captureDeclaredMSWData(sched, rptStep, ih, grid, smry, wrc);
 
     const auto& iseg = amswd.getISeg();
     const auto& rseg = amswd.getRSeg();

--- a/tests/test_AggregateNetworkData.cpp
+++ b/tests/test_AggregateNetworkData.cpp
@@ -54,7 +54,7 @@
 
 namespace {
 
-    Opm::Deck first_sim(std::string fname) {
+    Opm::Deck first_sim(const std::string& fname) {
         return Opm::Parser{}.parseFile(fname);
     }
 
@@ -95,9 +95,9 @@ namespace {
 struct SimulationCase
 {
     explicit SimulationCase(const Opm::Deck& deck)
-        : es   ( deck )
-        , grid { deck }
-        , sched(deck, es, std::make_shared<Opm::Python>())
+        : es    { deck }
+        , grid  { deck }
+        , sched { deck, es, std::make_shared<Opm::Python>() }
     {}
 
     // Order requirement: 'es' must be declared/initialised before 'sched'.
@@ -116,14 +116,10 @@ BOOST_AUTO_TEST_CASE (Constructor)
     namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
     const auto simCase = SimulationCase{first_sim("TEST_NETWORK_ALL.DATA")};
 
-    Opm::EclipseState es = simCase.es;
-    Opm::Runspec rspec   = es.runspec();
-    Opm::SummaryState st = sum_state();
-    Opm::Schedule     sched = simCase.sched;
-    Opm::EclipseGrid  grid = simCase.grid;
-    //const auto& ioConfig = es.getIOConfig();
-    const auto& units    = es.getUnits();
-
+    const auto& es    = simCase.es;
+    const auto& sched = simCase.sched;
+    const auto& grid  = simCase.grid;
+    const auto  st    = sum_state();
 
     // Report Step 1: 2008-10-10 --> 2011-01-20
     const auto rptStep = std::size_t{1};
@@ -134,7 +130,7 @@ BOOST_AUTO_TEST_CASE (Constructor)
                        rptStep, rptStep+1, rptStep);
 
     auto networkData = Opm::RestartIO::Helpers::AggregateNetworkData(ih);
-    networkData.captureDeclaredNetworkData(es, sched, units, rptStep, st, ih);
+    networkData.captureDeclaredNetworkData(es, sched, rptStep, st, ih);
 
     BOOST_CHECK_EQUAL(static_cast<int>(networkData.getINode().size()), ih[VI::NINODE] * ih[VI::NODMAX]);
     BOOST_CHECK_EQUAL(static_cast<int>(networkData.getIBran().size()), ih[VI::NIBRAN] * ih[VI::NBRMAX]);

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -332,8 +332,7 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
 
             {
                 auto group_aggregator = Opm::RestartIO::Helpers::AggregateGroupData(ih);
-                group_aggregator.captureDeclaredGroupData(sched, es.getUnits(),
-                                                          rptStep - 1, st, ih);
+                group_aggregator.captureDeclaredGroupData(sched, rptStep - 1, st, ih);
 
                 rstFile.write("IGRP", group_aggregator.getIGroup());
                 rstFile.write("SGRP", group_aggregator.getSGroup());
@@ -358,7 +357,7 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
             {
                 auto conn_aggregator = Opm::RestartIO::Helpers::AggregateConnectionData(ih);
                 auto xw = Opm::data::Wells {};
-                conn_aggregator.captureDeclaredConnData(sched, grid, es.getUnits(), xw, st, rptStep-1);
+                conn_aggregator.captureDeclaredConnData(sched, grid, xw, st, rptStep-1);
 
                 rstFile.write("ICON", conn_aggregator.getIConn());
                 rstFile.write("SCON", conn_aggregator.getSConn());

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -1076,8 +1076,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data)
                 auto conn_aggregator = Opm::RestartIO::Helpers::AggregateConnectionData(IH);
                 auto xw = Opm::data::Wells {};
                 conn_aggregator.captureDeclaredConnData(simCase.sched, simCase.es.getInputGrid(),
-                                                        simCase.es.getUnits(), xw,
-                                                        sim_state(), rptStep);
+                                                        xw, sim_state(), rptStep);
 
                 rstFile.write("ICON", conn_aggregator.getIConn());
                 rstFile.write("SCON", conn_aggregator.getSConn());
@@ -1775,7 +1774,7 @@ BOOST_AUTO_TEST_CASE(WELL_POD)
                                     sim_step, xw, sumState);
 
     auto connectionData = Opm::RestartIO::Helpers::AggregateConnectionData(ih);
-    connectionData.captureDeclaredConnData(simCase.sched, simCase.grid, units,
+    connectionData.captureDeclaredConnData(simCase.sched, simCase.grid,
                                            xw, sumState, sim_step);
 
     const auto& iwel = wellData.getIWell();

--- a/tests/test_AggregateWellDataLGR.cpp
+++ b/tests/test_AggregateWellDataLGR.cpp
@@ -74,33 +74,34 @@ namespace {
     struct MockIH
     {
         explicit MockIH(const int numWells,
-                        const int iwelPerWell = 155,  // E100
-                        const int swelPerWell = 122,  // E100
-                        const int xwelPerWell = 130,  // E100
-                        const int zwelPerWell =   3); // E100
+                        const int iwelPerWell = 155,  // Number of elements per well in IWEL.
+                        const int swelPerWell = 122,  // Number of elements per well in SWEL.
+                        const int xwelPerWell = 131,  // Number of elements per well in XWEL.
+                        const int zwelPerWell =   3); // Number of elements per well in ZWEL.
         void add_icon_data(const int, const int,
                            const int, const int);
         void add_igr_data(const int, const int, const int,
-                           const int, const int, const int);
+                          const int, const int, const int);
+
         std::vector<int> value;
 
         using Sz = std::vector<int>::size_type;
 
-        Sz nwells;
-        Sz niwelz;
-        Sz nswelz;
-        Sz nxwelz;
-        Sz nzwelz;
-        Sz niconz;
-        Sz nsconz;
-        Sz nxconz;
-        Sz ncwmax;
-        Sz nwgmax;
-        Sz ngmaxz;
-        Sz nigrpz;
-        Sz nsgrpz;
-        Sz nxgrpz;
-        Sz nzgrpz;
+        Sz nwells{};
+        Sz niwelz{};
+        Sz nswelz{};
+        Sz nxwelz{};
+        Sz nzwelz{};
+        Sz niconz{};
+        Sz nsconz{};
+        Sz nxconz{};
+        Sz ncwmax{};
+        Sz nwgmax{};
+        Sz ngmaxz{};
+        Sz nigrpz{};
+        Sz nsgrpz{};
+        Sz nxgrpz{};
+        Sz nzgrpz{};
     };
 
     Opm::Deck msw_sim(const std::string& fname)
@@ -139,15 +140,14 @@ namespace {
                               const int entXGR,  const int entZGR,
                               const int wellnumMaxGroup, const int maxGroupField)
     {
-    using Ix = ::Opm::RestartIO::Helpers::VectorItems::intehead;
-    this->nigrpz = this->value[Ix::NIGRPZ] = entIGR;
-    this->nsgrpz = this->value[Ix::NSGRPZ] = entSGR;
-    this->nxgrpz =  this->value[Ix::NXGRPZ] = entXGR;
-    this->nzgrpz =  this->value[Ix::NZGRPZ] = entZGR;
-    this->nwgmax = this->value[Ix::NWGMAX] = wellnumMaxGroup;
-    this->ngmaxz = this->value[Ix::NGMAXZ] = maxGroupField;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::intehead;
 
-
+        this->nigrpz = this->value[Ix::NIGRPZ] = entIGR;
+        this->nsgrpz = this->value[Ix::NSGRPZ] = entSGR;
+        this->nxgrpz = this->value[Ix::NXGRPZ] = entXGR;
+        this->nzgrpz = this->value[Ix::NZGRPZ] = entZGR;
+        this->nwgmax = this->value[Ix::NWGMAX] = wellnumMaxGroup;
+        this->ngmaxz = this->value[Ix::NGMAXZ] = maxGroupField;
     }
 
     struct SimulationCase
@@ -175,468 +175,11 @@ namespace {
 
     Opm::Deck simLGR_full()
     {
-        const auto input = std::string {
-            R"~(
-            RUNSPEC
-            TITLE
-            SPE1 - CASE 1
-            DIMENS
-            10 10 3 /
-            EQLDIMS
-            /
-            TABDIMS
-            /
-            OIL
-            GAS
-            WATER
-            DISGAS
-            FIELD
-            START
-            1 'JAN' 2015 /
-            WELLDIMS
-            2 3 1 2 /
-            UNIFOUT
-            GRID
-            CARFIN
-            'LGR1'  1  1  1  1  1  3  3  3  9 /
-            ENDFIN
-            CARFIN
-            'LGR2'  10  10  10  10  1  3  3  3  9 /
-            ENDFIN
-            INIT
-            DX
-                300*1000 /
-            DY
-                300*1000 /
-            DZ
-                100*20 100*30 100*50 /
-            TOPS
-                100*8325 /
-            PORO
-                300*0.3 /
-            PERMX
-                100*500 100*50 100*200 /
-            PERMY
-                100*500 100*50 100*200 /
-            PERMZ
-                100*500 100*50 100*200 /
-            ECHO
-            SCHEDULE
-            RPTSCHED
-                'PRES' 'SGAS' 'RS' 'WELLS' /
-            RPTRST
-                'BASIC=1' /
-            DRSDT
-            0 /
-            WELSPECL
-                    'PROD'	'G1'  'LGR2'	2	2	8400	'OIL' /
-                'INJ'	'G1'  'LGR1'    2	2	8335	'GAS' /
-            /
-            COMPDATL
-                'PROD'	'LGR2'  2	2	7	9	'OPEN'	1*	1*	0.5 /
-                'INJ'	'LGR1'  2	2	1	3	'OPEN'	1*	1*	0.5 /
-            /
-            WCONPROD
-                'PROD' 'OPEN' 'ORAT' 20000 4* 1000 /
-            /
-            WCONINJE
-                'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 9014 /
-            /
-            TSTEP
-            31 28 31 30 31 30 31 31 30 31 30 31
-            /
-            END
-            )~" };
-        return Opm::Parser{}.parseString(input);
-    }
-
-
-    Opm::Deck simLGR_full_crossing()
-    {
-        const auto input = std::string {
-            R"~(
-            RUNSPEC
-            TITLE
-            SPE1 - CASE 1
-            DIMENS
-            10 10 3 /
-            EQLDIMS
-            /
-            TABDIMS
-            /
-            OIL
-            GAS
-            WATER
-            DISGAS
-            FIELD
-            START
-            1 'JAN' 2015 /
-            WELLDIMS
-            2 3 1 2 /
-            UNIFOUT
-            GRID
-            CARFIN
-            'LGR1'  1  1  1  1  1  3  3  3  9 /
-            ENDFIN
-            CARFIN
-            'LGR2'  10  10  10  10  1  3  3  3  9 /
-            ENDFIN
-            INIT
-            DX
-                300*1000 /
-            DY
-                300*1000 /
-            DZ
-                100*20 100*30 100*50 /
-            TOPS
-                100*8325 /
-            PORO
-                300*0.3 /
-            PERMX
-                100*500 100*50 100*200 /
-            PERMY
-                100*500 100*50 100*200 /
-            PERMZ
-                100*500 100*50 100*200 /
-            ECHO
-            SCHEDULE
-            RPTSCHED
-                'PRES' 'SGAS' 'RS' 'WELLS' /
-            RPTRST
-                'BASIC=1' /
-            DRSDT
-            0 /
-            WELSPECL
-                'PROD'	'G1'  'LGR2'	2	2	8400	'OIL' /
-                'INJ'	'G1'  'LGR1'    2	2	8335	'GAS' /
-            /
-            COMPDATL
-                'PROD'	'LGR2'  2	2	1	9	'OPEN'	1*	1*	0.5 /
-                'INJ'	'LGR1'  2	2	1	3	'OPEN'	1*	1*	0.5 /
-            /
-            WCONPROD
-                'PROD' 'OPEN' 'ORAT' 20000 4* 1000 /
-            /
-            WCONINJE
-                'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 9014 /
-            /
-            TSTEP
-            31 28 31 30 31 30 31 31 30 31 30 31
-            /
-            END
-            )~" };
-        return Opm::Parser{}.parseString(input);
-    }
-
-
-    Opm::Deck simLGR_CARFIN_GR()
-    {
-        const auto input = std::string {
-        R"~(
-        RUNSPEC
-        TITLE
-        SPE1 - CASE 1
-        DIMENS
-        10 10 3 /
-        EQLDIMS
-        /
-        TABDIMS
-        /
-        OIL
-        GAS
-        WATER
-        DISGAS
-        FIELD
-        START
-        1 'JAN' 2015 /
-        WELLDIMS
-        2 3 1 2 /
-        UNIFOUT
-        GRID
-        CARFIN
-        'LGR1'   1  10  1  10  1  3   30  30  9 /
-        ENDFIN
-        INIT
-        DX
-            300*1000 /
-        DY
-            300*1000 /
-        DZ
-            100*20 100*30 100*50 /
-        TOPS
-            100*8325 /
-        PORO
-            300*0.3 /
-        PERMX
-            100*500 100*50 100*200 /
-        PERMY
-            100*500 100*50 100*200 /
-        PERMZ
-            100*500 100*50 100*200 /
-        ECHO
-        SCHEDULE
-        RPTSCHED
-            'PRES' 'SGAS' 'RS' 'WELLS' /
-        RPTRST
-            'BASIC=1' /
-        DRSDT
-        0 /
-        WELSPECL
-            'PROD'	'G1'  'LGR1'   29	29	8400	'OIL' /
-            'INJ'	'G1'  'LGR1'   2	2	8335	'GAS' /
-        /
-        COMPDATL
-            'PROD'	'LGR1' 29	29	7	9	'OPEN'	1*	1*	0.5 /
-            'INJ'	'LGR1' 2	2	1	3	'OPEN'	1*	1*	0.5 /
-        /
-        WCONPROD
-            'PROD' 'OPEN' 'ORAT' 20000 4* 1000 /
-        /
-        WCONINJE
-            'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 9014 /
-        /
-        TSTEP
-        31 28 31 30 31 30 31 31 30 31 30 31
-        /
-        END
-        )~" };
-        return Opm::Parser{}.parseString(input);
-    }
-
-
-    Opm::Deck simLGR_1global2lgrwellmixed()
-    {
-        // ONE LGR Cells with wells with 1 Global Well and 2 LGR Wells in the same cell
-        // 1 Global Well and 1 LGR well in G1 - 1 LGR well in G2
-        const auto input = std::string {
-            R"~(
-    RUNSPEC
-    TITLE
-    SPE1 - CASE 1
-    DIMENS
-    3 1 1 /
-    EQLDIMS
-    /
-    TABDIMS
-    /
-    OIL
-    GAS
-    WATER
-    DISGAS
-    FIELD
-    START
-    1 'JAN' 2015 /
-    WELLDIMS
-    3 2 2 3 /
-    UNIFOUT
-    GRID
-    CARFIN
-    'LGR1'  1  1  1  1  1  1  3  3  1 2/
-    ENDFIN
-    CARFIN
-    'LGR2'  3  3  1  1  1  1  3  3  1 2/
-    ENDFIN
-    INIT
-    DX
-        3*2333 /
-    DY
-        3*3500 /
-    DZ
-        3*50 /
-    TOPS
-        3*8325 /
-    PORO
-        3*0.3 /
-    PERMX
-        3*500 /
-    PERMY
-        3*250 /
-    PERMZ
-        3*200 /
-    ECHO
-    PROPS
-    PVTW
-            4017.55 1.038 3.22E-6 0.318 0.0 /
-    ROCK
-    14.7 3E-6 /
-    SWOF
-    0.12	0    		 	1	0
-    0.18	4.64876033057851E-008	1	0
-    0.24	0.000000186		0.997	0
-    0.3	4.18388429752066E-007	0.98	0
-    0.36	7.43801652892562E-007	0.7	0
-    0.42	1.16219008264463E-006	0.35	0
-    0.48	1.67355371900826E-006	0.2	0
-    0.54	2.27789256198347E-006	0.09	0
-    0.6	2.97520661157025E-006	0.021	0
-    0.66	3.7654958677686E-006	0.01	0
-    0.72	4.64876033057851E-006	0.001	0
-    0.78	0.000005625		0.0001	0
-    0.84	6.69421487603306E-006	0	0
-    0.91	8.05914256198347E-006	0	0
-    1	0.00001			0	0 /
-    SGOF
-    0	0	1	0
-    0.001	0	1	0
-    0.02	0	0.997	0
-    0.05	0.005	0.980	0
-    0.12	0.025	0.700	0
-    0.2	0.075	0.350	0
-    0.25	0.125	0.200	0
-    0.3	0.190	0.090	0
-    0.4	0.410	0.021	0
-    0.45	0.60	0.010	0
-    0.5	0.72	0.001	0
-    0.6	0.87	0.0001	0
-    0.7	0.94	0.000	0
-    0.85	0.98	0.000	0
-    0.88	0.984	0.000	0 /
-    DENSITY
-            53.66 64.49 0.0533 /
-    PVDG
-    14.700	166.666	0.008000
-    264.70	12.0930	0.009600
-    514.70	6.27400	0.011200
-    1014.7	3.19700	0.014000
-    2014.7	1.61400	0.018900
-    2514.7	1.29400	0.020800
-    3014.7	1.08000	0.022800
-    4014.7	0.81100	0.026800
-    5014.7	0.64900	0.030900
-    6014.7	0.58700	0.035900
-    7014.7	0.45500	0.039900
-    8014.7	0.41200	0.044900
-    9014.7	0.38600	0.047000 /
-    PVTO
-    0.0010	14.7	1.0620	1.0400 /
-    0.0905	264.7	1.1500	0.9750 /
-    0.1800	514.7	1.2070	0.9100 /
-    0.3710	1014.7	1.2950	0.8300 /
-    0.6360	2014.7	1.4350	0.6950 /
-    0.7750	2514.7	1.5000	0.6410 /
-    0.9300	3014.7	1.5650	0.5940 /
-    1.2700	4014.7	1.6950	0.5100
-            5014.7	1.6650	0.5500
-            6014.7	1.6250	0.6100
-            7014.7	1.6050	0.6500
-            8014.7	1.5850	0.6900
-            9014.7	1.5790	0.7400 /
-    1.6180	5014.7	1.8270	0.4490
-            6014.7	1.8070	0.4890
-            7014.7	1.770	0.5490
-            8014.7	1.7570	0.5990
-            9014.7	1.7370	0.6310 /
-    /
-    SOLUTION
-    EQUIL
-        8400 2800 8450 0 8300 0 1 0 0 /
-    RSVD
-    8300 1.270
-    8450 1.270 /
-    SUMMARY
-    FOPR
-    WGOR
-    'PROD'
-    /
-    FGOR
-    WBHP
-    'INJ'
-    'PROD'
-    /
-    WGIR
-    'INJ'
-    'PROD'
-    /
-    WGIT
-    'INJ'
-    'PROD'
-    /
-    WGPR
-    'INJ'
-    'PROD'
-    /
-    WGPT
-    'INJ'
-    'PROD'
-    /
-    WOIR
-    'INJ'
-    'PROD'
-    /
-    WOIT
-    'INJ'
-    'PROD'
-    /
-    WOPR
-    'INJ'
-    'PROD'
-    /
-    WOPT
-    'INJ'
-    'PROD'
-    /
-    WWIR
-    'INJ'
-    'PROD'
-    /
-    WWIT
-    'INJ'
-    'PROD'
-    /
-    WWPR
-    'INJ'
-    'PROD'
-    /
-    WWPT
-    'INJ'
-    'PROD'
-    /
-    SCHEDULE
-    RPTSCHED
-        'PRES' 'SGAS' 'RS' 'WELLS' /
-    RPTRST
-        'BASIC=1' /
-    DRSDT
-    0 /
-    WELSPECL
-        'PROD1'	'G1' 'LGR1'	3	3	8400	'OIL' /
-        'PROD2'	'G2' 'LGR2'	1	1	8400	'OIL' /
-    /
-    WELSPECS
-        'INJ'	'G1' 	2	1	8335	'GAS' /
-    /
-    COMPDATL
-        'PROD1' 'LGR1'	3	3	1	1	'OPEN'	1*	1*	0.5 /
-        'PROD2' 'LGR2'	1	1	1	1	'OPEN'	1*	1*	0.5 /
-    /
-    COMPDAT
-        'INJ'    2	1	1	1	'OPEN'	1*	1*	0.5 /
-    /
-    WCONPROD
-        'PROD1' 'OPEN' 'ORAT' 20000 4* 1000 /
-        'PROD2' 'OPEN' 'ORAT' 20000 4* 2000 /
-    /
-    WCONINJE
-        'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 5014 /
-    /
-    TSTEP
-    0.1 1 31
-    /
-    END
-            )~" };
-        return Opm::Parser{}.parseString(input);
-    }
-
-    Opm::Deck simLGR_1global2lgrwell()
-    {
-        // ONE LGR Cells with wells with 1 Global Well and 2 LGR Wells in the same cell
-        const auto input = std::string {
-            R"~(
-RUNSPEC
+        const auto input = std::string { R"~(RUNSPEC
 TITLE
-   SPE1 - CASE 1
+SPE1 - CASE 1
 DIMENS
-   3 1 1 /
+10 10 3 /
 EQLDIMS
 /
 TABDIMS
@@ -647,39 +190,269 @@ WATER
 DISGAS
 FIELD
 START
-   1 'JAN' 2015 /
+1 'JAN' 2015 /
 WELLDIMS
-  3 2 2 3 /
+2 3 1 2 /
 UNIFOUT
 GRID
+CARFIN
+'LGR1'  1  1  1  1  1  3  3  3  9 /
+ENDFIN
+CARFIN
+'LGR2'  10  10  10  10  1  3  3  3  9 /
+ENDFIN
+INIT
+DX
+    300*1000 /
+DY
+    300*1000 /
+DZ
+    100*20 100*30 100*50 /
+TOPS
+    100*8325 /
+PORO
+    300*0.3 /
+PERMX
+    100*500 100*50 100*200 /
+PERMY
+    100*500 100*50 100*200 /
+PERMZ
+    100*500 100*50 100*200 /
+ECHO
+SCHEDULE
+RPTSCHED
+    'PRES' 'SGAS' 'RS' 'WELLS' /
+RPTRST
+    'BASIC=1' /
+DRSDT
+0 /
+WELSPECL
+        'PROD'	'G1'  'LGR2'	2	2	8400	'OIL' /
+    'INJ'	'G1'  'LGR1'    2	2	8335	'GAS' /
+/
+COMPDATL
+    'PROD'	'LGR2'  2	2	7	9	'OPEN'	1*	1*	0.5 /
+    'INJ'	'LGR1'  2	2	1	3	'OPEN'	1*	1*	0.5 /
+/
+WCONPROD
+    'PROD' 'OPEN' 'ORAT' 20000 4* 1000 /
+/
+WCONINJE
+    'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 9014 /
+/
+TSTEP
+31 28 31 30 31 30 31 31 30 31 30 31
+/
+END
+)~" };
+
+        return Opm::Parser{}.parseString(input);
+    }
+
+    Opm::Deck simLGR_full_crossing()
+    {
+        const auto input = std::string { R"~(RUNSPEC
+TITLE
+SPE1 - CASE 1
+DIMENS
+10 10 3 /
+EQLDIMS
+/
+TABDIMS
+/
+OIL
+GAS
+WATER
+DISGAS
+FIELD
+START
+1 'JAN' 2015 /
+WELLDIMS
+2 3 1 2 /
+UNIFOUT
+GRID
+CARFIN
+'LGR1'  1  1  1  1  1  3  3  3  9 /
+ENDFIN
+CARFIN
+'LGR2'  10  10  10  10  1  3  3  3  9 /
+ENDFIN
+INIT
+DX
+    300*1000 /
+DY
+    300*1000 /
+DZ
+    100*20 100*30 100*50 /
+TOPS
+    100*8325 /
+PORO
+    300*0.3 /
+PERMX
+    100*500 100*50 100*200 /
+PERMY
+    100*500 100*50 100*200 /
+PERMZ
+    100*500 100*50 100*200 /
+ECHO
+SCHEDULE
+RPTSCHED
+    'PRES' 'SGAS' 'RS' 'WELLS' /
+RPTRST
+    'BASIC=1' /
+DRSDT
+0 /
+WELSPECL
+    'PROD'	'G1'  'LGR2'	2	2	8400	'OIL' /
+    'INJ'	'G1'  'LGR1'    2	2	8335	'GAS' /
+/
+COMPDATL
+    'PROD'	'LGR2'  2	2	1	9	'OPEN'	1*	1*	0.5 /
+    'INJ'	'LGR1'  2	2	1	3	'OPEN'	1*	1*	0.5 /
+/
+WCONPROD
+    'PROD' 'OPEN' 'ORAT' 20000 4* 1000 /
+/
+WCONINJE
+    'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 9014 /
+/
+TSTEP
+31 28 31 30 31 30 31 31 30 31 30 31
+/
+END
+)~" };
+
+        return Opm::Parser{}.parseString(input);
+    }
+
+    Opm::Deck simLGR_CARFIN_GR()
+    {
+        const auto input = std::string { R"~(RUNSPEC
+TITLE
+SPE1 - CASE 1
+DIMENS
+10 10 3 /
+EQLDIMS
+/
+TABDIMS
+/
+OIL
+GAS
+WATER
+DISGAS
+FIELD
+START
+1 'JAN' 2015 /
+WELLDIMS
+2 3 1 2 /
+UNIFOUT
+GRID
+CARFIN
+'LGR1'   1  10  1  10  1  3   30  30  9 /
+ENDFIN
+INIT
+DX
+    300*1000 /
+DY
+    300*1000 /
+DZ
+    100*20 100*30 100*50 /
+TOPS
+    100*8325 /
+PORO
+    300*0.3 /
+PERMX
+    100*500 100*50 100*200 /
+PERMY
+    100*500 100*50 100*200 /
+PERMZ
+    100*500 100*50 100*200 /
+ECHO
+SCHEDULE
+RPTSCHED
+    'PRES' 'SGAS' 'RS' 'WELLS' /
+RPTRST
+    'BASIC=1' /
+DRSDT
+0 /
+WELSPECL
+    'PROD'	'G1'  'LGR1'   29	29	8400	'OIL' /
+    'INJ'	'G1'  'LGR1'   2	2	8335	'GAS' /
+/
+COMPDATL
+    'PROD'	'LGR1' 29	29	7	9	'OPEN'	1*	1*	0.5 /
+    'INJ'	'LGR1' 2	2	1	3	'OPEN'	1*	1*	0.5 /
+/
+WCONPROD
+    'PROD' 'OPEN' 'ORAT' 20000 4* 1000 /
+/
+WCONINJE
+    'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 9014 /
+/
+TSTEP
+31 28 31 30 31 30 31 31 30 31 30 31
+/
+END
+)~" };
+
+        return Opm::Parser{}.parseString(input);
+    }
+
+    Opm::Deck simLGR_1global2lgrwellmixed()
+    {
+        // ONE LGR Cells with wells with 1 Global Well and 2 LGR Wells in the same cell
+        // 1 Global Well and 1 LGR well in G1 - 1 LGR well in G2
+        const auto input = std::string { R"~(RUNSPEC
+TITLE
+SPE1 - CASE 1
+DIMENS
+3 1 1 /
+EQLDIMS
+/
+TABDIMS
+/
+OIL
+GAS
+WATER
+DISGAS
+FIELD
+START
+1 'JAN' 2015 /
+WELLDIMS
+3 2 2 3 /
+UNIFOUT
+GRID
+CARFIN
+'LGR1'  1  1  1  1  1  1  3  3  1 2/
+ENDFIN
 CARFIN
 'LGR2'  3  3  1  1  1  1  3  3  1 2/
 ENDFIN
 INIT
 DX
-   	3*2333 /
+    3*2333 /
 DY
-	3*3500 /
+    3*3500 /
 DZ
-	3*50 /
+    3*50 /
 TOPS
-	3*8325 /
+    3*8325 /
 PORO
-   	3*0.3 /
+    3*0.3 /
 PERMX
-	3*500 /
+    3*500 /
 PERMY
-	3*250 /
+    3*250 /
 PERMZ
-	3*200 /
+    3*200 /
 ECHO
 PROPS
 PVTW
-    	4017.55 1.038 3.22E-6 0.318 0.0 /
+        4017.55 1.038 3.22E-6 0.318 0.0 /
 ROCK
 14.7 3E-6 /
 SWOF
-0.12	0    		 	1	0
+0.12	0                       1	0
 0.18	4.64876033057851E-008	1	0
 0.24	0.000000186		0.997	0
 0.3	4.18388429752066E-007	0.98	0
@@ -711,7 +484,225 @@ SGOF
 0.85	0.98	0.000	0
 0.88	0.984	0.000	0 /
 DENSITY
-      	53.66 64.49 0.0533 /
+        53.66 64.49 0.0533 /
+PVDG
+14.700	166.666	0.008000
+264.70	12.0930	0.009600
+514.70	6.27400	0.011200
+1014.7	3.19700	0.014000
+2014.7	1.61400	0.018900
+2514.7	1.29400	0.020800
+3014.7	1.08000	0.022800
+4014.7	0.81100	0.026800
+5014.7	0.64900	0.030900
+6014.7	0.58700	0.035900
+7014.7	0.45500	0.039900
+8014.7	0.41200	0.044900
+9014.7	0.38600	0.047000 /
+PVTO
+0.0010	14.7	1.0620	1.0400 /
+0.0905	264.7	1.1500	0.9750 /
+0.1800	514.7	1.2070	0.9100 /
+0.3710	1014.7	1.2950	0.8300 /
+0.6360	2014.7	1.4350	0.6950 /
+0.7750	2514.7	1.5000	0.6410 /
+0.9300	3014.7	1.5650	0.5940 /
+1.2700	4014.7	1.6950	0.5100
+        5014.7	1.6650	0.5500
+        6014.7	1.6250	0.6100
+        7014.7	1.6050	0.6500
+        8014.7	1.5850	0.6900
+        9014.7	1.5790	0.7400 /
+1.6180	5014.7	1.8270	0.4490
+        6014.7	1.8070	0.4890
+        7014.7	1.770	0.5490
+        8014.7	1.7570	0.5990
+        9014.7	1.7370	0.6310 /
+/
+SOLUTION
+EQUIL
+    8400 2800 8450 0 8300 0 1 0 0 /
+RSVD
+8300 1.270
+8450 1.270 /
+SUMMARY
+FOPR
+WGOR
+'PROD'
+/
+FGOR
+WBHP
+'INJ'
+'PROD'
+/
+WGIR
+'INJ'
+'PROD'
+/
+WGIT
+'INJ'
+'PROD'
+/
+WGPR
+'INJ'
+'PROD'
+/
+WGPT
+'INJ'
+'PROD'
+/
+WOIR
+'INJ'
+'PROD'
+/
+WOIT
+'INJ'
+'PROD'
+/
+WOPR
+'INJ'
+'PROD'
+/
+WOPT
+'INJ'
+'PROD'
+/
+WWIR
+'INJ'
+'PROD'
+/
+WWIT
+'INJ'
+'PROD'
+/
+WWPR
+'INJ'
+'PROD'
+/
+WWPT
+'INJ'
+'PROD'
+/
+SCHEDULE
+RPTSCHED
+    'PRES' 'SGAS' 'RS' 'WELLS' /
+RPTRST
+    'BASIC=1' /
+DRSDT
+0 /
+WELSPECL
+    'PROD1'	'G1' 'LGR1'	3	3	8400	'OIL' /
+    'PROD2'	'G2' 'LGR2'	1	1	8400	'OIL' /
+/
+WELSPECS
+    'INJ'	'G1'    2	1	8335	'GAS' /
+/
+COMPDATL
+    'PROD1' 'LGR1'	3	3	1	1	'OPEN'	1*	1*	0.5 /
+    'PROD2' 'LGR2'	1	1	1	1	'OPEN'	1*	1*	0.5 /
+/
+COMPDAT
+    'INJ'    2	1	1	1	'OPEN'	1*	1*	0.5 /
+/
+WCONPROD
+    'PROD1' 'OPEN' 'ORAT' 20000 4* 1000 /
+    'PROD2' 'OPEN' 'ORAT' 20000 4* 2000 /
+/
+WCONINJE
+    'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 5014 /
+/
+TSTEP
+0.1 1 31
+/
+END
+)~" };
+
+        return Opm::Parser{}.parseString(input);
+    }
+
+    Opm::Deck simLGR_1global2lgrwell()
+    {
+        // ONE LGR Cells with wells with 1 Global Well and 2 LGR Wells in the same cell
+        const auto input = std::string { R"~(RUNSPEC
+TITLE
+   SPE1 - CASE 1
+DIMENS
+   3 1 1 /
+EQLDIMS
+/
+TABDIMS
+/
+OIL
+GAS
+WATER
+DISGAS
+FIELD
+START
+   1 'JAN' 2015 /
+WELLDIMS
+  3 2 2 3 /
+UNIFOUT
+GRID
+CARFIN
+'LGR2'  3  3  1  1  1  1  3  3  1 2/
+ENDFIN
+INIT
+DX
+        3*2333 /
+DY
+        3*3500 /
+DZ
+        3*50 /
+TOPS
+        3*8325 /
+PORO
+        3*0.3 /
+PERMX
+        3*500 /
+PERMY
+        3*250 /
+PERMZ
+        3*200 /
+ECHO
+PROPS
+PVTW
+        4017.55 1.038 3.22E-6 0.318 0.0 /
+ROCK
+14.7 3E-6 /
+SWOF
+0.12	0                       1	0
+0.18	4.64876033057851E-008	1	0
+0.24	0.000000186		0.997	0
+0.3	4.18388429752066E-007	0.98	0
+0.36	7.43801652892562E-007	0.7	0
+0.42	1.16219008264463E-006	0.35	0
+0.48	1.67355371900826E-006	0.2	0
+0.54	2.27789256198347E-006	0.09	0
+0.6	2.97520661157025E-006	0.021	0
+0.66	3.7654958677686E-006	0.01	0
+0.72	4.64876033057851E-006	0.001	0
+0.78	0.000005625		0.0001	0
+0.84	6.69421487603306E-006	0	0
+0.91	8.05914256198347E-006	0	0
+1	0.00001			0	0 /
+SGOF
+0	0	1	0
+0.001	0	1	0
+0.02	0	0.997	0
+0.05	0.005	0.980	0
+0.12	0.025	0.700	0
+0.2	0.075	0.350	0
+0.25	0.125	0.200	0
+0.3	0.190	0.090	0
+0.4	0.410	0.021	0
+0.45	0.60	0.010	0
+0.5	0.72	0.001	0
+0.6	0.87	0.0001	0
+0.7	0.94	0.000	0
+0.85	0.98	0.000	0
+0.88	0.984	0.000	0 /
+DENSITY
+        53.66 64.49 0.0533 /
 PVDG
 14.700	166.666	0.008000
 264.70	12.0930	0.009600
@@ -736,19 +727,19 @@ PVTO
 0.9300	3014.7	1.5650	0.5940 /
 1.2700	4014.7	1.6950	0.5100
          5014.7	1.6650	0.5500
-		 6014.7	1.6250	0.6100
-		 7014.7	1.6050	0.6500
-		 8014.7	1.5850	0.6900
-	    9014.7	1.5790	0.7400 /
+                 6014.7	1.6250	0.6100
+                 7014.7	1.6050	0.6500
+                 8014.7	1.5850	0.6900
+            9014.7	1.5790	0.7400 /
 1.6180	5014.7	1.8270	0.4490
         6014.7	1.8070	0.4890
-		7014.7	1.770	0.5490
-		8014.7	1.7570	0.5990
-	    9014.7	1.7370	0.6310 /
+                7014.7	1.770	0.5490
+                8014.7	1.7570	0.5990
+            9014.7	1.7370	0.6310 /
 /
 SOLUTION
 EQUIL
-	8400 2800 8450 0 8300 0 1 0 0 /
+        8400 2800 8450 0 8300 0 1 0 0 /
 RSVD
 8300 1.270
 8450 1.270 /
@@ -812,31 +803,31 @@ WWPT
 /
 SCHEDULE
 RPTSCHED
-	'PRES' 'SGAS' 'RS' 'WELLS' /
+        'PRES' 'SGAS' 'RS' 'WELLS' /
 RPTRST
-	'BASIC=1' /
+        'BASIC=1' /
 DRSDT
  0 /
 WELSPECL
-	'PROD1'	'G1' 'LGR2'	3	3	8400	'OIL' /
-	'PROD2'	'G1' 'LGR2'	1	1	8400	'OIL' /
+        'PROD1'	'G1' 'LGR2'	3	3	8400	'OIL' /
+        'PROD2'	'G1' 'LGR2'	1	1	8400	'OIL' /
 /
 WELSPECS
-	'INJ'	'G1' 	1	1	8335	'GAS' /
+        'INJ'	'G1'    1	1	8335	'GAS' /
 /
 COMPDATL
-	'PROD1' 'LGR2'	3	3	1	1	'OPEN'	1*	1*	0.5 /
-	'PROD2' 'LGR2'	1	1	1	1	'OPEN'	1*	1*	0.5 /
+        'PROD1' 'LGR2'	3	3	1	1	'OPEN'	1*	1*	0.5 /
+        'PROD2' 'LGR2'	1	1	1	1	'OPEN'	1*	1*	0.5 /
 /
 COMPDAT
-	'INJ'    1	1	1	1	'OPEN'	1*	1*	0.5 /
+        'INJ'    1	1	1	1	'OPEN'	1*	1*	0.5 /
 /
 WCONPROD
-	'PROD1' 'OPEN' 'ORAT' 20000 4* 1000 /
-	'PROD2' 'OPEN' 'ORAT' 20000 4* 2000 /
+        'PROD1' 'OPEN' 'ORAT' 20000 4* 1000 /
+        'PROD2' 'OPEN' 'ORAT' 20000 4* 2000 /
 /
 WCONINJE
-	'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 5014 /
+        'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 5014 /
 /
 TSTEP
 0.1 1 31
@@ -847,13 +838,10 @@ END
         return Opm::Parser{}.parseString(input);
     }
 
-
     Opm::Deck simLGR_2lgrwell()
     {
         // TWO LGR Cells with wells in each LGR.
-        const auto input = std::string {
-            R"~(
-RUNSPEC
+        const auto input = std::string { R"~(RUNSPEC
 TITLE
    SPE1 - CASE 1
 DIMENS
@@ -881,29 +869,29 @@ CARFIN
 ENDFIN
 INIT
 DX
-   	3*2333 /
+        3*2333 /
 DY
-	3*3500 /
+        3*3500 /
 DZ
-	3*50 /
+        3*50 /
 TOPS
-	3*8325 /
+        3*8325 /
 PORO
-   	3*0.3 /
+        3*0.3 /
 PERMX
-	3*500 /
+        3*500 /
 PERMY
-	3*250 /
+        3*250 /
 PERMZ
-	3*200 /
+        3*200 /
 ECHO
 PROPS
 PVTW
-    	4017.55 1.038 3.22E-6 0.318 0.0 /
+        4017.55 1.038 3.22E-6 0.318 0.0 /
 ROCK
 14.7 3E-6 /
 SWOF
-0.12	0    		 	1	0
+0.12	0                       1	0
 0.18	4.64876033057851E-008	1	0
 0.24	0.000000186		0.997	0
 0.3	4.18388429752066E-007	0.98	0
@@ -935,7 +923,7 @@ SGOF
 0.85	0.98	0.000	0
 0.88	0.984	0.000	0 /
 DENSITY
-      	53.66 64.49 0.0533 /
+        53.66 64.49 0.0533 /
 PVDG
 14.700	166.666	0.008000
 264.70	12.0930	0.009600
@@ -960,19 +948,19 @@ PVTO
 0.9300	3014.7	1.5650	0.5940 /
 1.2700	4014.7	1.6950	0.5100
          5014.7	1.6650	0.5500
-		 6014.7	1.6250	0.6100
-		 7014.7	1.6050	0.6500
-		 8014.7	1.5850	0.6900
-	    9014.7	1.5790	0.7400 /
+                 6014.7	1.6250	0.6100
+                 7014.7	1.6050	0.6500
+                 8014.7	1.5850	0.6900
+            9014.7	1.5790	0.7400 /
 1.6180	5014.7	1.8270	0.4490
         6014.7	1.8070	0.4890
-		7014.7	1.770	0.5490
-		8014.7	1.7570	0.5990
-	    9014.7	1.7370	0.6310 /
+                7014.7	1.770	0.5490
+                8014.7	1.7570	0.5990
+            9014.7	1.7370	0.6310 /
 /
 SOLUTION
 EQUIL
-	8400 2800 8450 0 8300 0 1 0 0 /
+        8400 2800 8450 0 8300 0 1 0 0 /
 RSVD
 8300 1.270
 8450 1.270 /
@@ -1036,27 +1024,27 @@ WWPT
 /
 SCHEDULE
 RPTSCHED
-	'PRES' 'SGAS' 'RS' 'WELLS' /
+        'PRES' 'SGAS' 'RS' 'WELLS' /
 RPTRST
-	'BASIC=1' /
+        'BASIC=1' /
 DRSDT
  0 /
 WELSPECL
-	'PROD'	'G1' 'LGR2'	3	3	8400	'OIL' /
-	'INJ'	'G1' 'LGR1'	1	1	8335	'GAS' /
+        'PROD'	'G1' 'LGR2'	3	3	8400	'OIL' /
+        'INJ'	'G1' 'LGR1'	1	1	8335	'GAS' /
 /
 COMPDATL
-	'PROD' 'LGR2'	3	3	1	1	'OPEN'	1*	1*	0.5 /
-	'INJ'  'LGR1'   1	1	1	1	'OPEN'	1*	1*	0.5 /
+        'PROD' 'LGR2'	3	3	1	1	'OPEN'	1*	1*	0.5 /
+        'INJ'  'LGR1'   1	1	1	1	'OPEN'	1*	1*	0.5 /
 /
 WCONPROD
 -- Item #:1	2      3     4	   5  9
-	'PROD' 'OPEN' 'ORAT' 20000 4* 1000 /
+        'PROD' 'OPEN' 'ORAT' 20000 4* 1000 /
 /
 
 WCONINJE
 -- Item #:1	 2	 3	 4	5      6  7
-	'INJ'	'WATER'	'OPEN'	'RATE'	40000 1* 9014 /
+        'INJ'	'WATER'	'OPEN'	'RATE'	40000 1* 9014 /
 /
 TSTEP
 0.1 1 31
@@ -1442,7 +1430,6 @@ END
 
 } // Anonymous namespace
 
-
 // --------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
@@ -1466,7 +1453,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         static_cast<int>(simCase.sched.getWells(rptStep).size())
     };
 
-    ih.add_icon_data(26, 42 ,58 , 2);
+    ih.add_icon_data(26, 42, 58, 2);
 
     BOOST_CHECK_EQUAL(ih.nwells, MockIH::Sz{2});
 
@@ -1476,12 +1463,12 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
     auto ih_lgr1 = MockIH {
         static_cast<int>(num_lgr1)
     };
-    ih_lgr1.add_icon_data(26, 42 ,58 , 1);
+    ih_lgr1.add_icon_data(26, 42, 58, 1);
 
     auto ih_lgr2 = MockIH {
         static_cast<int>(num_lgr2)
     };
-    ih_lgr2.add_icon_data(26, 42 ,58 , 1);
+    ih_lgr2.add_icon_data(26, 42, 58, 1);
 
 
     BOOST_CHECK_EQUAL(ih.nwells, ih_lgr1.nwells + ih_lgr2.nwells);
@@ -1492,13 +1479,13 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
     auto awd_lgr2 = Opm::RestartIO::Helpers::AggregateWellData{ih_lgr2.value};
 
     awd.captureDeclaredWellData(simCase.sched,
-                            simCase.grid,
-                            simCase.es.tracer(),
-                            rptStep,
-                            action_state,
-                            wtest_state,
-                            smry,
-                            ih.value);
+                                simCase.grid,
+                                simCase.es.tracer(),
+                                rptStep,
+                                action_state,
+                                wtest_state,
+                                smry,
+                                ih.value);
 
 
     awd_lgr1.captureDeclaredWellDataLGR(simCase.sched,
@@ -1521,7 +1508,6 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
                                         ih.value,
                                         "LGR2");
 
-
     // -------------------------- IWEL FOR GLOBAL WELLS --------------------------
     // GLOBAL WELLS
     // IWEL (PROD)
@@ -1539,6 +1525,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         BOOST_CHECK_EQUAL(iwell[start + Ix::LGRIndex] , 2); // LOCATED LGR2
 
     }
+
     // GLOBAL WELLS
     // IWEL (INJ)
     {
@@ -1554,6 +1541,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         BOOST_CHECK_EQUAL(iwell[start + Ix::WType] , 3); // INJ -> Injector
         BOOST_CHECK_EQUAL(iwell[start + Ix::LGRIndex] , 1); // LOCATED LGR1
     }
+
     // -------------------------- IWEL FOR LGR WELLS --------------------------
     // LGR02 WELL
     // IWEL (PROD)
@@ -1570,6 +1558,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         BOOST_CHECK_EQUAL(iwell[start + Ix::WType] , 1); // PROD -> Producer
         BOOST_CHECK_EQUAL(iwell[start + Ix::LGRIndex] , 1); // LGR WELL LGR
     }
+
     // LGR02 WELL
     // LGWEL (PROD)
     {
@@ -1593,6 +1582,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         BOOST_CHECK_EQUAL(iwell[start + Ix::WType] , 3); // PROD -> Producer
         BOOST_CHECK_EQUAL(iwell[start + Ix::LGRIndex] , 2); // LOCATED LGR2
     }
+
     // LGR01 WELL
     // LGWEL (INJ)
     {
@@ -1609,6 +1599,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         const auto& zwell = awd.getZWell();
         BOOST_CHECK_EQUAL(zwell[i0 + Ix::WellName].c_str(), "PROD    ");
     }
+
     // ZWEL (INJ)
     {
         using Ix = ::Opm::RestartIO::Helpers::VectorItems::ZWell::index;
@@ -1616,6 +1607,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         const auto& zwell = awd.getZWell();
         BOOST_CHECK_EQUAL(zwell[i1 + Ix::WellName].c_str(), "INJ     ");
     }
+
     // -------------------------- ZWEL FOR LGR WELLS --------------------------
     // LGR02 WELL
     // ZWEL (PROD)
@@ -1625,6 +1617,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         const auto& zwell = awd_lgr2.getZWell();
         BOOST_CHECK_EQUAL(zwell[i0 + Ix::WellName].c_str(), "PROD    ");
     }
+
     // LGR01 WELL
     // ZWEL (INJ)
     {
@@ -1634,24 +1627,19 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         BOOST_CHECK_EQUAL(zwell[i1 + Ix::WellName].c_str(), "INJ     ");
     }
 
-
     auto conn_aggregator = Opm::RestartIO::Helpers::AggregateConnectionData(ih.value);
     auto xw = Opm::data::Wells {};
     conn_aggregator.captureDeclaredConnData(simCase.sched, simCase.es.getInputGrid(),
-                                            simCase.es.getUnits(), xw,
-                                            sim_stateLGR(), rptStep);
-
+                                            xw, sim_stateLGR(), rptStep);
 
     auto conn_aggregator_lgr1 = Opm::RestartIO::Helpers::AggregateConnectionData(ih_lgr1.value);
     conn_aggregator_lgr1.captureDeclaredConnDataLGR(simCase.sched, simCase.es.getInputGrid(),
-                                                    simCase.es.getUnits(), xw,
-                                                    sim_stateLGR(), rptStep, "LGR1");
+                                                    xw, sim_stateLGR(), rptStep, "LGR1");
 
 
     auto conn_aggregator_lgr2 = Opm::RestartIO::Helpers::AggregateConnectionData(ih_lgr2.value);
     conn_aggregator_lgr2.captureDeclaredConnDataLGR(simCase.sched, simCase.es.getInputGrid(),
-                                                    simCase.es.getUnits(), xw,
-                                                    sim_stateLGR(), rptStep, "LGR2");
+                                                    xw, sim_stateLGR(), rptStep, "LGR2");
 
     // -------------------------- ICON FOR GLOBAL GRID --------------------------
     // ICON (PROD)
@@ -1663,6 +1651,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellJ] , 1); // PROD    -> ICON
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellK] , 1); // PROD    -> ICON
     }
+
     // ICON (PROD)
     {
         using Ix = ::Opm::RestartIO::Helpers::VectorItems::IConn::index;
@@ -1672,6 +1661,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellJ] , 1); // INJ    -> ICON
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellK] , 1); // INJ    -> ICON
     }
+
     // -------------------------- ICON FOR LGLS GRID --------------------------
     // ICON (PROD)
     {
@@ -1682,6 +1672,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellJ] , 3); // PROD    -> ICON
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellK] , 1); // PROD    -> ICON
     }
+
     // ICON (INK)
     {
         using Ix = ::Opm::RestartIO::Helpers::VectorItems::IConn::index;
@@ -1702,39 +1693,42 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
     // const auto& units1    = simCase.es.getUnits();
     // group_aggregator1.captureDeclaredGroupData(simCase.sched, units1, rptStep, smry,
     //     ihw);
+
     // -------------------------- GROUP DATA FOR GLOBAL GRID --------------------------
-    ih.add_igr_data(99,112, 181,
-                    5,2, 2);
+
+    ih.add_igr_data(99, 112, 181, 5, 2, 2);
     auto group_aggregator = Opm::RestartIO::Helpers::AggregateGroupData(ih.value);
-    const auto& units    = simCase.es.getUnits();
-    group_aggregator.captureDeclaredGroupData(simCase.sched, units, rptStep, smry,
-        ih.value);
+    group_aggregator.captureDeclaredGroupData(simCase.sched,
+                                              rptStep, smry, ih.value);
+
     // -------------------------- GROUP DATA FOR LGR GRID LGR1--------------------------
-    ih_lgr1.add_igr_data(99,112, 181,
-                      5,2, 2);
-    ih_lgr2.add_igr_data(99,112, 181,
-                         5,2, 2);
+
+    ih_lgr1.add_igr_data(99, 112, 181, 5, 2, 2);
+    ih_lgr2.add_igr_data(99, 112, 181, 5, 2, 2);
+
     auto group_aggregator_lgr1 = Opm::RestartIO::Helpers::AggregateGroupData(ih_lgr1.value);
     auto group_aggregator_lgr2 = Opm::RestartIO::Helpers::AggregateGroupData(ih_lgr2.value);
-    group_aggregator_lgr1.captureDeclaredGroupDataLGR(simCase.sched, units,
-                                                      rptStep, smry, "LGR1");
-    group_aggregator_lgr2.captureDeclaredGroupDataLGR(simCase.sched, units,
-                                                      rptStep, smry, "LGR2");
+
+    group_aggregator_lgr1.captureDeclaredGroupDataLGR(simCase.sched, rptStep, smry, "LGR1");
+    group_aggregator_lgr2.captureDeclaredGroupDataLGR(simCase.sched, rptStep, smry, "LGR2");
 
     // -------------------------- IGR FOR GLOBAL GRID --------------------------
     // IGR (G1 GLOBAL)
     {
         auto start = 0*ih.nigrpz;
         const auto& iGrp = group_aggregator.getIGroup();
+
         BOOST_CHECK_EQUAL(iGrp[start + 0] ,  1); // Group G1 - Child group number one
         BOOST_CHECK_EQUAL(iGrp[start + 1] ,  2); // Group G1 - Child group number two
         BOOST_CHECK_EQUAL(iGrp[start + 2] ,  2); // Group G1 - Num of elements in group
 
         BOOST_CHECK_EQUAL(iGrp[start + ih.nwgmax + 26] ,  0); // Group G1 - Group type (well group = 0, node group = 1)
         BOOST_CHECK_EQUAL(iGrp[start + ih.nwgmax + 27] ,  1); // Group G1 - Group level (FIELD level is 0)
+
         // Group G1 - INDEX 1 - Group FIELD INDEX 2
         BOOST_CHECK_EQUAL(iGrp[start + ih.nwgmax + 28] ,  2); // Group G1 - index of parent group (= 0 for FIELD)
     }
+
     // IGR (FIELD GLOBAL)
     {
         auto start = 1*ih.nigrpz;
@@ -1763,6 +1757,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         // Group G1 - INDEX 1 - Group FIELD INDEX 2
         BOOST_CHECK_EQUAL(iGrp[start + ih.nwgmax + 28] ,  2); // Group G1 - index of parent group (= 0 for FIELD)
     }
+
     // IGR (FIELD LGR1)
     {
         auto start = 1*ih.nigrpz;
@@ -1791,6 +1786,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         // Group G1 - INDEX 1 - Group FIELD INDEX 2
         BOOST_CHECK_EQUAL(iGrp[start + ih.nwgmax + 28] ,  2); // Group G1 - index of parent group (= 0 for FIELD)
     }
+
     // IGR (FIELD LGR2)
     {
         auto start = 1*ih.nigrpz;
@@ -1804,7 +1800,6 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
         // Group G1 - INDEX 1 - Group FIELD INDEX 2
         BOOST_CHECK_EQUAL(iGrp[start + ih.nwgmax + 28] ,  0); // Group G1 - index of parent group (= 0 for FIELD)
     }
-
 }
 
 BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
@@ -1828,31 +1823,27 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         static_cast<int>(simCase.sched.getWells(rptStep).size())
     };
 
-    ih.add_icon_data(26, 42 ,58 , 3);
+    ih.add_icon_data(26, 42, 58, 3);
     BOOST_CHECK_EQUAL(ih.nwells, MockIH::Sz{3});
-
-
 
     int num_lgr2 = countWells("LGR2");
     auto ih_lgr2 = MockIH {
         static_cast<int>(num_lgr2)
     };
-    ih_lgr2.add_icon_data(26, 42 ,58 , 1);
-
+    ih_lgr2.add_icon_data(26, 42, 58, 1);
 
     const auto smry = sim_stateLGR();
     auto awd = Opm::RestartIO::Helpers::AggregateWellData{ih.value};
     auto awd_lgr2 = Opm::RestartIO::Helpers::AggregateWellData{ih_lgr2.value};
 
     awd.captureDeclaredWellData(simCase.sched,
-                            simCase.grid,
-                            simCase.es.tracer(),
-                            rptStep,
-                            action_state,
-                            wtest_state,
-                            smry,
-                            ih.value);
-
+                                simCase.grid,
+                                simCase.es.tracer(),
+                                rptStep,
+                                action_state,
+                                wtest_state,
+                                smry,
+                                ih.value);
 
     awd_lgr2.captureDeclaredWellDataLGR(simCase.sched,
                                         simCase.grid,
@@ -1881,6 +1872,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         BOOST_CHECK_EQUAL(iwell[start + Ix::WType] , 1); // PROD -> Producer
         BOOST_CHECK_EQUAL(iwell[start + Ix::LGRIndex] , 1); // LOCATED LGR2 (LGR2 is the only LGR well in this case)
     }
+
     // IWEL (PROD2)
     {
         using Ix = ::Opm::RestartIO::Helpers::VectorItems::IWell::index;
@@ -1895,6 +1887,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         BOOST_CHECK_EQUAL(iwell[start + Ix::WType] , 1); // PROD -> Producer
         BOOST_CHECK_EQUAL(iwell[start + Ix::LGRIndex] , 1); // LOCATED LGR2 (LGR2 is the only LGR well in this case)
     }
+
     // GLOBAL WELLS
     // IWEL (INJ)
     {
@@ -1910,6 +1903,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         BOOST_CHECK_EQUAL(iwell[start + Ix::WType] , 4); // INJ -> Injector
         BOOST_CHECK_EQUAL(iwell[start + Ix::LGRIndex] , 0); // GLOBAL WELL (no LGR well)
     }
+
     // -------------------------- IWEL FOR LGR WELLS --------------------------
     // LGR02 WELL
     // IWEL (PROD1)
@@ -1926,6 +1920,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         BOOST_CHECK_EQUAL(iwell[start + Ix::WType] , 1); // PROD -> Producer
         BOOST_CHECK_EQUAL(iwell[start + Ix::LGRIndex] , 1); // LGR WELL LGR
     }
+
     // LGR02 WELL
     // IWEL (PROD2)
     {
@@ -1960,6 +1955,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         const auto& zwell = awd.getZWell();
         BOOST_CHECK_EQUAL(zwell[i0 + Ix::WellName].c_str(), "PROD1   ");
     }
+
     // ZWEL (PROD2)
     {
         using Ix = ::Opm::RestartIO::Helpers::VectorItems::ZWell::index;
@@ -1967,6 +1963,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         const auto& zwell = awd.getZWell();
         BOOST_CHECK_EQUAL(zwell[i0 + Ix::WellName].c_str(), "PROD2   ");
     }
+
     // ZWEL (INJ)
     {
         using Ix = ::Opm::RestartIO::Helpers::VectorItems::ZWell::index;
@@ -1974,6 +1971,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         const auto& zwell = awd.getZWell();
         BOOST_CHECK_EQUAL(zwell[i1 + Ix::WellName].c_str(), "INJ     ");
     }
+
     // -------------------------- ZWEL FOR LGR WELLS --------------------------
     // LGR02 WELL
     // ZWEL (PROD)
@@ -1983,6 +1981,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         const auto& zwell = awd_lgr2.getZWell();
         BOOST_CHECK_EQUAL(zwell[i0 + Ix::WellName].c_str(), "PROD1   ");
     }
+
     {
         using Ix = ::Opm::RestartIO::Helpers::VectorItems::ZWell::index;
         const auto i0 = 1*ih_lgr2.nzwelz;
@@ -1993,13 +1992,11 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
     auto conn_aggregator = Opm::RestartIO::Helpers::AggregateConnectionData(ih.value);
     auto xw = Opm::data::Wells {};
     conn_aggregator.captureDeclaredConnData(simCase.sched, simCase.es.getInputGrid(),
-                                            simCase.es.getUnits(), xw,
-                                            sim_stateLGR(), rptStep);
+                                            xw, sim_stateLGR(), rptStep);
 
     auto conn_aggregator_lgr2 = Opm::RestartIO::Helpers::AggregateConnectionData(ih_lgr2.value);
     conn_aggregator_lgr2.captureDeclaredConnDataLGR(simCase.sched, simCase.es.getInputGrid(),
-                                                    simCase.es.getUnits(), xw,
-                                                    sim_stateLGR(), rptStep, "LGR2");
+                                                    xw, sim_stateLGR(), rptStep, "LGR2");
 
     // -------------------------- ICON FOR GLOBAL GRID --------------------------
     // ICON (PROD1)
@@ -2011,6 +2008,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellJ] , 1); // PROD    -> ICON
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellK] , 1); // PROD    -> ICON
     }
+
     // ICON (PROD2)
     {
         using Ix = ::Opm::RestartIO::Helpers::VectorItems::IConn::index;
@@ -2020,6 +2018,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellJ] , 1); // INJ    -> ICON
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellK] , 1); // INJ    -> ICON
     }
+
     // ICON (INJ)
     {
         using Ix = ::Opm::RestartIO::Helpers::VectorItems::IConn::index;
@@ -2029,6 +2028,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellJ] , 1); // INJ    -> ICON
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellK] , 1); // INJ    -> ICON
     }
+
     // -------------------------- ICON FOR LGRS GRID --------------------------
     // ICON (PROD1)
     {
@@ -2039,6 +2039,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellJ] , 3); // PROD    -> ICON
         BOOST_CHECK_EQUAL(icon[i0 + Ix::CellK] , 1); // PROD    -> ICON
     }
+
     // ICON (PROD2)
     {
         using Ix = ::Opm::RestartIO::Helpers::VectorItems::IConn::index;
@@ -2050,21 +2051,19 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
     }
 
     // -------------------------- GROUP DATA FOR GLOBAL GRID --------------------------
-    ih.add_igr_data(100,112, 181,
-                    5,3, 3);
+    ih.add_igr_data(100,112, 181, 5, 3, 3);
+
     auto group_aggregator = Opm::RestartIO::Helpers::AggregateGroupData(ih.value);
-    const auto& units    = simCase.es.getUnits();
-    group_aggregator.captureDeclaredGroupData(simCase.sched, units, rptStep, smry,
-        ih.value);
+    group_aggregator.captureDeclaredGroupData(simCase.sched,
+                                              rptStep, smry, ih.value);
+
     // -------------------------- GROUP DATA FOR LGR GRID LGR1--------------------------
     auto gp = simCase.sched.restart_groups(rptStep);
 
-    ih_lgr2.add_igr_data(100,112, 181,
-                         5,3, 2);
-    auto group_aggregator_lgr2 = Opm::RestartIO::Helpers::AggregateGroupData(ih_lgr2.value);
-    group_aggregator_lgr2.captureDeclaredGroupDataLGR(simCase.sched, units,
-                                                      rptStep, smry, "LGR2");
+    ih_lgr2.add_igr_data(100,112, 181, 5, 3, 2);
 
+    auto group_aggregator_lgr2 = Opm::RestartIO::Helpers::AggregateGroupData(ih_lgr2.value);
+    group_aggregator_lgr2.captureDeclaredGroupDataLGR(simCase.sched, rptStep, smry, "LGR2");
 
     // IGRP allocation is different for LGRs. GLOBAL use the nwgmax of the global grid,
     // while LGRs use the nwgmax of the LGR grid.
@@ -2084,6 +2083,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         // Group G1 - INDEX 1 - Group FIELD INDEX 2
         BOOST_CHECK_EQUAL(iGrp[start + ih.nwgmax + 28] ,  3); // Group G1 - index of parent group (= 0 for FIELD)
     }
+
     // IGR (EMPTY GLOBAL GROUP)
     {
         auto start = 1*ih.nigrpz;
@@ -2131,6 +2131,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         // Group G1 - INDEX 1 - Group FIELD INDEX 2
         BOOST_CHECK_EQUAL(iGrp[start + ih.nwgmax + 28] ,  2); // Group G1 - index of parent group (= 0 for FIELD)
     }
+
     // IGR (FIELD LGR2)
     {
         auto start = 1*ih.nigrpz;
@@ -2146,9 +2147,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
         // Group G1 - INDEX 1 - Group FIELD INDEX 2
         BOOST_CHECK_EQUAL(iGrp[start + ih.nwgmax + 28] ,  0); // Group FIELD - index of parent group (= 0 for FIELD)
     }
-
 }
-
 
 BOOST_AUTO_TEST_CASE (LGR_WellingitSameHostGrid)
 {
@@ -2171,9 +2170,8 @@ BOOST_AUTO_TEST_CASE (LGR_WellingitSameHostGrid)
         static_cast<int>(simCase.sched.getWells(rptStep).size())
     };
 
-    ih.add_icon_data(26, 42 ,58 , 3);
+    ih.add_icon_data(26, 42, 58, 3);
     BOOST_CHECK_EQUAL(ih.nwells, MockIH::Sz{2});
-
 
     int num_lgr1 = countWells("LGR1");
     int num_lgr2 = countWells("LGR2");
@@ -2184,24 +2182,25 @@ BOOST_AUTO_TEST_CASE (LGR_WellingitSameHostGrid)
     auto ih_lgr2 = MockIH {
         static_cast<int>(num_lgr2)
     };
-    ih_lgr1.add_icon_data(26, 42 ,58 , 1);
-    ih_lgr2.add_icon_data(26, 42 ,58 , 1);
 
+    ih_lgr1.add_icon_data(26, 42, 58, 1);
+    ih_lgr2.add_icon_data(26, 42, 58, 1);
 
     const auto smry = sim_stateLGR();
-    auto awd = Opm::RestartIO::Helpers::AggregateWellData{ih.value};
-    auto awd_lgr1 = Opm::RestartIO::Helpers::AggregateWellData{ih_lgr1.value};
 
+    auto awd = Opm::RestartIO::Helpers::AggregateWellData{ih.value};
+
+    auto awd_lgr1 = Opm::RestartIO::Helpers::AggregateWellData{ih_lgr1.value};
     auto awd_lgr2 = Opm::RestartIO::Helpers::AggregateWellData{ih_lgr2.value};
 
     awd.captureDeclaredWellData(simCase.sched,
-                            simCase.grid,
-                            simCase.es.tracer(),
-                            rptStep,
-                            action_state,
-                            wtest_state,
-                            smry,
-                            ih.value);
+                                simCase.grid,
+                                simCase.es.tracer(),
+                                rptStep,
+                                action_state,
+                                wtest_state,
+                                smry,
+                                ih.value);
 
     awd_lgr1.captureDeclaredWellDataLGR(simCase.sched,
                                         simCase.grid,
@@ -2240,6 +2239,7 @@ BOOST_AUTO_TEST_CASE (LGR_WellingitSameHostGrid)
         BOOST_CHECK_EQUAL(iwell[start + Ix::WType] , 1); // PROD -> Producer
         BOOST_CHECK_EQUAL(iwell[start + Ix::LGRIndex] , 2); // LOCATED IN LGR2
     }
+
     // GLOBAL WELLS
     // IWEL (INJ)
     {
@@ -2255,6 +2255,7 @@ BOOST_AUTO_TEST_CASE (LGR_WellingitSameHostGrid)
         BOOST_CHECK_EQUAL(iwell[start + Ix::WType] , 4); // INJ -> Injector
         BOOST_CHECK_EQUAL(iwell[start + Ix::LGRIndex] , 1); // LOCATRED IN LGR1
     }
+
     // -------------------------- IWEL FOR LGR WELLS --------------------------
     // LGR01 WELL
     // IWEL (PROD)
@@ -2286,7 +2287,6 @@ BOOST_AUTO_TEST_CASE (LGR_WellingitSameHostGrid)
         BOOST_CHECK_EQUAL(iwell[start + Ix::WType] , 4); // INJ -> Producer
     }
 }
-
 
 BOOST_AUTO_TEST_CASE (LGR_BugFixCrossingLGRWell)
 {
@@ -2425,7 +2425,6 @@ BOOST_AUTO_TEST_CASE (LGR_BugFixCrossingLGRWell)
     }
 }
 
-
 BOOST_AUTO_TEST_CASE (LGR_CARFINGR)
 {
     const auto simCase = SimulationCase{simLGR_CARFIN_GR()};
@@ -2543,8 +2542,6 @@ BOOST_AUTO_TEST_CASE (LGR_CARFINGR)
         BOOST_CHECK_EQUAL(iwell[start + Ix::NConn] , 3); // INJ #Compl
     }
 }
-
-
 
 BOOST_AUTO_TEST_CASE (Declared_Well_Data3MixedGroupsWells)
 {
@@ -2764,19 +2761,16 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3MixedGroupsWells)
     auto conn_aggregator = Opm::RestartIO::Helpers::AggregateConnectionData(ih.value);
     auto xw = Opm::data::Wells {};
     conn_aggregator.captureDeclaredConnData(simCase.sched, simCase.es.getInputGrid(),
-                                            simCase.es.getUnits(), xw,
-                                            sim_stateLGR(), rptStep);
+                                            xw, sim_stateLGR(), rptStep);
 
     auto conn_aggregator_lgr1 = Opm::RestartIO::Helpers::AggregateConnectionData(ih_lgr1.value);
     conn_aggregator_lgr1.captureDeclaredConnDataLGR(simCase.sched, simCase.es.getInputGrid(),
-                                                    simCase.es.getUnits(), xw,
-                                                    sim_stateLGR(), rptStep, "LGR1");
+                                                    xw, sim_stateLGR(), rptStep, "LGR1");
 
 
     auto conn_aggregator_lgr2 = Opm::RestartIO::Helpers::AggregateConnectionData(ih_lgr2.value);
     conn_aggregator_lgr2.captureDeclaredConnDataLGR(simCase.sched, simCase.es.getInputGrid(),
-                                                    simCase.es.getUnits(), xw,
-                                                    sim_stateLGR(), rptStep, "LGR2");
+                                                    xw, sim_stateLGR(), rptStep, "LGR2");
 
     // -------------------------- ICON FOR GLOBAL GRID --------------------------
     // ICON (PROD1)
@@ -2827,27 +2821,25 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3MixedGroupsWells)
     }
 
     // -------------------------- GROUP DATA FOR GLOBAL GRID --------------------------
-    ih.add_igr_data(100,112, 181,
-                    5,3, 3);
+    ih.add_igr_data(100, 112, 181, 5, 3, 3);
     auto group_aggregator = Opm::RestartIO::Helpers::AggregateGroupData(ih.value);
-    const auto& units    = simCase.es.getUnits();
-    group_aggregator.captureDeclaredGroupData(simCase.sched, units, rptStep, smry,
-        ih.value);
+    group_aggregator.captureDeclaredGroupData(simCase.sched,
+                                              rptStep, smry, ih.value);
+
     // -------------------------- GROUP DATA FOR LGR GRID LGR1--------------------------
-    ih_lgr1.add_igr_data(100,112, 181,
-        5,3, 2);
+    ih_lgr1.add_igr_data(100, 112, 181, 5, 3, 2);
     auto group_aggregator_lgr1 = Opm::RestartIO::Helpers::AggregateGroupData(ih_lgr1.value);
-    group_aggregator_lgr1.captureDeclaredGroupDataLGR(simCase.sched, units,
-                                                      rptStep, smry, "LGR1");
+    group_aggregator_lgr1.captureDeclaredGroupDataLGR(simCase.sched, rptStep, smry, "LGR1");
+
     // -------------------------- GROUP DATA FOR LGR GRID LGR2--------------------------
-    ih_lgr2.add_igr_data(100,112, 181,
-                         5,3, 2);
+    ih_lgr2.add_igr_data(100, 112, 181, 5, 3, 2);
     auto group_aggregator_lgr2 = Opm::RestartIO::Helpers::AggregateGroupData(ih_lgr2.value);
-    group_aggregator_lgr2.captureDeclaredGroupDataLGR(simCase.sched, units,
-                                                      rptStep, smry, "LGR2");
+    group_aggregator_lgr2.captureDeclaredGroupDataLGR(simCase.sched, rptStep, smry, "LGR2");
+
     // IGRP allocation is different for LGRs. GLOBAL use the nwgmax of the global grid,
     // while LGRs use the nwgmax of the LGR grid.
     // however inside the IGRP the ngwgmax used to count is the same the same as for GLOBAL GRID even for LGRs.
+
     // -------------------------- IGR FOR GLOBAL GRID --------------------------
     // IGR (G1 GLOBAL)
     {
@@ -2961,7 +2953,6 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3MixedGroupsWells)
     }
 
 }
-
 
 BOOST_AUTO_TEST_CASE (Declared_WellDynamicDataLGR)
 {
@@ -3284,36 +3275,50 @@ BOOST_AUTO_TEST_CASE (Declared_GroupDataLGR)
     auto report_step = 1;
     auto lookup_step = 1;
 
-    std::vector<int> ih = Opm::RestartIO::Helpers::
-                                          createInteHead(es_state, grid, sched, simTime, num_solver_steps, report_step, lookup_step);
+    const auto ih = Opm::RestartIO::Helpers::createInteHead(
+        es_state, grid, sched, simTime, num_solver_steps, report_step, lookup_step);
 
-    std::vector<int> ih_lgr1   = Opm::RestartIO::Helpers::
-                                          createInteHead(es_state, grid.getLGRCell("LGR1"), sched, simTime, num_solver_steps, report_step, lookup_step);
+    const auto ih_lgr1 = Opm::RestartIO::Helpers::createInteHead(es_state,
+                                                                 grid.getLGRCell("LGR1"),
+                                                                 sched,
+                                                                 simTime,
+                                                                 num_solver_steps,
+                                                                 report_step,
+                                                                 lookup_step);
 
-    std::vector<int> ih_lgr2   = Opm::RestartIO::Helpers::
-                                          createInteHead(es_state, grid.getLGRCell("LGR2"), sched, simTime, num_solver_steps, report_step, lookup_step);
+    const auto ih_lgr2 = Opm::RestartIO::Helpers::createInteHead(es_state,
+                                                                 grid.getLGRCell("LGR2"),
+                                                                 sched,
+                                                                 simTime,
+                                                                 num_solver_steps,
+                                                                 report_step,
+                                                                 lookup_step);
 
-    std::vector<int> ih_lgr3   = Opm::RestartIO::Helpers::
-                                          createInteHead(es_state, grid.getLGRCell("LGR3"), sched, simTime, num_solver_steps, report_step, lookup_step);
+    const auto ih_lgr3 = Opm::RestartIO::Helpers::createInteHead(es_state,
+                                                                 grid.getLGRCell("LGR3"),
+                                                                 sched,
+                                                                 simTime,
+                                                                 num_solver_steps,
+                                                                 report_step,
+                                                                 lookup_step);
 
     const auto rptStep = std::size_t{1};
 
     // -------------------------- GROUP DATA FOR GLOBAL GRID --------------------------
     auto group_aggregator = Opm::RestartIO::Helpers::AggregateGroupData(ih);
-    const auto& units    = simCase.es.getUnits();
-    group_aggregator.captureDeclaredGroupData(simCase.sched, units, rptStep, smry, ih);
+    group_aggregator.captureDeclaredGroupData(simCase.sched, rptStep, smry, ih);
 
     // -------------------------- GROUP DATA FOR LGR GRID LGR1--------------------------
     auto group_aggregator_lgr1 = Opm::RestartIO::Helpers::AggregateGroupData(ih_lgr1);
-    group_aggregator_lgr1.captureDeclaredGroupDataLGR(simCase.sched, units, rptStep, smry, "LGR1");
+    group_aggregator_lgr1.captureDeclaredGroupDataLGR(simCase.sched, rptStep, smry, "LGR1");
 
     // -------------------------- GROUP DATA FOR LGR GRID LGR2--------------------------
     auto group_aggregator_lgr2 = Opm::RestartIO::Helpers::AggregateGroupData(ih_lgr2);
-    group_aggregator_lgr2.captureDeclaredGroupDataLGR(simCase.sched, units, rptStep, smry, "LGR2");
+    group_aggregator_lgr2.captureDeclaredGroupDataLGR(simCase.sched, rptStep, smry, "LGR2");
 
     // -------------------------- GROUP DATA FOR LGR GRID LGR2--------------------------
-    auto group_aggregator_lgr3 = Opm::RestartIO::Helpers::AggregateGroupData(ih_lgr2);
-    group_aggregator_lgr3.captureDeclaredGroupDataLGR(simCase.sched, units, rptStep, smry, "LGR3");
+    auto group_aggregator_lgr3 = Opm::RestartIO::Helpers::AggregateGroupData(ih_lgr3);
+    group_aggregator_lgr3.captureDeclaredGroupDataLGR(simCase.sched, rptStep, smry, "LGR3");
 
     // IGR (LGR PSEUDOGROUP1 from LGR1)
     {
@@ -3630,8 +3635,6 @@ BOOST_AUTO_TEST_CASE (Declared_GroupDataLGR)
             BOOST_CHECK_CLOSE_FRACTION(xGrp[start + XGroup::HistWatInjTotal] , element_sum(XGroup::HistWatInjTotal), tol);
             BOOST_CHECK_CLOSE_FRACTION(xGrp[start + XGroup::HistGasPrTotal] , element_sum(XGroup::HistGasPrTotal), tol);
             BOOST_CHECK_CLOSE_FRACTION(xGrp[start + XGroup::HistGasInjTotal] , element_sum(XGroup::HistGasInjTotal), tol);
-            BOOST_CHECK_CLOSE_FRACTION(xGrp[start + XGroup::TracerOffset] , element_sum(XGroup::TracerOffset), tol);
-
         }
 
         // XGRP (LGR FIELD from LGR1)

--- a/tests/test_rst.cpp
+++ b/tests/test_rst.cpp
@@ -316,8 +316,7 @@ END
 
     Opm::Deck historic_period_whistctl()
     {
-        return Opm::Parser{}.parseString(R"~(
-RUNSPEC
+        return Opm::Parser{}.parseString(R"~(RUNSPEC
 OIL
 GAS
 WATER
@@ -390,8 +389,7 @@ END
                       const std::string&    baseName,
                       const std::size_t     rptStep)
     {
-        const auto& units    = simCase.es.getUnits();
-        const auto  sim_step = rptStep - 1;
+        const auto sim_step = rptStep - 1;
 
         const auto sumState     = Opm::SummaryState { Opm::TimeService::now(), 0.0 };
         const auto action_state = Opm::Action::State{};
@@ -414,11 +412,12 @@ END
                                         sim_step, {}, sumState);
 
         auto connectionData = Opm::RestartIO::Helpers::AggregateConnectionData(ih);
-        connectionData.captureDeclaredConnData(simCase.sched, simCase.grid, units,
+        connectionData.captureDeclaredConnData(simCase.sched, simCase.grid,
                                                {}, sumState, sim_step);
 
         auto groupData = Opm::RestartIO::Helpers::AggregateGroupData(ih);
-        groupData.captureDeclaredGroupData(simCase.sched, units, sim_step, sumState, ih);
+        groupData.captureDeclaredGroupData(simCase.sched,
+                                           sim_step, sumState, ih);
 
         const auto outputDir = std::string { "./" };
 
@@ -483,10 +482,11 @@ END
 BOOST_AUTO_TEST_CASE(group_test)
 {
     const auto simCase = SimulationCase{first_sim()};
-    const auto& units = simCase.es.getUnits();
+
     // Report Step 2: 2011-01-20 --> 2013-06-15
     const auto rptStep = std::size_t{2};
     const auto sim_step = rptStep - 1;
+
     Opm::SummaryState sumState(Opm::TimeService::now(), 0.0);
 
     const auto ih = Opm::RestartIO::Helpers::createInteHead(simCase.es,
@@ -506,18 +506,18 @@ BOOST_AUTO_TEST_CASE(group_test)
                                                             0, 0);
 
     auto groupData = Opm::RestartIO::Helpers::AggregateGroupData(ih);
-    groupData.captureDeclaredGroupData(simCase.sched, units, sim_step, sumState, ih);
+    groupData.captureDeclaredGroupData(simCase.sched,
+                                       sim_step, sumState, ih);
 
     const auto& igrp = groupData.getIGroup();
     const auto& sgrp = groupData.getSGroup();
     const auto& xgrp = groupData.getXGroup();
-    const auto& zgrp8 = groupData.getZGroup();
 
-    Opm::UnitSystem unit_system(Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC);
-    std::vector<std::string> zgrp;
-    std::ranges::transform(zgrp8, std::back_inserter(zgrp),
+    std::vector<std::string> zgrp{};
+    std::ranges::transform(groupData.getZGroup(), std::back_inserter(zgrp),
                            [](const auto& s8) { return s8.c_str(); });
 
+    Opm::UnitSystem unit_system(Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC);
     Opm::RestartIO::RstHeader header(simCase.es.runspec(), unit_system,ih,lh,dh);
     for (int ig=0; ig < header.ngroup; ig++) {
         std::size_t zgrp_offset = ig * header.nzgrpz;


### PR DESCRIPTION
In particular

  * Remove `UnitSystem` arguments from functions that take `EclipseState` and/or `Schedule` objects.  The `UnitSystem` is available directly from those.
  * Remove `Opm::` namespace qualifiers from type names when inside the `Opm` namespace.
  * Prefer vectors of `const T*` over vectors of `reference_wrapper<>`.
  * For AggregateGroupData, move the mapping arrays into the implementation file and switch to iterating over the "keyToIndex" maps directly.  This way we don't have to perform a full `map::find()` for each restart file key.

While here, also readjust whitespace where appropriate&ndash;notably in raw string literals for consumption by `Parser::parseString()`.  While our parser is lenient in this respect, input deck keywords are supposed to start in the first column.