### PR TITLE
Support Group/Field Level Tracer Quantities in Restart File

### DIFF
--- a/opm/output/eclipse/AggregateGroupData.cpp
+++ b/opm/output/eclipse/AggregateGroupData.cpp
@@ -28,6 +28,9 @@
 #include <opm/output/eclipse/VectorItems/well.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+#include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
+
 #include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
@@ -47,6 +50,7 @@
 #include <initializer_list>
 #include <numeric>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -1527,9 +1531,194 @@ namespace XGrp {
         };
     }
 
+    template <typename TempCallback, typename WaterCallback, typename HCCallback>
+    void tracerLoop(std::span<double>        xGroup,
+                    const Opm::TracerConfig& tracers,
+                    TempCallback&&           processTemperature,
+                    WaterCallback&&          processWaterTracer,
+                    HCCallback&&             processHCTracer)
+    {
+        auto ix = std::size_t {0};
+
+        ix += processTemperature(&xGroup[ix]);
+
+        for (const auto& tracer : tracers) {
+            if (tracer.phase == Opm::Phase::WATER) {
+                ix += processWaterTracer(tracer, &xGroup[ix]);
+            }
+            else {
+                ix += processHCTracer(tracer, &xGroup[ix]);
+            }
+        }
+    }
+
+    void assignTracerQuantity(const bool               isTemp,
+                              const std::string&       quantity,
+                              const std::string&       groupName,
+                              const Opm::TracerConfig& tracers,
+                              const Opm::SummaryState& smry,
+                              std::span<double>        xGroup)
+    {
+        auto getValue = [isField = groupName == "FIELD",
+                         &smry, &quantity, &groupName]
+            (const std::string& tracerName)
+        {
+            const auto level  = isField ? 'F' : 'G';
+
+            // FTIRHEA, GTPTFXF2, GTITWT1, ...
+            const auto vector = fmt::format("{}T{}{}", level,
+                                            quantity, tracerName);
+
+            if (isField) {
+                return smry.get(vector, 0.0);
+            }
+
+            return smry.get_group_var(groupName, vector, 0.0);
+        };
+
+        auto processWaterTracer = [&getValue]
+            (const auto& tracer, auto* xgrp)
+        {
+            xgrp[0] = getValue(tracer.name);
+
+            return std::size_t {1};
+        };
+
+        auto processHCTracer = [dgas = tracers.supportsSolutionGasTracer(),
+                                voil = tracers.supportsVaporisedOilTracer(),
+                                &getValue]
+            (const auto& tracer, auto* xgrp)
+        {
+            const auto supportsSolution = (dgas && tracer.phase == Opm::Phase::GAS)
+                || (voil && tracer.phase == Opm::Phase::OIL);
+
+            xgrp[0] = getValue(tracer.wellfname());
+
+            if (!supportsSolution) {
+                return std::size_t {1};
+            }
+
+            xgrp[1] = getValue(tracer.wellsname());
+            return std::size_t {2};
+        };
+
+        if (!isTemp) {
+            return tracerLoop(xGroup, tracers,
+                              [](auto*) { return std::size_t {0}; },
+                              processWaterTracer,
+                              processHCTracer);
+        }
+
+        auto processTemperature = [tempQuant = getValue("HEA")](auto* xgrp)
+        {
+            xgrp[0] = tempQuant;
+
+            return std::size_t {1};
+        };
+
+        tracerLoop(xGroup, tracers, processTemperature, processWaterTracer, processHCTracer);
+    }
+
+    void assignTracerRates(const bool               isInjector,
+                           const bool               isTemp,
+                           const std::string&       groupName,
+                           const Opm::TracerConfig& tracers,
+                           const Opm::SummaryState& smry,
+                           std::span<double>        xGroup)
+    {
+        const auto prefix = isInjector ? std::string {"IR"} : std::string {"PR"};
+
+        assignTracerQuantity(isTemp, prefix, groupName, tracers, smry, xGroup);
+    }
+
+    void assignTracerCumulatives(const bool               isInjection,
+                                 const bool               isTemp,
+                                 const std::string&       groupName,
+                                 const Opm::TracerConfig& tracers,
+                                 const Opm::SummaryState& smry,
+                                 std::span<double>        xGroup)
+    {
+        const auto prefix = isInjection ? std::string {"IT"} : std::string {"PT"};
+
+        assignTracerQuantity(isTemp, prefix, groupName, tracers, smry, xGroup);
+    }
+
+    template <class XGroupArray>
+    void assignTracerData(const Opm::Runspec&      runspec,
+                          const Opm::TracerConfig& tracers,
+                          const Opm::SummaryState& smry,
+                          const Opm::Group&        group,
+                          XGroupArray&             xGroup)
+    {
+        if (tracers.empty() && !runspec.temp()) {
+            return;
+        }
+
+        const auto numTracerElems = [&runspec, &tracers]()
+        {
+            const auto& t = runspec.tracers();
+
+            return t.water_tracers() + (runspec.temp() ? 1 : 0)
+                + (1 + tracers.supportsSolutionGasTracer())  * t.gas_tracers()
+                + (1 + tracers.supportsVaporisedOilTracer()) * t.oil_tracers();
+        }();
+
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::XGroup::index;
+
+        auto tracerElems = std::span<double> {
+            xGroup.begin() + Ix::TracerOffset, xGroup.end()
+        };
+
+        std::ranges::fill(tracerElems, 0.0);
+
+        const auto& gname = group.name();
+
+        auto qtyIndex = std::size_t {0};
+
+        // Order of quantities in restart file is:
+        //   1. Injection rates
+        //   2. Production rates
+        //   3. Cumulative injection volume
+        //   4. Cumulative production volume
+
+        // 1. Injection rates.
+        assignTracerRates(/* injection = */ true,
+                          runspec.temp(),
+                          gname,
+                          tracers,
+                          smry,
+                          tracerElems.subspan(qtyIndex++ * numTracerElems, numTracerElems));
+
+        // 2. Production rates.
+        assignTracerRates(/* injection = */ false,
+                          runspec.temp(),
+                          gname,
+                          tracers,
+                          smry,
+                          tracerElems.subspan(qtyIndex++ * numTracerElems, numTracerElems));
+
+        // 3. Cumulative injection volume.
+        assignTracerCumulatives(/* injection = */ true,
+                                runspec.temp(),
+                                gname,
+                                tracers,
+                                smry,
+                                tracerElems.subspan(qtyIndex++ * numTracerElems, numTracerElems));
+
+        // 4. Cumulative production volume.
+        assignTracerCumulatives(/* injection = */ false,
+                                runspec.temp(),
+                                gname,
+                                tracers,
+                                smry,
+                                tracerElems.subspan(qtyIndex++ * numTracerElems, numTracerElems));
+    }
+
     // Populate restart file's XGRP array for this group.
     template <class XGrpArray>
     void dynamicContrib(const Opm::Group&        group,
+                        const Opm::Runspec&      runspec,
+                        const Opm::TracerConfig& tracers,
                         const Opm::SummaryState& sumState,
                         XGrpArray&               xGrp)
     {
@@ -1552,7 +1741,7 @@ namespace XGrp {
         xGrp[Ix::VoidPrGuideRate_2] = xGrp[Ix::VoidPrGuideRate];
         xGrp[Ix::WatInjGuideRate_2] = xGrp[Ix::WatInjGuideRate];
 
-        std::fill(xGrp.begin() + Ix::TracerOffset, xGrp.end(), 0);
+        assignTracerData(runspec, tracers, sumState, group, xGrp);
     }
 
     template <class XGrpArray>
@@ -1628,6 +1817,7 @@ AggregateGroupData(const std::vector<int>& inteHead)
 void
 Opm::RestartIO::Helpers::AggregateGroupData::
 captureDeclaredGroupData(const Schedule&         sched,
+                         const TracerConfig&     tracer,
                          const std::size_t       simStep,
                          const SummaryState&     sumState,
                          const std::vector<int>& inteHead)
@@ -1655,12 +1845,12 @@ captureDeclaredGroupData(const Schedule&         sched,
     });
 
     // Define Dynamic Contributions to XGrp Array.
-    groupLoop(curGroups, [&sumState, this]
+    groupLoop(curGroups, [&runspec = sched.runspec(), &tracer, &sumState, this]
               (const Group& group, const std::size_t groupID) -> void
     {
         auto xg = this->xGroup_[groupID];
 
-        XGrp::dynamicContrib(group, sumState, xg);
+        XGrp::dynamicContrib(group, runspec, tracer, sumState, xg);
     });
 
     // Define Static Contributions to ZGrp Array.

--- a/opm/output/eclipse/AggregateGroupData.hpp
+++ b/opm/output/eclipse/AggregateGroupData.hpp
@@ -32,6 +32,7 @@
 namespace Opm {
 class Schedule;
 class SummaryState;
+class TracerConfig;
 } // namespace Opm
 
 namespace Opm::RestartIO::Helpers {
@@ -42,6 +43,7 @@ public:
     explicit AggregateGroupData(const std::vector<int>& inteHead);
 
     void captureDeclaredGroupData(const Schedule&         sched,
+                                  const TracerConfig&     tracer,
                                   const std::size_t       simStep,
                                   const SummaryState&     sumState,
                                   const std::vector<int>& inteHead);

--- a/opm/output/eclipse/LoadRestart.cpp
+++ b/opm/output/eclipse/LoadRestart.cpp
@@ -1355,6 +1355,35 @@ namespace {
         });
     }
 
+    void assign_group_tracer_cumulatives(const std::string&       group,
+                                         const std::size_t        groupID,
+                                         const bool               isTemp,
+                                         const Opm::Tracers&      tracer_dims,
+                                         const Opm::TracerConfig& tracer_config,
+                                         const GroupVectors&      groupData,
+                                         Opm::SummaryState&       smry)
+    {
+        const auto tracerCumulatives = groupData.xgrp(groupID)
+            .subspan(VI::XGroup::index::TracerOffset);
+
+        // Group tracer cumulatives start at offset 2 (rates are at offsets zero and one)
+        // and appear in the order of injection/production totals, i.e., "I" then "P".
+        assign_tracer_cumulatives(2, "IP", isTemp, tracer_dims, tracer_config,
+                                  tracerCumulatives,
+                                  [&smry, &group](const char       type,
+                                                  std::string_view tracerName,
+                                                  const double     value)
+        {
+            // Note: This will update/assign GT*:FIELD as well.  That's intentional
+            // since vectors of that form might be needed for ACTIONX conditions.
+            smry.update_group_var(group, fmt::format("GT{}T{}", type, tracerName), value);
+
+            if (group == "FIELD") {
+                smry.update(fmt::format("FT{}T{}", type, tracerName), value);
+            }
+        });
+    }
+
     void assign_well_cumulatives(const std::string&       well,
                                  const std::size_t        wellID,
                                  const bool               isTemp,
@@ -1415,10 +1444,13 @@ namespace {
         }
     }
 
-    void assign_group_cumulatives(const std::string&  group,
-                                  const std::size_t   groupID,
-                                  const GroupVectors& groupData,
-                                  Opm::SummaryState&  smry)
+    void assign_group_cumulatives(const std::string&       group,
+                                  const std::size_t        groupID,
+                                  const bool               isTemp,
+                                  const Opm::Tracers&      tracer_dims,
+                                  const Opm::TracerConfig& tracer_config,
+                                  const GroupVectors&      groupData,
+                                  Opm::SummaryState&       smry)
     {
         if (! groupData.hasDefinedValues()) {
             // Result set does not provide group information.
@@ -1477,6 +1509,14 @@ namespace {
 
         update("GCT",  xgrp[VI::XGroup::index::GasConsumptionTotal]);
         update("GIMT", xgrp[VI::XGroup::index::GasImportTotal]);
+
+        if (isTemp || !tracer_config.empty()) {
+            assign_group_tracer_cumulatives(group, groupID,
+                                            isTemp,
+                                            tracer_dims,
+                                            tracer_config,
+                                            groupData, smry);
+        }
     }
 
     bool isDefaultedUDQ(const double x)
@@ -1623,22 +1663,23 @@ namespace {
                             const Opm::TracerConfig&                     tracer_config,
                             std::shared_ptr<Opm::EclIO::RestartFileView> rst_view)
     {
-        const auto  sim_step = rst_view->simStep();
-        const auto& intehead = rst_view->intehead();
+        const auto  sim_step    = rst_view->simStep();
+        const auto& intehead    = rst_view->intehead();
+        const auto  isTemp      = schedule.runspec().temp();
+        const auto& tracer_dims = schedule.runspec().tracers();
 
         smry.update_elapsed(schedule.seconds(rst_view->reportStep()));
 
         // Well cumulatives
         {
-            const auto isTemp = schedule.runspec().temp();
-            const auto  wellData = WellVectors { intehead, rst_view };
-            const auto& wells    = schedule.wellNames(sim_step);
+            const auto wellData = WellVectors { intehead, rst_view };
+            const auto wells    = schedule.wellNames(sim_step);
 
             for (auto nWells = wells.size(), wellID = 0*nWells;
                  wellID < nWells; ++wellID)
             {
                 assign_well_cumulatives(wells[wellID], wellID, isTemp,
-                                        schedule.runspec().tracers(), tracer_config,
+                                        tracer_dims, tracer_config,
                                         wellData, smry);
             }
         }
@@ -1666,7 +1707,9 @@ namespace {
                     ? groupData.maxGroups() // NGMAXZ -- Item 3 of WELLDIMS
                     : std::max(group.insert_index(), std::size_t{1}) - 1;
 
-                assign_group_cumulatives(gname, groupOrderIx, groupData, smry);
+                assign_group_cumulatives(gname, groupOrderIx, isTemp,
+                                         tracer_dims, tracer_config,
+                                         groupData, smry);
             }
         }
     }

--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -215,6 +215,7 @@ namespace {
     }
 
     void writeGroup(int                           sim_step,
+                    const TracerConfig&           tracer,
                     const Schedule&               schedule,
                     const Opm::SummaryState&      sumState,
                     const std::vector<int>&       ih,
@@ -225,7 +226,7 @@ namespace {
 
         auto  groupData = Helpers::AggregateGroupData(ih);
 
-        groupData.captureDeclaredGroupData(schedule, simStep, sumState, ih);
+        groupData.captureDeclaredGroupData(schedule, tracer, simStep, sumState, ih);
 
         rstFile.write("IGRP", groupData.getIGroup());
         rstFile.write("SGRP", groupData.getSGroup());
@@ -550,7 +551,7 @@ namespace {
         const int norst_value = schedule[sim_step].rst_config().norst.value_or(0);
 
         if (norst_value == 0) {
-            writeGroup(sim_step, schedule, sumState, inteHD, rstFile);
+            writeGroup(sim_step, es.tracer(), schedule, sumState, inteHD, rstFile);
         }
 
         // Write network data if the network option is used and network defined

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -414,9 +414,19 @@ namespace {
             if (grp_name == "FIELD") { continue; }
 
             makeEntities('G', Cat::Group, extra_group_vectors, grp_name);
+
+            // Tracer rates and cumulatives.  Concentrations are
+            // intentionally omitted here since those are not needed at the
+            // group level for simulation restart.
+            makeTracerEntities('G', Cat::Group, required_tracer_vectors, grp_name);
         }
 
         makeEntities('F', Cat::Field, extra_field_vectors, "FIELD");
+
+        // Tracer rates and cumulatives.  Concentrations are intentionally
+        // omitted here since those are not needed at the field level for
+        // simulation restart.
+        makeTracerEntities('F', Cat::Field, required_tracer_vectors, "FIELD");
 
         return entities;
     }

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
             rstFile.write("LOGIHEAD", lh);
             {
                 auto group_aggregator = Opm::RestartIO::Helpers::AggregateGroupData(ih);
-                group_aggregator.captureDeclaredGroupData(sched, rptStep-1, st, ih);
+                group_aggregator.captureDeclaredGroupData(sched, es.tracer(), rptStep-1, st, ih);
 
                 rstFile.write("IGRP", group_aggregator.getIGroup());
                 rstFile.write("SGRP", group_aggregator.getSGroup());

--- a/tests/test_AggregateGroupData.cpp
+++ b/tests/test_AggregateGroupData.cpp
@@ -23,22 +23,20 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <opm/output/eclipse/AggregateWellData.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
 #include <opm/output/eclipse/VectorItems/group.hpp>
 #include <opm/output/eclipse/VectorItems/well.hpp>
 
-#include <opm/output/data/Wells.hpp>
-
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+#include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
 
 #include <opm/input/eclipse/Python/Python.hpp>
 
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 #include <opm/common/utility/TimeService.hpp>
 
@@ -47,9 +45,38 @@
 
 #include <cstddef>
 #include <exception>
+#include <memory>
+#include <span>
 #include <stdexcept>
+#include <string_view>
+#include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
+
+namespace {
+
+    struct SimulationCase
+    {
+        explicit SimulationCase(std::string_view deck)
+            : SimulationCase { Opm::Parser{}.parseString(std::string {deck}) }
+        {}
+
+        explicit SimulationCase(const Opm::Deck& deck)
+            : es    {deck}
+            , grid  {deck}
+            , sched {deck, es, std::make_shared<Opm::Python>()}
+        {}
+
+        // Order requirement: 'es' must be declared/initialised before 'sched'.
+        Opm::EclipseState es;
+        Opm::EclipseGrid grid;
+        Opm::Schedule sched;
+    };
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Aggregate_Group)
 
 namespace {
 
@@ -95,8 +122,9 @@ MockIH::MockIH(const int numWells,
     this->nzgrpz = this->value[Ix::NZGRPZ] = zgrpPerGrp;
 }
 
-Opm::Deck second_sim(std::string fname) {
-    return Opm::Parser {} .parseFile(fname);
+Opm::Deck second_sim(std::string_view fname)
+{
+    return Opm::Parser {}.parseFile(std::string{fname});
 }
 
 Opm::Deck first_sim()
@@ -575,29 +603,8 @@ Opm::SummaryState sim_state_3()
 
     return state;
 }
-}
 
-struct SimulationCase
-{
-    explicit SimulationCase(const char* deck)
-        : SimulationCase { Opm::Parser{}.parseString(deck) }
-    {}
-
-    explicit SimulationCase(const Opm::Deck& deck)
-        : es    { deck }
-        , grid  { deck }
-        , sched { deck, es, std::make_shared<Opm::Python>() }
-    {}
-
-    // Order requirement: 'es' must be declared/initialised before 'sched'.
-    Opm::EclipseState es;
-    Opm::EclipseGrid  grid;
-    Opm::Schedule     sched;
-};
-
-// =====================================================================
-
-BOOST_AUTO_TEST_SUITE(Aggregate_Group)
+} // Anonymous namespace
 
 // test dimensions of multisegment data
 BOOST_AUTO_TEST_CASE (Constructor)
@@ -628,7 +635,7 @@ BOOST_AUTO_TEST_CASE (Declared_Group_Data)
     const auto smry = sim_state();
 
     auto agrpd = Opm::RestartIO::Helpers::AggregateGroupData {ih.value};
-    agrpd.captureDeclaredGroupData(simCase.sched, rptStep, smry, ih.value);
+    agrpd.captureDeclaredGroupData(simCase.sched, simCase.es.tracer(), rptStep, smry, ih.value);
 
     // IGRP (PROD)
     {
@@ -776,7 +783,7 @@ BOOST_AUTO_TEST_CASE (Declared_Group_Data_2)
                                                             rptStep, rptStep + 1, rptStep);
 
     auto agrpd = Opm::RestartIO::Helpers::AggregateGroupData(ih);
-    agrpd.captureDeclaredGroupData(sched, rptStep, st, ih);
+    agrpd.captureDeclaredGroupData(sched, es.tracer(), rptStep, st, ih);
 
     // IGRP (PROD)
     {
@@ -1052,7 +1059,7 @@ END
                                                             rptStep, rptStep + 1, rptStep);
 
     auto agrpd = Opm::RestartIO::Helpers::AggregateGroupData(ih);
-    agrpd.captureDeclaredGroupData(sched, rptStep, st, ih);
+    agrpd.captureDeclaredGroupData(sched, es.tracer(), rptStep, st, ih);
 
     const auto& sgrp = agrpd.getSGroup();
     const auto& zgrp = agrpd.getZGroup();
@@ -1128,3 +1135,1432 @@ END
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE(Tracer_Values)
+
+namespace {
+    // Note: We intentionally omit concentrations ([FG]T[IR]C*) here.
+    // While very useful for engineers, those values don't appear in
+    // the restart file to which this set of unit tests apply.
+    //
+    // This function sets up a dynamic state for group (and field) level
+    // tracer related summary vectors.  We have the following tracers
+    //
+    //    TRACER
+    //    SEA  WAT  /
+    //    OCE  GAS  /
+    //    OCF  GAS  /
+    //    SEB  WAT  /
+    //    /
+    //
+    // with or without temperature ("HEA") and the following group tree
+    //
+    //    'PLAT_A' FIELD
+    //    INJE     'PLAT_A'
+    //    PROD     'PLAT_A'
+    //    'INJE-G' INJE
+    //    'INJE-W' INJE
+    //
+    // Note as well that the synthetic values here don't make physical
+    // sense and have no internal consistency; they are purely for
+    // testing purposes and to be distinct at each level and quantity.
+    Opm::SummaryState dynamicState()
+    {
+        auto ret = Opm::SummaryState { Opm::TimeService::now(), 0.0 };
+
+        // Field level values
+        {
+            ret.update("FTIRSEA", 112233.44);
+            ret.update("FTITSEA", 11223344.55);
+            ret.update("FTPRSEA", 2233.44);
+            ret.update("FTPTSEA", 223344.55);
+
+            ret.update("FTIRSEB", 111222.333);
+            ret.update("FTITSEB", 111222333.444555);
+            ret.update("FTPRSEB", 222333.444);
+            ret.update("FTPTSEB", 222333444.555);
+
+            ret.update("FTIROCF", 111.222);
+            ret.update("FTIRFOCF", 111.0);
+            ret.update("FTIRSOCF", 11.202);
+            ret.update("FTPROCF", 22.33);
+            ret.update("FTPRFOCF", 22.0);
+            ret.update("FTPRSOCF", 0.33);
+            ret.update("FTPTOCF", 223.34455);
+            ret.update("FTPTFOCF", 3.34455);
+            ret.update("FTPTSOCF", 22.0);
+
+            ret.update("FTIROCE", 11.1222);
+            ret.update("FTIRFOCE", 11.11);
+            ret.update("FTIRSOCE", 11.1212);
+            ret.update("FTITOCE", 1.122);
+            ret.update("FTITFOCE", 1.1);
+            ret.update("FTITSOCE", 0.022);
+            ret.update("FTPROCE", 2.233);
+            ret.update("FTPRFOCE", 2.2);
+            ret.update("FTPRSOCE", 2.033);
+            ret.update("FTPTOCE", 2233.4455);
+            ret.update("FTPTFOCE", 2200.44);
+            ret.update("FTPTSOCE", 33.0055);
+
+            ret.update("FTIRHEA", 11122.2);
+            ret.update("FTITHEA", 0.1122);
+            ret.update("FTPRHEA", 0.2233);
+            ret.update("FTPTHEA", 22.334455);
+        }
+
+        // PLAT_A group level values
+        {
+            ret.update_group_var("PLAT_A", "GTIRSEA", 2000.0);
+            ret.update_group_var("PLAT_A", "GTITSEA", 2200.0);
+            ret.update_group_var("PLAT_A", "GTPRSEA", 2220.0);
+            ret.update_group_var("PLAT_A", "GTPTSEA", 2222.0);
+
+            ret.update_group_var("PLAT_A", "GTIRSEB", 2.0);
+            ret.update_group_var("PLAT_A", "GTITSEB", 2.2);
+            ret.update_group_var("PLAT_A", "GTPRSEB", 2.22);
+            ret.update_group_var("PLAT_A", "GTPTSEB", 2.222);
+
+            ret.update_group_var("PLAT_A", "GTIROCF", 22.0);
+            ret.update_group_var("PLAT_A", "GTIRFOCF", 22.0);
+            ret.update_group_var("PLAT_A", "GTITOCF", 22.2);
+            ret.update_group_var("PLAT_A", "GTITFOCF", 20.02);
+            ret.update_group_var("PLAT_A", "GTITSOCF", 2.24);
+            ret.update_group_var("PLAT_A", "GTPROCF", 22.22);
+            ret.update_group_var("PLAT_A", "GTPRFOCF", 22.02);
+            ret.update_group_var("PLAT_A", "GTPRSOCF", 0.2);
+            ret.update_group_var("PLAT_A", "GTPTOCF", 22.222);
+            ret.update_group_var("PLAT_A", "GTPTFOCF", 22.202);
+            ret.update_group_var("PLAT_A", "GTPTSOCF", 24.02);
+
+            ret.update_group_var("PLAT_A", "GTIROCE", 222.0);
+            ret.update_group_var("PLAT_A", "GTIRSOCE", 202.02);
+            ret.update_group_var("PLAT_A", "GTITOCE", 222.2);
+            ret.update_group_var("PLAT_A", "GTITFOCE", 200.002);
+            ret.update_group_var("PLAT_A", "GTITSOCE", 2.202);
+            ret.update_group_var("PLAT_A", "GTPROCE", 222.22);
+            ret.update_group_var("PLAT_A", "GTPRFOCE", 202.0);
+            ret.update_group_var("PLAT_A", "GTPRSOCE", 20.22);
+            ret.update_group_var("PLAT_A", "GTPTOCE", 222.222);
+            ret.update_group_var("PLAT_A", "GTPTFOCE", 222.202);
+            ret.update_group_var("PLAT_A", "GTPTSOCE", 242.242);
+
+            ret.update_group_var("PLAT_A", "GTIRHEA", 22222.0);
+            ret.update_group_var("PLAT_A", "GTITHEA", 22222.2);
+            ret.update_group_var("PLAT_A", "GTPRHEA", 22222.22);
+            ret.update_group_var("PLAT_A", "GTPTHEA", 22222.222);
+        }
+
+        // INJE group level values
+        {
+            ret.update_group_var("INJE", "GTIRSEA", 3000.0);
+            ret.update_group_var("INJE", "GTITSEA", 3300.0);
+            ret.update_group_var("INJE", "GTPRSEA", 3330.0);
+            ret.update_group_var("INJE", "GTPTSEA", 3333.0);
+
+            ret.update_group_var("INJE", "GTIRSEB", 3.0);
+            ret.update_group_var("INJE", "GTITSEB", 3.3);
+            ret.update_group_var("INJE", "GTPRSEB", 3.33);
+            ret.update_group_var("INJE", "GTPTSEB", 3.333);
+
+            ret.update_group_var("INJE", "GTIROCF", 33.0);
+            ret.update_group_var("INJE", "GTIRFOCF", 3.3);
+            ret.update_group_var("INJE", "GTIRSOCF", 30.7);
+            ret.update_group_var("INJE", "GTITOCF", 33.3);
+            ret.update_group_var("INJE", "GTITFOCF", 33.303);
+            ret.update_group_var("INJE", "GTPROCF", 33.33);
+            ret.update_group_var("INJE", "GTPRFOCF", 30.03);
+            ret.update_group_var("INJE", "GTPRSOCF", 43.34);
+            ret.update_group_var("INJE", "GTPTOCF", 33.333);
+            ret.update_group_var("INJE", "GTPTFOCF", 33.003);
+            ret.update_group_var("INJE", "GTPTSOCF", 0.33);
+
+            ret.update_group_var("INJE", "GTIROCE", 333.0);
+            ret.update_group_var("INJE", "GTIRFOCE", 303.0);
+            ret.update_group_var("INJE", "GTIRSOCE", 30.3);
+            ret.update_group_var("INJE", "GTITOCE", 333.3);
+            ret.update_group_var("INJE", "GTITFOCE", 343.43);
+            ret.update_group_var("INJE", "GTITSOCE", 334.3);
+            ret.update_group_var("INJE", "GTPROCE", 333.33);
+            ret.update_group_var("INJE", "GTPRSOCE", 303.03);
+            ret.update_group_var("INJE", "GTPTOCE", 333.333);
+            ret.update_group_var("INJE", "GTPTFOCE", 334.334);
+            ret.update_group_var("INJE", "GTPTSOCE", 343.5);
+
+            ret.update_group_var("INJE", "GTIRHEA", 33333.0);
+            ret.update_group_var("INJE", "GTITHEA", 33333.3);
+            ret.update_group_var("INJE", "GTPRHEA", 33333.33);
+            ret.update_group_var("INJE", "GTPTHEA", 33333.333);
+        }
+
+        // PROD group level values
+        {
+            ret.update_group_var("PROD", "GTIRSEA", 4000.0);
+            ret.update_group_var("PROD", "GTITSEA", 4400.0);
+            ret.update_group_var("PROD", "GTPRSEA", 4440.0);
+            ret.update_group_var("PROD", "GTPTSEA", 4444.0);
+
+            ret.update_group_var("PROD", "GTIRSEB", 4.0);
+            ret.update_group_var("PROD", "GTITSEB", 4.4);
+            ret.update_group_var("PROD", "GTPRSEB", 4.44);
+            ret.update_group_var("PROD", "GTPTSEB", 4.444);
+
+            ret.update_group_var("PROD", "GTIROCF", 44.0);
+            ret.update_group_var("PROD", "GTIRFOCF", 40.0);
+            ret.update_group_var("PROD", "GTIRSOCF", 44.4);
+            ret.update_group_var("PROD", "GTITOCF", 44.4);
+            ret.update_group_var("PROD", "GTITFOCF", 44.44);
+            ret.update_group_var("PROD", "GTITSOCF", 45.54);
+            ret.update_group_var("PROD", "GTPROCF", 44.44);
+            ret.update_group_var("PROD", "GTPRFOCF", 40.04);
+            ret.update_group_var("PROD", "GTPRSOCF", 44.56);
+            ret.update_group_var("PROD", "GTPTOCF", 44.444);
+            ret.update_group_var("PROD", "GTPTFOCF", 44.434);
+            ret.update_group_var("PROD", "GTPTSOCF", 44.454);
+
+            ret.update_group_var("PROD", "GTIROCE", 444.0);
+            ret.update_group_var("PROD", "GTIRFOCE", 404.0);
+            ret.update_group_var("PROD", "GTIRSOCE", 440.4);
+            ret.update_group_var("PROD", "GTITOCE", 444.4);
+            ret.update_group_var("PROD", "GTITFOCE", 404.505);
+            ret.update_group_var("PROD", "GTITSOCE", 444.4567);
+            ret.update_group_var("PROD", "GTPROCE", 444.44);
+            ret.update_group_var("PROD", "GTPRFOCE", 444.54);
+            ret.update_group_var("PROD", "GTPRSOCE", 404.04);
+            ret.update_group_var("PROD", "GTPTOCE", 444.444);
+            ret.update_group_var("PROD", "GTPTFOCE", 454.454);
+            ret.update_group_var("PROD", "GTPTSOCE", 434.434);
+
+            ret.update_group_var("PROD", "GTIRHEA", 44444.0);
+            ret.update_group_var("PROD", "GTITHEA", 44444.4);
+            ret.update_group_var("PROD", "GTPRHEA", 44444.44);
+            ret.update_group_var("PROD", "GTPTHEA", 44444.444);
+        }
+
+        // INJE-G group level values
+        {
+            ret.update_group_var("INJE-G", "GTIRSEA", 5000.0);
+            ret.update_group_var("INJE-G", "GTITSEA", 5500.0);
+            ret.update_group_var("INJE-G", "GTPRSEA", 5550.0);
+            ret.update_group_var("INJE-G", "GTPTSEA", 5555.0);
+
+            ret.update_group_var("INJE-G", "GTIRSEB", 5.0);
+            ret.update_group_var("INJE-G", "GTITSEB", 5.5);
+            ret.update_group_var("INJE-G", "GTPRSEB", 5.55);
+            ret.update_group_var("INJE-G", "GTPTSEB", 5.555);
+
+            ret.update_group_var("INJE-G", "GTIROCF", 55.0);
+            ret.update_group_var("INJE-G", "GTIRFOCF", 55.055);
+            ret.update_group_var("INJE-G", "GTIRSOCF", 55.55055);
+            ret.update_group_var("INJE-G", "GTITOCF", 55.5);
+            ret.update_group_var("INJE-G", "GTITFOCF", 55.55);
+            ret.update_group_var("INJE-G", "GTITSOCF", 55.678);
+            ret.update_group_var("INJE-G", "GTPROCF", 55.55);
+            ret.update_group_var("INJE-G", "GTPRFOCF", 50.05);
+            ret.update_group_var("INJE-G", "GTPRSOCF", 56.65);
+            ret.update_group_var("INJE-G", "GTPTOCF", 55.555);
+            ret.update_group_var("INJE-G", "GTPTFOCF", 55.585);
+            ret.update_group_var("INJE-G", "GTPTSOCF", 55.575);
+
+            ret.update_group_var("INJE-G", "GTIROCE", 555.0);
+            ret.update_group_var("INJE-G", "GTIRFOCE", 505.05);
+            ret.update_group_var("INJE-G", "GTITOCE", 555.5);
+            ret.update_group_var("INJE-G", "GTITFOCE", 555.555);
+            ret.update_group_var("INJE-G", "GTITSOCE", 565.565);
+            ret.update_group_var("INJE-G", "GTPROCE", 555.55);
+            ret.update_group_var("INJE-G", "GTPRFOCE", 555.505);
+            ret.update_group_var("INJE-G", "GTPRSOCE", 505.565);
+            ret.update_group_var("INJE-G", "GTPTOCE", 555.555);
+            ret.update_group_var("INJE-G", "GTPTFOCE", 565.5656);
+            ret.update_group_var("INJE-G", "GTPTSOCE", 545.5454);
+
+            ret.update_group_var("INJE-G", "GTIRHEA", 55555.0);
+            ret.update_group_var("INJE-G", "GTITHEA", 55555.5);
+            ret.update_group_var("INJE-G", "GTPRHEA", 55555.55);
+            ret.update_group_var("INJE-G", "GTPTHEA", 55555.555);
+        }
+
+        // INJE-W group level values
+        {
+            ret.update_group_var("INJE-W", "GTIRSEA", 6000.0);
+            ret.update_group_var("INJE-W", "GTITSEA", 6600.0);
+            ret.update_group_var("INJE-W", "GTPRSEA", 6660.0);
+            ret.update_group_var("INJE-W", "GTPTSEA", 6666.0);
+
+            ret.update_group_var("INJE-W", "GTIRSEB", 6.0);
+            ret.update_group_var("INJE-W", "GTITSEB", 6.6);
+            ret.update_group_var("INJE-W", "GTPRSEB", 6.66);
+            ret.update_group_var("INJE-W", "GTPTSEB", 6.666);
+
+            ret.update_group_var("INJE-W", "GTIROCF", 66.0);
+            ret.update_group_var("INJE-W", "GTIRSOCF", 66.33);
+            ret.update_group_var("INJE-W", "GTITOCF", 66.6);
+            ret.update_group_var("INJE-W", "GTITFOCF", 66.678);
+            ret.update_group_var("INJE-W", "GTITSOCF", 66.9876);
+            ret.update_group_var("INJE-W", "GTPROCF", 66.66);
+            ret.update_group_var("INJE-W", "GTPTOCF", 66.666);
+            ret.update_group_var("INJE-W", "GTPTFOCF", 66.006);
+            ret.update_group_var("INJE-W", "GTPTSOCF", 66.007);
+
+            ret.update_group_var("INJE-W", "GTIROCE", 666.0);
+            ret.update_group_var("INJE-W", "GTIRFOCE", 606.06);
+            ret.update_group_var("INJE-W", "GTIRSOCE", 660.066);
+            ret.update_group_var("INJE-W", "GTITOCE", 666.6);
+            ret.update_group_var("INJE-W", "GTITFOCE", 666.5678);
+            ret.update_group_var("INJE-W", "GTITSOCE", 666.9876);
+            ret.update_group_var("INJE-W", "GTPROCE", 666.66);
+            ret.update_group_var("INJE-W", "GTPRFOCE", 666.666);
+            ret.update_group_var("INJE-W", "GTPRSOCE", 666.066);
+            ret.update_group_var("INJE-W", "GTPTOCE", 666.666);
+            ret.update_group_var("INJE-W", "GTPTFOCE", 666.006);
+            ret.update_group_var("INJE-W", "GTPTSOCE", 666.007);
+
+            ret.update_group_var("INJE-W", "GTIRHEA", 66666.0);
+            ret.update_group_var("INJE-W", "GTITHEA", 66666.6);
+            ret.update_group_var("INJE-W", "GTPRHEA", 66666.66);
+            ret.update_group_var("INJE-W", "GTPTHEA", 66666.666);
+        }
+
+        return ret;
+    }
+
+    namespace VI = Opm::RestartIO::Helpers::VectorItems;
+
+    std::tuple<int, int, double> timePoint(const SimulationCase& cse)
+    {
+        constexpr auto report_step = 7;
+        constexpr auto sim_step = report_step - 1;
+        const auto simTime = cse.sched.seconds(report_step);
+
+        BOOST_CHECK_CLOSE(simTime, (1 + 2 + 3 + 4 + 5 + 10 + 15) * 86'400.0, 1.0e-7);
+
+        return {report_step, sim_step, simTime};
+    }
+
+    std::vector<int> intehead(const SimulationCase& cse)
+    {
+        const auto [report_step, sim_step, simTime] = timePoint(cse);
+
+        return Opm::RestartIO::Helpers::createInteHead
+            (cse.es, cse.grid, cse.sched, simTime,
+             report_step, // Should really be number of timesteps
+             report_step, sim_step);
+    }
+
+    Opm::RestartIO::Helpers::AggregateGroupData
+    groupData(const SimulationCase&    cse,
+              const std::vector<int>&  ih,
+              const Opm::SummaryState& smry)
+    {
+        auto gd = Opm::RestartIO::Helpers::AggregateGroupData{ih};
+
+        const auto tp = timePoint(cse);
+        const auto sim_step = std::get<1>(tp);
+
+        gd.captureDeclaredGroupData(cse.sched, cse.es.tracer(),
+                                    sim_step, smry, ih);
+
+        return gd;
+    }
+}
+
+BOOST_AUTO_TEST_SUITE(Isothermal)
+
+namespace {
+    SimulationCase defineCase()
+    {
+        return SimulationCase { R"(RUNSPEC
+DIMENS
+  5 5 2 /
+OIL
+GAS
+WATER
+DISGAS
+TABDIMS
+/
+WELLDIMS
+  3 2 5 3 / -- Item 3 (NGMAX) must be at least 5 for this test.
+EQLDIMS
+  3 1 1 /
+TRACERS
+--  oil  water  gas  env
+     1*  3      2    1*   /
+GRID
+DXV
+  5*100 /
+DYV
+  5*100 /
+DZV
+  5 10 /
+DEPTHZ
+  36*2000.0 /
+EQUALS
+  PORO 0.25 /
+  PERMX 100 /
+  PERMY 100 /
+  PERMZ 10 /
+/
+PROPS
+DENSITY
+  852.6 1014.3 0.83 /
+TRACER
+SEA  WAT  /
+OCE  GAS  /
+OCF  GAS  /
+SEB  WAT  /
+/
+TVDPFSEA
+1000   0.0
+5000   0.0 /
+TVDPFSEB
+1000   0.0
+5000   0.0 /
+TBLKFOCE
+1.0 2.0 3.0 /
+TBLKFOCF
+1.0 2.0 3.0 /
+SCHEDULE
+GRUPTREE
+  'PLAT_A' FIELD /
+  INJE     'PLAT_A' /
+  PROD     'PLAT_A' /
+  'INJE-G' INJE /
+  'INJE-W' INJE /
+/
+WELSPECS
+  IW 'INJE-W' 1 1 2010.0 'WATER' /
+  IG 'INJE-G' 1 5 2010.0 'GAS' /
+  P  'PROD'   5 3 2002.5 'LIQ' /
+/
+COMPDAT
+  IW 1 1 2 2 'OPEN' 2* 0.5 /
+  IG 1 5 1 1 'OPEN' 2* 0.5 /
+  P  5 3 1 2 'OPEN' 2* 0.5 /
+/
+WTRACER
+  IW SEA 0.123 /
+  IG OCE 0.456 /
+/
+WCONINJE
+  IW 'WATER' 'OPEN' RATE 12345.6 1* 512.256 /
+  IG 'GAS' 'OPEN' RATE 678910.1112 1* 256.128 /
+/
+WCONPROD
+  P 'OPEN' LRAT 3* 100E3 1* 25.125 /
+/
+TSTEP
+  1 2 3 4 5 10 15 4*20 /
+END
+)"
+        };
+    }
+
+    // 3 Water + 2 Gas*(free + solution)
+    constexpr auto tracerStride = std::size_t{7};
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(InteHEAD_Allocation_Sizes)
+{
+    const auto cse = defineCase();
+    const auto ih  = intehead(cse);
+
+    const auto expectNumTracers = [&trcCount = cse.es.runspec().tracers()]()
+    {
+        return trcCount.water_tracers()
+             + trcCount.oil_tracers()
+             + trcCount.gas_tracers();
+    }();
+
+    BOOST_CHECK_EQUAL(expectNumTracers, 5);
+
+    const auto expectNumTrcElems = [&trcCount = cse.es.runspec().tracers()]()
+    {
+        return trcCount.water_tracers()
+             + 0*trcCount.oil_tracers()
+             + 2*trcCount.gas_tracers();
+    }();
+
+    BOOST_CHECK_EQUAL(expectNumTrcElems, static_cast<int>(tracerStride));
+
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NGRP], 5);
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NWGMAX], 5);
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NGMAXZ], 6);
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NXGRPZ], static_cast<int>(VI::XGroup::TracerOffset) + 4*expectNumTrcElems);
+}
+
+BOOST_AUTO_TEST_CASE(Field)
+{
+    const auto cse  = defineCase();
+    const auto ih   = intehead(cse);
+    const auto smry = dynamicState();
+
+    const auto gd = groupData(cse, ih, smry);
+    const auto xgsz = ih[VI::intehead::NXGRPZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xgsz) > VI::XGroup::TracerOffset,
+                          "XGRP must allocate space for tracer concentrations");
+
+    // FIELD group is *last* in XGRP.
+    const auto grpID = ih[VI::intehead::NGMAXZ] - 1;
+
+    const auto xgrptrc = std::span {gd.getXGroup()}
+        .subspan(grpID * xgsz, xgsz)
+        .subspan(VI::XGroup::TracerOffset);
+
+    BOOST_REQUIRE_EQUAL(xgrptrc.size(), 4 * tracerStride);
+
+    // Injection rates
+    const auto fti_rate = xgrptrc.subspan(0*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(fti_rate[0], 112233.44, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(fti_rate[1], 11.11, 1.0e-6);      // FOCE
+    BOOST_CHECK_CLOSE(fti_rate[2], 11.1212, 1.0e-6);    // SOCE
+    BOOST_CHECK_CLOSE(fti_rate[3], 111.0, 1.0e-6);      // FOCF
+    BOOST_CHECK_CLOSE(fti_rate[4], 11.202, 1.0e-6);     // SOCF
+    BOOST_CHECK_CLOSE(fti_rate[5], 111222.333, 1.0e-6); // SEB
+    BOOST_CHECK_CLOSE(fti_rate[6], 0.0, 1.0e-6);        // Unused
+
+    // Production rates
+    const auto ftp_rate = xgrptrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(ftp_rate[0], 2233.44, 1.0e-6);    // SEA
+    BOOST_CHECK_CLOSE(ftp_rate[1], 2.2, 1.0e-6);        // FOCE
+    BOOST_CHECK_CLOSE(ftp_rate[2], 2.033, 1.0e-6);      // SOCE
+    BOOST_CHECK_CLOSE(ftp_rate[3], 22.0, 1.0e-6);       // FOCF
+    BOOST_CHECK_CLOSE(ftp_rate[4], 0.33, 1.0e-6);       // SOCF
+    BOOST_CHECK_CLOSE(ftp_rate[5], 222333.444, 1.0e-6); // SEB
+    BOOST_CHECK_CLOSE(ftp_rate[6], 0.0, 1.0e-6);        // Unused
+
+    // Total injected volume
+    const auto fti_vol = xgrptrc.subspan(2*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(fti_vol[0], 11223344.55, 1.0e-6);      // SEA
+    BOOST_CHECK_CLOSE(fti_vol[1], 1.1, 1.0e-6);              // FOCE
+    BOOST_CHECK_CLOSE(fti_vol[2], 0.022, 1.0e-6);            // SOCE
+    BOOST_CHECK_CLOSE(fti_vol[3], 0.0, 1.0e-6);              // FOCF
+    BOOST_CHECK_CLOSE(fti_vol[4], 0.0, 1.0e-6);              // SOCF
+    BOOST_CHECK_CLOSE(fti_vol[5], 111222333.444555, 1.0e-6); // SEB
+    BOOST_CHECK_CLOSE(fti_vol[6], 0.0, 1.0e-6);              // Unused
+
+    // Total produced volume
+    const auto ftp_vol = xgrptrc.subspan(3*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(ftp_vol[0], 223344.55, 1.0e-6);     // SEA
+    BOOST_CHECK_CLOSE(ftp_vol[1], 2200.44, 1.0e-6);       // FOCE
+    BOOST_CHECK_CLOSE(ftp_vol[2], 33.0055, 1.0e-6);       // SOCE
+    BOOST_CHECK_CLOSE(ftp_vol[3], 3.34455, 1.0e-6);       // FOCF
+    BOOST_CHECK_CLOSE(ftp_vol[4], 22.0, 1.0e-6);          // SOCF
+    BOOST_CHECK_CLOSE(ftp_vol[5], 222333444.555, 1.0e-6); // SEB
+    BOOST_CHECK_CLOSE(ftp_vol[6], 0.0, 1.0e-6);           // Unused
+}
+
+BOOST_AUTO_TEST_CASE(Plat_A)
+{
+    const auto cse  = defineCase();
+    const auto ih   = intehead(cse);
+    const auto smry = dynamicState();
+
+    const auto gd = groupData(cse, ih, smry);
+    const auto xgsz = ih[VI::intehead::NXGRPZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xgsz) > VI::XGroup::TracerOffset,
+                          "XGRP must allocate space for tracer concentrations");
+
+    const auto grpID = 0;
+
+    {
+        const auto zgrp = std::span{gd.getZGroup()}
+            .subspan(grpID * ih[VI::intehead::NZGRPZ],
+                     ih[VI::intehead::NZGRPZ]);
+
+        BOOST_CHECK_EQUAL(zgrp[0].c_str(), "PLAT_A  ");
+    }
+
+    const auto xgrptrc = std::span {gd.getXGroup()}
+        .subspan(grpID * xgsz, xgsz)
+        .subspan(VI::XGroup::TracerOffset);
+
+    BOOST_REQUIRE_EQUAL(xgrptrc.size(), 4 * tracerStride);
+
+    // Injection rates
+    const auto gti_rates = xgrptrc.subspan(0 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_rates[0], 2000.0, 1.0e-6); // SEA
+    BOOST_CHECK_CLOSE(gti_rates[1], 0.0, 1.0e-6);    // FOCE
+    BOOST_CHECK_CLOSE(gti_rates[2], 202.02, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gti_rates[3], 22.0, 1.0e-6);   // FOCF
+    BOOST_CHECK_CLOSE(gti_rates[4], 0.0, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gti_rates[5], 2.0, 1.0e-6);    // SEB
+    BOOST_CHECK_CLOSE(gti_rates[6], 0.0, 1.0e-6);    // Unused
+
+    // Production rates
+    const auto gtp_rates = xgrptrc.subspan(1 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_rates[0], 2220.0, 1.0e-6); // SEA
+    BOOST_CHECK_CLOSE(gtp_rates[1], 202.0, 1.0e-6);  // FOCE
+    BOOST_CHECK_CLOSE(gtp_rates[2], 20.22, 1.0e-6);  // SOCE
+    BOOST_CHECK_CLOSE(gtp_rates[3], 22.02, 1.0e-6);  // FOCF
+    BOOST_CHECK_CLOSE(gtp_rates[4], 0.2, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gtp_rates[5], 2.22, 1.0e-6);   // SEB
+    BOOST_CHECK_CLOSE(gtp_rates[6], 0.0, 1.0e-6);    // Unused
+
+    // Total injected volumes
+    const auto gti_vol = xgrptrc.subspan(2 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_vol[0], 2200.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gti_vol[1], 200.002, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gti_vol[2], 2.202, 1.0e-6);   // SOCE
+    BOOST_CHECK_CLOSE(gti_vol[3], 20.02, 1.0e-6);   // FOCF
+    BOOST_CHECK_CLOSE(gti_vol[4], 2.24, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gti_vol[5], 2.2, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gti_vol[6], 0.0, 1.0e-6);     // Unused
+
+    // Total produced volumes
+    const auto gtp_vol = xgrptrc.subspan(3 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_vol[0], 2222.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gtp_vol[1], 222.202, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gtp_vol[2], 242.242, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gtp_vol[3], 22.202, 1.0e-6);  // FOCF
+    BOOST_CHECK_CLOSE(gtp_vol[4], 24.02, 1.0e-6);   // SOCF
+    BOOST_CHECK_CLOSE(gtp_vol[5], 2.222, 1.0e-6);   // SEB
+    BOOST_CHECK_CLOSE(gtp_vol[6], 0.0, 1.0e-6);     // Unused
+}
+
+BOOST_AUTO_TEST_CASE(Inje)
+{
+    const auto cse  = defineCase();
+    const auto ih   = intehead(cse);
+    const auto smry = dynamicState();
+
+    const auto gd = groupData(cse, ih, smry);
+    const auto xgsz = ih[VI::intehead::NXGRPZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xgsz) > VI::XGroup::TracerOffset,
+                          "XGRP must allocate space for tracer concentrations");
+
+    const auto grpID = 1;
+
+    {
+        const auto zgrp = std::span{gd.getZGroup()}
+            .subspan(grpID * ih[VI::intehead::NZGRPZ],
+                     ih[VI::intehead::NZGRPZ]);
+
+        BOOST_CHECK_EQUAL(zgrp[0].c_str(), "INJE    ");
+    }
+
+    const auto xgrptrc = std::span {gd.getXGroup()}
+        .subspan(grpID * xgsz, xgsz)
+        .subspan(VI::XGroup::TracerOffset);
+
+    BOOST_REQUIRE_EQUAL(xgrptrc.size(), 4 * tracerStride);
+
+    // Injection rates
+    const auto gti_rates = xgrptrc.subspan(0 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_rates[0], 3000.0, 1.0e-6); // SEA
+    BOOST_CHECK_CLOSE(gti_rates[1], 303, 1.0e-6);    // FOCE
+    BOOST_CHECK_CLOSE(gti_rates[2], 30.3, 1.0e-6);   // SOCE
+    BOOST_CHECK_CLOSE(gti_rates[3], 3.3, 1.0e-6);    // FOCF
+    BOOST_CHECK_CLOSE(gti_rates[4], 30.7, 1.0e-6);   // SOCF
+    BOOST_CHECK_CLOSE(gti_rates[5], 3.0, 1.0e-6);    // SEB
+    BOOST_CHECK_CLOSE(gti_rates[6], 0.0, 1.0e-6);    // Unused
+
+    // Production rates
+    const auto gtp_rates = xgrptrc.subspan(1 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_rates[0], 3330.0, 1.0e-6); // SEA
+    BOOST_CHECK_CLOSE(gtp_rates[1], 0.0, 1.0e-6);    // FOCE
+    BOOST_CHECK_CLOSE(gtp_rates[2], 303.03, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gtp_rates[3], 30.03, 1.0e-6);  // FOCF
+    BOOST_CHECK_CLOSE(gtp_rates[4], 43.34, 1.0e-6);  // SOCF
+    BOOST_CHECK_CLOSE(gtp_rates[5], 3.33, 1.0e-6);   // SEB
+    BOOST_CHECK_CLOSE(gtp_rates[6], 0.0, 1.0e-6);    // Unused
+
+    // Total injected volumes
+    const auto gti_vol = xgrptrc.subspan(2 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_vol[0], 3300.0, 1.0e-6); // SEA
+    BOOST_CHECK_CLOSE(gti_vol[1], 343.43, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gti_vol[2], 334.3, 1.0e-6);  // SOCE
+    BOOST_CHECK_CLOSE(gti_vol[3], 33.303, 1.0e-6); // FOCF
+    BOOST_CHECK_CLOSE(gti_vol[4], 0.0, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gti_vol[5], 3.3, 1.0e-6);    // SEB
+    BOOST_CHECK_CLOSE(gti_vol[6], 0.0, 1.0e-6);    // Unused
+
+    // Total produced volumes
+    const auto gtp_vol = xgrptrc.subspan(3 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_vol[0], 3333.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gtp_vol[1], 334.334, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gtp_vol[2], 343.5, 1.0e-6);   // SOCE
+    BOOST_CHECK_CLOSE(gtp_vol[3], 33.003, 1.0e-6);  // FOCF
+    BOOST_CHECK_CLOSE(gtp_vol[4], 0.33, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gtp_vol[5], 3.333, 1.0e-6);   // SEB
+    BOOST_CHECK_CLOSE(gtp_vol[6], 0.0, 1.0e-6);     // Unused
+}
+
+BOOST_AUTO_TEST_CASE(Prod)
+{
+    const auto cse  = defineCase();
+    const auto ih   = intehead(cse);
+    const auto smry = dynamicState();
+
+    const auto gd = groupData(cse, ih, smry);
+    const auto xgsz = ih[VI::intehead::NXGRPZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xgsz) > VI::XGroup::TracerOffset,
+                          "XGRP must allocate space for tracer concentrations");
+
+    const auto grpID = 2;
+
+    {
+        const auto zgrp = std::span{gd.getZGroup()}
+            .subspan(grpID * ih[VI::intehead::NZGRPZ],
+                     ih[VI::intehead::NZGRPZ]);
+
+        BOOST_CHECK_EQUAL(zgrp[0].c_str(), "PROD    ");
+    }
+
+    const auto xgrptrc = std::span {gd.getXGroup()}
+        .subspan(grpID * xgsz, xgsz)
+        .subspan(VI::XGroup::TracerOffset);
+
+    BOOST_REQUIRE_EQUAL(xgrptrc.size(), 4 * tracerStride);
+
+    // Injection rates
+    const auto gti_rates = xgrptrc.subspan(0 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_rates[0], 4000.0, 1.0e-6); // SEA
+    BOOST_CHECK_CLOSE(gti_rates[1], 404.0, 1.0e-6);  // FOCE
+    BOOST_CHECK_CLOSE(gti_rates[2], 440.4, 1.0e-6);  // SOCE
+    BOOST_CHECK_CLOSE(gti_rates[3], 40.0, 1.0e-6);   // FOCF
+    BOOST_CHECK_CLOSE(gti_rates[4], 44.4, 1.0e-6);   // SOCF
+    BOOST_CHECK_CLOSE(gti_rates[5], 4.0, 1.0e-6);    // SEB
+    BOOST_CHECK_CLOSE(gti_rates[6], 0.0, 1.0e-6);    // Unused
+
+    // Production rates
+    const auto gtp_rates = xgrptrc.subspan(1 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_rates[0], 4440.0, 1.0e-6); // SEA
+    BOOST_CHECK_CLOSE(gtp_rates[1], 444.54, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gtp_rates[2], 404.04, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gtp_rates[3], 40.04, 1.0e-6);  // FOCF
+    BOOST_CHECK_CLOSE(gtp_rates[4], 44.56, 1.0e-6);  // SOCF
+    BOOST_CHECK_CLOSE(gtp_rates[5], 4.44, 1.0e-6);   // SEB
+    BOOST_CHECK_CLOSE(gtp_rates[6], 0.0, 1.0e-6);    // Unused
+
+    // Total injected volumes
+    const auto gti_vol = xgrptrc.subspan(2 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_vol[0], 4400.0, 1.0e-6);   // SEA
+    BOOST_CHECK_CLOSE(gti_vol[1], 404.505, 1.0e-6);  // FOCE
+    BOOST_CHECK_CLOSE(gti_vol[2], 444.4567, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gti_vol[3], 44.44, 1.0e-6);    // FOCF
+    BOOST_CHECK_CLOSE(gti_vol[4], 45.54, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gti_vol[5], 4.4, 1.0e-6);      // SEB
+    BOOST_CHECK_CLOSE(gti_vol[6], 0.0, 1.0e-6);      // Unused
+
+    // Total produced volumes
+    const auto gtp_vol = xgrptrc.subspan(3 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_vol[0], 4444.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gtp_vol[1], 454.454, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gtp_vol[2], 434.434, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gtp_vol[3], 44.434, 1.0e-6);  // FOCF
+    BOOST_CHECK_CLOSE(gtp_vol[4], 44.454, 1.0e-6);  // SOCF
+    BOOST_CHECK_CLOSE(gtp_vol[5], 4.444, 1.0e-6);   // SEB
+    BOOST_CHECK_CLOSE(gtp_vol[6], 0.0, 1.0e-6);     // Unused
+}
+
+BOOST_AUTO_TEST_CASE(Inje_G)
+{
+    const auto cse  = defineCase();
+    const auto ih   = intehead(cse);
+    const auto smry = dynamicState();
+
+    const auto gd = groupData(cse, ih, smry);
+    const auto xgsz = ih[VI::intehead::NXGRPZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xgsz) > VI::XGroup::TracerOffset,
+                          "XGRP must allocate space for tracer concentrations");
+
+    const auto grpID = 3;
+
+    {
+        const auto zgrp = std::span{gd.getZGroup()}
+            .subspan(grpID * ih[VI::intehead::NZGRPZ],
+                     ih[VI::intehead::NZGRPZ]);
+
+        BOOST_CHECK_EQUAL(zgrp[0].c_str(), "INJE-G  ");
+    }
+
+    const auto xgrptrc = std::span {gd.getXGroup()}
+        .subspan(grpID * xgsz, xgsz)
+        .subspan(VI::XGroup::TracerOffset);
+
+    BOOST_REQUIRE_EQUAL(xgrptrc.size(), 4 * tracerStride);
+
+    // Injection rates
+    const auto gti_rates = xgrptrc.subspan(0 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_rates[0], 5000.0, 1.0e-6);   // SEA
+    BOOST_CHECK_CLOSE(gti_rates[1], 505.05, 1.0e-6);   // FOCE
+    BOOST_CHECK_CLOSE(gti_rates[2], 0.0, 1.0e-6);      // SOCE
+    BOOST_CHECK_CLOSE(gti_rates[3], 55.055, 1.0e-6);   // FOCF
+    BOOST_CHECK_CLOSE(gti_rates[4], 55.55055, 1.0e-6); // SOCF
+    BOOST_CHECK_CLOSE(gti_rates[5], 5.0, 1.0e-6);      // SEB
+    BOOST_CHECK_CLOSE(gti_rates[6], 0.0, 1.0e-6);      // Unused
+
+    // Production rates
+    const auto gtp_rates = xgrptrc.subspan(1 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_rates[0], 5550.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gtp_rates[1], 555.505, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gtp_rates[2], 505.565, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gtp_rates[3], 50.05, 1.0e-6);   // FOCF
+    BOOST_CHECK_CLOSE(gtp_rates[4], 56.65, 1.0e-6);   // SOCF
+    BOOST_CHECK_CLOSE(gtp_rates[5], 5.55, 1.0e-6);    // SEB
+    BOOST_CHECK_CLOSE(gtp_rates[6], 0.0, 1.0e-6);     // Unused
+
+    // Total injected volumes
+    const auto gti_vol = xgrptrc.subspan(2 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_vol[0], 5500.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gti_vol[1], 555.555, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gti_vol[2], 565.565, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gti_vol[3], 55.55, 1.0e-6);   // FOCF
+    BOOST_CHECK_CLOSE(gti_vol[4], 55.678, 1.0e-6);  // SOCF
+    BOOST_CHECK_CLOSE(gti_vol[5], 5.5, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gti_vol[6], 0.0, 1.0e-6);     // Unused
+
+    // Total produced volumes
+    const auto gtp_vol = xgrptrc.subspan(3 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_vol[0], 5555.0, 1.0e-6);   // SEA
+    BOOST_CHECK_CLOSE(gtp_vol[1], 565.5656, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gtp_vol[2], 545.5454, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gtp_vol[3], 55.585, 1.0e-6);   // FOCF
+    BOOST_CHECK_CLOSE(gtp_vol[4], 55.575, 1.0e-6);   // SOCF
+    BOOST_CHECK_CLOSE(gtp_vol[5], 5.555, 1.0e-6);    // SEB
+    BOOST_CHECK_CLOSE(gtp_vol[6], 0.0, 1.0e-6);      // Unused
+}
+
+BOOST_AUTO_TEST_CASE(Inje_W)
+{
+    const auto cse  = defineCase();
+    const auto ih   = intehead(cse);
+    const auto smry = dynamicState();
+
+    const auto gd = groupData(cse, ih, smry);
+    const auto xgsz = ih[VI::intehead::NXGRPZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xgsz) > VI::XGroup::TracerOffset,
+                          "XGRP must allocate space for tracer concentrations");
+
+    const auto grpID = 4;
+
+    {
+        const auto zgrp = std::span{gd.getZGroup()}
+            .subspan(grpID * ih[VI::intehead::NZGRPZ],
+                     ih[VI::intehead::NZGRPZ]);
+
+        BOOST_CHECK_EQUAL(zgrp[0].c_str(), "INJE-W  ");
+    }
+
+    const auto xgrptrc = std::span {gd.getXGroup()}
+        .subspan(grpID * xgsz, xgsz)
+        .subspan(VI::XGroup::TracerOffset);
+
+    BOOST_REQUIRE_EQUAL(xgrptrc.size(), 4 * tracerStride);
+
+    // Injection rates.
+    const auto gti_rates = xgrptrc.subspan(0 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_rates[0], 6000.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gti_rates[1], 606.06, 1.0e-6);  // FOCE
+    BOOST_CHECK_CLOSE(gti_rates[2], 660.066, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gti_rates[3], 0.0, 1.0e-6);     // FOCF
+    BOOST_CHECK_CLOSE(gti_rates[4], 66.33, 1.0e-6);   // SOCF
+    BOOST_CHECK_CLOSE(gti_rates[5], 6.0, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gti_rates[6], 0.0, 1.0e-6);     // Unused
+
+    // Production rates.
+    const auto gtp_rates = xgrptrc.subspan(1 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_rates[0], 6660.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gtp_rates[1], 666.666, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gtp_rates[2], 666.066, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gtp_rates[3], 0.0, 1.0e-6);     // FOCF
+    BOOST_CHECK_CLOSE(gtp_rates[4], 0.0, 1.0e-6);     // SOCF
+    BOOST_CHECK_CLOSE(gtp_rates[5], 6.66, 1.0e-6);    // SEB
+    BOOST_CHECK_CLOSE(gtp_rates[6], 0.0, 1.0e-6);     // Unused
+
+    // Total injected volumes.
+    const auto gti_vol = xgrptrc.subspan(2 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_vol[0], 6600.0, 1.0e-6);   // SEA
+    BOOST_CHECK_CLOSE(gti_vol[1], 666.5678, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gti_vol[2], 666.9876, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gti_vol[3], 66.678, 1.0e-6);   // FOCF
+    BOOST_CHECK_CLOSE(gti_vol[4], 66.9876, 1.0e-6);  // SOCF
+    BOOST_CHECK_CLOSE(gti_vol[5], 6.6, 1.0e-6);      // SEB
+    BOOST_CHECK_CLOSE(gti_vol[6], 0.0, 1.0e-6);      // Unused
+
+    // Total produced volumes.
+    const auto gtp_vol = xgrptrc.subspan(3 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_vol[0], 6666.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gtp_vol[1], 666.006, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gtp_vol[2], 666.007, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gtp_vol[3], 66.006, 1.0e-6);  // FOCF
+    BOOST_CHECK_CLOSE(gtp_vol[4], 66.007, 1.0e-6);  // SOCF
+    BOOST_CHECK_CLOSE(gtp_vol[5], 6.666, 1.0e-6);   // SEB
+    BOOST_CHECK_CLOSE(gtp_vol[6], 0.0, 1.0e-6);     // Unused
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Isothermal
+
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Thermal)
+
+namespace {
+    SimulationCase defineCase()
+    {
+        return SimulationCase { R"(RUNSPEC
+DIMENS
+  5 5 2 /
+OIL
+GAS
+WATER
+DISGAS
+TEMP
+TABDIMS
+/
+WELLDIMS
+  3 2 5 3 / -- Item 3 (NGMAX) must be at least 5 for this test.
+EQLDIMS
+  3 1 1 /
+TRACERS
+--  oil  water  gas  env
+     1*  3      2    1*   /
+GRID
+DXV
+  5*100 /
+DYV
+  5*100 /
+DZV
+  5 10 /
+DEPTHZ
+  36*2000.0 /
+EQUALS
+  PORO 0.25 /
+  PERMX 100 /
+  PERMY 100 /
+  PERMZ 10 /
+/
+PROPS
+DENSITY
+  852.6 1014.3 0.83 /
+TRACER
+SEA  WAT  /
+OCE  GAS  /
+OCF  GAS  /
+SEB  WAT  /
+/
+TVDPFSEA
+1000   0.0
+5000   0.0 /
+TVDPFSEB
+1000   0.0
+5000   0.0 /
+TBLKFOCE
+1.0 2.0 3.0 /
+TBLKFOCF
+1.0 2.0 3.0 /
+TEMPI
+  50*42.0 /
+SCHEDULE
+GRUPTREE
+  'PLAT_A' FIELD /
+  INJE     'PLAT_A' /
+  PROD     'PLAT_A' /
+  'INJE-G' INJE /
+  'INJE-W' INJE /
+/
+WELSPECS
+  IW 'INJE-W' 1 1 2010.0 'WATER' /
+  IG 'INJE-G' 1 5 2010.0 'GAS' /
+  P  'PROD'   5 3 2002.5 'LIQ' /
+/
+COMPDAT
+  IW 1 1 2 2 'OPEN' 2* 0.5 /
+  IG 1 5 1 1 'OPEN' 2* 0.5 /
+  P  5 3 1 2 'OPEN' 2* 0.5 /
+/
+WTRACER
+  IW SEA 0.123 /
+  IG OCE 0.456 /
+/
+WCONINJE
+  IW 'WATER' 'OPEN' RATE 12345.6 1* 512.256 /
+  IG 'GAS' 'OPEN' RATE 678910.1112 1* 256.128 /
+/
+WCONPROD
+  P 'OPEN' LRAT 3* 100E3 1* 25.125 /
+/
+TSTEP
+  1 2 3 4 5 10 15 4*20 /
+END
+)"
+        };
+    }
+
+    // 3 Water + 2 Gas*(free + solution) + Temperature.
+    constexpr auto tracerStride = std::size_t{8};
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(InteHEAD_Allocation_Sizes)
+{
+    const auto cse = defineCase();
+    const auto ih  = intehead(cse);
+
+    const auto expectNumTracers = [&trcCount = cse.es.runspec().tracers()]()
+    {
+        return trcCount.water_tracers()
+             + trcCount.oil_tracers()
+             + trcCount.gas_tracers()
+             + 1; // Temperature
+    }();
+
+    BOOST_CHECK_EQUAL(expectNumTracers, 6);
+
+    const auto expectNumTrcElems = [&trcCount = cse.es.runspec().tracers()]()
+    {
+        return trcCount.water_tracers()
+             + 0*trcCount.oil_tracers()
+             + 2*trcCount.gas_tracers()
+             + 1; // Temperature
+    }();
+
+    BOOST_CHECK_EQUAL(expectNumTrcElems, static_cast<int>(tracerStride));
+
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NGRP], 5);
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NWGMAX], 5);
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NGMAXZ], 6);
+    BOOST_CHECK_EQUAL(ih[VI::intehead::NXGRPZ], static_cast<int>(VI::XGroup::TracerOffset) + 4*expectNumTrcElems);
+}
+
+BOOST_AUTO_TEST_CASE(Field)
+{
+    const auto cse  = defineCase();
+    const auto ih   = intehead(cse);
+    const auto smry = dynamicState();
+
+    const auto gd = groupData(cse, ih, smry);
+    const auto xgsz = ih[VI::intehead::NXGRPZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xgsz) > VI::XGroup::TracerOffset,
+                          "XGRP must allocate space for tracer concentrations");
+
+    // FIELD group is *last* in XGRP.
+    const auto grpID = ih[VI::intehead::NGMAXZ] - 1;
+
+    const auto xgrptrc = std::span {gd.getXGroup()}
+        .subspan(grpID * xgsz, xgsz)
+        .subspan(VI::XGroup::TracerOffset);
+
+    BOOST_REQUIRE_EQUAL(xgrptrc.size(), 4 * tracerStride);
+
+    // Injection rates
+    const auto fti_rate = xgrptrc.subspan(0*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(fti_rate[0], 11122.2, 1.0e-6);    // HEA
+    BOOST_CHECK_CLOSE(fti_rate[1], 112233.44, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(fti_rate[2], 11.11, 1.0e-6);      // FOCE
+    BOOST_CHECK_CLOSE(fti_rate[3], 11.1212, 1.0e-6);    // SOCE
+    BOOST_CHECK_CLOSE(fti_rate[4], 111.0, 1.0e-6);      // FOCF
+    BOOST_CHECK_CLOSE(fti_rate[5], 11.202, 1.0e-6);     // SOCF
+    BOOST_CHECK_CLOSE(fti_rate[6], 111222.333, 1.0e-6); // SEB
+    BOOST_CHECK_CLOSE(fti_rate[7], 0.0, 1.0e-6);        // Unused
+
+    // Production rates
+    const auto ftp_rate = xgrptrc.subspan(1*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(ftp_rate[0], 0.2233, 1.0e-6);     // HEA
+    BOOST_CHECK_CLOSE(ftp_rate[1], 2233.44, 1.0e-6);    // SEA
+    BOOST_CHECK_CLOSE(ftp_rate[2], 2.2, 1.0e-6);        // FOCE
+    BOOST_CHECK_CLOSE(ftp_rate[3], 2.033, 1.0e-6);      // SOCE
+    BOOST_CHECK_CLOSE(ftp_rate[4], 22.0, 1.0e-6);       // FOCF
+    BOOST_CHECK_CLOSE(ftp_rate[5], 0.33, 1.0e-6);       // SOCF
+    BOOST_CHECK_CLOSE(ftp_rate[6], 222333.444, 1.0e-6); // SEB
+    BOOST_CHECK_CLOSE(ftp_rate[7], 0.0, 1.0e-6);        // Unused
+
+    // Total injected volume
+    const auto fti_vol = xgrptrc.subspan(2*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(fti_vol[0], 0.1122, 1.0e-6);           // HEA
+    BOOST_CHECK_CLOSE(fti_vol[1], 11223344.55, 1.0e-6);      // SEA
+    BOOST_CHECK_CLOSE(fti_vol[2], 1.1, 1.0e-6);              // FOCE
+    BOOST_CHECK_CLOSE(fti_vol[3], 0.022, 1.0e-6);            // SOCE
+    BOOST_CHECK_CLOSE(fti_vol[4], 0.0, 1.0e-6);              // FOCF
+    BOOST_CHECK_CLOSE(fti_vol[5], 0.0, 1.0e-6);              // SOCF
+    BOOST_CHECK_CLOSE(fti_vol[6], 111222333.444555, 1.0e-6); // SEB
+    BOOST_CHECK_CLOSE(fti_vol[7], 0.0, 1.0e-6);              // Unused
+
+    // Total produced volume
+    const auto ftp_vol = xgrptrc.subspan(3*tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(ftp_vol[0], 22.334455, 1.0e-6);     // HEA
+    BOOST_CHECK_CLOSE(ftp_vol[1], 223344.55, 1.0e-6);     // SEA
+    BOOST_CHECK_CLOSE(ftp_vol[2], 2200.44, 1.0e-6);       // FOCE
+    BOOST_CHECK_CLOSE(ftp_vol[3], 33.0055, 1.0e-6);       // SOCE
+    BOOST_CHECK_CLOSE(ftp_vol[4], 3.34455, 1.0e-6);       // FOCF
+    BOOST_CHECK_CLOSE(ftp_vol[5], 22.0, 1.0e-6);          // SOCF
+    BOOST_CHECK_CLOSE(ftp_vol[6], 222333444.555, 1.0e-6); // SEB
+    BOOST_CHECK_CLOSE(ftp_vol[7], 0.0, 1.0e-6);           // Unused
+}
+
+BOOST_AUTO_TEST_CASE(Plat_A)
+{
+    const auto cse  = defineCase();
+    const auto ih   = intehead(cse);
+    const auto smry = dynamicState();
+
+    const auto gd = groupData(cse, ih, smry);
+    const auto xgsz = ih[VI::intehead::NXGRPZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xgsz) > VI::XGroup::TracerOffset,
+                          "XGRP must allocate space for tracer concentrations");
+
+    const auto grpID = 0;
+
+    {
+        const auto zgrp = std::span{gd.getZGroup()}
+            .subspan(grpID * ih[VI::intehead::NZGRPZ],
+                     ih[VI::intehead::NZGRPZ]);
+
+        BOOST_CHECK_EQUAL(zgrp[0].c_str(), "PLAT_A  ");
+    }
+
+    const auto xgrptrc = std::span {gd.getXGroup()}
+        .subspan(grpID * xgsz, xgsz)
+        .subspan(VI::XGroup::TracerOffset);
+
+    BOOST_REQUIRE_EQUAL(xgrptrc.size(), 4 * tracerStride);
+
+    // Injection rates
+    const auto gti_rates = xgrptrc.subspan(0 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_rates[0], 22222.0, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gti_rates[1], 2000.0, 1.0e-6); // SEA
+    BOOST_CHECK_CLOSE(gti_rates[2], 0.0, 1.0e-6);    // FOCE
+    BOOST_CHECK_CLOSE(gti_rates[3], 202.02, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gti_rates[4], 22.0, 1.0e-6);   // FOCF
+    BOOST_CHECK_CLOSE(gti_rates[5], 0.0, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gti_rates[6], 2.0, 1.0e-6);    // SEB
+    BOOST_CHECK_CLOSE(gti_rates[7], 0.0, 1.0e-6);    // Unused
+
+    // Production rates
+    const auto gtp_rates = xgrptrc.subspan(1 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_rates[0], 22222.22, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gtp_rates[1], 2220.0, 1.0e-6);   // SEA
+    BOOST_CHECK_CLOSE(gtp_rates[2], 202.0, 1.0e-6);    // FOCE
+    BOOST_CHECK_CLOSE(gtp_rates[3], 20.22, 1.0e-6);    // SOCE
+    BOOST_CHECK_CLOSE(gtp_rates[4], 22.02, 1.0e-6);    // FOCF
+    BOOST_CHECK_CLOSE(gtp_rates[5], 0.2, 1.0e-6);      // SOCF
+    BOOST_CHECK_CLOSE(gtp_rates[6], 2.22, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gtp_rates[7], 0.0, 1.0e-6);      // Unused
+
+    // Total injected volumes
+    const auto gti_vol = xgrptrc.subspan(2 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_vol[0], 22222.2, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gti_vol[1], 2200.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gti_vol[2], 200.002, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gti_vol[3], 2.202, 1.0e-6);   // SOCE
+    BOOST_CHECK_CLOSE(gti_vol[4], 20.02, 1.0e-6);   // FOCF
+    BOOST_CHECK_CLOSE(gti_vol[5], 2.24, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gti_vol[6], 2.2, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gti_vol[7], 0.0, 1.0e-6);     // Unused
+
+    // Total produced volumes
+    const auto gtp_vol = xgrptrc.subspan(3 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_vol[0], 22222.222, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gtp_vol[1], 2222.0, 1.0e-6);    // SEA
+    BOOST_CHECK_CLOSE(gtp_vol[2], 222.202, 1.0e-6);   // FOCE
+    BOOST_CHECK_CLOSE(gtp_vol[3], 242.242, 1.0e-6);   // SOCE
+    BOOST_CHECK_CLOSE(gtp_vol[4], 22.202, 1.0e-6);    // FOCF
+    BOOST_CHECK_CLOSE(gtp_vol[5], 24.02, 1.0e-6);     // SOCF
+    BOOST_CHECK_CLOSE(gtp_vol[6], 2.222, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gtp_vol[7], 0.0, 1.0e-6);       // Unused
+}
+
+BOOST_AUTO_TEST_CASE(Inje)
+{
+    const auto cse  = defineCase();
+    const auto ih   = intehead(cse);
+    const auto smry = dynamicState();
+
+    const auto gd = groupData(cse, ih, smry);
+    const auto xgsz = ih[VI::intehead::NXGRPZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xgsz) > VI::XGroup::TracerOffset,
+                          "XGRP must allocate space for tracer concentrations");
+
+    const auto grpID = 1;
+
+    {
+        const auto zgrp = std::span{gd.getZGroup()}
+            .subspan(grpID * ih[VI::intehead::NZGRPZ],
+                     ih[VI::intehead::NZGRPZ]);
+
+        BOOST_CHECK_EQUAL(zgrp[0].c_str(), "INJE    ");
+    }
+
+    const auto xgrptrc = std::span {gd.getXGroup()}
+        .subspan(grpID * xgsz, xgsz)
+        .subspan(VI::XGroup::TracerOffset);
+
+    BOOST_REQUIRE_EQUAL(xgrptrc.size(), 4 * tracerStride);
+
+    // Injection rates
+    const auto gti_rates = xgrptrc.subspan(0 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_rates[0], 33333.0, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gti_rates[1], 3000.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gti_rates[2], 303, 1.0e-6);     // FOCE
+    BOOST_CHECK_CLOSE(gti_rates[3], 30.3, 1.0e-6);    // SOCE
+    BOOST_CHECK_CLOSE(gti_rates[4], 3.3, 1.0e-6);     // FOCF
+    BOOST_CHECK_CLOSE(gti_rates[5], 30.7, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gti_rates[6], 3.0, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gti_rates[7], 0.0, 1.0e-6);     // Unused
+
+    // Production rates
+    const auto gtp_rates = xgrptrc.subspan(1 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_rates[0], 33333.33, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gtp_rates[1], 3330.0, 1.0e-6);   // SEA
+    BOOST_CHECK_CLOSE(gtp_rates[2], 0.0, 1.0e-6);      // FOCE
+    BOOST_CHECK_CLOSE(gtp_rates[3], 303.03, 1.0e-6);   // SOCE
+    BOOST_CHECK_CLOSE(gtp_rates[4], 30.03, 1.0e-6);    // FOCF
+    BOOST_CHECK_CLOSE(gtp_rates[5], 43.34, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gtp_rates[6], 3.33, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gtp_rates[7], 0.0, 1.0e-6);      // Unused
+
+    // Total injected volumes
+    const auto gti_vol = xgrptrc.subspan(2 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_vol[0], 33333.3, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gti_vol[1], 3300.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gti_vol[2], 343.43, 1.0e-6);  // FOCE
+    BOOST_CHECK_CLOSE(gti_vol[3], 334.3, 1.0e-6);   // SOCE
+    BOOST_CHECK_CLOSE(gti_vol[4], 33.303, 1.0e-6);  // FOCF
+    BOOST_CHECK_CLOSE(gti_vol[5], 0.0, 1.0e-6);     // SOCF
+    BOOST_CHECK_CLOSE(gti_vol[6], 3.3, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gti_vol[7], 0.0, 1.0e-6);     // Unused
+
+    // Total produced volumes
+    const auto gtp_vol = xgrptrc.subspan(3 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_vol[0], 33333.333, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gtp_vol[1], 3333.0, 1.0e-6);    // SEA
+    BOOST_CHECK_CLOSE(gtp_vol[2], 334.334, 1.0e-6);   // FOCE
+    BOOST_CHECK_CLOSE(gtp_vol[3], 343.5, 1.0e-6);     // SOCE
+    BOOST_CHECK_CLOSE(gtp_vol[4], 33.003, 1.0e-6);    // FOCF
+    BOOST_CHECK_CLOSE(gtp_vol[5], 0.33, 1.0e-6);      // SOCF
+    BOOST_CHECK_CLOSE(gtp_vol[6], 3.333, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gtp_vol[7], 0.0, 1.0e-6);       // Unused
+}
+
+BOOST_AUTO_TEST_CASE(Prod)
+{
+    const auto cse  = defineCase();
+    const auto ih   = intehead(cse);
+    const auto smry = dynamicState();
+
+    const auto gd = groupData(cse, ih, smry);
+    const auto xgsz = ih[VI::intehead::NXGRPZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xgsz) > VI::XGroup::TracerOffset,
+                          "XGRP must allocate space for tracer concentrations");
+
+    const auto grpID = 2;
+
+    {
+        const auto zgrp = std::span{gd.getZGroup()}
+            .subspan(grpID * ih[VI::intehead::NZGRPZ],
+                     ih[VI::intehead::NZGRPZ]);
+
+        BOOST_CHECK_EQUAL(zgrp[0].c_str(), "PROD    ");
+    }
+
+    const auto xgrptrc = std::span {gd.getXGroup()}
+        .subspan(grpID * xgsz, xgsz)
+        .subspan(VI::XGroup::TracerOffset);
+
+    BOOST_REQUIRE_EQUAL(xgrptrc.size(), 4 * tracerStride);
+
+    // Injection rates
+    const auto gti_rates = xgrptrc.subspan(0 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_rates[0], 44444.0, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gti_rates[1], 4000.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gti_rates[2], 404.0, 1.0e-6);   // FOCE
+    BOOST_CHECK_CLOSE(gti_rates[3], 440.4, 1.0e-6);   // SOCE
+    BOOST_CHECK_CLOSE(gti_rates[4], 40.0, 1.0e-6);    // FOCF
+    BOOST_CHECK_CLOSE(gti_rates[5], 44.4, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gti_rates[6], 4.0, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gti_rates[7], 0.0, 1.0e-6);     // Unused
+
+    // Production rates
+    const auto gtp_rates = xgrptrc.subspan(1 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_rates[0], 44444.44, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gtp_rates[1], 4440.0, 1.0e-6);   // SEA
+    BOOST_CHECK_CLOSE(gtp_rates[2], 444.54, 1.0e-6);   // FOCE
+    BOOST_CHECK_CLOSE(gtp_rates[3], 404.04, 1.0e-6);   // SOCE
+    BOOST_CHECK_CLOSE(gtp_rates[4], 40.04, 1.0e-6);    // FOCF
+    BOOST_CHECK_CLOSE(gtp_rates[5], 44.56, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gtp_rates[6], 4.44, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gtp_rates[7], 0.0, 1.0e-6);      // Unused
+
+    // Total injected volumes
+    const auto gti_vol = xgrptrc.subspan(2 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_vol[0], 44444.4, 1.0e-6);  // HEA
+    BOOST_CHECK_CLOSE(gti_vol[1], 4400.0, 1.0e-6);   // SEA
+    BOOST_CHECK_CLOSE(gti_vol[2], 404.505, 1.0e-6);  // FOCE
+    BOOST_CHECK_CLOSE(gti_vol[3], 444.4567, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gti_vol[4], 44.44, 1.0e-6);    // FOCF
+    BOOST_CHECK_CLOSE(gti_vol[5], 45.54, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gti_vol[6], 4.4, 1.0e-6);      // SEB
+    BOOST_CHECK_CLOSE(gti_vol[7], 0.0, 1.0e-6);      // Unused
+
+    // Total produced volumes
+    const auto gtp_vol = xgrptrc.subspan(3 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_vol[0], 44444.444, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gtp_vol[1], 4444.0, 1.0e-6);    // SEA
+    BOOST_CHECK_CLOSE(gtp_vol[2], 454.454, 1.0e-6);   // FOCE
+    BOOST_CHECK_CLOSE(gtp_vol[3], 434.434, 1.0e-6);   // SOCE
+    BOOST_CHECK_CLOSE(gtp_vol[4], 44.434, 1.0e-6);    // FOCF
+    BOOST_CHECK_CLOSE(gtp_vol[5], 44.454, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gtp_vol[6], 4.444, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gtp_vol[7], 0.0, 1.0e-6);       // Unused
+}
+
+BOOST_AUTO_TEST_CASE(Inje_G)
+{
+    const auto cse  = defineCase();
+    const auto ih   = intehead(cse);
+    const auto smry = dynamicState();
+
+    const auto gd = groupData(cse, ih, smry);
+    const auto xgsz = ih[VI::intehead::NXGRPZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xgsz) > VI::XGroup::TracerOffset,
+                          "XGRP must allocate space for tracer concentrations");
+
+    const auto grpID = 3;
+
+    {
+        const auto zgrp = std::span{gd.getZGroup()}
+            .subspan(grpID * ih[VI::intehead::NZGRPZ],
+                     ih[VI::intehead::NZGRPZ]);
+
+        BOOST_CHECK_EQUAL(zgrp[0].c_str(), "INJE-G  ");
+    }
+
+    const auto xgrptrc = std::span {gd.getXGroup()}
+        .subspan(grpID * xgsz, xgsz)
+        .subspan(VI::XGroup::TracerOffset);
+
+    BOOST_REQUIRE_EQUAL(xgrptrc.size(), 4 * tracerStride);
+
+    // Injection rates
+    const auto gti_rates = xgrptrc.subspan(0 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_rates[0], 55555.0, 1.0e-6);  // HEA
+    BOOST_CHECK_CLOSE(gti_rates[1], 5000.0, 1.0e-6);   // SEA
+    BOOST_CHECK_CLOSE(gti_rates[2], 505.05, 1.0e-6);   // FOCE
+    BOOST_CHECK_CLOSE(gti_rates[3], 0.0, 1.0e-6);      // SOCE
+    BOOST_CHECK_CLOSE(gti_rates[4], 55.055, 1.0e-6);   // FOCF
+    BOOST_CHECK_CLOSE(gti_rates[5], 55.55055, 1.0e-6); // SOCF
+    BOOST_CHECK_CLOSE(gti_rates[6], 5.0, 1.0e-6);      // SEB
+    BOOST_CHECK_CLOSE(gti_rates[7], 0.0, 1.0e-6);      // Unused
+
+    // Production rates
+    const auto gtp_rates = xgrptrc.subspan(1 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_rates[0], 55555.55, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gtp_rates[1], 5550.0, 1.0e-6);   // SEA
+    BOOST_CHECK_CLOSE(gtp_rates[2], 555.505, 1.0e-6);  // FOCE
+    BOOST_CHECK_CLOSE(gtp_rates[3], 505.565, 1.0e-6);  // SOCE
+    BOOST_CHECK_CLOSE(gtp_rates[4], 50.05, 1.0e-6);    // FOCF
+    BOOST_CHECK_CLOSE(gtp_rates[5], 56.65, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gtp_rates[6], 5.55, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gtp_rates[7], 0.0, 1.0e-6);      // Unused
+
+    // Total injected volumes
+    const auto gti_vol = xgrptrc.subspan(2 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_vol[0], 55555.5, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gti_vol[1], 5500.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gti_vol[2], 555.555, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gti_vol[3], 565.565, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gti_vol[4], 55.55, 1.0e-6);   // FOCF
+    BOOST_CHECK_CLOSE(gti_vol[5], 55.678, 1.0e-6);  // SOCF
+    BOOST_CHECK_CLOSE(gti_vol[6], 5.5, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gti_vol[7], 0.0, 1.0e-6);     // Unused
+
+    // Total produced volumes
+    const auto gtp_vol = xgrptrc.subspan(3 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_vol[0], 55555.555, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gtp_vol[1], 5555.0, 1.0e-6);    // SEA
+    BOOST_CHECK_CLOSE(gtp_vol[2], 565.5656, 1.0e-6);  // FOCE
+    BOOST_CHECK_CLOSE(gtp_vol[3], 545.5454, 1.0e-6);  // SOCE
+    BOOST_CHECK_CLOSE(gtp_vol[4], 55.585, 1.0e-6);    // FOCF
+    BOOST_CHECK_CLOSE(gtp_vol[5], 55.575, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gtp_vol[6], 5.555, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gtp_vol[7], 0.0, 1.0e-6);       // Unused
+}
+
+BOOST_AUTO_TEST_CASE(Inje_W)
+{
+    const auto cse  = defineCase();
+    const auto ih   = intehead(cse);
+    const auto smry = dynamicState();
+
+    const auto gd = groupData(cse, ih, smry);
+    const auto xgsz = ih[VI::intehead::NXGRPZ];
+
+    BOOST_REQUIRE_MESSAGE(static_cast<std::size_t>(xgsz) > VI::XGroup::TracerOffset,
+                          "XGRP must allocate space for tracer concentrations");
+
+    const auto grpID = 4;
+
+    {
+        const auto zgrp = std::span{gd.getZGroup()}
+            .subspan(grpID * ih[VI::intehead::NZGRPZ],
+                     ih[VI::intehead::NZGRPZ]);
+
+        BOOST_CHECK_EQUAL(zgrp[0].c_str(), "INJE-W  ");
+    }
+
+    const auto xgrptrc = std::span {gd.getXGroup()}
+        .subspan(grpID * xgsz, xgsz)
+        .subspan(VI::XGroup::TracerOffset);
+
+    BOOST_REQUIRE_EQUAL(xgrptrc.size(), 4 * tracerStride);
+
+    // Injection rates.
+    const auto gti_rates = xgrptrc.subspan(0 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_rates[0], 66666.0, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gti_rates[1], 6000.0, 1.0e-6);  // SEA
+    BOOST_CHECK_CLOSE(gti_rates[2], 606.06, 1.0e-6);  // FOCE
+    BOOST_CHECK_CLOSE(gti_rates[3], 660.066, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gti_rates[4], 0.0, 1.0e-6);     // FOCF
+    BOOST_CHECK_CLOSE(gti_rates[5], 66.33, 1.0e-6);   // SOCF
+    BOOST_CHECK_CLOSE(gti_rates[6], 6.0, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gti_rates[7], 0.0, 1.0e-6);     // Unused
+
+    // Production rates.
+    const auto gtp_rates = xgrptrc.subspan(1 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_rates[0], 66666.66, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gtp_rates[1], 6660.0, 1.0e-6);   // SEA
+    BOOST_CHECK_CLOSE(gtp_rates[2], 666.666, 1.0e-6);  // FOCE
+    BOOST_CHECK_CLOSE(gtp_rates[3], 666.066, 1.0e-6);  // SOCE
+    BOOST_CHECK_CLOSE(gtp_rates[4], 0.0, 1.0e-6);      // FOCF
+    BOOST_CHECK_CLOSE(gtp_rates[5], 0.0, 1.0e-6);      // SOCF
+    BOOST_CHECK_CLOSE(gtp_rates[6], 6.66, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gtp_rates[7], 0.0, 1.0e-6);      // Unused
+
+    // Total injected volumes.
+    const auto gti_vol = xgrptrc.subspan(2 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gti_vol[0], 66666.6, 1.0e-6);  // HEA
+    BOOST_CHECK_CLOSE(gti_vol[1], 6600.0, 1.0e-6);   // SEA
+    BOOST_CHECK_CLOSE(gti_vol[2], 666.5678, 1.0e-6); // FOCE
+    BOOST_CHECK_CLOSE(gti_vol[3], 666.9876, 1.0e-6); // SOCE
+    BOOST_CHECK_CLOSE(gti_vol[4], 66.678, 1.0e-6);   // FOCF
+    BOOST_CHECK_CLOSE(gti_vol[5], 66.9876, 1.0e-6);  // SOCF
+    BOOST_CHECK_CLOSE(gti_vol[6], 6.6, 1.0e-6);      // SEB
+    BOOST_CHECK_CLOSE(gti_vol[7], 0.0, 1.0e-6);      // Unused
+
+    // Total produced volumes.
+    const auto gtp_vol = xgrptrc.subspan(3 * tracerStride, tracerStride);
+    BOOST_CHECK_CLOSE(gtp_vol[0], 66666.666, 1.0e-6); // HEA
+    BOOST_CHECK_CLOSE(gtp_vol[1], 6666.0, 1.0e-6);    // SEA
+    BOOST_CHECK_CLOSE(gtp_vol[2], 666.006, 1.0e-6);   // FOCE
+    BOOST_CHECK_CLOSE(gtp_vol[3], 666.007, 1.0e-6);   // SOCE
+    BOOST_CHECK_CLOSE(gtp_vol[4], 66.006, 1.0e-6);    // FOCF
+    BOOST_CHECK_CLOSE(gtp_vol[5], 66.007, 1.0e-6);    // SOCF
+    BOOST_CHECK_CLOSE(gtp_vol[6], 6.666, 1.0e-6);     // SEB
+    BOOST_CHECK_CLOSE(gtp_vol[7], 0.0, 1.0e-6);       // Unused
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Thermal
+
+BOOST_AUTO_TEST_SUITE_END() // Tracer_Values

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
 
             {
                 auto group_aggregator = Opm::RestartIO::Helpers::AggregateGroupData(ih);
-                group_aggregator.captureDeclaredGroupData(sched, rptStep - 1, st, ih);
+                group_aggregator.captureDeclaredGroupData(sched, es.tracer(), rptStep - 1, st, ih);
 
                 rstFile.write("IGRP", group_aggregator.getIGroup());
                 rstFile.write("SGRP", group_aggregator.getSGroup());

--- a/tests/test_AggregateWellDataLGR.cpp
+++ b/tests/test_AggregateWellDataLGR.cpp
@@ -1699,6 +1699,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data2LGRWells)
     ih.add_igr_data(99, 112, 181, 5, 2, 2);
     auto group_aggregator = Opm::RestartIO::Helpers::AggregateGroupData(ih.value);
     group_aggregator.captureDeclaredGroupData(simCase.sched,
+                                              simCase.es.tracer(),
                                               rptStep, smry, ih.value);
 
     // -------------------------- GROUP DATA FOR LGR GRID LGR1--------------------------
@@ -2055,6 +2056,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3Wells1G2LGR)
 
     auto group_aggregator = Opm::RestartIO::Helpers::AggregateGroupData(ih.value);
     group_aggregator.captureDeclaredGroupData(simCase.sched,
+                                              simCase.es.tracer(),
                                               rptStep, smry, ih.value);
 
     // -------------------------- GROUP DATA FOR LGR GRID LGR1--------------------------
@@ -2823,7 +2825,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data3MixedGroupsWells)
     // -------------------------- GROUP DATA FOR GLOBAL GRID --------------------------
     ih.add_igr_data(100, 112, 181, 5, 3, 3);
     auto group_aggregator = Opm::RestartIO::Helpers::AggregateGroupData(ih.value);
-    group_aggregator.captureDeclaredGroupData(simCase.sched,
+    group_aggregator.captureDeclaredGroupData(simCase.sched, simCase.es.tracer(),
                                               rptStep, smry, ih.value);
 
     // -------------------------- GROUP DATA FOR LGR GRID LGR1--------------------------
@@ -3306,7 +3308,7 @@ BOOST_AUTO_TEST_CASE (Declared_GroupDataLGR)
 
     // -------------------------- GROUP DATA FOR GLOBAL GRID --------------------------
     auto group_aggregator = Opm::RestartIO::Helpers::AggregateGroupData(ih);
-    group_aggregator.captureDeclaredGroupData(simCase.sched, rptStep, smry, ih);
+    group_aggregator.captureDeclaredGroupData(simCase.sched, simCase.es.tracer(), rptStep, smry, ih);
 
     // -------------------------- GROUP DATA FOR LGR GRID LGR1--------------------------
     auto group_aggregator_lgr1 = Opm::RestartIO::Helpers::AggregateGroupData(ih_lgr1);

--- a/tests/test_GroupStructureViz.cpp
+++ b/tests/test_GroupStructureViz.cpp
@@ -512,7 +512,9 @@ namespace {
                                                {}, sumState, sim_step);
 
         auto groupData = Opm::RestartIO::Helpers::AggregateGroupData(ih);
-        groupData.captureDeclaredGroupData(simCase.sched, sim_step, sumState, ih);
+        groupData.captureDeclaredGroupData(simCase.sched,
+                                           simCase.es.tracer(),
+                                           sim_step, sumState, ih);
 
         Opm::EclIO::OutputStream::Restart rstFile {
             Opm::EclIO::OutputStream::ResultSet { "./", baseName },

--- a/tests/test_rst.cpp
+++ b/tests/test_rst.cpp
@@ -417,6 +417,7 @@ END
 
         auto groupData = Opm::RestartIO::Helpers::AggregateGroupData(ih);
         groupData.captureDeclaredGroupData(simCase.sched,
+                                           simCase.es.tracer(),
                                            sim_step, sumState, ih);
 
         const auto outputDir = std::string { "./" };
@@ -507,6 +508,7 @@ BOOST_AUTO_TEST_CASE(group_test)
 
     auto groupData = Opm::RestartIO::Helpers::AggregateGroupData(ih);
     groupData.captureDeclaredGroupData(simCase.sched,
+                                       simCase.es.tracer(),
                                        sim_step, sumState, ih);
 
     const auto& igrp = groupData.getIGroup();


### PR DESCRIPTION
We save four tracer quantities at the group and field levels

  1. Injection rates (`[FG]TIR*`)
  2. Production rates (`[FG]TPR*`)
  3. Cumulative injected volumes (`[FG]TIT*`)
  4. Cumulative produced volumes (`[FG]TPT*`)

with the usual convention that temperatures and energies (`*HEA`) are emitted as the first array element when applicable. When restarting, we reload just the cumulative volumes.

Arrays pertaining to local grid refinement are intentionally omitted at this time.