### PR TITLE
Track Whether or not Run Supports Solution Tracers

### DIFF
--- a/opm/input/eclipse/EclipseState/TracerConfig.cpp
+++ b/opm/input/eclipse/EclipseState/TracerConfig.cpp
@@ -33,8 +33,12 @@
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Deck/DeckItem.hpp>
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/D.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/V.hpp>
 
 #include <fmt/format.h>
 
@@ -73,10 +77,12 @@ TracerConfig::TracerConfig([[maybe_unused]] const UnitSystem& unit_system,
 {
     using TR = ParserKeywords::TRACER;
 
+    this->supportsSolutionGasTracer_ = deck.hasKeyword<ParserKeywords::DISGAS>();
+    this->supportsVaporisedOilTracer_ = deck.hasKeyword<ParserKeywords::VAPOIL>();
+
     if (! deck.hasKeyword<TR>()) {
         return;
     }
-
 
     const auto& keyword = deck.get<TR>().back();
     OpmLog::info(
@@ -193,7 +199,10 @@ TracerConfig::TracerConfig([[maybe_unused]] const UnitSystem& unit_system,
 TracerConfig TracerConfig::serializationTestObject()
 {
     TracerConfig result;
+
     result.tracers = {{"test", "", Phase::OIL, {1.0}}};
+    result.supportsSolutionGasTracer_ = true;
+    result.supportsVaporisedOilTracer_ = true;
 
     return result;
 }
@@ -228,7 +237,10 @@ const TracerConfig::TracerEntry& TracerConfig::operator[](const std::string& nam
 
 bool TracerConfig::operator==(const TracerConfig& other) const
 {
-    return this->tracers == other.tracers;
+    return (this->tracers == other.tracers)
+        && (this->supportsSolutionGasTracer_ == other.supportsSolutionGasTracer_)
+        && (this->supportsVaporisedOilTracer_ == other.supportsVaporisedOilTracer_)
+        ;
 }
 
 std::string TracerConfig::get_unit_string(const UnitSystem& unit_system,

--- a/opm/input/eclipse/EclipseState/TracerConfig.hpp
+++ b/opm/input/eclipse/EclipseState/TracerConfig.hpp
@@ -133,6 +133,9 @@ public:
     decltype(auto) begin() const { return this->tracers.begin(); }
     decltype(auto) end() const { return this->tracers.end(); }
 
+    bool supportsSolutionGasTracer() const { return this->supportsSolutionGasTracer_; }
+    bool supportsVaporisedOilTracer() const { return this->supportsVaporisedOilTracer_; }
+
     const TracerEntry& operator[](const std::string& name) const;
     const TracerEntry& operator[](std::size_t index) const;
 
@@ -140,6 +143,8 @@ public:
     void serializeOp(Serializer& serializer)
     {
         serializer(tracers);
+        serializer(supportsSolutionGasTracer_);
+        serializer(supportsVaporisedOilTracer_);
     }
 
     bool operator==(const TracerConfig& data) const;
@@ -148,6 +153,9 @@ public:
 
 private:
     std::vector<TracerEntry> tracers;
+
+    bool supportsSolutionGasTracer_{false};
+    bool supportsVaporisedOilTracer_{false};
 };
 
 } // namespace Opm

--- a/tests/parser/TracerTests.cpp
+++ b/tests/parser/TracerTests.cpp
@@ -22,18 +22,20 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
 
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
 
 using namespace Opm;
 
+namespace {
 
-static Deck createDeck() {
+Deck createDeck()
+{
     // Using a raw string literal with xxx as delimiter.
-    const char *deckData = R"xxx(
+    return Parser{}.parseString(R"xxx(RUNSPEC
 DIMENS
  10 10 10 /
 TABDIMS
@@ -64,18 +66,21 @@ TVDPFSEA
 5000   0.0 /
 TBLKFOCE
 1.0 2.0 3.0 /
-)xxx"; // End of raw string literal with xxx as delimiter.
-    Parser parser;
-    return parser.parseString( deckData );
+)xxx");
+
 }
 
+} // Anonymous namespace
 
-
-BOOST_AUTO_TEST_CASE(TracerConfigTest) {
-    auto deck = createDeck();
-    EclipseState state(deck);
-    const TracerConfig& tc = state.tracer();
+BOOST_AUTO_TEST_CASE(TracerConfigTest)
+{
+    const auto deck = createDeck();
+    const auto state = EclipseState{deck};
+    const auto& tc = state.tracer();
     BOOST_CHECK_EQUAL(tc.size(), 2U);
+
+    BOOST_CHECK_MESSAGE(! tc.supportsSolutionGasTracer(), "Solution gas tracer should not be supported");
+    BOOST_CHECK_MESSAGE(! tc.supportsVaporisedOilTracer(), "Vaporised oil tracer should not be supported");
 
     auto it = tc.begin();
     BOOST_CHECK_EQUAL(it->name, "SEA");
@@ -88,4 +93,102 @@ BOOST_AUTO_TEST_CASE(TracerConfigTest) {
     BOOST_CHECK_EQUAL(it->phase, Phase::GAS);
     BOOST_CHECK_EQUAL(it->free_concentration.value().size(), 3U);
     BOOST_CHECK(!it->free_tvdp.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(SolutionGasSupportTest)
+{
+    const auto deck = Parser{}.parseString(R"xxx(RUNSPEC
+DIMENS
+  5 1 2 /
+OIL
+GAS
+WATER
+DISGAS
+TABDIMS
+/
+EQLDIMS
+  3 1 1 /
+TRACERS
+--  oil  water  gas  env
+  1*  1      1    1*   /
+GRID
+DXV
+  5*100 /
+DYV
+  1*100 /
+DZV
+  5 10 /
+DEPTHZ
+  12*2000.0 /
+EQUALS
+  PORO 0.25 /
+  PERMX 100 /
+  PERMY 100 /
+  PERMZ 10 /
+/
+PROPS
+TRACER
+SEA  WAT  /
+OCE  GAS /
+/
+TVDPFSEA
+1000   0.0
+5000   0.0 /
+TBLKFOCE
+1.0 2.0 3.0 /
+)xxx");
+
+    const auto tc = TracerConfig{deck.getDefaultUnitSystem(), deck};
+
+    BOOST_CHECK_MESSAGE(tc.supportsSolutionGasTracer(), "Solution gas tracer should be supported");
+    BOOST_CHECK_MESSAGE(! tc.supportsVaporisedOilTracer(), "Vaporised oil tracer should not be supported");
+}
+
+BOOST_AUTO_TEST_CASE(VaporisedOilSupportTest)
+{
+    const auto deck = Parser{}.parseString(R"xxx(RUNSPEC
+DIMENS
+  5 1 2 /
+OIL
+GAS
+WATER
+VAPOIL
+TABDIMS
+/
+EQLDIMS
+  3 1 1 /
+TRACERS
+--  oil  water  gas  env
+  1*  1      1    1*   /
+GRID
+DXV
+  5*100 /
+DYV
+  1*100 /
+DZV
+  5 10 /
+DEPTHZ
+  12*2000.0 /
+EQUALS
+  PORO 0.25 /
+  PERMX 100 /
+  PERMY 100 /
+  PERMZ 10 /
+/
+PROPS
+TRACER
+SEA  WAT  /
+OCE  GAS  /
+/
+TVDPFSEA
+1000   0.0
+5000   0.0 /
+TBLKFOCE
+1.0 2.0 3.0 /
+)xxx");
+
+    const auto tc = TracerConfig{deck.getDefaultUnitSystem(), deck};
+
+    BOOST_CHECK_MESSAGE(! tc.supportsSolutionGasTracer(), "Solution gas tracer should not be supported");
+    BOOST_CHECK_MESSAGE(tc.supportsVaporisedOilTracer(), "Vaporised oil tracer should be supported");
 }


### PR DESCRIPTION
Solution gas tracers are supported only if the run itself enables gas dissolution (`DISGAS` keyword).  Similarly, solution oil tracers are supported only if the run enables oil vaporisation (`VAPOIL` keyword).

The immediate use case for this is assisting the restart component's array allocation.  Certain arrays must be sized according to the number of tracer components and we need to know whether or not solution tracers are active.  In the future, these flags will also permit greater consistency checking and diagnostics for the simulation input deck.