### PR TITLE
Always write LOGIHEAD and DOUBHEAD to the restart file

### DIFF
--- a/opm/output/eclipse/RestartIO.cpp
+++ b/opm/output/eclipse/RestartIO.cpp
@@ -165,7 +165,6 @@ namespace {
                 const EclipseState&           es,
                 EclIO::OutputStream::Restart& rstFile)
     {
-        const int norst_value = schedule[sim_step].rst_config().norst.value_or(0);
         // write INTEHEAD to restart file
         auto ih = Helpers::
             createInteHead(es, grid, schedule, simTime,
@@ -174,19 +173,20 @@ namespace {
 
         rstFile.write("INTEHEAD", ih);
 
-        // LOGIHEAD and DOUBHEAD are only written for full restarts (NORST=0).
-        if (norst_value == 0) {
-            // write LOGIHEAD to restart file
-            if (report_step == 0) {
-                rstFile.write("LOGIHEAD", Helpers::createLogiHead(es));
-            }
-            else {
-                rstFile.write("LOGIHEAD", Helpers::createLogiHead(es, schedule[report_step - 1]));
-            }
+        // LOGIHEAD and DOUBHEAD go in whatever NORST asks for.  They are a few
+        // hundred values against a file of millions, and leaving them out costs
+        // the reader the simulated time (DOUBHEAD) and the dual-porosity flag
+        // (LOGIHEAD): libecl leaves both uninitialised rather than failing, and
+        // our own LoadRestart refuses the file outright.  ECLIPSE writes them
+        // for a graphics-only restart too.
+        if (report_step == 0) {
+            rstFile.write("LOGIHEAD", Helpers::createLogiHead(es));
+        }
+        else {
+            rstFile.write("LOGIHEAD", Helpers::createLogiHead(es, schedule[report_step - 1]));
         }
 
-        if (norst_value == 0) {
-            // write DOUBHEAD to restart file
+        {
             const auto dh = Helpers::createDoubHead(es, schedule,
                                                     sim_step, report_step,
                                                     simTime, next_step_size);


### PR DESCRIPTION
`RPTRST ... NORST=1` currently suppresses `LOGIHEAD` and `DOUBHEAD`. Without them libecl builds its restart header from uninitialised memory (it null-checks both and leaves `sim_days`/`dualp` unset), so ResInsight shows a case with no dynamic data at all — and our own `LoadRestart` rejects the file: "missing required header arrays (INTEHEAD/LOGIHEAD/DOUBHEAD)". ECLIPSE writes both for a graphics-only restart; checked against a reference run of a `NORST=1` deck.

`opm-tests/sector01/SECTOR01_MSW1.DATA` is affected today: 21 report steps, `INTEHEAD` on each and neither of the other two. `pinch/PINCH_NONE` and both Drogon decks are `NORST=1` as well.

The two arrays are 121 logicals and 229 doubles against a file of millions of values, so nothing is saved by leaving them out — but if the intent was that a graphics-only restart should be smaller, the alternative is to keep them out and teach `RestartFileView::hasAllHeaders()` and libecl-based readers to cope, which seems worse.

Draft: no test added yet. Suggestions welcome on where one belongs — `test_NORST` seemed the natural home but it does not currently read the written file back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)