### PR TITLE
Infer Action Dimensions From Restart File Information

### DIFF
--- a/opm/input/eclipse/Schedule/OilVaporizationProperties.hpp
+++ b/opm/input/eclipse/Schedule/OilVaporizationProperties.hpp
@@ -32,7 +32,8 @@ namespace Opm
      * The DRSDTCON implements a dissolution rate based on convective mixing.
      * Ask for type first and the ask for the correct values for this type, asking for values not valid for the current type will throw a logic exception.
      */
-    class OilVaporizationProperties {
+    class OilVaporizationProperties
+    {
     public:
         enum class OilVaporization {
             UNDEF = 0,
@@ -40,7 +41,6 @@ namespace Opm
             DRDT = 2, // DRSDT or DRVDT
             DRSDTCON = 3 // DRSDTCON
         };
-
 
         OilVaporizationProperties();
         explicit OilVaporizationProperties(const std::size_t numPvtReginIdx);
@@ -95,13 +95,13 @@ namespace Opm
 
     private:
         OilVaporization m_type = OilVaporization::UNDEF;
-        double m_vap1;
-        double m_vap2;
-        std::vector<double> m_maxDRSDT;
-        std::vector<bool> m_maxDRSDT_allCells;
-        std::vector<double> m_maxDRVDT;
-        std::vector<double> m_psi;
-        std::vector<double> m_omega;
+        double m_vap1{};
+        double m_vap2{};
+        std::vector<double> m_maxDRSDT{};
+        std::vector<bool> m_maxDRSDT_allCells{};
+        std::vector<double> m_maxDRVDT{};
+        std::vector<double> m_psi{};
+        std::vector<double> m_omega{};
     };
 }
 #endif // DRSDT_H

--- a/opm/io/eclipse/rst/header.cpp
+++ b/opm/io/eclipse/rst/header.cpp
@@ -25,26 +25,101 @@
 
 #include <opm/common/utility/TimeService.hpp>
 
-#include <opm/input/eclipse/EclipseState/Runspec.hpp>
-
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <array>
+#include <cmath>
 #include <cstddef>
 #include <ctime>
+#include <optional>
 #include <utility>
 #include <vector>
 
 namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
 using M = ::Opm::UnitSystem::measure;
 
+namespace {
+
+std::optional<Opm::TimeStampUTC>
+inferStartFromDateNum(const std::vector<double>& doubhead)
+{
+    if (doubhead.size() <= VI::doubhead::Start) {
+        return std::nullopt;
+    }
+
+    const auto encoded = doubhead[VI::doubhead::Start];
+    if (!std::isfinite(encoded)) {
+        return std::nullopt;
+    }
+
+    const auto dateNum = static_cast<long long>(std::llround(encoded));
+    if (dateNum <= 0) {
+        return std::nullopt;
+    }
+
+    constexpr auto daysPerYear = 365.25;
+
+    auto year = static_cast<int>(std::floor((static_cast<double>(dateNum) - 1.0) / daysPerYear));
+
+    auto dayOfYear = static_cast<int>(dateNum - static_cast<long long>(std::floor(daysPerYear * year)));
+    while (dayOfYear < 1) {
+        --year;
+        dayOfYear = static_cast<int>(dateNum - static_cast<long long>(std::floor(daysPerYear * year)));
+    }
+    while (dayOfYear > 365) {
+        ++year;
+        dayOfYear = static_cast<int>(dateNum - static_cast<long long>(std::floor(daysPerYear * year)));
+    }
+
+    constexpr std::array<int, 12> monthLengths {
+        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
+    };
+
+    auto month = 1;
+    auto day = dayOfYear;
+    for (const auto& monthLen : monthLengths) {
+        if (day <= monthLen) {
+            break;
+        }
+
+        day -= monthLen;
+        ++month;
+    }
+
+    if (month > 12) {
+        return std::nullopt;
+    }
+
+    return Opm::TimeStampUTC(year, month, day);
+}
+
+std::optional<Opm::TimeStampUTC>
+inferStartFromElapsedSimDays(const std::time_t simTime,
+                             const std::vector<double>& doubhead)
+{
+    if (doubhead.size() <= VI::doubhead::SimTime) {
+        return std::nullopt;
+    }
+
+    const auto elapsedDays = doubhead[VI::doubhead::SimTime];
+    if (!std::isfinite(elapsedDays)) {
+        return std::nullopt;
+    }
+
+    constexpr auto secPerDay = 86400.0;
+    const auto elapsedSeconds = elapsedDays * secPerDay;
+
+    return Opm::TimeStampUTC { Opm::TimeService::advance(simTime, -elapsedSeconds) };
+}
+
+} // Anonymous namespace
+
 namespace Opm::RestartIO {
 
-RstHeader::RstHeader(const Runspec&             runspec_,
-                     const Opm::UnitSystem&     unit_system,
+RstHeader::RstHeader(const Opm::UnitSystem&     unit_system,
                      const std::vector<int>&    intehead,
                      const std::vector<bool>&   logihead,
                      const std::vector<double>& doubhead) :
-    runspec(runspec_),
     nx(intehead[VI::intehead::NX]),
     ny(intehead[VI::intehead::NY]),
     nz(intehead[VI::intehead::NZ]),
@@ -105,8 +180,19 @@ RstHeader::RstHeader(const Runspec&             runspec_,
     nsegment_udq(intehead[VI::intehead::NO_SEG_UDQS]),
     nwell_udq(intehead[VI::intehead::NO_WELL_UDQS]),
     num_action(intehead[VI::intehead::NOOFACTIONS]),
+    max_action_lines(intehead[VI::intehead::MAXNOLINES]),
+    max_action_line_size(intehead[VI::intehead::MAXNOSTRPRLINE]),
+    max_action_conditions(intehead[VI::intehead::MAX_ACT_COND]),
+    action_zact_size(intehead[VI::intehead::ACTION_ZACT_SIZE]),
+    action_sact_size(intehead[VI::intehead::ACTION_SACT_SIZE]),
+    action_iact_size(intehead[VI::intehead::ACTION_IACT_SIZE]),
+    action_iacn_size(intehead[VI::intehead::ACTION_IACN_SIZE]),
+    action_sacn_size(intehead[VI::intehead::ACTION_SACN_SIZE]),
+    action_zacn_size(intehead[VI::intehead::ACTION_ZACN_SIZE]),
     guide_rate_nominated_phase(intehead[VI::intehead::NGRNPH]),
     max_wlist(intehead[VI::intehead::MXWLSTPRWELL]),
+    //
+    // ----------------------------------------------------------------------
     //
     e300_radial(logihead[VI::logihead::E300Radial]),
     e100_radial(logihead[VI::logihead::E100Radial]),
@@ -123,6 +209,9 @@ RstHeader::RstHeader(const Runspec&             runspec_,
     alt_eps(logihead[VI::logihead::AltEPS]),
     group_control_active(intehead[VI::intehead::NGRNPH] == 1),
     glift_all_nupcol(intehead[VI::intehead::EACHNCITS] == VI::InteheadValues::LiftOpt::EachNupCol),
+    has_temperature(logihead[VI::logihead::HasTemp] || logihead[VI::logihead::HasTemp2]),
+    //
+    // ----------------------------------------------------------------------
     //
     next_timestep1(unit_system.to_si(M::time, doubhead[VI::doubhead::TsInit])),
     next_timestep2(0),
@@ -144,6 +233,10 @@ RstHeader::RstHeader(const Runspec&             runspec_,
 {
     this->microsecond = (intehead.size() > VI::intehead::ISECND)
         ? intehead[VI::intehead::ISECND] : 0;
+
+    this->inferred_start_from_doubhead_start = inferStartFromDateNum(doubhead);
+    this->inferred_start_from_elapsed_simtime =
+        inferStartFromElapsedSimDays(this->sim_time(), doubhead);
 }
 
 std::time_t RstHeader::sim_time() const
@@ -160,6 +253,20 @@ RstHeader::restart_info() const
 {
     return std::make_pair(asTimeT(TimeStampUTC(this->year, this->month, this->mday)),
                           std::size_t(this->report_step));
+}
+
+std::optional<double>
+RstHeader::inferred_start_time_drift_seconds() const
+{
+    if (!this->inferred_start_from_doubhead_start.has_value() ||
+        !this->inferred_start_from_elapsed_simtime.has_value()) {
+        return std::nullopt;
+    }
+
+    const auto t0 = asTimeT(this->inferred_start_from_doubhead_start.value());
+    const auto t1 = asTimeT(this->inferred_start_from_elapsed_simtime.value());
+
+    return std::abs(std::difftime(t0, t1));
 }
 
 int RstHeader::num_udq() const

--- a/opm/io/eclipse/rst/header.hpp
+++ b/opm/io/eclipse/rst/header.hpp
@@ -20,10 +20,11 @@
 #ifndef RST_HEADER
 #define RST_HEADER
 
-#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <cstddef>
 #include <ctime>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -37,13 +38,11 @@ namespace Opm::RestartIO {
 
 struct RstHeader
 {
-    RstHeader(const Runspec& runspec,
-              const UnitSystem& unit_system,
+    RstHeader(const UnitSystem& unit_system,
               const std::vector<int>& intehead,
               const std::vector<bool>& logihead,
               const std::vector<double>& doubhead);
 
-    Runspec runspec;
     int nx;
     int ny;
     int nz;
@@ -105,6 +104,15 @@ struct RstHeader
     int nsegment_udq;
     int nwell_udq;
     int num_action;
+    int max_action_lines;
+    int max_action_line_size;
+    int max_action_conditions;
+    int action_zact_size;
+    int action_sact_size;
+    int action_iact_size;
+    int action_iacn_size;
+    int action_sacn_size;
+    int action_zacn_size;
     int guide_rate_nominated_phase;
     int max_wlist;
 
@@ -123,6 +131,7 @@ struct RstHeader
     bool alt_eps;
     bool group_control_active;
     bool glift_all_nupcol;
+    bool has_temperature;
 
     double next_timestep1;
     double next_timestep2;
@@ -141,6 +150,16 @@ struct RstHeader
     double glift_min_wait;
     double glift_rate_delta;
     double glift_min_eco_grad;
+
+    // Start date inferred from DOUBHEAD[START] (date number encoding).
+    std::optional<TimeStampUTC> inferred_start_from_doubhead_start;
+
+    // Start timestamp inferred from sim_time - DOUBHEAD[0] (elapsed days).
+    std::optional<TimeStampUTC> inferred_start_from_elapsed_simtime;
+
+    // Absolute drift in seconds between the two inferred start timestamps.
+    // Returns std::nullopt if either source is unavailable.
+    std::optional<double> inferred_start_time_drift_seconds() const;
 
     std::time_t sim_time() const;
     std::pair<std::time_t, std::size_t> restart_info() const;

--- a/opm/io/eclipse/rst/state.cpp
+++ b/opm/io/eclipse/rst/state.cpp
@@ -23,7 +23,6 @@
 #include <opm/io/eclipse/PaddedOutputString.hpp>
 
 #include <opm/io/eclipse/rst/aquifer.hpp>
-#include <opm/io/eclipse/rst/action.hpp>
 #include <opm/io/eclipse/rst/connection.hpp>
 #include <opm/io/eclipse/rst/group.hpp>
 #include <opm/io/eclipse/rst/header.hpp>
@@ -45,7 +44,9 @@
 
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
-#include <opm/input/eclipse/Schedule/Action/Actdims.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
+
 #include <opm/input/eclipse/Schedule/Action/Condition.hpp>
 #include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
 
@@ -369,14 +370,20 @@ namespace {
 namespace Opm::RestartIO {
 
 RstState::RstState(std::shared_ptr<EclIO::RestartFileView> rstView,
-                   const Runspec&                          runspec,
-                   const ::Opm::EclipseGrid*               grid)
-    : unit_system(rstView->intehead()[VI::intehead::UNIT])
-    , header(runspec, unit_system, rstView->intehead(), rstView->logihead(), rstView->doubhead())
-    , aquifers(rstView, grid, unit_system)
-    , netbalan(rstView->intehead(), rstView->doubhead(), unit_system)
-    , network(rstView, unit_system)
-    , oilvap(runspec.tabdims().getNumPVTTables())
+                   const ::Opm::EclipseGrid*               grid,
+                   std::optional<int>                      numPVTTables)
+    : unit_system { rstView->intehead()[VI::intehead::UNIT] }
+    , header      { unit_system, rstView->intehead(), rstView->logihead(), rstView->doubhead() }
+    , aquifers    { rstView, grid, unit_system }
+    , netbalan    { rstView->intehead(), rstView->doubhead(), unit_system }
+    , network     { rstView, unit_system }
+    , oilvap      { static_cast<std::size_t>([](const std::optional<int>& n) {
+                        const auto v = n.value_or(1);
+                        if (v < 1) {
+                            throw std::invalid_argument{"numPVTTables must be >= 1"};
+                        }
+                        return v;
+                    }(numPVTTables)) }
 {
     this->load_tuning(rstView->intehead(), rstView->doubhead());
 
@@ -404,6 +411,14 @@ RstState RstState::load(std::shared_ptr<EclIO::RestartFileView> rstView,
                         const Parser&                           parser,
                         const ::Opm::EclipseGrid*               grid)
 {
+    return load(std::move(rstView), parser, runspec.tabdims().getNumPVTTables(), grid);
+}
+
+RstState RstState::load(std::shared_ptr<EclIO::RestartFileView> rstView,
+                        const Parser&                           parser,
+                        std::optional<int>                      numPVTTables,
+                        const ::Opm::EclipseGrid*               grid)
+{
     if (rstView->isGraphicsOnly()) {
         throw std::runtime_error {
             fmt::format("Cannot restart from restart file "
@@ -414,7 +429,7 @@ RstState RstState::load(std::shared_ptr<EclIO::RestartFileView> rstView,
         };
     }
 
-    RstState state(rstView, runspec, grid);
+    auto state = RstState { rstView, grid, numPVTTables };
 
     // At minimum we need any applicable constraint data for FIELD.  Load
     // groups unconditionally.
@@ -477,9 +492,7 @@ RstState RstState::load(std::shared_ptr<EclIO::RestartFileView> rstView,
             .z = rstView->getKeyword<std::string>("ZACN")
         };
 
-        state.add_actions(parser, runspec,
-                          state.header.sim_time(),
-                          actionArrays, conditions,
+        state.add_actions(parser, actionArrays, conditions,
                           rstView->getKeyword<std::string>("ZLACT"));
     }
 
@@ -718,22 +731,18 @@ void RstState::add_udqs(std::shared_ptr<EclIO::RestartFileView> rstView)
 }
 
 void RstState::add_actions(const Parser&                parser,
-                           const Runspec&               runspec,
-                           const std::time_t            sim_time,
                            ActionData<float>            actionArrays,
                            ActionData<double>           conditions,
                            std::span<const std::string> zlact)
 {
     const auto num_actions = static_cast<std::size_t>(this->header.num_action);
-
-    const auto& actdims = runspec.actdims();
     const auto zlact_action_size = zlact.size() / num_actions;
 
     for (std::size_t index = 0; index < num_actions; ++index) {
-        auto actionConditions = this->restore_conditions(actdims, conditions, index);
-        this->create_action(runspec, sim_time, actionArrays, index, std::move(actionConditions));
+        auto actionConditions = this->restore_conditions(conditions, index);
+        this->create_action(actionArrays, index, std::move(actionConditions));
 
-        this->restore_action_keywords(parser, actdims,
+        this->restore_action_keywords(parser,
                                       zlact.subspan(index * zlact_action_size, zlact_action_size));
     }
 }
@@ -766,28 +775,28 @@ void RstState::add_wlist(const std::vector<std::string>& zwls,
 }
 
 std::vector<RstAction::Condition>
-RstState::restore_conditions(const Actdims&     actdims,
-                             ActionData<double> conditions,
+RstState::restore_conditions(ActionData<double> conditions,
                              const std::size_t  index) const
 {
     auto actConditions = std::vector<RstAction::Condition> {};
 
-    const auto iacn_action_size = RestartIO::Helpers::entriesPerIACN(actdims);
-    const auto sacn_action_size = RestartIO::Helpers::entriesPerSACN(actdims);
-    const auto zacn_action_size = RestartIO::Helpers::entriesPerZACN(actdims);
+    const auto iacn_cond_size = static_cast<std::size_t>(this->header.action_iacn_size);
+    const auto sacn_cond_size = static_cast<std::size_t>(this->header.action_sacn_size);
+    const auto zacn_cond_size = static_cast<std::size_t>(this->header.action_zacn_size);
 
-    constexpr auto iacn_cond_size = RestartIO::Helpers::VectorItems::IACN::ConditionSize;
-    constexpr auto sacn_cond_size = RestartIO::Helpers::VectorItems::SACN::ConditionSize;
-    constexpr auto zacn_cond_size = RestartIO::Helpers::VectorItems::ZACN::ConditionSize;
+    const auto iacn_action_size = this->header.max_action_conditions * iacn_cond_size;
+    const auto sacn_action_size = this->header.max_action_conditions * sacn_cond_size;
+    const auto zacn_action_size = this->header.max_action_conditions * zacn_cond_size;
 
     const auto act_iacn = conditions.i.subspan(index * iacn_action_size, iacn_action_size);
     const auto act_sacn = conditions.s.subspan(index * sacn_action_size, sacn_action_size);
     const auto act_zacn = conditions.z.subspan(index * zacn_action_size, zacn_action_size);
 
-    for (std::size_t icond = 0; icond < actdims.max_conditions(); ++icond) {
-        const auto iacn = act_iacn.subspan(icond * iacn_cond_size, iacn_cond_size);
-        const auto sacn = act_sacn.subspan(icond * sacn_cond_size, sacn_cond_size);
-        const auto zacn = act_zacn.subspan(icond * zacn_cond_size, zacn_cond_size);
+    for (auto icond = 0; icond < this->header.max_action_conditions; ++icond) {
+        const auto cond = static_cast<std::size_t>(icond);
+        const auto iacn = act_iacn.subspan(cond * iacn_cond_size, iacn_cond_size);
+        const auto sacn = act_sacn.subspan(cond * sacn_cond_size, sacn_cond_size);
+        const auto zacn = act_zacn.subspan(cond * zacn_cond_size, zacn_cond_size);
 
         if (RstAction::Condition::valid(iacn, zacn)) {
             actConditions.emplace_back(iacn, sacn, zacn);
@@ -798,15 +807,13 @@ RstState::restore_conditions(const Actdims&     actdims,
 }
 
 void
-RstState::create_action(const Runspec&                      runspec,
-                        const std::time_t                   sim_time,
-                        ActionData<float>                   actionArrays,
+RstState::create_action(ActionData<float>                   actionArrays,
                         const std::size_t                   index,
                         std::vector<RstAction::Condition>&& conditions)
 {
-    constexpr auto iact_action_size = RestartIO::Helpers::entriesPerIACT();
-    constexpr auto sact_action_size = RestartIO::Helpers::entriesPerSACT();
-    constexpr auto zact_action_size = RestartIO::Helpers::entriesPerZACT();
+    const auto iact_action_size = static_cast<std::size_t>(this->header.action_iact_size);
+    const auto sact_action_size = static_cast<std::size_t>(this->header.action_sact_size);
+    const auto zact_action_size = static_cast<std::size_t>(this->header.action_zact_size);
 
     const auto iact = actionArrays.i.subspan(index * iact_action_size, iact_action_size);
     const auto sact = actionArrays.s.subspan(index * sact_action_size, sact_action_size);
@@ -819,30 +826,41 @@ RstState::create_action(const Runspec&                      runspec,
     const auto min_wait = this->unit_system.to_si(UnitSystem::measure::time, sact[3]);
     const auto last_run_elapsed = this->unit_system.to_si(UnitSystem::measure::time, sact[4]);
 
-    const auto last_run_time = TimeService::advance(runspec.start_time(), last_run_elapsed);
+    if (!this->header.inferred_start_from_elapsed_simtime.has_value()) {
+        throw std::runtime_error {
+            "Could not infer ACTION timing: missing inferred "
+            "start time from elapsed simulation time"
+        };
+    }
 
-    this->actions.emplace_back(name, max_run, run_count,
-                               min_wait, sim_time, last_run_time,
+    const auto start_time = *this->header.inferred_start_from_elapsed_simtime;
+
+    const auto last_run_time = TimeService::advance(asTimeT(start_time), last_run_elapsed);
+
+    this->actions.emplace_back(name, max_run, run_count, min_wait,
+                               this->header.sim_time(),
+                               last_run_time,
                                std::move(conditions));
 }
 
 void
 RstState::restore_action_keywords(const Parser& parser,
-                                  const Actdims& actdims,
                                   std::span<const std::string> zlact)
 {
     auto action_deck = std::string{};
 
-    auto lineIdx = 0 * actdims.line_size();
+    const auto line_size = static_cast<std::size_t>(this->header.max_action_line_size);
+
+    auto lineIdx = 0 * line_size;
     while (true) {
-        const auto offset = lineIdx++ * actdims.line_size();
-        if (offset + actdims.line_size() > zlact.size()) {
+        const auto offset = lineIdx++ * line_size;
+        if (offset + line_size > zlact.size()) {
             throw std::runtime_error {
                 "Malformed ZLACT: missing ENDACTIO terminator"
             };
         }
 
-        auto zlact_line = zlact.subspan(offset, actdims.line_size());
+        auto zlact_line = zlact.subspan(offset, line_size);
 
         auto line = std::string{};
         for (const auto& line_item : zlact_line) {

--- a/opm/io/eclipse/rst/state.hpp
+++ b/opm/io/eclipse/rst/state.hpp
@@ -57,8 +57,13 @@ namespace Opm { namespace RestartIO {
 struct RstState
 {
     RstState(std::shared_ptr<EclIO::RestartFileView> rstView,
-             const Runspec&                          runspec,
-             const ::Opm::EclipseGrid*               grid);
+             const ::Opm::EclipseGrid*               grid,
+             std::optional<int>                      numPVTTables = std::nullopt);
+
+    static RstState load(std::shared_ptr<EclIO::RestartFileView> rstView,
+                         const Parser&                           parser,
+                         std::optional<int>                      numPVTTables = std::nullopt,
+                         const ::Opm::EclipseGrid*               grid = nullptr);
 
     static RstState load(std::shared_ptr<EclIO::RestartFileView> rstView,
                          const Runspec&                          runspec,
@@ -153,8 +158,6 @@ private:
     ///
     /// \param[in] zlact The action block keywords.
     void add_actions(const Parser&                parser,
-                     const Runspec&               runspec,
-                     std::time_t                  sim_time,
                      ActionData<float>            actions,
                      ActionData<double>           conditions,
                      std::span<const std::string> zlact);
@@ -164,17 +167,13 @@ private:
 
     /// Restore conditions for single action from restart file information.
     ///
-    /// \param[in] actdims The action dimensions, e.g., maximum number of
-    /// conditions and sizes of condition arrays per condition.
-    ///
     /// \param[in] conditions The condition data (i.e., the [ISZ]ACN arrays).
     ///
     /// \param[in] index The action index.
     ///
     /// \return The restored conditions for the \p index-th action.
     std::vector<RstAction::Condition>
-    restore_conditions(const Actdims&     actdims,
-                       ActionData<double> conditions,
+    restore_conditions(ActionData<double> conditions,
                        std::size_t        index) const;
 
     /// Restore a single action from restart file information.
@@ -190,9 +189,7 @@ private:
     /// \param[in] index The action index.
     ///
     /// \param[in] conditions The restored conditions for the \p index-th action.
-    void create_action(const Runspec&                      runspec,
-                       const std::time_t                   sim_time,
-                       ActionData<float>                   actionArrays,
+    void create_action(ActionData<float>                   actionArrays,
                        std::size_t                         index,
                        std::vector<RstAction::Condition>&& conditions);
 
@@ -203,13 +200,9 @@ private:
     ///
     /// \param[in] parser The parser used to interpret action block keywords.
     ///
-    /// \param[in] actdims The action dimensions, e.g., maximum number of
-    /// conditions and sizes of condition arrays per condition.
-    ///
     /// \param[in] zlact Linearised collection of action block keyword strings.
     /// Assumed to encompass only those strings that pertain to \code actions.back() \endcode.
     void restore_action_keywords(const Parser&                parser,
-                                 const Actdims&               actdims,
                                  std::span<const std::string> zlact);
 
 };

--- a/opm/io/eclipse/rst/well.cpp
+++ b/opm/io/eclipse/rst/well.cpp
@@ -19,6 +19,8 @@
 
 #include <opm/io/eclipse/rst/well.hpp>
 
+#include <opm/common/utility/String.hpp>
+
 #include <opm/io/eclipse/rst/header.hpp>
 #include <opm/io/eclipse/rst/connection.hpp>
 
@@ -28,18 +30,19 @@
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
-#include <opm/common/utility/String.hpp>
-
 #include <opm/input/eclipse/Parser/ParserItem.hpp>
 #include <opm/input/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/input/eclipse/Parser/ParserRecord.hpp>
+
 #include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <span>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -184,18 +187,39 @@ Opm::RestartIO::RstWell::RstWell(const UnitSystem&  unit_system,
         active_control = VI::IWell::Value::WellCtrlMode::Group;
     }
 
-    // If the TEMP option is active, this is the first tracer
-    std::size_t tracer_index = 0;
-    const bool isTemp = header.runspec.temp();
-    if (isTemp) {
-        this->inj_temperature = unit_system.to_si(M::temperature, swel[VI::SWell::TracerOffset + tracer_index++]);
+    if (header.nswelz <= 0) {
+        throw std::invalid_argument {
+            "Number of SWEL elements per well must be strictly positive"
+        };
     }
-    const auto& tracers = header.runspec.tracers();
-    for (const auto num_tracer_injconcs = tracers.water_tracers() + 2*(tracers.gas_tracers() + tracers.oil_tracers()) + tracer_index;
-         tracer_index < static_cast<std::size_t>(num_tracer_injconcs);
-         ++tracer_index)
+
+    if (const auto nswelz = static_cast<std::underlying_type_t<VI::SWell::index>>(header.nswelz);
+        nswelz > VI::SWell::TracerOffset)
     {
-        this->tracer_concentration_injection.push_back(swel[VI::SWell::TracerOffset + tracer_index]);
+        const auto numTrcElems = nswelz - VI::SWell::TracerOffset;
+
+        if (numTrcElems % 2 != 0) {
+            throw std::invalid_argument {
+                "Number of tracer elements in SWEL is odd"
+            };
+        }
+
+        const auto tracerData = std::span<const float> {
+            swel + VI::SWell::TracerOffset, numTrcElems / 2
+        };
+
+        auto tracer_index = std::size_t{0};
+
+        if (header.has_temperature) {
+            // If the TEMP option is active, the temperature is
+            // the first tracer "concentration".
+            this->inj_temperature = unit_system
+                .to_si(M::temperature, tracerData[tracer_index++]);
+        }
+
+        // Pull any applicable tracer concentrations into per-well data member.
+        this->tracer_concentration_injection
+            .assign(tracerData.begin() + tracer_index, tracerData.end());
     }
 
     for (int ic = 0; ic < iwel[VI::IWell::NConn]; ++ic) {

--- a/opm/output/eclipse/CreateInteHead.cpp
+++ b/opm/output/eclipse/CreateInteHead.cpp
@@ -689,7 +689,6 @@ createInteHead(const EclipseState& es,
         .variousParam       (202204, 100, num_tracer_comps)  // Output should be compatible with Eclipse 100, 2022.04 version.
         .udqParam_1         (getUdqParam(rspec, sched, report_step, lookup_step))
         .actionParam        (getActionParam(rspec, acts, report_step))
-        .variousUDQ_ACTIONXParam()
         .nominatedPhaseGuideRate(setGuideRateNominatedPhase(sched, report_step, lookup_step))
         .whistControlMode   (getWhistctlMode(sched, report_step, lookup_step))
         .activeNetwork      (getActiveNetwork(sched, lookup_step))

--- a/opm/output/eclipse/DoubHEAD.cpp
+++ b/opm/output/eclipse/DoubHEAD.cpp
@@ -47,7 +47,7 @@ namespace VI = Opm::RestartIO::Helpers::VectorItems;
 
 enum Index : std::vector<double>::size_type {
     // 0..9
-    SimTime =   0,
+    SimTime =   VI::doubhead::SimTime,
     TsInit  =   VI::doubhead::TsInit,
     TsMaxz  =   VI::doubhead::TsMaxz,
     TsMinz  =   VI::doubhead::TsMinz,
@@ -239,7 +239,7 @@ enum Index : std::vector<double>::size_type {
     dh_159  = 159,
 
     // 160..169
-    Start   = 160,
+    Start   = VI::doubhead::Start,
     Time    = 161,
     dh_162  = 162,
     dh_163  = 163,

--- a/opm/output/eclipse/InteHEAD.cpp
+++ b/opm/output/eclipse/InteHEAD.cpp
@@ -779,24 +779,14 @@ actionParam(const ActionParam& act_par)
     this -> data_[NO_ACT]     = act_par.no_actions;
     this -> data_[MAX_LINES]  = act_par.max_no_sched_lines_per_action;
     this -> data_[MXACTC]     = act_par.max_no_conditions_per_action;
-    this -> data_[MAXSPRLINE] = ((act_par.max_no_characters_per_line % 8) == 0) ? act_par.max_no_characters_per_line / 8 :
-                                (act_par.max_no_characters_per_line / 8) + 1;
+    this -> data_[MAXSPRLINE] = (act_par.max_no_characters_per_line + 7) / 8;
 
-    return *this;
-}
-
-// InteHEAD parameters which meaning are currently not known, but which are
-// needed for Eclipse restart runs with UDQ and ACTIONX data
-Opm::RestartIO::InteHEAD&
-Opm::RestartIO::InteHEAD::
-variousUDQ_ACTIONXParam()
-{
-    this -> data_[159]  =  4; // entriesPerZACT??
-    this -> data_[160]  =  5; // entriesPerSACT??
-    this -> data_[161]  =  9; // entriesPerIACT??
-    this -> data_[246]  = 26; // entriesPerIACN (multiply max_conditions)
-    this -> data_[247]  = 16; // entriesPerSACN (multiply max_conditions)
-    this -> data_[248]  = 13; // entriesPerZACN (multiply max_conditions)
+    this -> data_[VI::intehead::ACTION_ZACT_SIZE] =  4;  // entriesPerZACT
+    this -> data_[VI::intehead::ACTION_SACT_SIZE] =  5;  // entriesPerSACT
+    this -> data_[VI::intehead::ACTION_IACT_SIZE] =  9;  // entriesPerIACT
+    this -> data_[VI::intehead::ACTION_IACN_SIZE] = 26;  // entriesPerIACN (multiply max_conditions)
+    this -> data_[VI::intehead::ACTION_SACN_SIZE] = 16;  // entriesPerSACN (multiply max_conditions)
+    this -> data_[VI::intehead::ACTION_ZACN_SIZE] = 13;  // entriesPerZACN (multiply max_conditions)
 
     return *this;
 }

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -237,7 +237,6 @@ namespace Opm { namespace RestartIO {
         InteHEAD& ngroups(const Group& gr);
         InteHEAD& udqParam_1(const UdqParam& udqpar);
         InteHEAD& actionParam(const ActionParam& act_par);
-        InteHEAD& variousUDQ_ACTIONXParam();
         InteHEAD& nominatedPhaseGuideRate(GuideRateNominatedPhase nphase);
         InteHEAD& whistControlMode(int mode);
         InteHEAD& liftOptParam(int in_enc);

--- a/opm/output/eclipse/LogiHEAD.cpp
+++ b/opm/output/eclipse/LogiHEAD.cpp
@@ -73,7 +73,7 @@ lh_028	=	28	,		//	FALSE
 lh_029	=	29	,		//	FALSE
 lh_030	=	30	,		//	FALSE		Flag for coalbed methane (ECLIPSE 100)
 lh_031	=	31	,		//	TRUE
-lh_032	=	32	,		//	FALSE       Flag for TEMP option (ECLIPSE 100)
+HasTemp	=	VI::logihead::HasTemp,		//	FALSE       Flag for TEMP option (ECLIPSE 100)
 lh_033	=	33	,		//	FALSE
 lh_034	=	34	,		//	FALSE
 lh_035	=	35	,		//	FALSE
@@ -85,7 +85,7 @@ lh_036	=	36	,		//	FALSE
     // Flag to signify constant oil compressibility
     ConstCo = VI::logihead::ConstCo,
 
-lh_039	=	39	,		//	FALSE       Flag for TEMP option (ECLIPSE 100)
+HasTemp2	=	VI::logihead::HasTemp2,		//	FALSE       Flag for TEMP option (ECLIPSE 100)
 lh_040	=	40	,		//	FALSE
 lh_041	=	41	,		//	FALSE
 lh_042	=	42	,		//	FALSE
@@ -201,8 +201,9 @@ variousParam(const bool e300_radial,
     this -> data_[Hyster]     = enableHyster;
     this -> data_[HasMSWells] = nswlmx >= 1; // True if MS Wells exist.
 
-    this -> data_[32] = hasTemp;
-    this -> data_[39] = hasTemp;
+    this -> data_[HasTemp ] = hasTemp;
+    this -> data_[HasTemp2] = hasTemp;
+
     return *this;
 }
 

--- a/opm/output/eclipse/VectorItems/doubhead.hpp
+++ b/opm/output/eclipse/VectorItems/doubhead.hpp
@@ -28,6 +28,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
     // This is a subset of the items in src/opm/output/eclipse/DoubHEAD.cpp .
     // Promote items from that list to this in order to make them public.
     enum doubhead : std::vector<double>::size_type {
+        SimTime = 0,
         TsInit  = 1,             // Maximum Length of Next Timestep
         TsMaxz  = 2,             // Maximum Length of Timestep After Next
         TsMinz  = 3,             // Minumum Length of All Timesteps
@@ -89,6 +90,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         GRpar_damp = 144,     // Guiderate parameter damping factor
         WsegRedFac = 145,     // WSEGITER parameter (item 3) Reduction factor (F_R)
         WsegIncFac = 146,     // WSEGITER parameter (item 4) Increas factor (F_I)
+        Start = 160,
         UdqPar_2 = 212,		// UDQPARAM item number 2 (Permitted range (+/-) of user-defined quantities)
         UdqPar_3 = 213,		// UDQPARAM item number 3 (Value given to undefined elements when outputting data)
         UdqPar_4 = 214,		// UDQPARAM item number 4 (fractional equality tolerance used in ==, <= etc. functions)

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -129,6 +129,9 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         NOOFACTIONS = 156, //  The number of actions in the dataset
         MAXNOLINES = 157, //  Maximum number of lines of schedule data for ACTION keyword - including ENDACTIO
         MAXNOSTRPRLINE = 158, //  Maximum number of 8-chars strings pr input line of Action data (rounded up from input)
+        ACTION_ZACT_SIZE = 159, // Number of entries per action in ZACT
+        ACTION_SACT_SIZE = 160, // Number of entries per action in SACT
+        ACTION_IACT_SIZE = 161, // Number of entries per action in IACT
 
         MAX_ACT_ANLYTIC_AQUCONN = 162, // Maximum number of *active* connections across all analytic aquifers
         NWMAXZ = 163, //  Maximum number of wells in the model (per Grid)
@@ -153,6 +156,10 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         NIRAQN = 224, // Number of data elements in RAQN array pr AQUNUM record
 
         NUM_AQUNUM_RECORDS = 226, // Number of AQUNUM records (lines of AQUNUM data)
+
+        ACTION_IACN_SIZE = 246, // Number of entries per condition in IACN (ConditionSize)
+        ACTION_SACN_SIZE = 247, // Number of entries per condition in SACN (ConditionSize)
+        ACTION_ZACN_SIZE = 248, // Number of entries per condition in ZACN (ConditionSize)
 
         MAX_ACT_COND = 245, //  Maximum number of conditions pr action
         MAX_AN_AQUIFER_ID = 252, // Maximum aquifer ID of all analytic aquifers (<= AQUDIMS(5))

--- a/opm/output/eclipse/VectorItems/logihead.hpp
+++ b/opm/output/eclipse/VectorItems/logihead.hpp
@@ -40,6 +40,8 @@ namespace Opm::RestartIO::Helpers::VectorItems {
         DirEPS     = 17,    // Directional end-point scaling
         RevEPS     = 18,    // Reversible end-point scaling
         AltEPS     = 19,    // Alternative (3-pt) end-point scaling
+        HasTemp    = 32,    // Model has temperature
+        HasTemp2   = 39,    // Model has temperature
         HasNetwork = 37,    // Indicates Network option used
         ConstCo    = 38,    // Constant oil compressibility (PVCDO)
 

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -1786,7 +1786,7 @@ BOOST_AUTO_TEST_CASE(WELL_POD)
     const auto& xcon = connectionData.getXConn();
 
     const auto header = Opm::RestartIO::RstHeader {
-        simCase.es.runspec(), units, ih, std::vector<bool>(100), std::vector<double>(1000)
+        units, ih, std::vector<bool>(100), std::vector<double>(1000)
     };
 
     std::vector<Opm::RestartIO::RstWell> wells;

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -681,9 +681,8 @@ BOOST_AUTO_TEST_CASE(TestHeader)
          .regionDimensions({ntfip, nmfipr, 0,0,0})
          .ngroups({ngroup});
 
-    Opm::Runspec runspec;
     Opm::RestartIO::RstHeader header {
-        runspec, unit_system, ih.data(), std::vector<bool>(100), std::vector<double>(1000)
+        unit_system, ih.data(), std::vector<bool>(100), std::vector<double>(1000)
     };
 
     BOOST_CHECK_EQUAL(header.nx, nx);

--- a/tests/test_rst.cpp
+++ b/tests/test_rst.cpp
@@ -518,8 +518,9 @@ BOOST_AUTO_TEST_CASE(group_test)
                            [](const auto& s8) { return s8.c_str(); });
 
     Opm::UnitSystem unit_system(Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC);
-    Opm::RestartIO::RstHeader header(simCase.es.runspec(), unit_system,ih,lh,dh);
-    for (int ig=0; ig < header.ngroup; ig++) {
+    const auto header = Opm::RestartIO::RstHeader {unit_system, ih, lh, dh};
+
+    for (int ig = 0; ig < header.ngroup; ++ig) {
         std::size_t zgrp_offset = ig * header.nzgrpz;
         std::size_t igrp_offset = ig * header.nigrpz;
         std::size_t sgrp_offset = ig * header.nsgrpz;


### PR DESCRIPTION
PRs #2651 and #2663 added a `Runspec` argument to the restart loader as a means of inferring the maximum number of actions, the number of conditions per action and other essential pieces of information needed to correctly interpret the *ACT and *ACN restart file arrays. While this practice has served us well in the interim, it's strictly speaking somewhat fragile.  A restarted simulation run is allowed to increase these dimensions compared to the base run and in that case we'd be basing our offsets on out-of-bounds values.

This commit switches to loading the base run's action dimensions directly from the pertinent INTEHEAD array items which, in turn, enables removing the `Runspec` argument to `RstState::load().`  We still need the run's number of tabulated PVT regions in order to correctly load the oil vaporisation properties, but I want to push the scattering to the client side at some point in the future.  For now we add a new overload of RstState::load() function that takes the number of PVT regions as an `optional<int>`&ndash;defaulting to `nullopt` which we treat as a single PVT region&ndash;and make the overload taking the `Runspec` argument call the other overload.  The `Runspec` overload will be marked "deprecated" once all downstream users have been converted to the new overload.

The one compromise that we have to add here is a floating-point based derivation of each actions "start" time.  We would previously infer this from the `Runspec` argument's START value, but this is no longer available.  Instead we use a calculation based on the `RstHeader`'s `sim_time()` and the `SimTim` element of DOUBHEAD.  Other derivations may be possible, but this appears sufficiently accurate for now.