### PR TITLE
Amend Restart File HC Tracer Logic for Solution Tracer Presence

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -476,35 +476,51 @@ Well::Well(const RestartIO::RstWell& rst_well,
 
         this->updateInjection(std::move(i));
 
-        const auto isTemp = (rst_well.inj_temperature < RestartIO::RstWell::UNDEFINED_VALUE);
-        std::size_t tracer_conc_index = 0;
-        if (isTemp) {
-            this->well_inj_temperature = rst_well.inj_temperature;
-            ++tracer_conc_index;
+        if (rst_well.inj_temperature < RestartIO::RstWell::UNDEFINED_VALUE) {
+            this->well_inj_temperature.emplace(rst_well.inj_temperature);
         }
 
         if (!rst_well.tracer_concentration_injection.empty()) {
-            auto tracer = std::make_shared<WellTracerProperties>(this->getTracerProperties());
-            for (std::size_t tracer_index = 0; tracer_index < tracer_config.size(); ++tracer_index) {
-                const auto& trName = tracer_config[tracer_index].name;
-                const auto phase = tracer_config[tracer_index].phase;
-                if (phase == Phase::WATER) {
-                    const auto concentration = rst_well.tracer_concentration_injection[tracer_conc_index];
-                    tracer->setConcentration(WellTracerProperties::Tracer { trName },
-                                                UDAValue { concentration } );
-                } else {
-                    const auto free_conc = rst_well.tracer_concentration_injection[tracer_conc_index];
-                    const auto sol_conc = rst_well.tracer_concentration_injection[++tracer_conc_index];
-                    if (WellType::gas_injector(this->wtype.ecl_wtype()) || WellType::oil_injector(this->wtype.ecl_wtype())) {
-                        tracer->setConcentration( WellTracerProperties::Tracer { trName },
-                                                    UDAValue { free_conc } );
+            auto nextConcentrationValue = [idx = std::size_t{0}, &rst_well]() mutable {
+                return rst_well.tracer_concentration_injection[idx++];
+            };
+
+            const auto dgas = tracer_config.supportsSolutionGasTracer();
+            const auto voil = tracer_config.supportsVaporisedOilTracer();
+
+            auto tracerProps = std::make_shared<WellTracerProperties>(this->getTracerProperties());
+
+            for (const auto& tracer : tracer_config) {
+                if (tracer.phase == Phase::WATER) {
+                    const auto concentration = nextConcentrationValue();
+
+                    tracerProps->setConcentration(WellTracerProperties::Tracer { tracer.name },
+                                                  UDAValue { concentration });
+                }
+                else {
+                    const auto supportsSolution = (dgas && tracer.phase == Phase::GAS)
+                        || (voil && tracer.phase == Phase::OIL);
+
+                    const auto free_conc = nextConcentrationValue();
+                    const auto sol_conc = supportsSolution ? nextConcentrationValue() : 0.0;
+
+                    if (WellType::gas_injector(this->wtype.ecl_wtype()) ||
+                        WellType::oil_injector(this->wtype.ecl_wtype()))
+                    {
+                        tracerProps->setConcentration(WellTracerProperties::Tracer { tracer.name },
+                                                      UDAValue { free_conc });
+
                         if (sol_conc > 0.0) {
-                            OpmLog::warning(fmt::format("Well {}: Restoring a non-zero solution concentration of tracer {} is not yet supported.", rst_well.name, trName));
+                            OpmLog::warning(
+                                fmt::format("Well {}: Restoring a non-zero solution "
+                                            "concentration of tracer {} is not yet "
+                                            "supported.", rst_well.name, tracer.name));
                         }
                     }
                 }
             }
-            this->updateTracer(tracer);
+
+            this->updateTracer(std::move(tracerProps));
         }
     }
 }

--- a/opm/output/eclipse/AggregateWellData.cpp
+++ b/opm/output/eclipse/AggregateWellData.cpp
@@ -26,6 +26,10 @@
 #include <opm/output/data/Wells.hpp>
 
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/input/eclipse/EclipseState/Phase.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+#include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
+
 #include <opm/input/eclipse/Schedule/Action/ActionAST.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionContext.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
@@ -38,8 +42,8 @@
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
-#include <opm/input/eclipse/Schedule/Well/WDFAC.hpp>
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+#include <opm/input/eclipse/Schedule/Well/WDFAC.hpp>
 #include <opm/input/eclipse/Schedule/Well/WELDRAW.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
@@ -48,7 +52,6 @@
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPDP.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>
-#include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 #include <opm/input/eclipse/Units/Units.hpp>
@@ -67,6 +70,7 @@
 #include <iostream>
 #include <iterator>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -1210,18 +1214,34 @@ namespace {
                               const bool               isTemp = false)
         {
             auto output_index = static_cast<std::size_t>(VI::SWell::index::TracerOffset);
+
+            const auto conc = [&smry, &wname](const std::string& tname)
+            {
+                return smry.get_well_var(wname, fmt::format("WTIC{}", tname), 0.0);
+            };
+
             // Temperature tracer is first, if present
-            if (isTemp) sWell[output_index++] = smry.get_well_var(wname, "WTICHEA", 0.0);
+            if (isTemp) {
+                sWell[output_index++] = conc("HEA");
+            }
+
+            const auto dgas = tracers.supportsSolutionGasTracer();
+            const auto voil = tracers.supportsVaporisedOilTracer();
 
             for (const auto& tracer : tracers) {
                 if (tracer.phase == Opm::Phase::WATER) {
-                    sWell[output_index++] =
-                        smry.get_well_var(wname, fmt::format("WTIC{}", tracer.name), 0.0);
-                } else {
-                    sWell[output_index++] =
-                        smry.get_well_var(wname, fmt::format("WTICF{}", tracer.name), 0.0);
-                    sWell[output_index++] =
-                        smry.get_well_var(wname, fmt::format("WTICS{}", tracer.name), 0.0);
+                    sWell[output_index++] = conc(tracer.name);
+                }
+                else {
+                    sWell[output_index++] = conc(tracer.wellfname());
+
+                    const auto supportsSolution =
+                        (dgas && tracer.phase == Opm::Phase::GAS)
+                        || (voil && tracer.phase == Opm::Phase::OIL);
+
+                    if (supportsSolution) {
+                        sWell[output_index++] = conc(tracer.wellsname());
+                    }
                 }
             }
         }
@@ -1469,15 +1489,12 @@ namespace {
             xWell[Ix::PrimGuideRate] = xWell[Ix::PrimGuideRate_2] = -get("WOIGR");
         }
 
-        template <typename XWellArray,
-                typename TempCallback,
-                typename WaterCallback,
-                typename HCCallback>
-        std::size_t tracerLoop(XWellArray& xWell,
-                            const Opm::TracerConfig& tracers,
-                            TempCallback&& processTemperature,
-                            WaterCallback&& processWaterTracer,
-                            HCCallback&& processHCTracer)
+        template <typename TempCallback, typename WaterCallback, typename HCCallback>
+        void tracerLoop(std::span<double>        xWell,
+                        const Opm::TracerConfig& tracers,
+                        TempCallback&&           processTemperature,
+                        WaterCallback&&          processWaterTracer,
+                        HCCallback&&             processHCTracer)
         {
             auto ix = std::size_t {0};
 
@@ -1491,134 +1508,164 @@ namespace {
                     ix += processHCTracer(tracer, &xWell[ix]);
                 }
             }
-
-            return ix;
         }
 
-        template <typename XWellArray>
-        std::size_t assignTracerQuantity(const bool isTemp,
-                                        const double sign,
-                                        const std::string& quantityPrefix,
-                                        const std::string& wellName,
-                                        const Opm::TracerConfig& tracers,
-                                        const Opm::SummaryState& smry,
-                                        XWellArray& xWell)
+        void assignTracerQuantity(const bool               isTemp,
+                                  const double             sign,
+                                  const std::string&       quantity,
+                                  const std::string&       wellName,
+                                  const Opm::TracerConfig& tracers,
+                                  const Opm::SummaryState& smry,
+                                  std::span<double>        xWell)
         {
-            auto processWaterTracer = [&smry, sign, &quantityPrefix, &wellName](const auto& tracer, auto* xwel)
+            auto getValue = [&smry, sign, &quantity, &wellName]
+                (const std::string& tracerName)
             {
-                xwel[0] = sign * smry.get_well_var(wellName, quantityPrefix + tracer.name, 0.0);
+                // WTIRHEA, WTPTFXF2, WTITWT1, ...
+                const auto vector = fmt::format("WT{}{}", quantity, tracerName);
+
+                return sign * smry.get_well_var(wellName, vector, 0.0);
+            };
+
+            auto processWaterTracer = [&getValue](const auto& tracer, auto* xwel)
+            {
+                xwel[0] = getValue(tracer.name);
+
                 return std::size_t{1};
             };
 
-            auto processHCTracer = [&smry, sign, quantityPrefix, &wellName](const auto& tracer, auto* xwel)
+            auto processHCTracer = [dgas = tracers.supportsSolutionGasTracer(),
+                                    voil = tracers.supportsVaporisedOilTracer(),
+                                    &getValue](const auto& tracer, auto* xwel)
             {
-                xwel[0] = sign * smry.get_well_var(wellName, quantityPrefix + 'F' + tracer.name, 0.0);
-                xwel[1] = sign * smry.get_well_var(wellName, quantityPrefix + 'S' + tracer.name, 0.0);
+                const auto supportsSolution = (dgas && tracer.phase == Opm::Phase::GAS)
+                    || (voil && tracer.phase == Opm::Phase::OIL);
+
+                xwel[0] = getValue(tracer.wellfname());
+
+                if (!supportsSolution) {
+                    return std::size_t{1};
+                }
+
+                xwel[1] = getValue(tracer.wellsname());
                 return std::size_t{2};
             };
 
             if (! isTemp) {
                 return tracerLoop(xWell, tracers,
-                                [](auto*) { return std::size_t{0}; },
-                                processWaterTracer, processHCTracer);
+                                  [](auto*) { return std::size_t{0}; },
+                                  processWaterTracer, processHCTracer);
             }
 
-            const auto tempQuant = sign * smry.get_well_var(wellName, quantityPrefix + "HEA", 0.0);
-            auto processTemperature = [tempQuant](auto* xwell)
+            auto processTemperature = [tempQuant = getValue("HEA")](auto* xwell)
             {
                 xwell[0] = tempQuant;
-                return std::size_t {1};
+
+                return std::size_t{1};
             };
 
-            return tracerLoop(xWell, tracers, processTemperature, processWaterTracer, processHCTracer);
+            tracerLoop(xWell, tracers, processTemperature, processWaterTracer, processHCTracer);
         }
 
-        template <typename XWellArray>
-        std::size_t assignTracerRates(const bool isInjector,
-                                    const bool isTemp,
-                                    const std::string& wellName,
-                                    const Opm::TracerConfig& tracers,
-                                    const Opm::SummaryState& smry,
-                                    XWellArray xWell)
+        void assignTracerRates(const bool               isInjector,
+                               const bool               isTemp,
+                               const std::string&       wellName,
+                               const Opm::TracerConfig& tracers,
+                               const Opm::SummaryState& smry,
+                               std::span<double>        xWell)
         {
             const auto sign = isInjector ? -1.0 : 1.0;
-            const auto prefix = isInjector ? std::string { "WTIR" } : std::string { "WTPR" };
+            const auto prefix = isInjector ? std::string { "IR" } : std::string { "PR" };
 
-            return assignTracerQuantity(isTemp, sign, prefix, wellName, tracers, smry, xWell);
+            assignTracerQuantity(isTemp, sign, prefix, wellName, tracers, smry, xWell);
         }
 
-        template <typename XWellArray>
-        std::size_t assignTracerCumulatives(const bool isInjection,
-                                            const bool isTemp,
-                                            const std::string& wellName,
-                                            const Opm::TracerConfig& tracers,
-                                            const Opm::SummaryState& smry,
-                                            XWellArray xWell)
+        void assignTracerCumulatives(const bool               isInjection,
+                                     const bool               isTemp,
+                                     const std::string&       wellName,
+                                     const Opm::TracerConfig& tracers,
+                                     const Opm::SummaryState& smry,
+                                     std::span<double>        xWell)
         {
             const auto sign = 1.0; // Cumulatives are always positive;
-            const auto prefix = isInjection ? std::string { "WTIT" } : std::string { "WTPT" };
+            const auto prefix = isInjection ? std::string { "IT" } : std::string { "PT" };
 
-            return assignTracerQuantity(isTemp, sign, prefix, wellName, tracers, smry, xWell);
+            assignTracerQuantity(isTemp, sign, prefix, wellName, tracers, smry, xWell);
         }
 
-        template <typename XWellArray>
-        std::size_t assignTracerConcentration(const bool isInjection,
-                                            const bool isTemp,
-                                            const std::string& wellName,
-                                            const Opm::TracerConfig& tracers,
-                                            const Opm::SummaryState& smry,
-                                            XWellArray xWell)
+        void assignTracerConcentration(const bool               isInjection,
+                                       const bool               isTemp,
+                                       const std::string&       wellName,
+                                       const Opm::TracerConfig& tracers,
+                                       const Opm::SummaryState& smry,
+                                       std::span<double>        xWell)
         {
             const auto sign = 1.0; // Concentrations are always positive;
-            const auto prefix = isInjection ? std::string { "WTIC" } : std::string { "WTPC" };
+            const auto prefix = isInjection ? std::string { "IC" } : std::string { "PC" };
 
-            return assignTracerQuantity(isTemp, sign, prefix, wellName, tracers, smry, xWell);
+            assignTracerQuantity(isTemp, sign, prefix, wellName, tracers, smry, xWell);
         }
 
-
         template <class XWellArray>
-        void assignTracerData(const Opm::TracerConfig& tracers,
+        void assignTracerData(const Opm::Runspec&      runspec,
+                              const Opm::TracerConfig& tracers,
                               const Opm::SummaryState& smry,
-                              const Opm::Well& well,
-                              XWellArray& xWell,
-                              const bool isTemp)
+                              const Opm::Well&         well,
+                              XWellArray&              xWell)
         {
-            if (tracers.empty() && !isTemp)
-                return;
-
             using Ix = ::Opm::RestartIO::Helpers::VectorItems::XWell::index;
-            std::fill(xWell.begin() + Ix::TracerOffset, xWell.end(), 0);
+
+            if (tracers.empty() && !runspec.temp()) {
+                return;
+            }
+
+            const auto numTracerElems = [&runspec, &tracers]()
+            {
+                const auto& t = runspec.tracers();
+
+                return t.water_tracers() + (runspec.temp() ? 1 : 0)
+                     + (1 + tracers.supportsSolutionGasTracer()) * t.gas_tracers()
+                     + (1 + tracers.supportsVaporisedOilTracer()) * t.oil_tracers();
+            }();
+
+            auto tracerElems = std::span<double> {
+                xWell.begin() + Ix::TracerOffset, xWell.end()
+            };
+
+            std::ranges::fill(tracerElems, 0.0);
 
             // For each vector in rate, prod_total, inj_total, inj_conc, prod_conc:
-            //    TEMP (if present), then each tracer in definition order (TRACER) [free then solution conc for HC tracers]
+            //    TEMP (if present), then each tracer in definition order (TRACER)
+            //    [free then solution conc for HC tracers]
 
             const auto& wname = well.name();
-            auto output_index = static_cast<std::size_t>(Ix::TracerOffset);
+
+            auto qtyIndex = std::size_t{0};
 
             // Flow rates.
-            output_index += assignTracerRates(well.isInjector(), isTemp, wname, tracers, smry, &xWell[output_index]);
+            assignTracerRates(well.isInjector(), runspec.temp(), wname, tracers, smry,
+                              tracerElems.subspan(qtyIndex++ * numTracerElems, numTracerElems));
 
             // Cumulative production volume.
-            output_index += assignTracerCumulatives(/* injection = */ false, isTemp, wname, tracers, smry, &xWell[output_index]);
+            assignTracerCumulatives(/* injection = */ false, runspec.temp(), wname, tracers, smry,
+                                    tracerElems.subspan(qtyIndex++ * numTracerElems, numTracerElems));
 
             // Cumulative injection volume.
-            output_index += assignTracerCumulatives(/* injection = */ true, isTemp, wname, tracers, smry, &xWell[output_index]);
+            assignTracerCumulatives(/* injection = */ true, runspec.temp(), wname, tracers, smry,
+                                    tracerElems.subspan(qtyIndex++ * numTracerElems, numTracerElems));
 
             // Tracer concentrations (twice)
             for (auto i = 0; i < 2; ++i) {
-                output_index += assignTracerConcentration(well.isInjector(), isTemp, wname, tracers, smry, &xWell[output_index]);
+                assignTracerConcentration(well.isInjector(), runspec.temp(), wname, tracers, smry,
+                                          tracerElems.subspan(qtyIndex++ * numTracerElems, numTracerElems));
             }
-
-
-            xWell[output_index++] = 0;
-            xWell[output_index++] = 0;
         }
 
         template <class XWellArray>
-        void dynamicContrib(const ::Opm::Well&         well,
+        void dynamicContrib(const Opm::Runspec&        rspec,
+                            const ::Opm::Well&         well,
                             const Opm::TracerConfig&   tracers,
                             const ::Opm::SummaryState& smry,
-                            const bool                 isTemp,
                             XWellArray&                xWell)
         {
             if (well.isProducer()) {
@@ -1626,9 +1673,8 @@ namespace {
             }
             else if (well.isInjector()) {
                 using IType = ::Opm::InjectorType;
-                const auto itype = well.injectionControls(smry).injector_type;
 
-                switch (itype) {
+                switch (well.injectionControls(smry).injector_type) {
                 case IType::OIL:
                     assignOilInjector(well.name(), smry, xWell);
                     break;
@@ -1647,8 +1693,9 @@ namespace {
                     break;
                 }
             }
+
             assignCumulatives(well.name(), smry, xWell);
-            assignTracerData(tracers, smry, well, xWell, isTemp);
+            assignTracerData(rspec, tracers, smry, well, xWell);
         }
     } // XWell
 
@@ -1986,10 +2033,9 @@ captureDynamicWellData(const Opm::Schedule&       sched,
     {
         auto xwell = this->xWell_[wellID];
 
-        XWell::dynamicContrib(well, tracers, smry, sched.runspec().temp(), xwell);
+        XWell::dynamicContrib(sched.runspec(), well, tracers, smry, xwell);
     });
 }
-
 
 void
 Opm::RestartIO::Helpers::AggregateWellData::
@@ -2026,6 +2072,6 @@ captureDynamicWellDataLGR(const Opm::Schedule&       sched,
     {
         auto xwell = this->xWell_[wellID];
 
-        XWell::dynamicContrib(well, tracers, smry, sched.runspec().temp(), xwell);
+        XWell::dynamicContrib(sched.runspec(), well, tracers, smry, xwell);
     });
 }

--- a/opm/output/eclipse/CreateInteHead.cpp
+++ b/opm/output/eclipse/CreateInteHead.cpp
@@ -21,6 +21,8 @@
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
 #include <opm/output/eclipse/InteHEAD.hpp>
+#include <opm/output/eclipse/VectorItems/connection.hpp>
+#include <opm/output/eclipse/VectorItems/group.hpp>
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
 #include <opm/output/eclipse/VectorItems/well.hpp>
 
@@ -28,6 +30,7 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
+#include <opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/Regdims.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 
@@ -59,6 +62,71 @@
 #include <vector>
 
 namespace {
+
+    struct WellArrayDims
+    {
+        /// Number of entries per well in the IWEL array.
+        int iwell{};
+
+        /// Number of entries per well in the SWEL array.
+        int swell{};
+
+        /// Number of entries per well in the XWEL array.
+        int xwell{};
+
+        /// Number of entries per well in the ZWEL array.
+        int zwell{3};
+    };
+
+    struct ConnArrayDims
+    {
+        /// Number of entries per connection in the ICON array.
+        int iconn{};
+
+        /// Number of entries per connection in the SCON array.
+        int sconn{};
+
+        /// Number of entries per connection in the XCON array.
+        int xconn{};
+    };
+
+    // Declared number of tracers in the run.  Temperature, if present,
+    // is treated as a tracer for the purpose of determining the number
+    // of well array elements.  Oil and gas tracers have both free and
+    // solution parts, so they count double for the number of elements.
+    struct TracerSizes
+    {
+        explicit TracerSizes(const Opm::Runspec&          rspec,
+                             const Opm::SimulationConfig& simConfig)
+            : numTracers(rspec.tracers().water_tracers()
+                         + rspec.tracers().oil_tracers()
+                         + rspec.tracers().gas_tracers()
+                         + (rspec.temp() ? 1 : 0))
+            , numTracerElems(numTracers)
+        {
+            if (simConfig.hasDISGAS()) {
+                // Gas tracers have both free and solution parts when
+                // gas dissolves in the oil phase.  Include solution
+                // part in the count of array elements.
+                numTracerElems += rspec.tracers().gas_tracers();
+            }
+
+            if (simConfig.hasVAPOIL()) {
+                // Oil tracers have both free and solution parts when
+                // oil vaporizes into the gas phase.  Include solution
+                // part in the count of array elements.
+                numTracerElems += rspec.tracers().oil_tracers();
+            }
+        }
+
+        // Maximum number of tracer-like objects in the run,
+        // including temperature if present.
+        int numTracers{};
+
+        // Declared number of array elements per tracer quantity
+        // in the run.
+        int numTracerElems{};
+    };
 
     using nph_enum = Opm::GuideRateModel::Target;
     const std::map<nph_enum, int> nph_enumToECL = {
@@ -280,7 +348,6 @@ namespace {
         };
     }
 
-
     Opm::RestartIO::InteHEAD::WellTableDim
     getWellTableDims(const int              nwgmax,
                      const int              ngmax,
@@ -327,12 +394,54 @@ namespace {
         };
     }
 
-    std::array<int, 4>
-    getNGRPZ(const int             grpsz,
-             const int             ngrp,
-             const int             num_tracers,
-             const ::Opm::Runspec& rspec)
+    WellArrayDims getWellArrayDims(const TracerSizes& tz)
     {
+        namespace VectorItems = Opm::RestartIO::Helpers::VectorItems;
+
+        // Five quantities (flow rate, cumulative production, cumulative injection, 2*concentration)
+        // per tracer component, plus two additional elements if any tracers are present.
+        constexpr auto tracer_quantity_count = 5;
+        const auto nxwelz_tracer_elems =
+            tracer_quantity_count*tz.numTracerElems
+            + ((tz.numTracers > 0) ? 2 : 0);
+
+        constexpr auto iwTo = static_cast<int>(VectorItems::IWell::index::TracerOffset);
+        constexpr auto swTo = static_cast<int>(VectorItems::SWell::index::TracerOffset);
+        constexpr auto xwTo = static_cast<int>(VectorItems::XWell::index::TracerOffset);
+
+        return {
+            .iwell = iwTo + tz.numTracers,         // #IWEL elems per well
+            .swell = swTo + 2 * tz.numTracerElems, // #SWEL elems per well
+            .xwell = xwTo + nxwelz_tracer_elems,   // #XWEL elems per well
+            .zwell = 3                             // #ZWEL elems per well
+        };
+    }
+
+    ConnArrayDims getConnArrayDims(const TracerSizes& tz)
+    {
+        namespace VectorItems = Opm::RestartIO::Helpers::VectorItems;
+
+        // Allocate XCON space for five quantities per tracer component.
+        constexpr auto tracer_quantity_count = 5;
+        const auto nxcon_tracer_elems = tracer_quantity_count * tz.numTracerElems;
+
+        constexpr auto xcTo = static_cast<int>(VectorItems::XConn::index::TracerOffset);
+
+        return {
+            .iconn = 26,                          // #ICON elems per conn
+            .sconn = 42,                          // #SCON elems per conn
+            .xconn = xcTo + nxcon_tracer_elems    // #XCON elems per conn
+        };
+    }
+
+    std::array<int, 4>
+    getNGRPZ(const ::Opm::Runspec& rspec,
+             const TracerSizes&    tz,
+             const int             grpsz,
+             const int             ngrp)
+    {
+        namespace VectorItems = Opm::RestartIO::Helpers::VectorItems;
+
         const auto& wd = rspec.wellDimensions();
 
         const auto nwgmax = std::max(grpsz, wd.maxWellsPerGroup());
@@ -340,17 +449,16 @@ namespace {
 
         const int nigrpz = 97 + std::max(nwgmax, ngmax);
         const int nsgrpz = 112;
-        const int nxgrpz = 181 + 4*num_tracers;
+        const int nxgrpz = static_cast<int>(VectorItems::XGroup::index::TracerOffset) + 4*tz.numTracerElems;
         const int nzgrpz = 5;
 
-        return {{
+        return {
             nigrpz,
             nsgrpz,
             nxgrpz,
             nzgrpz,
-        }};
+        };
     }
-
 
     Opm::RestartIO::InteHEAD::Phases
     getActivePhases(const ::Opm::Runspec& rspec)
@@ -411,7 +519,7 @@ namespace {
             return { 0, 0, 0, 0 };
         }
 
-        const auto& no_act = acts.ecl_size();
+        const auto no_act = acts.ecl_size();
         const auto max_lines_pr_action = acts.max_input_lines();
         const auto max_cond_per_action = rspec.actdims().max_conditions();
         const auto max_characters_per_line = rspec.actdims().max_characters();
@@ -424,11 +532,10 @@ namespace {
         };
     }
 
-
     Opm::RestartIO::InteHEAD::WellSegDims
-    getWellSegDims(const int              num_tracers,
-                   const ::Opm::Runspec&  rspec,
+    getWellSegDims(const ::Opm::Runspec&  rspec,
                    const ::Opm::Schedule& sched,
+                   const TracerSizes&     tz,
                    const std::size_t      report_step,
                    const std::size_t      lookup_step)
     {
@@ -439,14 +546,14 @@ namespace {
         const auto maxNumBr = maxNumLateralBranches(sched, report_step, lookup_step);
 
         return {
-            numMSW,
-            std::max(numMSW, wsd.maxSegmentedWells()),
-            std::max(maxNumSeg, wsd.maxSegmentsPerWell()),
-            std::max(maxNumBr, wsd.maxLateralBranchesPerWell()),
-            22,           // #ISEG elems per segment
-            Opm::RestartIO::InteHEAD::numRsegElem(rspec.phases())
-               + 8*num_tracers, // #RSEG elems per segment
-            10            // #ILBR elems per branch
+            .nsegwl = numMSW,
+            .nswlmx = std::max(numMSW, wsd.maxSegmentedWells()),
+            .nsegmx = std::max(maxNumSeg, wsd.maxSegmentsPerWell()),
+            .nlbrmx = std::max(maxNumBr, wsd.maxLateralBranchesPerWell()),
+            .nisegz = 22,                       // #ISEG elems per segment
+            .nrsegz = Opm::RestartIO::InteHEAD::numRsegElem(rspec.phases())
+               + 8*tz.numTracerElems,           // #RSEG elems per segment
+            .nilbrz = 10                        // #ILBR elems per branch
         };
     }
 
@@ -640,61 +747,59 @@ createInteHead(const EclipseState& es,
                const int           report_step,
                const int           lookup_step)
 {
+    const auto nwgmax = ::maxGroupSize(sched, report_step,
+                                       lookup_step,
+                                       grid.get_lgr_tag());
 
-    const auto nwgmax = ::maxGroupSize(sched, report_step, lookup_step,
-                                      grid.get_lgr_tag());
     const auto ngmax  = (report_step == 0)
         ? 0 : numGroupsInField(sched, lookup_step, grid.get_lgr_tag());
 
-    const auto& acts  = sched[lookup_step].actions.get();
     const auto& rspec = es.runspec();
     const auto& tdim  = es.getTableManager();
     const auto& rdim  = tdim.getRegdims();
-    const auto& rckcfg = es.getSimulationConfig().rock_config();
-    const auto& tracers = es.runspec().tracers();
-    // TEMP is a tracer, oil&gas tracers have both free and solution parts.
-    const auto num_tracers = tracers.water_tracers() + tracers.oil_tracers() + tracers.gas_tracers() + (es.runspec().temp() ? 1 : 0);
-    const auto num_tracer_comps = num_tracers + tracers.oil_tracers() + tracers.gas_tracers();
-    int nxwelz_tracer_shift = num_tracer_comps*5 + 2 * (num_tracers > 0);
+
+    const auto tz = TracerSizes{rspec, es.getSimulationConfig()};
+
+    const auto wellArrayDims = getWellArrayDims(tz);
+    const auto connArrayDims = getConnArrayDims(tz);
 
     const auto ih = InteHEAD{}
         .dimensions         (grid.getNXYZ())
         .numActive          (static_cast<int>(grid.getNumActive()))
         .unitConventions    (es.getDeckUnitSystem())
         .wellTableDimensions(getWellTableDims(nwgmax, ngmax, rspec, sched,
-                                              report_step, lookup_step, grid.get_lgr_tag()))
+                                              report_step, lookup_step,
+                                              grid.get_lgr_tag()))
         .calendarDate       (getSimulationTimePoint(sched.posixStartTime(), simTime))
         .activePhases       (getActivePhases(rspec))
-             // The numbers below have been determined experimentally to work
-             // across a range of reference cases, but are not guaranteed to be
-             // universally valid.
-        .drsdt(sched, lookup_step)
+        .drsdt              (sched, lookup_step)
              // -----------------------------------------------------------------------------------
-             //              NIWELZ                | NSWELZ                     | NXWELZ                                                      | NZWELZ
-             //              #IWEL elems per well  | #SWEL elems per well       | #XWEL elems per well                                        | #ZWEL elems per well
-        .params_NWELZ       (155 + num_tracers,      122 + 2 * num_tracer_comps, VectorItems::XWell::index::TracerOffset + nxwelz_tracer_shift, 3)
+             //              NIWELZ               | NSWELZ               | NXWELZ               | NZWELZ
+             //              #IWEL elems per well | #SWEL elems per well | #XWEL elems per well | #ZWEL elems per well
+        .params_NWELZ       (wellArrayDims.iwell  , wellArrayDims.swell  , wellArrayDims.xwell  , wellArrayDims.zwell)
              // -----------------------------------------------------------------------------------
              //              NICONZ               | NSCONZ               | NXCONZ
              //              #ICON elems per conn | #SCON elems per conn | #XCON elems per conn
-        .params_NCON        (26,                    42,                    58 + 5*num_tracer_comps)
-        .params_GRPZ        (getNGRPZ(nwgmax, ngmax, num_tracer_comps, rspec))
+        .params_NCON        (connArrayDims.iconn  , connArrayDims.sconn  , connArrayDims.xconn)
+        .params_GRPZ        (getNGRPZ(rspec, tz, nwgmax, ngmax))
         .aquiferDimensions  (inferAquiferDimensions(es, sched[lookup_step]))
         .stepParam          (num_solver_steps, report_step)
         .tuningParam        (getTuningPars(sched[lookup_step].tuning()))
         .liftOptParam       (getLiftOptPar(sched, report_step, lookup_step))
-        .wellSegDimensions  (getWellSegDims(num_tracer_comps, rspec, sched, report_step, lookup_step))
+        .wellSegDimensions  (getWellSegDims(rspec, sched, tz, report_step, lookup_step))
         .regionDimensions   (getRegDims(tdim, rdim))
         .ngroups            ({ ngmax })
         .params_NGCTRL      (GroupControl(sched, report_step, lookup_step))
-        .variousParam       (202204, 100, num_tracer_comps)  // Output should be compatible with Eclipse 100, 2022.04 version.
+        .variousParam       (202204, 100)
         .udqParam_1         (getUdqParam(rspec, sched, report_step, lookup_step))
-        .actionParam        (getActionParam(rspec, acts, report_step))
+        .actionParam        (getActionParam(rspec, sched[lookup_step].actions(), report_step))
         .nominatedPhaseGuideRate(setGuideRateNominatedPhase(sched, report_step, lookup_step))
         .whistControlMode   (getWhistctlMode(sched, report_step, lookup_step))
         .activeNetwork      (getActiveNetwork(sched, lookup_step))
         .networkDimensions  (getNetworkDims(sched, lookup_step, rspec))
         .netBalanceData     (getNetworkBalanceParameters(sched, report_step))
-        .rockOpts           (getRockOpts(rckcfg, rdim))
+        .rockOpts           (getRockOpts(es.getSimulationConfig().rock_config(), rdim))
+        .tracerCounts       (rspec.tracers())
         ;
 
     return ih.data();

--- a/opm/output/eclipse/InteHEAD.cpp
+++ b/opm/output/eclipse/InteHEAD.cpp
@@ -112,8 +112,8 @@ enum index : std::vector<int>::size_type {
   ih_052       =       52       ,              //       0       0
   ih_053       =       53       ,              //       0       0
   ih_054       =       54       ,              //       0       0
-  ih_055       =       55       ,              //       0       0
-  ih_056       =       56       ,              //       0       0
+  MaxWatTracers =      VI::intehead::MaxWatTracers,   // Run's maximum number of water tracers in the model (per Grid)
+  MaxGasTracers =      VI::intehead::MaxGasTracers,   // Run's maximum number of gas tracers in the model (per Grid)
   ih_057       =       57       ,              //       0       0
   NGRNPHASE    =       VI::intehead::NGRNPH,   //       Parameter to determine the nominated phase for the guiderate
   EACHNC       =       VI::intehead::EACHNCITS, //  Index indicating if lift gas distribution optimized each of the NUPCOL first iterations or not
@@ -680,8 +680,7 @@ Opm::RestartIO::InteHEAD::tuningParam(const TuningPar& tunpar)
 
 Opm::RestartIO::InteHEAD&
 Opm::RestartIO::InteHEAD::variousParam(const int version,
-                                       const int iprog,
-                      [[maybe_unused]] const int num_tracer_comps)
+                                       const int iprog)
 {
     this->data_[VERSION] = version;
     this->data_[IPROG]   = iprog;
@@ -819,14 +818,21 @@ liftOptParam(int in_enc)
 }
 
 Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::tracerCounts(const Tracers& tracers)
+{
+    this->data_[MaxWatTracers] = tracers.water_tracers();
+    this->data_[MaxGasTracers] = tracers.gas_tracers();
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
 Opm::RestartIO::InteHEAD::activeNetwork(const ActiveNetwork& actntwrk)
 {
     this->data_[ACTIVENETWRK] = actntwrk.actnetwrk;
 
     return *this;
 }
-
-
 
 Opm::RestartIO::InteHEAD&
 Opm::RestartIO::InteHEAD::networkDimensions(const NetworkDims& nwdim)

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -36,6 +36,7 @@ class EclipseState;
 class Phases;
 class Schedule;
 class ScheduleState;
+class Tracers;
 class UDQInput;
 class UnitSystem;
 
@@ -227,7 +228,7 @@ namespace Opm { namespace RestartIO {
 
         InteHEAD& stepParam(const int tstep, const int report_step);
         InteHEAD& tuningParam(const TuningPar& tunpar);
-        InteHEAD& variousParam(const int version, const int iprog, const int num_tracers = 0);
+        InteHEAD& variousParam(const int version, const int iprog);
         InteHEAD& wellSegDimensions(const WellSegDims& wsdim);
         InteHEAD& activeNetwork(const ActiveNetwork& actntwrk);
         InteHEAD& networkDimensions(const NetworkDims& nwdim);
@@ -240,6 +241,7 @@ namespace Opm { namespace RestartIO {
         InteHEAD& nominatedPhaseGuideRate(GuideRateNominatedPhase nphase);
         InteHEAD& whistControlMode(int mode);
         InteHEAD& liftOptParam(int in_enc);
+        InteHEAD& tracerCounts(const Tracers& tracers);
 
         static int numRsegElem(const Opm::Phases& phase);
 

--- a/opm/output/eclipse/LoadRestart.cpp
+++ b/opm/output/eclipse/LoadRestart.cpp
@@ -67,8 +67,10 @@
 #include <initializer_list>
 #include <map>
 #include <memory>
+#include <span>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>
@@ -78,13 +80,11 @@
 
 #include <fmt/format.h>
 
-#include <boost/range.hpp>
-
 namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
 
 namespace {
     template <typename T>
-    boost::iterator_range<typename std::vector<T>::const_iterator>
+    std::span<const T>
     getDataWindow(const std::vector<T>& arr,
                   const std::size_t     windowSize,
                   const std::size_t     entity,
@@ -177,9 +177,7 @@ class WellVectors
 {
 public:
     template <typename T>
-    using Window = boost::iterator_range<
-        typename std::vector<T>::const_iterator
-    >;
+    using Window = std::span<const T>;
 
     explicit WellVectors(const std::vector<int>&                      intehead,
                          std::shared_ptr<Opm::EclIO::RestartFileView> rst_view);
@@ -288,9 +286,7 @@ class GroupVectors
 {
 public:
     template <typename T>
-    using Window = boost::iterator_range<
-        typename std::vector<T>::const_iterator
-    >;
+    using Window = std::span<const T>;
 
     explicit GroupVectors(const std::vector<int>&                      intehead,
                           std::shared_ptr<Opm::EclIO::RestartFileView> rst_view);
@@ -361,9 +357,7 @@ class SegmentVectors
 {
 public:
     template <typename T>
-    using Window = boost::iterator_range<
-        typename std::vector<T>::const_iterator
-    >;
+    using Window = std::span<const T>;
 
     explicit SegmentVectors(const std::vector<int>&                      intehead,
                             std::shared_ptr<Opm::EclIO::RestartFileView> rst_view);
@@ -432,9 +426,7 @@ class AquiferVectors
 {
 public:
     template <typename T>
-    using Window = boost::iterator_range<
-        typename std::vector<T>::const_iterator
-    >;
+    using Window = std::span<const T>;
 
     explicit AquiferVectors(const std::vector<int>&                      intehead,
                             std::shared_ptr<Opm::EclIO::RestartFileView> rst_view);
@@ -1288,13 +1280,88 @@ namespace {
         return aquifers;
     }
 
-    void assign_well_cumulatives(const std::string& well,
-                                 const std::size_t  wellID,
-                                 const Opm::Tracers& tracer_dims,
+    template <typename UpdateCumulative>
+    void assign_tracer_cumulatives(const std::size_t        cumulativeOffset,
+                                   std::string_view         cumulativeType,
+                                   const bool               isTemp,
+                                   const Opm::Tracers&      tracer_dims,
+                                   const Opm::TracerConfig& tracer_config,
+                                   std::span<const double>  trcCumulatives,
+                                   UpdateCumulative&&       updateCumulative)
+    {
+        assert (isTemp || !tracer_config.empty());
+
+        const auto dgas = tracer_config.supportsSolutionGasTracer();
+        const auto voil = tracer_config.supportsVaporisedOilTracer();
+
+        // Tracer production/injection totals
+        const auto num_cumulative_elems = (isTemp ? 1 : 0)
+            +              tracer_dims.water_tracers()
+            + (1 + dgas) * tracer_dims.gas_tracers()
+            + (1 + voil) * tracer_dims.oil_tracers();
+
+        for (auto qtyIdx = cumulativeOffset; const auto type : cumulativeType) {
+            auto nextCumulative = [idx = std::size_t{0},
+                                   values = trcCumulatives.subspan(qtyIdx++ * num_cumulative_elems,
+                                                                   num_cumulative_elems)]() mutable
+            {
+                 return values[idx++];
+            };
+
+            if (isTemp) {
+                updateCumulative(type, "HEA", nextCumulative());
+            }
+
+            for (const auto& tracer : tracer_config) {
+                if (tracer.phase == Opm::Phase::WATER) {
+                    updateCumulative(type, tracer.name, nextCumulative());
+                }
+                else {
+                    const auto supportsSolution =
+                        (dgas && tracer.phase == Opm::Phase::GAS) ||
+                        (voil && tracer.phase == Opm::Phase::OIL);
+
+                    const auto free_total = nextCumulative();
+                    const auto solution_total = supportsSolution ? nextCumulative() : 0.0;
+
+                    updateCumulative(type, tracer.wellfname(), free_total);
+                    updateCumulative(type, tracer.wellsname(), solution_total);
+                    updateCumulative(type, tracer.name, free_total + solution_total);
+                }
+            }
+        }
+    }
+
+    void assign_well_tracer_cumulatives(const std::string&       well,
+                                        const std::size_t        wellID,
+                                        const bool               isTemp,
+                                        const Opm::Tracers&      tracer_dims,
+                                        const Opm::TracerConfig& tracer_config,
+                                        const WellVectors&       wellData,
+                                        Opm::SummaryState&       smry)
+    {
+        const auto tracerCumulatives = wellData.xwel(wellID)
+            .subspan(VI::XWell::index::TracerOffset);
+
+        // Well tracer cumulatives start at offset 1 (rates are at offset zero)
+        // and are in the order of production/injection totals, i.e., "P" then "I".
+        assign_tracer_cumulatives(1, "PI", isTemp, tracer_dims, tracer_config,
+                                  tracerCumulatives,
+                                  [&smry, &well](const char       type,
+                                                 std::string_view tracerName,
+                                                 const double     value)
+        {
+            smry.update_well_var(well, fmt::format("WT{}T{}", type, tracerName), value);
+        });
+    }
+
+    void assign_well_cumulatives(const std::string&       well,
+                                 const std::size_t        wellID,
+                                 const bool               isTemp,
+                                 const Opm::Tracers&      tracer_dims,
                                  const Opm::TracerConfig& tracer_config,
-                                 const WellVectors& wellData,
-                                 const bool isTemp,
-                                 Opm::SummaryState& smry)
+                                 const WellVectors&       wellData,
+                                 Opm::SummaryState&       smry)
     {
         if (! wellData.hasDefinedWellValues()) {
             // Result set does not provide well information.
@@ -1339,27 +1406,12 @@ namespace {
         smry.update_well_var(well, "WWITH", xwel[VI::XWell::index::HistWatInjTotal]);
         smry.update_well_var(well, "WGITH", xwel[VI::XWell::index::HistGasInjTotal]);
 
-        // Tracer production/injection totals
-        const auto num_tracer_comps = tracer_dims.water_tracers() + 2* (tracer_dims.oil_tracers() + tracer_dims.gas_tracers()) + (isTemp ? 1 : 0);
-        auto offset = VI::XWell::index::TracerOffset + num_tracer_comps; // First num_tracer_comps are the rates
-        for (const auto* type : { "P", "I", }) { // Production followed by injection
-            if (isTemp) {
-                smry.update_well_var(well, fmt::format("WT{}THEA", type), xwel[offset++]);
-            }
-
-            for (const auto& tracer : tracer_config) {
-                if (tracer.phase == Opm::Phase::WATER) {
-                    smry.update_well_var(well, fmt::format("WT{}T{}", type, tracer.name), xwel[offset++]);
-                }
-                else {
-                    const auto free_total = xwel[offset++];
-                    const auto solution_total = xwel[offset++];
-
-                    smry.update_well_var(well, fmt::format("WT{}TF{}", type, tracer.name), free_total);
-                    smry.update_well_var(well, fmt::format("WT{}TS{}", type, tracer.name), solution_total);
-                    smry.update_well_var(well, fmt::format("WT{}T{}", type, tracer.name), free_total + solution_total);
-                }
-            }
+        if (isTemp || !tracer_config.empty()) {
+            assign_well_tracer_cumulatives(well, wellID,
+                                           isTemp,
+                                           tracer_dims,
+                                           tracer_config,
+                                           wellData, smry);
         }
     }
 
@@ -1585,8 +1637,9 @@ namespace {
             for (auto nWells = wells.size(), wellID = 0*nWells;
                  wellID < nWells; ++wellID)
             {
-                assign_well_cumulatives(wells[wellID], wellID, schedule.runspec().tracers(), tracer_config,
-                                        wellData, isTemp, smry);
+                assign_well_cumulatives(wells[wellID], wellID, isTemp,
+                                        schedule.runspec().tracers(), tracer_config,
+                                        wellData, smry);
             }
         }
 
@@ -1598,6 +1651,7 @@ namespace {
 
             for (const auto& gname : schedule.groupNames(sim_step)) {
                 const auto& group = schedule.getGroup(gname, sim_step);
+
                 // Note: Order of group values in {I,X}GRP arrays mostly
                 // matches group's order of occurrence in .DATA file.
                 // Values pertaining to FIELD are stored at zero-based order
@@ -1621,15 +1675,15 @@ namespace {
 namespace Opm::RestartIO  {
 
     RestartValue
-    load(const std::string&             filename,
-         int                            report_step,
-         Action::State&                 /*  action_state  */,
-         SummaryState&                  summary_state,
-         const std::vector<RestartKey>& solution_keys,
-         const EclipseState&            es,
-         const EclipseGrid&             grid,
-         const Schedule&                schedule,
-         const std::vector<RestartKey>& extra_keys)
+    load(const std::string&              filename,
+         int                             report_step,
+         [[maybe_unused]] Action::State& action_state,
+         SummaryState&                   summary_state,
+         const std::vector<RestartKey>&  solution_keys,
+         const EclipseState&             es,
+         const EclipseGrid&              grid,
+         const Schedule&                 schedule,
+         const std::vector<RestartKey>&  extra_keys)
     {
         auto rst_view = std::make_shared<Opm::EclIO::RestartFileView>
             (std::make_shared<Opm::EclIO::ERst>(filename), report_step);

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -212,19 +212,18 @@ namespace {
     }
 
     std::vector<Opm::EclIO::SummaryNode>
-    requiredRestartVectors(const ::Opm::Schedule& sched, const ::Opm::TracerConfig& trConfig)
+    requiredRestartVectors(const ::Opm::Schedule&     sched,
+                           const ::Opm::TracerConfig& trConfig)
     {
         auto entities = std::vector<Opm::EclIO::SummaryNode> {};
 
         const auto vectors = requiredRestartVectors();
 
         const auto required_tracer_vectors = std::vector<ParamCTorArgs> {
-            { "TPR", Opm::EclIO::SummaryNode::Type::Rate     },
-            { "TIR", Opm::EclIO::SummaryNode::Type::Rate     },
-            { "TPT", Opm::EclIO::SummaryNode::Type::Total    },
-            { "TIT", Opm::EclIO::SummaryNode::Type::Total    },
-            { "TPC", Opm::EclIO::SummaryNode::Type::Ratio    },
-            { "TIC", Opm::EclIO::SummaryNode::Type::Ratio    },
+            { "TPR", Opm::EclIO::SummaryNode::Type::Rate  },
+            { "TIR", Opm::EclIO::SummaryNode::Type::Rate  },
+            { "TPT", Opm::EclIO::SummaryNode::Type::Total },
+            { "TIT", Opm::EclIO::SummaryNode::Type::Total },
         };
 
         const auto extra_well_vectors = std::vector<ParamCTorArgs> {
@@ -275,10 +274,8 @@ namespace {
 
             { "WWITH", Opm::EclIO::SummaryNode::Type::Total    },
             { "WGITH", Opm::EclIO::SummaryNode::Type::Total    },
-
-
-
         };
+
         const auto extra_group_vectors = std::vector<ParamCTorArgs> {
             { "GOPGR", Opm::EclIO::SummaryNode::Type::Rate },
             { "GGPGR", Opm::EclIO::SummaryNode::Type::Rate },
@@ -326,6 +323,11 @@ namespace {
             {"CWGR", Opm::EclIO::SummaryNode::Type::Ratio},
         };
 
+        const auto extra_tracer_vectors = std::vector<ParamCTorArgs> {
+            { "TPC", Opm::EclIO::SummaryNode::Type::Ratio },
+            { "TIC", Opm::EclIO::SummaryNode::Type::Ratio },
+        };
+
         using Cat = Opm::EclIO::SummaryNode::Category;
 
         auto makeEntities = [&vectors, &entities]
@@ -351,38 +353,46 @@ namespace {
             std::ranges::transform(extra_vectors, std::back_inserter(entities), toNode);
         };
 
-        auto makeTracerEntities = [&entities, &trConfig]
-            (   const char kwpref,
-                const Cat cat,
-                const std::vector<ParamCTorArgs>& tracer_vectors,
-                const std::string& name,
-                const bool isTemp
-            )
+        auto makeTracerEntities = [isTemp = sched.runspec().temp(),
+                                   &entities, &trConfig]
+            (const char                        kwpref,
+             const Cat                         cat,
+             const std::vector<ParamCTorArgs>& tr_vectors,
+             const std::string&                name)
         {
-            const auto dflt_num = Opm::EclIO::SummaryNode::default_number;
-            std::string kwp(1, kwpref);
-            for (const auto& tvec : tracer_vectors) {
+            constexpr auto dflt_num = Opm::EclIO::SummaryNode::default_number;
+
+            for (const auto& tvec : tr_vectors) {
+                auto vectorName = [kwpref, &tvec](const std::string& tracerName)
+                { return fmt::format("{}{}{}", kwpref, tvec.kw, tracerName); };
+
                 if (isTemp) {
-                    entities.push_back(Opm::EclIO::SummaryNode({kwp + tvec.kw + "HEA", cat,
-                                                                tvec.type, name, dflt_num, {}, {}}));
+                    entities.emplace_back(vectorName("HEA"), cat, tvec.type, name, dflt_num);
                 }
+
                 for (const auto& tracer : trConfig) {
-                    entities.push_back(Opm::EclIO::SummaryNode({kwp + tvec.kw + tracer.name, cat,
-                                                                tvec.type, name, dflt_num, {}, {}}));
+                    entities.emplace_back(vectorName(tracer.name), cat,
+                                          tvec.type, name, dflt_num);
+
                     if (tracer.phase == ::Opm::Phase::OIL || tracer.phase == ::Opm::Phase::GAS) {
-                        entities.push_back(Opm::EclIO::SummaryNode({kwp + tvec.kw + "F" + tracer.name, cat,
-                                                                    tvec.type, name, dflt_num, {}, {}}));
-                        entities.push_back(Opm::EclIO::SummaryNode({kwp + tvec.kw + "S" + tracer.name, cat,
-                                                                    tvec.type, name, dflt_num, {}, {}}));
+                        entities.emplace_back(vectorName(tracer.wellfname()), cat,
+                                              tvec.type, name, dflt_num);
+
+                        entities.emplace_back(vectorName(tracer.wellsname()), cat,
+                                              tvec.type, name, dflt_num);
                     }
                 }
             }
         };
 
-        const bool isTemp = sched.runspec().temp();
         for (const auto& well_name : sched.wellNames()) {
             makeEntities('W', Cat::Well, extra_well_vectors, well_name);
-            makeTracerEntities('W', Cat::Well, required_tracer_vectors, well_name, isTemp);
+
+            // Tracer rates and cumulatives.
+            makeTracerEntities('W', Cat::Well, required_tracer_vectors, well_name);
+
+            // Concentrations &c.
+            makeTracerEntities('W', Cat::Well, extra_tracer_vectors, well_name);
 
             const auto& well = sched.getWellatEnd(well_name);
             for (const auto& conn : well.getConnections()) {

--- a/opm/output/eclipse/VectorItems/group.hpp
+++ b/opm/output/eclipse/VectorItems/group.hpp
@@ -226,7 +226,7 @@ namespace Opm::RestartIO::Helpers::VectorItems {
             HistGasInjTotal = 144, // Group's total cumulative gas injection
                                    // (observed/historical rates)
 
-            TracerOffset = 180,    // Tracer data starts here
+            TracerOffset = 181,    // Tracer data starts here
         };
     } // XGroup
 

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -82,6 +82,9 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
         NGCTRL = 51, //  Index indicating if group control is used or not (1 - if group control, 0 if not)
 
+        MaxWatTracers = 55, //  Maximum number of water tracers in the model (per Grid)
+        MaxGasTracers = 56, //  Maximum number of gas tracers in the model (per Grid)
+
         NGRNPH = 58, //  Index indicating if group control is used or not (1 - if group control, 0 if not)
         EACHNCITS = 59, //  Index indicating if lift gas distribution optimized each of the NUPCOL first iterations or not
                        // 1 - optimized only first newton iteration, 2 - optimized each of NUPCOL newton iterations

--- a/opm/output/eclipse/VectorItems/well.hpp
+++ b/opm/output/eclipse/VectorItems/well.hpp
@@ -163,6 +163,8 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             CompOrd = 98, // Well's completion ordering scheme.
 
             LiftOptAllocExtra = 144,
+
+            TracerOffset = 155, // Tracer data start at this index
         };
 
         namespace Value {
@@ -423,7 +425,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             WatVoidPrRate = 122, // Well's voidage production rate
             GasVoidPrRate = 123, // Well's voidage production rate
 
-            TracerOffset  = 131, // Tracer data start at this index (+1 since late 2022)
+            TracerOffset  = 131, // Tracer data start at this index
         };
     } // XWell
 

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -41,6 +41,8 @@
 #include <opm/io/eclipse/rst/state.hpp>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+#include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
 
 #include <opm/input/eclipse/Python/Python.hpp>
 
@@ -59,7 +61,9 @@
 #include <opm/common/utility/TimeService.hpp>
 
 #include <algorithm>
+#include <span>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -72,7 +76,7 @@ namespace {
         explicit MockIH(const int numWells,
                         const int iwelPerWell = 155,  // E100
                         const int swelPerWell = 122,  // E100
-                        const int xwelPerWell = 130,  // E100
+                        const int xwelPerWell = 131,  // E100
                         const int zwelPerWell =   3); // E100
 
         std::vector<int> value;
@@ -1989,3 +1993,981 @@ BOOST_AUTO_TEST_CASE(WdFac_Correlation)
 }
 
 BOOST_AUTO_TEST_SUITE_END()     // Extra_Effects
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Tracer_Values)
+
+namespace {
+
+    SimulationCase isothermalTracerCase()
+    {
+        return SimulationCase { Opm::Parser{}.parseString(R"xxx(RUNSPEC
+DIMENS
+  5 5 2 /
+OIL
+GAS
+WATER
+DISGAS
+TABDIMS
+/
+EQLDIMS
+  3 1 1 /
+TRACERS
+--  oil  water  gas  env
+     1*  2      2    1*   /
+GRID
+DXV
+  5*100 /
+DYV
+  5*100 /
+DZV
+  5 10 /
+DEPTHZ
+  36*2000.0 /
+EQUALS
+  PORO 0.25 /
+  PERMX 100 /
+  PERMY 100 /
+  PERMZ 10 /
+/
+PROPS
+DENSITY
+  852.6 1014.3 0.83 /
+TRACER
+SEA  WAT  /
+OCE  GAS /
+/
+TVDPFSEA
+1000   0.0
+5000   0.0 /
+TBLKFOCE
+1.0 2.0 3.0 /
+SCHEDULE
+WELSPECS
+  IW G 1 1 2010.0 'WATER' /
+  IG G 1 5 2010.0 'GAS' /
+  P  G 5 3 2002.5 'LIQ' /
+/
+COMPDAT
+  IW 1 1 2 2 'OPEN' 2* 0.5 /
+  IG 1 5 1 1 'OPEN' 2* 0.5 /
+  P  5 3 1 2 'OPEN' 2* 0.5 /
+/
+WTRACER
+  IW SEA 0.123 /
+  IG OCE 0.456 /
+/
+WCONINJE
+  IW 'WATER' 'OPEN' RATE 12345.6 1* 512.256 /
+  IG 'GAS' 'OPEN' RATE 678910.1112 1* 256.128 /
+/
+WCONPROD
+  P 'OPEN' LRAT 3* 100E3 1* 25.125 /
+/
+TSTEP
+  1 2 3 4 5 10 15 4*20 /
+END
+)xxx")
+        };
+    }
+
+    SimulationCase thermalTracerCase()
+    {
+        return SimulationCase { Opm::Parser{}.parseString(R"xxx(RUNSPEC
+DIMENS
+  5 5 2 /
+OIL
+GAS
+WATER
+DISGAS
+TEMP
+TABDIMS
+/
+EQLDIMS
+  3 1 1 /
+TRACERS
+--  oil  water  gas  env
+     1*  2      2    1*   /
+GRID
+DXV
+  5*100 /
+DYV
+  5*100 /
+DZV
+  5 10 /
+DEPTHZ
+  36*2000.0 /
+EQUALS
+  PORO 0.25 /
+  PERMX 100 /
+  PERMY 100 /
+  PERMZ 10 /
+/
+PROPS
+DENSITY
+  852.6 1014.3 0.83 /
+TRACER
+SEA  WAT  /
+OCE  GAS /
+/
+TVDPFSEA
+1000   0.0
+5000   0.0 /
+TBLKFOCE
+1.0 2.0 3.0 /
+TEMPI
+  50*42.0 /
+SCHEDULE
+WELSPECS
+  IW G 1 1 2010.0 'WATER' /
+  IG G 1 5 2010.0 'GAS' /
+  P  G 5 3 2002.5 'LIQ' /
+/
+COMPDAT
+  IW 1 1 2 2 'OPEN' 2* 0.5 /
+  IG 1 5 1 1 'OPEN' 2* 0.5 /
+  P  5 3 1 2 'OPEN' 2* 0.5 /
+/
+WTRACER
+  IW SEA 0.123 /
+  IG OCE 0.456 /
+/
+WTEMP
+  IW 10.0 /
+  IG 60.0 /
+/
+WCONINJE
+  IW 'WATER' 'OPEN' RATE 12345.6 1* 512.256 /
+  IG 'GAS' 'OPEN' RATE 678910.1112 1* 256.128 /
+/
+WCONPROD
+  P 'OPEN' LRAT 3* 100E3 1* 25.125 /
+/
+TSTEP
+  1 2 3 4 5 10 15 4*20 /
+END
+)xxx")
+        };
+    }
+
+    std::pair<Opm::data::Wells, Opm::SummaryState> dynamicStateIsothermTracers()
+    {
+        auto dyn_state = std::pair<Opm::data::Wells, Opm::SummaryState> {
+            std::piecewise_construct,
+            std::forward_as_tuple(),
+            std::forward_as_tuple(Opm::TimeService::now(), 0.0)
+        };
+
+        using o = ::Opm::data::Rates::opt;
+
+        auto& [xw, sum_state] = dyn_state;
+
+        {
+            const auto wname = std::string { "IW" };
+
+            xw[wname].rates.set(o::wat, 1.0);
+            xw[wname].bhp = 213.0*Opm::unit::barsa;
+        }
+
+        {
+            const auto wname = std::string { "IG" };
+
+            xw[wname].rates.set(o::gas, 3.0);
+            xw[wname].bhp = 213.0*Opm::unit::barsa;
+        }
+
+        {
+            const auto wname = std::string { "P" };
+
+            xw[wname].bhp = 234.0*Opm::unit::barsa;
+            xw[wname].rates
+                .set(o::wat,  5.0*Opm::unit::cubic(Opm::unit::meter)/Opm::unit::day)
+                .set(o::oil,  2.5*Opm::unit::cubic(Opm::unit::meter)/Opm::unit::day)
+                .set(o::gas, 10.0*Opm::unit::cubic(Opm::unit::meter)/Opm::unit::day);
+        }
+
+        sum_state.update_well_var("IW", "WTICSEA", 0.123);
+        sum_state.update_well_var("IW", "WTIRSEA", 1234.5);
+        sum_state.update_well_var("IW", "WTITSEA", 123456.7);
+
+        sum_state.update_well_var("IG", "WTICOCE", 0.456);
+        sum_state.update_well_var("IG", "WTIROCE", 4567.8);
+        sum_state.update_well_var("IG", "WTITOCE", 4567891.011);
+
+        sum_state.update_well_var("IG", "WTICFOCE", 0.456);
+        sum_state.update_well_var("IG", "WTIRFOCE", 4567.8);
+        sum_state.update_well_var("IG", "WTITFOCE", 4567891.011);
+
+        sum_state.update_well_var("P", "WTPCSEA", 0.0123);
+        sum_state.update_well_var("P", "WTPRSEA", 123.45);
+        sum_state.update_well_var("P", "WTPTSEA", 1234.567);
+
+        sum_state.update_well_var("P", "WTPCOCE", 0.00456);
+        sum_state.update_well_var("P", "WTPROCE", 45.678);
+        sum_state.update_well_var("P", "WTPTOCE", 4567.891011);
+
+        sum_state.update_well_var("P", "WTPCFOCE", 0.0045);
+        sum_state.update_well_var("P", "WTPRFOCE", 40.0);
+        sum_state.update_well_var("P", "WTPTFOCE", 4500.0);
+
+        sum_state.update_well_var("P", "WTPCSOCE", 0.00456 - 0.0045);
+        sum_state.update_well_var("P", "WTPRSOCE", 45.678 - 40.0);
+        sum_state.update_well_var("P", "WTPTSOCE", 4567.891011 - 4500.0);
+
+        return dyn_state;
+    }
+
+    std::pair<Opm::data::Wells, Opm::SummaryState> dynamicStateThermalTracers()
+    {
+        auto dynState = dynamicStateIsothermTracers();
+
+        auto& sum_state = dynState.second;
+
+        sum_state.update_well_var("IW", "WTICHEA", 10.0);
+        sum_state.update_well_var("IW", "WTIRHEA", 112233.44);
+        sum_state.update_well_var("IW", "WTITHEA", 100.0e6);
+
+        sum_state.update_well_var("IG", "WTICHEA", 60.0);
+        sum_state.update_well_var("IG", "WTIRHEA", 223344.55);
+        sum_state.update_well_var("IG", "WTITHEA", 2.0e9);
+
+        sum_state.update_well_var("P", "WTPCHEA", 45.67);
+        sum_state.update_well_var("P", "WTPRHEA", 445566.77);
+        sum_state.update_well_var("P", "WTPTHEA", 135.79e6);
+
+        return dynState;
+    }
+
+    namespace VI = Opm::RestartIO::Helpers::VectorItems;
+
+    std::tuple<int, int, double> timePoint(const SimulationCase& cse)
+    {
+        constexpr auto report_step = 7;
+        constexpr auto sim_step = report_step - 1;
+        const auto simTime = cse.sched.seconds(report_step);
+
+        BOOST_CHECK_CLOSE(simTime, (1 + 2 + 3 + 4 + 5 + 10 + 15) * 86'400.0, 1.0e-7);
+
+        return {report_step, sim_step, simTime};
+    }
+
+    std::vector<int> intehead(const SimulationCase& cse)
+    {
+        const auto [report_step, sim_step, simTime] = timePoint(cse);
+
+        return Opm::RestartIO::Helpers::createInteHead
+            (cse.es, cse.grid, cse.sched, simTime,
+             report_step, // Should really be number of timesteps
+             report_step, sim_step);
+    }
+
+    Opm::RestartIO::Helpers::AggregateWellData
+    wellData(const SimulationCase&    cse,
+             const std::vector<int>&  ih,
+             const Opm::data::Wells&  xw,
+             const Opm::SummaryState& smry)
+    {
+        auto wd = Opm::RestartIO::Helpers::AggregateWellData {ih};
+
+        const auto tp = timePoint(cse);
+        const auto sim_step = std::get<1>(tp);
+
+        wd.captureDeclaredWellData(cse.sched, cse.es.tracer(),
+                                   sim_step, {}, {}, smry, ih);
+
+        wd.captureDynamicWellData(cse.sched, cse.es.tracer(),
+                                  sim_step, xw, smry);
+
+        return wd;
+    }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Isothermal)
+
+namespace {
+    constexpr auto tracerStride = std::size_t{6};
+}
+
+BOOST_AUTO_TEST_CASE(InteHEAD_Allocation_Sizes)
+{
+    const auto cse = isothermalTracerCase();
+    const auto ih  = intehead(cse);
+
+    const auto expectNumTracers = [&trcCount = cse.es.runspec().tracers()]()
+    {
+        return trcCount.water_tracers()
+             + trcCount.oil_tracers()
+             + trcCount.gas_tracers();
+    }();
+
+    BOOST_CHECK_EQUAL(expectNumTracers, 4);
+
+    const auto expectNumTrcElems = [&trcCount = cse.es.runspec().tracers()]()
+    {
+        return trcCount.water_tracers()
+             + 0*trcCount.oil_tracers()
+             + 2*trcCount.gas_tracers();
+    }();
+
+    BOOST_CHECK_EQUAL(expectNumTrcElems, static_cast<int>(tracerStride));
+
+    namespace VI = Opm::RestartIO::Helpers::VectorItems;
+
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NIWELZ], static_cast<int>(VI::IWell::TracerOffset) + expectNumTracers);
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NSWELZ], static_cast<int>(VI::SWell::TracerOffset) + 2*expectNumTrcElems);
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NXWELZ], static_cast<int>(VI::XWell::TracerOffset) + 5*expectNumTrcElems + 2);
+}
+
+BOOST_AUTO_TEST_SUITE(SWEL)
+
+BOOST_AUTO_TEST_CASE(IW)
+{
+    const auto cse = isothermalTracerCase();
+    const auto& [xw, smry] = dynamicStateIsothermTracers();
+    const auto ih = intehead(cse);
+    const auto wd = wellData(cse, ih, xw, smry);
+
+    const auto swsz = ih[VI::intehead::NSWELZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(swsz) > VI::SWell::TracerOffset,
+                          "SWEL must allocate space for tracer concentrations");
+
+    const auto sweltrc = std::span {wd.getSWell()}
+        .subspan(0*swsz, swsz)
+        .subspan(VI::SWell::TracerOffset);
+
+    const auto wtic = sweltrc.subspan(0*tracerStride, tracerStride);
+
+    BOOST_CHECK_CLOSE(wtic[0], 0.123f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[1], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[2], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[3], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[4], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[5], 0.0f, 1e-6f);
+
+    const auto wtic2 = sweltrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic2[0], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[1], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[2], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[3], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[4], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[5], 0.0f, 1e-6f);
+}
+
+BOOST_AUTO_TEST_CASE(IG)
+{
+    const auto cse = isothermalTracerCase();
+    const auto& [xw, smry] = dynamicStateIsothermTracers();
+    const auto ih = intehead(cse);
+    const auto wd = wellData(cse, ih, xw, smry);
+
+    const auto swsz = ih[VI::intehead::NSWELZ];
+
+    const auto sweltrc = std::span {wd.getSWell()}
+        .subspan(1*swsz, swsz)
+        .subspan(VI::SWell::TracerOffset);
+
+    const auto wtic = sweltrc.subspan(0*tracerStride, tracerStride);
+
+    BOOST_CHECK_CLOSE(wtic[0], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[1], 0.456f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[2], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[3], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[4], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[5], 0.0f, 1e-6f);
+
+    const auto wtic2 = sweltrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic2[0], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[1], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[2], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[3], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[4], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[5], 0.0f, 1e-6f);
+}
+
+BOOST_AUTO_TEST_CASE(P)
+{
+    const auto cse = isothermalTracerCase();
+    const auto& [xw, smry] = dynamicStateIsothermTracers();
+    const auto ih = intehead(cse);
+    const auto wd = wellData(cse, ih, xw, smry);
+
+    const auto swsz = ih[VI::intehead::NSWELZ];
+
+    const auto sweltrc = std::span {wd.getSWell()}
+        .subspan(2*swsz, swsz)
+        .subspan(VI::SWell::TracerOffset);
+
+    const auto wtic = sweltrc.subspan(0*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic[0], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[1], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[2], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[3], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[4], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[5], 0.0f, 1e-6f);
+
+    const auto wtic2 = sweltrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic2[0], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[1], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[2], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[3], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[4], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[5], 0.0f, 1e-6f);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // SWEL
+
+// --------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(XWEL)
+
+BOOST_AUTO_TEST_CASE(IW)
+{
+    const auto cse = isothermalTracerCase();
+    const auto& [xw, smry] = dynamicStateIsothermTracers();
+    const auto ih = intehead(cse);
+    const auto wd = wellData(cse, ih, xw, smry);
+
+    const auto xwsz = ih[VI::intehead::NXWELZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xwsz) > VI::XWell::TracerOffset,
+                          "XWEL must allocate space for tracer concentrations");
+
+    const auto xweltrc = std::span {wd.getXWell()}
+        .subspan(0 * xwsz, xwsz)
+        .subspan(VI::XWell::TracerOffset);
+
+    const auto wt_rate = xweltrc.subspan(0*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wt_rate[0], -1234.5, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[5], 0.0, 1e-6);
+
+    const auto wtpt = xweltrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtpt[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[5], 0.0, 1e-6);
+
+    const auto wtit = xweltrc.subspan(2*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtit[0], 123456.7, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[5], 0.0, 1e-6);
+
+    const auto wtic = xweltrc.subspan(3*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic[0], 0.123, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[5], 0.0, 1e-6);
+
+    const auto wtic2 = xweltrc.subspan(4*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic2[0], 0.123, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[5], 0.0, 1e-6);
+
+    const auto extra = xweltrc.subspan(5*tracerStride);
+    BOOST_CHECK_EQUAL(extra.size(), std::size_t{2});
+    BOOST_CHECK_CLOSE(extra[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(extra[1], 0.0, 1e-6);
+}
+
+BOOST_AUTO_TEST_CASE(IG)
+{
+    const auto cse = isothermalTracerCase();
+    const auto& [xw, smry] = dynamicStateIsothermTracers();
+    const auto ih = intehead(cse);
+    const auto wd = wellData(cse, ih, xw, smry);
+
+    const auto xwsz = ih[VI::intehead::NXWELZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xwsz) > VI::XWell::TracerOffset,
+                          "XWEL must allocate space for tracer concentrations");
+
+    const auto xweltrc = std::span {wd.getXWell()}
+        .subspan(1 * xwsz, xwsz)
+        .subspan(VI::XWell::TracerOffset);
+
+    const auto wt_rate = xweltrc.subspan(0*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wt_rate[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[1], -4567.8, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[5], 0.0, 1e-6);
+
+    const auto wtpt = xweltrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtpt[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[5], 0.0, 1e-6);
+
+    const auto wtit = xweltrc.subspan(2*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtit[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[1], 4567891.011, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[5], 0.0, 1e-6);
+
+    const auto wtic = xweltrc.subspan(3*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[1], 0.456, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[5], 0.0, 1e-6);
+
+    const auto wtic2 = xweltrc.subspan(4*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic2[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[1], 0.456, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[5], 0.0, 1e-6);
+
+    const auto extra = xweltrc.subspan(5*tracerStride);
+    BOOST_CHECK_EQUAL(extra.size(), std::size_t{2});
+    BOOST_CHECK_CLOSE(extra[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(extra[1], 0.0, 1e-6);
+}
+
+BOOST_AUTO_TEST_CASE(P)
+{
+    const auto cse = isothermalTracerCase();
+    const auto& [xw, smry] = dynamicStateIsothermTracers();
+    const auto ih = intehead(cse);
+    const auto wd = wellData(cse, ih, xw, smry);
+
+    const auto xwsz = ih[VI::intehead::NXWELZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xwsz) > VI::XWell::TracerOffset,
+                          "XWEL must allocate space for tracer concentrations");
+
+    const auto xweltrc = std::span {wd.getXWell()}
+        .subspan(2 * xwsz, xwsz)
+        .subspan(VI::XWell::TracerOffset);
+
+    const auto wt_rate = xweltrc.subspan(0*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wt_rate[0], 123.45, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[1], 40.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[2], 5.678, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[5], 0.0, 1e-6);
+
+    const auto wtpt = xweltrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtpt[0], 1234.567, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[1], 4500.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[2], 67.891011, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[5], 0.0, 1e-6);
+
+    const auto wtit = xweltrc.subspan(2*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtit[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[5], 0.0, 1e-6);
+
+    const auto wtpc = xweltrc.subspan(3*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtpc[0], 0.0123, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc[1], 0.0045, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc[2], 0.00456 - 0.0045, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc[5], 0.0, 1e-6);
+
+    const auto wtpc2 = xweltrc.subspan(4*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtpc2[0], 0.0123, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc2[1], 0.0045, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc2[2], 0.00456 - 0.0045, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc2[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc2[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc2[5], 0.0, 1e-6);
+
+    const auto extra = xweltrc.subspan(5*tracerStride);
+    BOOST_CHECK_EQUAL(extra.size(), std::size_t{2});
+    BOOST_CHECK_CLOSE(extra[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(extra[1], 0.0, 1e-6);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // XWEL
+
+BOOST_AUTO_TEST_SUITE_END()     // Isothermal
+
+// ==========================================================================
+
+BOOST_AUTO_TEST_SUITE(Thermal)
+
+namespace {
+    constexpr auto tracerStride = std::size_t{7};
+}
+
+BOOST_AUTO_TEST_CASE(InteHEAD_Allocation_Sizes)
+{
+    const auto cse = thermalTracerCase();
+    const auto ih  = intehead(cse);
+
+    const auto expectNumTracers = [&trcCount = cse.es.runspec().tracers()]()
+    {
+        return trcCount.water_tracers()
+             + trcCount.oil_tracers()
+             + trcCount.gas_tracers()
+             + 1; // Temperature tracer
+    }();
+
+    BOOST_CHECK_EQUAL(expectNumTracers, 5);
+
+    const auto expectNumTrcElems = [&trcCount = cse.es.runspec().tracers()]()
+    {
+        return trcCount.water_tracers()
+             + 0*trcCount.oil_tracers()
+             + 2*trcCount.gas_tracers()
+             + 1; // Temperature tracer
+    }();
+
+    BOOST_CHECK_EQUAL(expectNumTrcElems, static_cast<int>(tracerStride));
+
+    namespace VI = Opm::RestartIO::Helpers::VectorItems;
+
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NIWELZ], static_cast<int>(VI::IWell::TracerOffset) + expectNumTracers);
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NSWELZ], static_cast<int>(VI::SWell::TracerOffset) + 2*expectNumTrcElems);
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NXWELZ], static_cast<int>(VI::XWell::TracerOffset) + 5*expectNumTrcElems + 2);
+}
+
+BOOST_AUTO_TEST_SUITE(SWEL)
+
+BOOST_AUTO_TEST_CASE(IW)
+{
+    const auto cse = thermalTracerCase();
+    const auto& [xw, smry] = dynamicStateThermalTracers();
+    const auto ih = intehead(cse);
+    const auto wd = wellData(cse, ih, xw, smry);
+
+    const auto swsz = ih[VI::intehead::NSWELZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(swsz) > VI::SWell::TracerOffset,
+                          "SWEL must allocate space for tracer concentrations");
+
+    const auto sweltrc = std::span {wd.getSWell()}
+        .subspan(0*swsz, swsz)
+        .subspan(VI::SWell::TracerOffset);
+
+    const auto wtic = sweltrc.subspan(0*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic[0], 10.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[1], 0.123f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[2], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[3], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[4], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[5], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[6], 0.0f, 1e-6f);
+
+    const auto wtic2 = sweltrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic2[0], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[1], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[2], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[3], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[4], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[5], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[6], 0.0f, 1e-6f);
+}
+
+BOOST_AUTO_TEST_CASE(IG)
+{
+    const auto cse = thermalTracerCase();
+    const auto& [xw, smry] = dynamicStateThermalTracers();
+    const auto ih = intehead(cse);
+    const auto wd = wellData(cse, ih, xw, smry);
+
+    const auto swsz = ih[VI::intehead::NSWELZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(swsz) > VI::SWell::TracerOffset,
+                          "SWEL must allocate space for tracer concentrations");
+
+    const auto sweltrc = std::span {wd.getSWell()}
+        .subspan(1*swsz, swsz)
+        .subspan(VI::SWell::TracerOffset);
+
+    const auto wtic = sweltrc.subspan(0*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic[0], 60.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[1], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[2], 0.456f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[3], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[4], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[5], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[6], 0.0f, 1e-6f);
+
+    const auto wtic2 = sweltrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic2[0], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[1], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[2], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[3], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[4], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[5], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[6], 0.0f, 1e-6f);
+}
+
+BOOST_AUTO_TEST_CASE(P)
+{
+    const auto cse = thermalTracerCase();
+    const auto& [xw, smry] = dynamicStateThermalTracers();
+    const auto ih = intehead(cse);
+    const auto wd = wellData(cse, ih, xw, smry);
+
+    const auto swsz = ih[VI::intehead::NSWELZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(swsz) > VI::SWell::TracerOffset,
+                          "SWEL must allocate space for tracer concentrations");
+
+    const auto sweltrc = std::span {wd.getSWell()}
+        .subspan(2*swsz, swsz)
+        .subspan(VI::SWell::TracerOffset);
+
+    const auto wtic = sweltrc.subspan(0*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic[0], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[1], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[2], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[3], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[4], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[5], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic[6], 0.0f, 1e-6f);
+
+    const auto wtic2 = sweltrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic2[0], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[1], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[2], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[3], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[4], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[5], 0.0f, 1e-6f);
+    BOOST_CHECK_CLOSE(wtic2[6], 0.0f, 1e-6f);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // SWEL
+
+// --------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(XWEL)
+
+BOOST_AUTO_TEST_CASE(IW)
+{
+    const auto cse = thermalTracerCase();
+    const auto& [xw, smry] = dynamicStateThermalTracers();
+    const auto ih = intehead(cse);
+    const auto wd = wellData(cse, ih, xw, smry);
+
+    const auto xwsz = ih[VI::intehead::NXWELZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xwsz) > VI::XWell::TracerOffset,
+                          "XWEL must allocate space for tracer concentrations");
+
+    const auto xweltrc = std::span {wd.getXWell()}
+        .subspan(0 * xwsz, xwsz)
+        .subspan(VI::XWell::TracerOffset);
+
+    const auto wt_rate = xweltrc.subspan(0*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wt_rate[0], -112233.44, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[1], -1234.5, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[6], 0.0, 1e-6);
+
+    const auto wtpt = xweltrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtpt[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[6], 0.0, 1e-6);
+
+    const auto wtit = xweltrc.subspan(2*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtit[0], 100.0e6, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[1], 123456.7, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[6], 0.0, 1e-6);
+
+    const auto wtic = xweltrc.subspan(3*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic[0], 10.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[1], 0.123, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[6], 0.0, 1e-6);
+
+    const auto wtic2 = xweltrc.subspan(4*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic2[0], 10.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[1], 0.123, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[6], 0.0, 1e-6);
+
+    const auto extra = xweltrc.subspan(5*tracerStride);
+    BOOST_CHECK_EQUAL(extra.size(), std::size_t{2});
+    BOOST_CHECK_CLOSE(extra[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(extra[1], 0.0, 1e-6);
+}
+
+BOOST_AUTO_TEST_CASE(IG)
+{
+    const auto cse = thermalTracerCase();
+    const auto& [xw, smry] = dynamicStateThermalTracers();
+    const auto ih = intehead(cse);
+    const auto wd = wellData(cse, ih, xw, smry);
+
+    const auto xwsz = ih[VI::intehead::NXWELZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xwsz) > VI::XWell::TracerOffset,
+                          "XWEL must allocate space for tracer concentrations");
+
+    const auto xweltrc = std::span {wd.getXWell()}
+        .subspan(1 * xwsz, xwsz)
+        .subspan(VI::XWell::TracerOffset);
+
+    const auto wt_rate = xweltrc.subspan(0*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wt_rate[0], -223344.55, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[2], -4567.8, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[6], 0.0, 1e-6);
+
+    const auto wtpt = xweltrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtpt[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[6], 0.0, 1e-6);
+
+    const auto wtit = xweltrc.subspan(2*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtit[0], 2.0e9, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[2], 4567891.011, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[6], 0.0, 1e-6);
+
+    const auto wtic = xweltrc.subspan(3*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic[0], 60.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[2], 0.456, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic[6], 0.0, 1e-6);
+
+    const auto wtic2 = xweltrc.subspan(4*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtic2[0], 60.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[2], 0.456, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtic2[6], 0.0, 1e-6);
+
+    const auto extra = xweltrc.subspan(5*tracerStride);
+    BOOST_CHECK_EQUAL(extra.size(), std::size_t{2});
+    BOOST_CHECK_CLOSE(extra[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(extra[1], 0.0, 1e-6);
+}
+
+BOOST_AUTO_TEST_CASE(P)
+{
+    const auto cse = thermalTracerCase();
+    const auto& [xw, smry] = dynamicStateThermalTracers();
+    const auto ih = intehead(cse);
+    const auto wd = wellData(cse, ih, xw, smry);
+
+    const auto xwsz = ih[VI::intehead::NXWELZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xwsz) > VI::XWell::TracerOffset,
+                          "XWEL must allocate space for tracer concentrations");
+
+    const auto xweltrc = std::span {wd.getXWell()}
+        .subspan(2 * xwsz, xwsz)
+        .subspan(VI::XWell::TracerOffset);
+
+    const auto wt_rate = xweltrc.subspan(0*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wt_rate[0], 445566.77, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[1], 123.45, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[2], 40.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[3], 5.678, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wt_rate[6], 0.0, 1e-6);
+
+    const auto wtpt = xweltrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtpt[0], 135.79e6, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[1], 1234.567, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[2], 4500.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[3], 67.891011, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpt[6], 0.0, 1e-6);
+
+    const auto wtit = xweltrc.subspan(2*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtit[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[1], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[2], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[3], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtit[6], 0.0, 1e-6);
+
+    const auto wtpc = xweltrc.subspan(3*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtpc[0], 45.67, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc[1], 0.0123, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc[2], 0.0045, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc[3], 0.00456 - 0.0045, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc[6], 0.0, 1e-6);
+
+    const auto wtpc2 = xweltrc.subspan(4*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(wtpc2[0], 45.67, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc2[1], 0.0123, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc2[2], 0.0045, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc2[3], 0.00456 - 0.0045, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc2[4], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc2[5], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(wtpc2[6], 0.0, 1e-6);
+
+    const auto extra = xweltrc.subspan(5*tracerStride);
+    BOOST_CHECK_EQUAL(extra.size(), std::size_t{2});
+    BOOST_CHECK_CLOSE(extra[0], 0.0, 1e-6);
+    BOOST_CHECK_CLOSE(extra[1], 0.0, 1e-6);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // XWEL
+
+BOOST_AUTO_TEST_SUITE_END()     // Thermal
+
+BOOST_AUTO_TEST_SUITE_END()     // Tracer_Values

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -96,16 +96,13 @@ struct SimulationCase
     explicit SimulationCase(const Opm::Deck& deck)
         : es   { deck }
         , grid { deck }
-        , python{ std::make_shared<Opm::Python>() }
-        , sched{ deck, es, python }
+        , sched{ deck, es, std::make_shared<Opm::Python>() }
     {}
 
     // Order requirement: 'es' must be declared/initialised before 'sched'.
     Opm::EclipseState es;
     Opm::EclipseGrid  grid;
-    std::shared_ptr<Opm::Python> python;
     Opm::Schedule     sched;
-
 };
 
 BOOST_AUTO_TEST_SUITE(Member_Functions)
@@ -427,7 +424,7 @@ BOOST_AUTO_TEST_CASE(Tuning_param)
 BOOST_AUTO_TEST_CASE(Various_Parameters)
 {
     const auto ih = Opm::RestartIO::InteHEAD{}
-        .variousParam(2015, 100, 0);
+        .variousParam(2015, 100);
 
     const auto& v = ih.data();
 
@@ -599,7 +596,7 @@ BOOST_AUTO_TEST_CASE(TestHeader)
     const auto nactive = 1345;
     const auto numWells        = 17;
     const auto maxPerf         = 29;
-    const auto maxWellsInGroup  =  3;
+    const auto maxWellsInGroup =  3;
     const auto maxGroupInField = 14;
     const auto maxWellsInField = 25;
     const auto year = 2010;
@@ -642,7 +639,6 @@ BOOST_AUTO_TEST_CASE(TestHeader)
     const auto mxwpit	= 6;
     const auto version = 2015;
     const auto iprog = 100;
-    const auto ntracers = 0;
     const auto nsegwl = 3;
     const auto nswlmx = 4;
     const auto nsegmx = 5;
@@ -676,13 +672,15 @@ BOOST_AUTO_TEST_CASE(TestHeader)
          .aquiferDimensions(aqudims)
          .stepParam(tstep, report_step)
          .tuningParam({newtmx, newtmn, litmax, litmin, mxwsit, mxwpit, 0})
-         .variousParam(version, iprog, ntracers)
+         .variousParam(version, iprog)
          .wellSegDimensions({nsegwl, nswlmx, nsegmx, nlbrmx, nisegz, nrsegz, nilbrz})
          .regionDimensions({ntfip, nmfipr, 0,0,0})
          .ngroups({ngroup});
 
     Opm::RestartIO::RstHeader header {
-        unit_system, ih.data(), std::vector<bool>(100), std::vector<double>(1000)
+        unit_system, ih.data(),
+        std::vector<bool>(100),
+        std::vector<double>(1000)
     };
 
     BOOST_CHECK_EQUAL(header.nx, nx);


### PR DESCRIPTION
We allocate and populate solution tracer elements only if present. In particular, gas tracer components dissolved in the oil phase are assigned (and reloaded) only if the run enables gas dissolution. This means that the `INTEHEAD` array size calculations must become slightly more involved, so we create a helper function to compute the number of array elements per tracer quantity.  We also store the number of (declared) gas and water tracers (`RUNSPEC` section keyword `TRACERS`) in `INTEHEAD`.  Finally, when populating the tracer portion of `XWEL`, we must take care to account for the number of declared tracers.  Each tracer quantity's values start at a multiple of the tracer elements from the `TracerOffset`.

As a final simplification, in Summary.cpp, we capture the "required tracer vectors" within the `makeTracerEntries` lambda. This never changes depending on the call site so there's no need to pass it in as a function argument.  While here, also leverage C++20's vector's `emplace_back()` function for "plain old data" structures.  Yay!