### PR TITLE
[DualPorosity] (3/5) Scale fracture well connection factors by porosity

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -90,6 +90,7 @@ list(APPEND MAIN_SOURCE_FILES
   opm/input/eclipse/EclipseState/EclipseState.cpp
   opm/input/eclipse/EclipseState/EndpointScaling.cpp
   opm/input/eclipse/EclipseState/Phase.cpp
+  opm/input/eclipse/EclipseState/PorosityModel.cpp
   opm/input/eclipse/EclipseState/Runspec.cpp
   opm/input/eclipse/EclipseState/TracerConfig.cpp
   opm/input/eclipse/EclipseState/WagHysteresisConfig.cpp
@@ -1005,6 +1006,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/input/eclipse/EclipseState/InitConfig/FoamConfig.hpp
   opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp
   opm/input/eclipse/EclipseState/Phase.hpp
+  opm/input/eclipse/EclipseState/PorosityModel.hpp
   opm/input/eclipse/EclipseState/Runspec.hpp
   opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.hpp
   opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.hpp

--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -49,8 +49,10 @@
 #include <opm/input/eclipse/Deck/DeckSection.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
 
+#include <opm/input/eclipse/Parser/ParserKeywords/D.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/M.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
 
 #include <fmt/format.h>
@@ -159,7 +161,18 @@ namespace Opm {
         if (field_props.depth_edited()) {
             this->m_inputGrid.setDEPTH(field_props.get_double("DEPTH"));
         }
+        const auto& porosityModel = this->m_runspec.porosityModel();
+        if ((this->m_inputGrid.dualPorosity() != porosityModel.dualContinuum()) ||
+            (this->m_inputGrid.dualPermeability() != porosityModel.dualPermeability()))
+        {
+            const auto& location = deck.hasKeyword<ParserKeywords::DUALPORO>()
+                ? deck.get<ParserKeywords::DUALPORO>().back().location()
+                : deck.get<ParserKeywords::DUALPERM>().back().location();
+            throw OpmInputError("DUALPORO/DUALPERM must be specified in the RUNSPEC section.",
+                                location);
+        }
         this->conveyNumericalAquiferEffects();
+        this->applyDualPorosityNNC(deck);
         if (field_props.has_double("MINPVV")) {
             field_props.deleteMINPVV();
         }
@@ -345,6 +358,22 @@ namespace Opm {
         const GRIDSection gridSection ( deck );
 
         m_lgrs = LgrCollection(gridSection, m_inputGrid);
+
+        // A refined region inside a dual-continuum grid is not supported. The well
+        // connection factors of refined cells are populated from their father cell
+        // without the fracture-permeability scaling the main-grid path applies, so
+        // allowing the combination would produce inconsistent factors silently.
+        // Refuse instead; the scaling rule and the refinement can be reconciled later.
+        if (this->m_runspec.porosityModel().dualContinuum() && (m_lgrs.size() > 0)) {
+            const auto& location = deck.hasKeyword<ParserKeywords::DUALPORO>()
+                ? deck.get<ParserKeywords::DUALPORO>().back().location()
+                : deck.get<ParserKeywords::DUALPERM>().back().location();
+
+            throw OpmInputError("Local grid refinement is not supported in a dual-continuum run: "
+                                "connection factors in refined cells would not carry the "
+                                "fracture-permeability scaling applied on the main grid.",
+                                location);
+        }
         m_inputGrid.init_lgr_cells(m_lgrs);
     }
 
@@ -457,6 +486,80 @@ namespace Opm {
         this->appendInputNNC(numerical_aquifer.aquiferCellNNCs());
 
         this->m_transMult.applyNumericalAquifer(numerical_aquifer.allAquiferCellIds());
+    }
+
+    // Dual porosity: couple every active matrix cell to its active fracture
+    // twin with one NNC carrying TR = PERMX_matrix * bulkVolume_matrix * sigma
+    // (all SI). sigma comes cell-by-cell from the SIGMAV property; a scalar
+    // SIGMA arrives through the same carrier (FieldProps broadcasts it, with
+    // the per-cell form taking precedence). The fracture-half entries carry
+    // no meaning. A zero sigma means "no coupling" and produces no connection.
+    void EclipseState::applyDualPorosityNNC(const Deck& deck)
+    {
+        if (! this->m_runspec.porosityModel().dualContinuum()) {
+            return;
+        }
+
+        const auto& grid = this->m_inputGrid;
+
+        if (!this->field_props.has_double("SIGMAV")) {
+            OpmLog::warning("DUALPORO: neither SIGMA nor SIGMAV is present — "
+                            "no matrix-fracture coupling will be created.");
+            return;
+        }
+        const std::vector<double> sigmav = this->field_props.get_global_double("SIGMAV");
+
+        if (!this->field_props.has_double("PERMX")) {
+            OpmLog::warning("DUALPORO: PERMX is not present — "
+                            "no matrix-fracture coupling will be created.");
+            return;
+        }
+        const auto& permx = this->field_props.get_global_double("PERMX");
+
+        std::vector<NNCdata> dp_nnc;
+        for (std::size_t g = 0; g < grid.getCartesianSize(); ++g) {
+            if (grid.isFractureCell(g)) {
+                break;  // matrix cells occupy the first half of the index range
+            }
+            const std::size_t twin = grid.fractureTwin(g);
+            if (!grid.cellActive(g) || !grid.cellActive(twin)) {
+                continue;
+            }
+
+            const double sigma = sigmav[g];
+            if (sigma < 0.0) {
+                // Broadcast scalars are validated at broadcast time, so a
+                // negative can only come from an explicit SIGMAV keyword.
+                throw OpmInputError("The SIGMAV shape factor cannot be negative.",
+                                    deck.get<ParserKeywords::SIGMAV>().back().location());
+            }
+            const double trans = permx[g] * grid.getCellVolume(g) * sigma;
+            if (trans > 0.0) {
+                dp_nnc.emplace_back(g, twin, trans);
+            }
+        }
+
+        this->appendInputNNC(dp_nnc);
+
+        // A deck edit that names a matrix-fracture pair would rescale the coupling the
+        // run computes from SIGMA and the matrix permeability. The two mechanisms
+        // disagree about who owns that transmissibility, and the edit wins silently
+        // because it is applied later. Refuse rather than let a deck quietly redefine
+        // the coupling: change SIGMA/SIGMAV, which is what the value is built from.
+        for (const auto* edits : { &this->m_inputNnc.edit(), &this->m_inputNnc.editr() }) {
+            for (const auto& e : *edits) {
+                if (! grid.isTwinPair(e.cell1, e.cell2)) {
+                    continue;
+                }
+
+                throw OpmInputError(fmt::format("Cells {} and {} are a matrix-fracture pair; "
+                                                "their coupling transmissibility is computed "
+                                                "from the shape factor and cannot be edited "
+                                                "directly. Adjust SIGMA or SIGMAV instead.",
+                                                e.cell1 + 1, e.cell2 + 1),
+                                    this->m_inputNnc.edit_location(e));
+            }
+        }
     }
 
     void EclipseState::applyMULTXYZ()

--- a/opm/input/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.hpp
@@ -188,6 +188,7 @@ namespace Opm {
         void reportNumberOfActivePhases() const;
         void initLgrs(const Deck& deck);
         void conveyNumericalAquiferEffects();
+        void applyDualPorosityNNC(const Deck& deck);
         void applyMULTXYZ();
         void initFaults(const Deck& deck);
         void initPara(const Deck& deck);

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -36,6 +36,7 @@
 #include <opm/input/eclipse/EclipseState/Grid/LgrCollection.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldProps.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
+#include <opm/input/eclipse/EclipseState/PorosityModel.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 #include <opm/input/eclipse/Units/Units.hpp>
@@ -59,6 +60,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/Z.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -285,6 +287,19 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
       m_pinchMaxEmptyGap(ParserKeywords::PINCH::MAX_EMPTY_GAP::defaultValue)
 {
     if (deck.hasKeyword("GDFILE")){
+        // Refuse a dual-continuum run here, before the grid file is opened: the reader
+        // takes NZ from the file header and treats every non-zero ACTNUM entry as active,
+        // so a doubled grid would come back as a half-height single-porosity one. Refuse
+        // rather than corrupt, and refuse before touching the file so the diagnosis is
+        // about the deck rather than about a missing path.
+        if (deck.hasKeyword<ParserKeywords::DUALPORO>() ||
+            deck.hasKeyword<ParserKeywords::DUALPERM>())
+        {
+            throw OpmInputError("A dual-continuum run cannot take its grid from GDFILE; "
+                                "the stored layout does not distinguish the matrix and "
+                                "fracture halves. Specify the grid in the deck.",
+                                deck.get<ParserKeywords::GDFILE>().front().location());
+        }
 
         if (deck.hasKeyword("ACTNUM")){
             if (keywInputBeforeGdfile(deck, "ACTNUM"))  {
@@ -296,9 +311,35 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
 
     }
 
+    // One reading of the RUNSPEC selection, the same one Runspec records.
+    {
+        const PorosityModel porosityModel{ deck };
+        this->m_dualPorosity = porosityModel.dualContinuum();
+        this->m_dualPermeability = porosityModel.dualPermeability();
+    }
+
     updateNumericalAquiferCells(deck);
 
     initGrid(deck, actnum);
+
+    if (this->m_dualPorosity) {
+        if (this->getNZ() % 2 != 0) {
+            const auto& location = deck.hasKeyword<ParserKeywords::DUALPORO>()
+                ? deck.get<ParserKeywords::DUALPORO>().front().location()
+                : deck.get<ParserKeywords::DUALPERM>().front().location();
+            throw OpmInputError(fmt::format("Dual-porosity runs require an even number of layers, but NZ={} was given. "
+                                            "The first NZ/2 layers hold the matrix cells and the last NZ/2 "
+                                            "layers the fracture cells.", this->getNZ()),
+                                location);
+        }
+
+        if (deck.hasKeyword<ParserKeywords::DPGRID>() && deck.hasKeyword<ParserKeywords::ZCORN>()) {
+            throw OpmInputError("DPGRID is supported for block-centred grid input only; "
+                                "with corner-point input specify both halves explicitly.",
+                                deck.get<ParserKeywords::DPGRID>().front().location());
+        }
+
+    }
 
     if (deck.hasKeyword<ParserKeywords::MAPAXES>())
         this->m_mapaxes = std::make_optional<MapAxes>( deck );
@@ -342,6 +383,106 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
 
     bool EclipseGrid::circle( ) const{
         return this->m_circle;
+    }
+
+    bool EclipseGrid::dualPorosity() const noexcept {
+        return this->m_dualPorosity;
+    }
+
+    std::size_t EclipseGrid::matrixLayerCount() const noexcept {
+        return this->m_dualPorosity ? this->getNZ() / 2 : this->getNZ();
+    }
+
+    bool EclipseGrid::isFractureCell(std::size_t globalIndex) const {
+        this->assertGlobalIndex(globalIndex);
+
+        // Natural ordering is K-major, so the fracture half (k >= NZ/2) is
+        // exactly the upper half of the global index range.
+        return this->m_dualPorosity && (globalIndex >= this->getCartesianSize() / 2);
+    }
+
+    // Construction-time capture for file encoding (the porosity-model header
+    // code); flag authority remains Runspec::porosityModel().
+    bool EclipseGrid::dualPermeability() const noexcept {
+        return this->m_dualPermeability;
+    }
+
+    std::size_t EclipseGrid::fractureTwin(std::size_t matrixGlobalIndex) const {
+        if (! this->m_dualPorosity) {
+            throw std::invalid_argument {
+                "fractureTwin() is meaningful only for a dual-continuum grid"
+            };
+        }
+
+        if (this->isFractureCell(matrixGlobalIndex)) {
+            throw std::invalid_argument {
+                fmt::format("Global index {} is a fracture cell and has no fracture twin.",
+                            matrixGlobalIndex)
+            };
+        }
+
+        return matrixGlobalIndex + this->getCartesianSize() / 2;
+    }
+
+    std::size_t EclipseGrid::matrixTwin(std::size_t fractureGlobalIndex) const {
+        if (! this->isFractureCell(fractureGlobalIndex)) {
+            throw std::invalid_argument {
+                fmt::format("Global index {} is not a fracture cell and has no matrix twin.",
+                            fractureGlobalIndex)
+            };
+        }
+
+        return fractureGlobalIndex - this->getCartesianSize() / 2;
+    }
+
+    bool EclipseGrid::isTwinPair(std::size_t a, std::size_t b) const {
+        if (! this->m_dualPorosity) {
+            return false;
+        }
+
+        this->assertGlobalIndex(a);
+        this->assertGlobalIndex(b);
+
+        const auto [lo, hi] = std::minmax(a, b);
+        return this->isFractureCell(hi)
+            && ! this->isFractureCell(lo)
+            && (this->matrixTwin(hi) == lo);
+    }
+
+    std::size_t EclipseGrid::matrixCellCount(const std::array<int, 3>& cartDims) {
+        return (static_cast<std::size_t>(cartDims[0]) * cartDims[1] * cartDims[2]) / 2;
+    }
+
+    // The fracture system has no geometry of its own: it shares the matrix
+    // geometry. The doubled internal grid keeps whatever (pillar-monotone)
+    // corner depths the deck/builder produced for the fracture half — that
+    // stacking is pure bookkeeping so downstream corner-point processing
+    // stays valid — while the PHYSICAL co-location is enforced through the
+    // cell-depth override: every fracture cell reports its matrix twin's
+    // depth (the same mechanism numerical-aquifer cells use). The override is
+    // ACTIVE-indexed, so it must be rebuilt whenever the active mapping
+    // changes (resetACTNUM — e.g. field-property processing deactivating
+    // zero-pore-volume cells after construction).
+    void EclipseGrid::updateDualPorosityDepth() {
+        if (!this->m_dualPorosity) {
+            return;
+        }
+        // resetACTNUM fires during initGrid, before the constructor rejects an
+        // odd layer count — the twin arithmetic is only meaningful once NZ is even.
+        if (this->getNZ() % 2 != 0) {
+            return;
+        }
+
+        this->m_depth.reset();
+
+        std::vector<double> depth(this->getNumActive());
+        for (std::size_t g = 0; g < this->getCartesianSize(); ++g) {
+            if (!this->cellActive(g))
+                continue;
+            const std::size_t geom = this->isFractureCell(g) ? this->matrixTwin(g) : g;
+            depth[this->activeIndex(g)] = this->getCellDepth(geom);
+        }
+        this->setDEPTH(depth);
     }
 
 
@@ -691,6 +832,26 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         std::vector<double> DX = EclipseGrid::createDVector(  this->getNXYZ(), 0 , "DX" , "DXV" , deck);
         std::vector<double> DY = EclipseGrid::createDVector(  this->getNXYZ(), 1 , "DY" , "DYV" , deck);
         std::vector<double> DZ = EclipseGrid::createDVector(  this->getNXYZ(), 2 , "DZ" , "DZV" , deck);
+
+        // DPGRID: the fracture system shares the matrix geometry — the matrix
+        // half's cell sizes are copied onto the fracture half regardless of
+        // what (if anything) the deck supplied there. Depths follow through
+        // the twin-depth contract; the stacked corner depths built below stay
+        // pillar-monotone.
+        // Odd NZ is rejected just after initGrid(); the parity guard here keeps
+        // the copy loop in bounds until that rejection fires.
+        if (this->m_dualPorosity &&
+            deck.hasKeyword<ParserKeywords::DPGRID>() &&
+            this->getNZ() % 2 == 0)
+        {
+            const std::size_t half = this->getCartesianSize() / 2;
+            for (std::size_t g = 0; g < half; ++g) {
+                DX[this->fractureTwin(g)] = DX[g];
+                DY[this->fractureTwin(g)] = DY[g];
+                DZ[this->fractureTwin(g)] = DZ[g];
+            }
+        }
+
         std::vector<double> TOPS = EclipseGrid::createTOPSVector( this->getNXYZ(), DZ , deck );
 
         m_coord = makeCoordDxDyDzTops(DX, DY, DZ, TOPS);
@@ -2148,8 +2309,17 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
         std::vector<int> nnc2;
 
         for (const NNCdata& n : nnc ) {
-            nnc1.push_back(n.cell1 + 1);
-            nnc2.push_back(n.cell2 + 1);
+            // Dual porosity: the matrix-fracture coupling connections are written
+            // fracture-cell first (NNC1 = fracture, NNC2 = matrix). Ordinary
+            // connections keep their stored order.
+            if (this->isTwinPair(n.cell1, n.cell2) && this->isFractureCell(n.cell2))
+            {
+                nnc1.push_back(n.cell2 + 1);
+                nnc2.push_back(n.cell1 + 1);
+            } else {
+                nnc1.push_back(n.cell1 + 1);
+                nnc2.push_back(n.cell2 + 1);
+            }
         }
 
         nnchead[0] = nnc1.size();
@@ -2197,9 +2367,21 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
         m_input_coord.reset();
         m_input_zcorn.reset();
 
+        // Dual porosity: the file carries geometry for the matrix half only —
+        // halved layer count, matrix-half ZCORN, and one ACTNUM value per
+        // geometric cell with the extended encoding (0 = inactive, 1 = matrix,
+        // 2 = fracture, 3 = both). The fracture system shares the matrix
+        // geometry and has none of its own in the file.
+        if (this->m_dualPorosity) {
+            zcorn_f.resize(zcorn_f.size() / 2);
+        }
+
         std::vector<int> filehead(100,0);
         filehead[0] = 3;                     // version number
         filehead[1] = 2007;                  // release year
+        filehead[5] = this->m_dualPorosity           // porosity model:
+            ? (this->m_dualPermeability ? 2 : 1)     //   1 = dual porosity, 2 = dual permeability
+            : 0;
         filehead[6] = 1;                     // corner point grid
 
         egridfile.write("FILEHEAD", filehead);
@@ -2208,7 +2390,7 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
         gridhead[0] = 1;                    // corner point grid
         gridhead[1] = dims[0];              // nI
         gridhead[2] = dims[1];              // nJ
-        gridhead[3] = dims[2];              // nK
+        gridhead[3] = this->matrixLayerCount();  // nK: matrix half only under dual porosity
         gridhead[24] = 1;                   // NUMRES (number of reservoirs)
         //gridhead[25] = 1;                 // TODO: This value depends on LGRs?
 
@@ -2248,7 +2430,21 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
         egridfile.write("COORD", coord_f);
         egridfile.write("ZCORN", zcorn_f);
 
-        egridfile.write("ACTNUM", m_actnum);
+        if (this->m_dualPorosity) {
+            // Extended ACTNUM encoding, one value per geometric cell:
+            // 0 = inactive, 1 = matrix active, 2 = fracture active, 3 = both.
+            constexpr int activeMatrix = 1;
+            constexpr int activeFracture = 2;
+            const std::size_t half = this->getCartesianSize() / 2;
+            std::vector<int> actnum_dp(half, 0);
+            for (std::size_t g = 0; g < half; ++g) {
+                actnum_dp[g] = (this->m_actnum[g] != 0 ? activeMatrix : 0)
+                             + (this->m_actnum[this->fractureTwin(g)] != 0 ? activeFracture : 0);
+            }
+            egridfile.write("ACTNUM", actnum_dp);
+        } else {
+            egridfile.write("ACTNUM", m_actnum);
+        }
         egridfile.write("ENDGRID", endgrid);
 
     }
@@ -2656,6 +2852,13 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
         std::iota(this->m_global_to_active.begin(), this->m_global_to_active.end(), 0);
         this->m_active_to_global = this->m_global_to_active;
         this->active_volume = std::nullopt;
+
+        // The twin-depth override is indexed by ACTIVE cell, so it must be rebuilt
+        // whenever the active mapping changes -- exactly as the ACTNUM-taking overload
+        // does. Reached when a grid file carries no ACTNUM; without this a fracture cell
+        // reports its stacked geometric depth instead of its matrix twin's. No-op unless
+        // the grid is dual-continuum.
+        this->updateDualPorosityDepth();
     }
 
     void EclipseGrid::resetACTNUM(const int* actnum) {
@@ -2685,6 +2888,8 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
             }
             this->active_volume = std::nullopt;
         }
+
+        this->updateDualPorosityDepth();
     }
 
 

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -278,6 +278,36 @@ namespace Opm {
         double getCellDepth(std::size_t globalIndex) const;
         ZcornMapper zcornMapper() const;
 
+        /// Dual-porosity twin bookkeeping (DUALPORO): the deck supplies an
+        /// even NZ where the first NZ/2 layers hold the matrix cells and the
+        /// last NZ/2 layers the co-located fracture cells. The authoritative
+        /// selection is Runspec::porosityModel(); these grid-side flags are
+        /// captured at construction for geometry-level queries only.
+        bool dualPorosity() const noexcept;
+        bool dualPermeability() const noexcept;
+        std::size_t matrixLayerCount() const noexcept;
+
+        /// Twin accessors. These take a global index and are therefore total:
+        /// an out-of-range index, or a cell on the wrong half of a dual-continuum
+        /// grid, throws std::invalid_argument the same way cellActive() does.
+        /// They are deliberately not noexcept — the previous assert-only form
+        /// compiled out under NDEBUG and returned an underflowed index.
+        bool isFractureCell(std::size_t globalIndex) const;
+        std::size_t fractureTwin(std::size_t matrixGlobalIndex) const;
+        std::size_t matrixTwin(std::size_t fractureGlobalIndex) const;
+
+        /// True when the two global indices are a matrix-fracture twin pair, in
+        /// either order. Published so that consumers stop re-deriving the test:
+        /// it was previously composed by hand in the EGRID writer here and again,
+        /// differently, in the simulator's writer and transmissibility paths.
+        bool isTwinPair(std::size_t a, std::size_t b) const;
+
+        /// The number of matrix cells implied by a set of Cartesian dimensions.
+        /// Static because a consumer may need the twin arithmetic where no grid
+        /// object is available -- on a distributed run the input grid exists on
+        /// the I/O process only, while the dimensions are known everywhere.
+        static std::size_t matrixCellCount(const std::array<int, 3>& cartDims);
+
         const std::vector<double>& getCOORD() const;
         const std::vector<double>& getZCORN() const;
         const std::vector<int>& getACTNUM( ) const;
@@ -367,6 +397,9 @@ namespace Opm {
         // Option 2 of PINCH (GAP/NOGAP)
         PinchMode m_pinchGapMode;
         double    m_pinchMaxEmptyGap;
+        bool m_dualPorosity = false;
+        bool m_dualPermeability = false;
+        void updateDualPorosityDepth();
         bool lgr_grid = false;
         mutable std::optional<std::vector<double>> active_volume;
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -2262,6 +2262,111 @@ void FieldProps::scanGRIDSection(const GRIDSection& grid_section)
 
         this->handle_keyword(Section::GRID, keyword, box);
     }
+
+    this->applyDPGRID(grid_section);
+    this->applyDualPorosityScalars(grid_section);
+}
+
+// The whole-grid scalar forms of the dual-porosity coupling properties
+// broadcast into their per-cell arrays, so every consumer reads one uniform
+// carrier.  A per-cell keyword supplied by the deck takes precedence.
+void FieldProps::applyDualPorosityScalars(const GRIDSection& grid_section)
+{
+    if (!this->grid_ptr->dualPorosity()) {
+        return;
+    }
+
+    const auto broadcast = [this, &grid_section](const std::string& scalar_kw,
+                                                 const std::string& item_name,
+                                                 const std::string& array_kw)
+    {
+        if (!grid_section.hasKeyword(scalar_kw) ||
+            (this->double_data.find(array_kw) != this->double_data.end()))
+        {
+            return;
+        }
+
+        const auto& keyword = grid_section[scalar_kw].back();
+        const double value = keyword.getRecord(0).getItem(item_name).getSIDouble(0);
+        if (value < 0.0) {
+            throw OpmInputError(fmt::format("The {} value cannot be negative.", scalar_kw),
+                                keyword.location());
+        }
+
+        this->init_get<double>(array_kw).default_assign(value);
+    };
+
+    broadcast("SIGMA",   "COUPLING", "SIGMAV");
+
+    // One validation policy for all three carriers. The scalar forms are checked above as
+    // they arrive; a per-cell keyword reaches the same array by a different route (BOX,
+    // EQUALS, OPERATE, or a plain array), so it is checked here rather than wherever the
+    // value happens to be consumed. Previously only SIGMAV was validated, inside the
+    // coupling builder, and the other two per-cell forms were not validated at all.
+    for (const auto& array_kw : {"SIGMAV"}) {
+        const auto it = this->double_data.find(array_kw);
+        if (it == this->double_data.end()) {
+            continue;
+        }
+
+        const auto& values = it->second.data;
+        const auto  bad    = std::find_if(values.begin(), values.end(),
+                                          [](const double v) { return v < 0.0; });
+        if (bad != values.end()) {
+            throw OpmInputError(fmt::format("The {} value cannot be negative "
+                                            "(cell {} has {}).",
+                                            array_kw,
+                                            std::distance(values.begin(), bad) + 1, *bad),
+                                grid_section.hasKeyword(array_kw)
+                                    ? grid_section[array_kw].back().location()
+                                    : KeywordLocation{});
+        }
+    }
+}
+
+void FieldProps::applyDPGRID(const GRIDSection& grid_section)
+{
+    // DPGRID: grid-section cell properties supplied for the matrix half only
+    // are copied onto the fracture twins. Values the deck DID supply for the
+    // fracture half are kept — decks routinely combine DPGRID with explicit
+    // per-half property boxes.
+    if (!grid_section.hasKeyword("DPGRID"))
+        return;
+    if (!this->grid_ptr->dualPorosity())
+        return;
+
+    const auto& grid = *this->grid_ptr;
+
+    // (global cartesian, matrix active, fracture active) index triples for
+    // every twin pair with both continua active — invariant across fields.
+    struct TwinIndices { std::size_t g; std::size_t twin; std::size_t ai_m; std::size_t ai_f; };
+    std::vector<TwinIndices> twins;
+    for (std::size_t g = 0; g < grid.getCartesianSize(); ++g) {
+        if (grid.isFractureCell(g))
+            break;  // matrix cells occupy the first half of the index range
+        const std::size_t twin = grid.fractureTwin(g);
+        if (grid.cellActive(g) && grid.cellActive(twin))
+            twins.push_back({g, twin, grid.activeIndex(g), grid.activeIndex(twin)});
+    }
+
+    for (auto& entry : this->double_data) {
+        auto& field = entry.second;
+        for (const auto& t : twins) {
+            if (value::has_value(field.value_status[t.ai_m]) &&
+                !value::has_value(field.value_status[t.ai_f]))
+            {
+                field.data[t.ai_f] = field.data[t.ai_m];
+                field.value_status[t.ai_f] = field.value_status[t.ai_m];
+            }
+            if (field.global_data.has_value() &&
+                value::has_value((*field.global_value_status)[t.g]) &&
+                !value::has_value((*field.global_value_status)[t.twin]))
+            {
+                (*field.global_data)[t.twin] = (*field.global_data)[t.g];
+                (*field.global_value_status)[t.twin] = (*field.global_value_status)[t.g];
+            }
+        }
+    }
 }
 
 void FieldProps::scanGRIDSectionOnlyACTNUM(const GRIDSection& grid_section)

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -134,6 +134,7 @@ namespace ALIAS {
 
 namespace GRID {
 static const std::unordered_map<std::string, keyword_info<double>> double_keywords = {{"DISPERC",keyword_info<double>{}.unit_string("Length")},
+                                                                                      {"SIGMAV",  keyword_info<double>{}.unit_string("1/Length*Length")},
                                                                                       {"MINPVV",  keyword_info<double>{}.init(0.0).unit_string("ReservoirVolume").global_kw(true)},
                                                                                       {"MULTPV",  keyword_info<double>{}.init(1.0).mult(true)},
                                                                                       {"NTG",     keyword_info<double>{}.init(1.0)},

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -715,6 +715,8 @@ public:
 private:
     void processMULTREGP(const Deck& deck);
     void scanGRIDSection(const GRIDSection& grid_section);
+    void applyDPGRID(const GRIDSection& grid_section);
+    void applyDualPorosityScalars(const GRIDSection& grid_section);
     void scanGRIDSectionOnlyACTNUM(const GRIDSection& grid_section);
     void initialize_depth_from_grid();
     void scanEDITSection(const EDITSection& edit_section);

--- a/opm/input/eclipse/EclipseState/PorosityModel.cpp
+++ b/opm/input/eclipse/EclipseState/PorosityModel.cpp
@@ -1,0 +1,77 @@
+/*
+  Copyright 2026 TNO
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/EclipseState/PorosityModel.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
+#include <opm/input/eclipse/Parser/ParserKeywords/D.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/N.hpp>
+
+namespace Opm {
+
+PorosityModel::PorosityModel(const Deck& deck)
+{
+    if (deck.hasKeyword<ParserKeywords::DUALPERM>()) {
+        this->m_type = Type::DualPermeability;
+    } else if (deck.hasKeyword<ParserKeywords::DUALPORO>()) {
+        this->m_type = Type::DualPorosity;
+    }
+
+    if (deck.hasKeyword<ParserKeywords::NODPPM>()) {
+        this->m_scale_fracture_perm = false;
+    }
+}
+
+PorosityModel::Type PorosityModel::type() const noexcept
+{
+    return this->m_type;
+}
+
+bool PorosityModel::dualContinuum() const noexcept
+{
+    return this->m_type != Type::SinglePorosity;
+}
+
+bool PorosityModel::dualPermeability() const noexcept
+{
+    return this->m_type == Type::DualPermeability;
+}
+
+bool PorosityModel::fracturePermeabilityScalingActive() const noexcept
+{
+    return this->dualContinuum() && this->m_scale_fracture_perm;
+}
+
+PorosityModel PorosityModel::serializationTestObject()
+{
+    PorosityModel result;
+    result.m_type = Type::DualPermeability;
+    result.m_scale_fracture_perm = false;
+
+    return result;
+}
+
+bool PorosityModel::operator==(const PorosityModel& other) const
+{
+    return (this->m_type == other.m_type)
+        && (this->m_scale_fracture_perm == other.m_scale_fracture_perm);
+}
+
+} // namespace Opm

--- a/opm/input/eclipse/EclipseState/PorosityModel.hpp
+++ b/opm/input/eclipse/EclipseState/PorosityModel.hpp
@@ -1,0 +1,102 @@
+/*
+  Copyright 2026 TNO
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_POROSITY_MODEL_HPP
+#define OPM_POROSITY_MODEL_HPP
+
+namespace Opm {
+
+class Deck;
+
+/// Porosity model of a simulation run, as selected in the RUNSPEC section.
+///
+/// A run resolves either one continuum per cell (single porosity, the
+/// default) or two: the rock matrix and the fracture system.  DUALPORO
+/// selects the dual-porosity model, in which fluid moves between fracture
+/// cells and between each matrix cell and its fracture twin, and DUALPERM
+/// the dual-permeability model, which adds flow between matrix cells.  In
+/// the dual-continuum models the fracture permeabilities are scaled by the
+/// fracture porosity unless NODPPM switches the scaling off.
+///
+/// This is the selection the EGRID file header records to distinguish
+/// single-porosity, dual-porosity and dual-permeability grids.
+class PorosityModel
+{
+public:
+    /// Which continua the run resolves.
+    enum class Type {
+        /// One continuum per cell.
+        SinglePorosity,
+
+        /// Matrix and fracture continua, with flow between fracture cells
+        /// and between each matrix cell and its fracture twin.
+        DualPorosity,
+
+        /// Dual porosity with flow between matrix cells as well.
+        DualPermeability,
+    };
+
+    /// Single porosity.
+    PorosityModel() = default;
+
+    /// Porosity model selected by the RUNSPEC keywords of a deck.
+    ///
+    /// \param[in] deck Input deck.  DUALPERM takes precedence over DUALPORO.
+    explicit PorosityModel(const Deck& deck);
+
+    /// Selected model.
+    Type type() const noexcept;
+
+    /// Whether the run resolves both a matrix and a fracture continuum,
+    /// i.e., whether the model is dual porosity or dual permeability.
+    bool dualContinuum() const noexcept;
+
+    /// Whether the run resolves flow between matrix cells, i.e., whether
+    /// the model is dual permeability.
+    bool dualPermeability() const noexcept;
+
+    /// Whether the fracture permeabilities are scaled by the fracture
+    /// porosity.  Active in the dual-continuum models unless NODPPM is
+    /// specified, never in single porosity.  Every consumer of the scaling
+    /// rule, well connection factors and cell transmissibilities alike,
+    /// must take the answer from here rather than derive its own.
+    bool fracturePermeabilityScalingActive() const noexcept;
+
+    static PorosityModel serializationTestObject();
+
+    bool operator==(const PorosityModel& other) const;
+
+    template <class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(this->m_type);
+        serializer(this->m_scale_fracture_perm);
+    }
+
+private:
+    Type m_type{Type::SinglePorosity};
+
+    /// Fracture permeability scaling as requested by the deck.  Only
+    /// meaningful in the dual-continuum models; NODPPM turns it off.
+    bool m_scale_fracture_perm{true};
+};
+
+} // namespace Opm
+
+#endif // OPM_POROSITY_MODEL_HPP

--- a/opm/input/eclipse/EclipseState/Runspec.cpp
+++ b/opm/input/eclipse/EclipseState/Runspec.cpp
@@ -823,6 +823,7 @@ Runspec::Runspec(const Deck& deck)
     , m_mechsolver (deck)
     , m_tracers    (deck)
     , m_geochem    (deck)
+    , m_porosity_model(deck)
     , m_co2storage (false)
     , m_co2sol     (false)
     , m_h2sol      (false)
@@ -1010,6 +1011,7 @@ Runspec Runspec::serializationTestObject()
     result.m_temp = true;
     result.m_biof = true;
     result.m_geochem = Geochem::serializationTestObject();
+    result.m_porosity_model = PorosityModel::serializationTestObject();
 
     return result;
 }
@@ -1135,6 +1137,11 @@ bool Runspec::biof() const noexcept
     return this->m_biof;
 }
 
+const PorosityModel& Runspec::porosityModel() const noexcept
+{
+    return this->m_porosity_model;
+}
+
 std::time_t Runspec::start_time() const noexcept
 {
     return this->m_start_time;
@@ -1186,6 +1193,7 @@ bool Runspec::rst_cmp(const Runspec& full_spec, const Runspec& rst_spec)
         full_spec.m_temp == rst_spec.m_temp &&
         full_spec.m_biof == rst_spec.m_biof &&
         full_spec.m_geochem == rst_spec.m_geochem &&
+        full_spec.m_porosity_model == rst_spec.m_porosity_model &&
         Welldims::rst_cmp(full_spec.wellDimensions(), rst_spec.wellDimensions());
 }
 
@@ -1218,6 +1226,7 @@ bool Runspec::operator==(const Runspec& data) const
         && (this->m_temp == data.m_temp)
         && (this->m_biof == data.m_biof)
         && (this->m_geochem == data.m_geochem)
+        && (this->m_porosity_model == data.m_porosity_model)
         ;
 }
 

--- a/opm/input/eclipse/EclipseState/Runspec.hpp
+++ b/opm/input/eclipse/EclipseState/Runspec.hpp
@@ -23,6 +23,7 @@
 
 #include <opm/input/eclipse/EclipseState/EndpointScaling.hpp>
 #include <opm/input/eclipse/EclipseState/Phase.hpp>
+#include <opm/input/eclipse/EclipseState/PorosityModel.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/Regdims.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
 
@@ -635,6 +636,7 @@ public:
 
     const Tracers& tracers() const;
     const Geochem& geochem() const;
+    const PorosityModel& porosityModel() const noexcept;
     bool compositionalMode() const;
     std::size_t numComps() const;
     std::size_t maxGasPlantTables() const;
@@ -683,6 +685,7 @@ public:
         serializer(m_mechsolver);
         serializer(m_biof);
         serializer(m_geochem);
+        serializer(m_porosity_model);
     }
 
 private:
@@ -703,6 +706,7 @@ private:
     MechSolver m_mechsolver{};
     Tracers m_tracers{};
     Geochem m_geochem{};
+    PorosityModel m_porosity_model{};
     std::size_t m_comps = 0;
     std::size_t m_max_gas_plant_tables = 0;
     bool m_co2storage{false};

--- a/opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -26,6 +26,9 @@
 #include <opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
+
 #include <opm/input/eclipse/Deck/DeckSection.hpp>
 
 #include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
@@ -83,6 +86,22 @@ namespace Opm {
                 }
 
                 m_useNONNC = true;
+
+                // The matrix-fracture coupling of a dual-continuum run is expressed as
+                // non-neighbour connections, so NONNC would remove it silently: the run
+                // completes, the matrix pore volume is stranded, and the material balance
+                // still closes.  Two keywords that contradict each other must not resolve
+                // in silence.
+                if (runspec.hasKeyword<ParserKeywords::DUALPORO>() ||
+                    runspec.hasKeyword<ParserKeywords::DUALPERM>())
+                {
+                    throw OpmInputError {
+                        "NONNC cannot be combined with a dual-continuum run mode: the "
+                        "matrix-fracture coupling is built as non-neighbour connections "
+                        "and would be removed, leaving the matrix continuum isolated.",
+                        nonnc.location()
+                    };
+                }
             }
 
             if (runspec.hasKeyword<ParserKeywords::DISGAS>()) {

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -170,7 +170,8 @@ namespace Opm {
             ecl_grid, fp,
             this->completed_cells,
             this->completed_cells_lgr,
-            this->completed_cells_lgr_map
+            this->completed_cells_lgr_map,
+            runspec
         };
 
         if (numAquifers.size() > 0) {

--- a/opm/input/eclipse/Schedule/ScheduleGrid.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleGrid.cpp
@@ -19,6 +19,8 @@
 
 #include <opm/input/eclipse/Schedule/ScheduleGrid.hpp>
 
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.hpp>
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
@@ -87,6 +89,18 @@ Opm::ScheduleGrid::ScheduleGrid(const EclipseGrid&           ecl_grid,
     , cells_lgr      { std::ref(completed_cells_lgr) }
     , label_to_index { std::cref(label_to_index_) }
 {}
+
+Opm::ScheduleGrid::ScheduleGrid(const EclipseGrid&           ecl_grid,
+                                const FieldPropsManager&     fpm,
+                                CompletedCells&              completed_cells,
+                                std::vector<CompletedCells>& completed_cells_lgr,
+                                const std::unordered_map<std::string, std::size_t>& label_to_index_,
+                                const Runspec& runspec)
+    : ScheduleGrid { ecl_grid, fpm, completed_cells,
+                     completed_cells_lgr, label_to_index_ }
+{
+    this->scale_fracture_perm = runspec.porosityModel().fracturePermeabilityScalingActive();
+}
 
 void Opm::ScheduleGrid::include_numerical_aquifers(const NumericalAquifers& num_aquifers)
 {
@@ -247,6 +261,21 @@ void Opm::ScheduleGrid::populate_props_from_main_grid_cell(CompletedCells::Cell&
     props.active_index = active_index;
 
     populate(*this->fp, active_index, props);
+
+    this->apply_fracture_perm_scaling(cell);
+}
+
+void Opm::ScheduleGrid::apply_fracture_perm_scaling(CompletedCells::Cell& cell) const
+{
+    if (! (this->scale_fracture_perm && this->grid->isFractureCell(cell.global_index))) {
+        return;
+    }
+
+    auto& props = *cell.props;
+
+    props.permx *= props.poro;
+    props.permy *= props.poro;
+    props.permz *= props.poro;
 }
 
 void Opm::ScheduleGrid::
@@ -257,7 +286,10 @@ populate_props_from_num_aquifer(const NumericalAquiferCell& numAquCell,
 
     props.active_index = this->grid->getActiveIndex(cell.global_index);
 
-    // Isotropic permeability tensor in numerical aquifer cells.
+    // Isotropic permeability tensor in numerical aquifer cells. Note that the
+    // dual-continuum fracture-permeability scaling deliberately does NOT apply here:
+    // an aquifer cell's properties come from the aquifer definition rather than from
+    // the grid's property arrays, so there is no deck permeability to scale.
     props.permx = props.permy = props.permz = numAquCell.permeability;
 
     props.poro = numAquCell.porosity;

--- a/opm/input/eclipse/Schedule/ScheduleGrid.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleGrid.hpp
@@ -32,6 +32,7 @@ namespace Opm {
 
 class EclipseGrid;
 class FieldPropsManager;
+class Runspec;
 class NumericalAquifers;
 struct NumericalAquiferCell;
 
@@ -121,6 +122,21 @@ public:
                  std::vector<CompletedCells>& completed_cells_lgr,
                  const std::unordered_map<std::string, std::size_t>& label_to_index_);
 
+    /// Constructor.
+    ///
+    /// Overload for a dual-continuum run.
+    ///
+    /// Takes the run specification rather than a precomputed flag: whether
+    /// fracture cells report a porosity-scaled permeability is a property of
+    /// the run, and deriving it here means the rule lives in one place instead
+    /// of in a doc comment that every caller has to re-type correctly.
+    ScheduleGrid(const EclipseGrid&           ecl_grid,
+                 const FieldPropsManager&     fpm,
+                 CompletedCells&              completed_cells,
+                 std::vector<CompletedCells>& completed_cells_lgr,
+                 const std::unordered_map<std::string, std::size_t>& label_to_index_,
+                 const Runspec&               runspec);
+
     /// Make collection aware of numerical aquifers
     ///
     /// Wells intersected in numerical aquifers should have properties from
@@ -191,6 +207,13 @@ private:
     /// Property container.
     const FieldPropsManager* fp{nullptr};
 
+    /// Whether dual-porosity fracture cells report their permeability
+    /// scaled by the fracture porosity (EclipseGrid::isFractureCell
+    /// identifies the cells; the run's PorosityModel, reached through
+    /// Runspec::porosityModel(), decides the behaviour at the
+    /// construction site).
+    bool scale_fracture_perm{false};
+
     /// Collection of intersected cells in main grid.
     ///
     /// Reference to a mutable object that must outlive the ScheduleGrid.
@@ -247,6 +270,19 @@ private:
     /// \param[in,out] cell Intersected cell object.  This function will
     /// populate its Cell::Props sub-object.
     void populate_props_from_main_grid_cell(CompletedCells::Cell& cell) const;
+
+    /// Scale a dual-porosity fracture cell's permeability by its porosity.
+    ///
+    /// The effective permeability of a fracture cell is the deck value
+    /// scaled by the fracture porosity, so connection factors computed
+    /// from the cell properties match the scaled fracture system.  No
+    /// effect unless scaling was requested at construction and the cell is
+    /// a fracture cell (EclipseGrid::isFractureCell); matrix cells keep
+    /// their deck values.
+    ///
+    /// \param[in,out] cell Intersected cell object with an already
+    /// populated Cell::Props sub-object.
+    void apply_fracture_perm_scaling(CompletedCells::Cell& cell) const;
 
     /// Populate intersected cell property data for cell in main grid.
     ///

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/N/NODPPM
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/N/NODPPM
@@ -1,7 +1,6 @@
 {
   "name": "NODPPM",
   "sections": [
-    "RUNSPEC",
-    "GRID"
+    "RUNSPEC"
   ]
 }

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/S/SIGMAV
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/S/SIGMAV
@@ -4,6 +4,7 @@
     "GRID"
   ],
   "data": {
-    "value_type": "DOUBLE"
+    "value_type": "DOUBLE",
+    "dimension": "1/Length*Length"
   }
 }

--- a/opm/output/eclipse/CreateLogiHead.cpp
+++ b/opm/output/eclipse/CreateLogiHead.cpp
@@ -56,6 +56,7 @@ namespace {
             .variousParam(false, false, wsd.maxSegmentedWells(), hystPar.active(), rspec.temp())
             .pvtModel(pvt)
             .network(rspec.networkDimensions().maxNONodes())
+            .dualPorosity(rspec.porosityModel().dualContinuum())
             ;
     }
 

--- a/opm/output/eclipse/LogiHEAD.cpp
+++ b/opm/output/eclipse/LogiHEAD.cpp
@@ -207,6 +207,13 @@ variousParam(const bool e300_radial,
 }
 
 Opm::RestartIO::LogiHEAD&
+Opm::RestartIO::LogiHEAD::dualPorosity(const bool dual_poro)
+{
+    this->data_[DualPoro] = dual_poro;
+    return *this;
+}
+
+Opm::RestartIO::LogiHEAD&
 Opm::RestartIO::LogiHEAD::pvtModel(const PVTModel& pvt)
 {
     this->data_[IsLiveOil] = pvt.isLiveOil;

--- a/opm/output/eclipse/LogiHEAD.hpp
+++ b/opm/output/eclipse/LogiHEAD.hpp
@@ -101,7 +101,7 @@ namespace Opm::RestartIO {
         ///
         /// \param[in] pvt Current run's PVT model characteristics.
         ///
-        /// \return \code *this \endcode.
+        /// \return \c *this
         LogiHEAD& pvtModel(const PVTModel& pvt);
 
         /// Assign saturation function characteristics.
@@ -109,12 +109,17 @@ namespace Opm::RestartIO {
         /// \param[in] satfunc Current run's saturation function
         ///    characteristics.
         ///
-        /// \return \code *this \endcode.
+        /// \return \c *this
         LogiHEAD& saturationFunction(const SatfuncFlags& satfunc);
 
         /// Logical switch to indicate that the network option is used.
         LogiHEAD& network(const int maxNoNodes);
 
+        /// Set the dual-porosity model flag.
+        ///
+        /// \param[in] dual_poro Whether the run models dual porosity.
+        /// \return \c *this
+        LogiHEAD& dualPorosity(const bool dual_poro);
         /// Linearised result array.
         ///
         /// This is the final output of LogiHEAD assembly.

--- a/opm/output/eclipse/WriteInit.cpp
+++ b/opm/output/eclipse/WriteInit.cpp
@@ -292,6 +292,7 @@ namespace {
             .variousParam(false, false, wsd.maxSegmentedWells(), hystPar.active(), rspec.temp())
             .pvtModel(pvtFlags(rspec, es.getTableManager()))
             .saturationFunction(satfuncFlags(rspec))
+            .dualPorosity(rspec.porosityModel().dualContinuum())
             ;
 
         return lh.data();

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -3969,3 +3969,460 @@ END
     BOOST_CHECK_CLOSE(grid.getCellDepth(1), 5.0, 1e-12);
 }
 
+
+namespace {
+
+Opm::Deck createDualPorosityDeck(const std::string& dimens, const std::string& gridProps, bool dualporo = true)
+{
+    const std::string deckData =
+        "RUNSPEC\n"
+        "\n"
+        "DIMENS\n"
+        " " + dimens + " /\n" +
+        (dualporo ? "DUALPORO\n" : "") +
+        "GRID\n" +
+        gridProps +
+        "EDIT\n"
+        "\n";
+    Opm::Parser parser;
+    return parser.parseString(deckData);
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(DualPorosityRequiresEvenNZ) {
+    // DUALPORO with odd NZ must be rejected as an input error.
+    const std::string props3 =
+        "DX\n 3*100 /\n"
+        "DY\n 3*100 /\n"
+        "DZ\n 3*10 /\n"
+        "TOPS\n 3*2000 /\n";
+    auto odd_dp = createDualPorosityDeck("1 1 3", props3, true);
+    BOOST_CHECK_THROW(Opm::EclipseGrid{ odd_dp }, Opm::OpmInputError);
+
+    // The same grid without DUALPORO is fine — no new constraint on
+    // single-porosity decks.
+    auto odd_sp = createDualPorosityDeck("1 1 3", props3, false);
+    BOOST_CHECK_NO_THROW(Opm::EclipseGrid{ odd_sp });
+
+    // Even NZ with DUALPORO constructs.
+    const std::string props2 =
+        "DX\n 2*100 /\n"
+        "DY\n 2*100 /\n"
+        "DZ\n 2*10 /\n"
+        "TOPS\n 2*2000 /\n";
+    auto even_dp = createDualPorosityDeck("1 1 2", props2, true);
+    BOOST_CHECK_NO_THROW(Opm::EclipseGrid{ even_dp });
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityIsTwinPair) {
+    // One published predicate, so consumers stop composing it by hand. It answers in
+    // either argument order, rejects a non-twin pair, and is false for a single-porosity
+    // grid rather than throwing.
+    const std::string props =
+        "DX\n 24*100 /\n"
+        "DY\n 24*100 /\n"
+        "DZ\n 24*10 /\n"
+        "TOPS\n 6*2000 6*2010 6*2000 6*2010 /\n";
+    auto deck = createDualPorosityDeck("3 2 4", props, true);
+    Opm::EclipseGrid grid( deck );
+
+    const std::size_t half = grid.getCartesianSize() / 2;
+
+    BOOST_CHECK(grid.isTwinPair(0, half));          // matrix, fracture
+    BOOST_CHECK(grid.isTwinPair(half, 0));          // and the other way round
+    BOOST_CHECK(!grid.isTwinPair(0, half + 1));     // a fracture cell, but not this one's twin
+    BOOST_CHECK(!grid.isTwinPair(0, 1));            // two matrix cells
+    BOOST_CHECK(!grid.isTwinPair(half, half + 1));  // two fracture cells
+
+    // The static form is the same arithmetic, for consumers with no grid object.
+    BOOST_CHECK_EQUAL(Opm::EclipseGrid::matrixCellCount({3, 2, 4}), half);
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityTwinApiIsTotal) {
+    // The twin accessors take a global index, so they must behave the same way in a
+    // release build as in a debug one. They used to be noexcept and assert-only, which
+    // meant that under NDEBUG -- how the simulator ships -- matrixTwin() on a matrix cell
+    // returned an underflowed index instead of complaining.
+    const std::string props =
+        "DX\n 24*100 /\n"
+        "DY\n 24*100 /\n"
+        "DZ\n 24*10 /\n"
+        "TOPS\n 6*2000 6*2010 6*2000 6*2010 /\n";
+    auto deck = createDualPorosityDeck("3 2 4", props, true);
+    Opm::EclipseGrid grid( deck );
+
+    const std::size_t half = grid.getCartesianSize() / 2;
+
+    // Out of range is rejected, not silently classified.
+    BOOST_CHECK_THROW(grid.isFractureCell(grid.getCartesianSize()), std::invalid_argument);
+
+    // Each twin accessor rejects the half it does not serve.
+    BOOST_CHECK_THROW(grid.matrixTwin(half - 1), std::invalid_argument);   // a matrix cell
+    BOOST_CHECK_THROW(grid.fractureTwin(half), std::invalid_argument);     // a fracture cell
+
+    // The supported directions are unchanged.
+    BOOST_CHECK_NO_THROW(grid.fractureTwin(half - 1));
+    BOOST_CHECK_NO_THROW(grid.matrixTwin(half));
+    BOOST_CHECK_EQUAL(grid.matrixTwin(grid.fractureTwin(0)), 0U);
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityTwinMapping) {
+    // 3x2x4: matrix = layers k=0,1; fracture = layers k=2,3. Co-located:
+    // fracture layer depths repeat the matrix layer depths.
+    const std::string props =
+        "DX\n 24*100 /\n"
+        "DY\n 24*100 /\n"
+        "DZ\n 24*10 /\n"
+        "TOPS\n 6*2000 6*2010 6*2000 6*2010 /\n";
+    auto deck = createDualPorosityDeck("3 2 4", props, true);
+    Opm::EclipseGrid grid( deck );
+
+    BOOST_CHECK(grid.dualPorosity());
+    BOOST_CHECK_EQUAL(grid.matrixLayerCount(), 2U);
+
+    const std::size_t half = grid.getCartesianSize() / 2;
+    BOOST_CHECK_EQUAL(half, 12U);
+    BOOST_CHECK(!grid.isFractureCell(half - 1));
+    BOOST_CHECK(grid.isFractureCell(half));
+
+    for (std::size_t g = 0; g < half; ++g) {
+        const std::size_t twin = grid.fractureTwin(g);
+        BOOST_CHECK_EQUAL(twin, g + half);
+        BOOST_CHECK(grid.isFractureCell(twin));
+        BOOST_CHECK_EQUAL(grid.matrixTwin(twin), g);
+    }
+
+    // The twin of (i,j,k) is (i,j,k + NZ/2).
+    const std::size_t g_m = grid.getGlobalIndex(2, 1, 1);
+    BOOST_CHECK_EQUAL(grid.fractureTwin(g_m), grid.getGlobalIndex(2, 1, 3));
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityColocatedGeometry) {
+    // 1x1x2, both halves 100x100x10 at 2000 m — the smallest dual-porosity case.
+    // Both continua carry the FULL block bulk volume; the fracture twin is
+    // co-located (same depth, same thickness).
+    const std::string props =
+        "DX\n 2*100 /\n"
+        "DY\n 2*100 /\n"
+        "DZ\n 2*10 /\n"
+        "TOPS\n 2*2000 /\n";
+    auto deck = createDualPorosityDeck("1 1 2", props, true);
+    Opm::EclipseGrid grid( deck );
+
+    BOOST_CHECK_CLOSE(grid.getCellThickness(0), 10.0, 1e-10);
+    BOOST_CHECK_CLOSE(grid.getCellThickness(1), 10.0, 1e-10);
+    BOOST_CHECK_CLOSE(grid.getCellVolume(std::size_t{0}), 1.0e5, 1e-10);
+    BOOST_CHECK_CLOSE(grid.getCellVolume(std::size_t{1}), 1.0e5, 1e-10);
+    BOOST_CHECK_CLOSE(grid.getCellDepth(0), 2005.0, 1e-10);
+    BOOST_CHECK_CLOSE(grid.getCellDepth(1), 2005.0, 1e-10);
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityDeckOffsetOverridden) {
+    // The fracture system has no geometry of its own: whatever the deck says
+    // for the fracture half, the physical co-location wins through the
+    // twin-depth contract.
+    const std::string props =
+        "DX\n 2*100 /\n"
+        "DY\n 2*100 /\n"
+        "DZ\n 2*10 /\n"
+        "TOPS\n 2000 2050 /\n";
+    auto deck = createDualPorosityDeck("1 1 2", props, true);
+    Opm::EclipseGrid grid( deck );
+
+    BOOST_CHECK(grid.dualPorosity());
+    BOOST_CHECK_CLOSE(grid.getCellDepth(0), 2005.0, 1e-10);
+    BOOST_CHECK_CLOSE(grid.getCellDepth(1), 2005.0, 1e-10);
+    BOOST_CHECK_CLOSE(grid.getCellThickness(1), 10.0, 1e-10);
+}
+
+BOOST_AUTO_TEST_CASE(DualPorositySinglePorosityUnchanged) {
+    // Without DUALPORO the new API reports single-porosity semantics and the
+    // classification predicates never fire.
+    const std::string props =
+        "DX\n 4*100 /\n"
+        "DY\n 4*100 /\n"
+        "DZ\n 4*10 /\n"
+        "TOPS\n 2000 2010 2020 2030 /\n";
+    auto deck = createDualPorosityDeck("1 1 4", props, false);
+    Opm::EclipseGrid grid( deck );
+
+    BOOST_CHECK(!grid.dualPorosity());
+    BOOST_CHECK_EQUAL(grid.matrixLayerCount(), 4U);
+    for (std::size_t g = 0; g < grid.getCartesianSize(); ++g)
+        BOOST_CHECK(!grid.isFractureCell(g));
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityEgridFileShape) {
+    // The written file carries geometry for the matrix half only: halved
+    // layer count, matrix-half ZCORN, extended one-per-geometric-cell ACTNUM,
+    // porosity-model flag set, and the coupling connection written
+    // fracture-cell first — the reference-simulator file layout.
+    const char* deckData =
+        "RUNSPEC\n"
+        "OIL\nWATER\n"
+        "DIMENS\n 1 1 2 /\n"
+        "DUALPORO\n"
+        "GRID\n"
+        "DX\n 2*100 /\n"
+        "DY\n 2*100 /\n"
+        "DZ\n 2*10 /\n"
+        "TOPS\n 2*2000 /\n"
+        "PORO\n 0.20 0.01 /\n"
+        "PERMX\n 1.0 1000.0 /\n"
+        "SIGMA\n 0.12 /\n"
+        "\n";
+    auto deck = Opm::Parser{}.parseString(deckData);
+    Opm::EclipseState es(deck);
+    const auto& grid = es.getInputGrid();
+    const auto units = Opm::UnitSystem::newMETRIC();
+
+    WorkArea work;
+    const std::string fileName = "DPSHAPE.EGRID";
+    grid.save(fileName, false, es.getInputNNC().input(), units);
+
+    Opm::EclIO::EclFile file(fileName);
+
+    const auto filehead = file.get<int>("FILEHEAD");
+    BOOST_CHECK_EQUAL(filehead[5], 1);      // porosity model: dual porosity
+
+    const auto gridhead = file.get<int>("GRIDHEAD");
+    BOOST_CHECK_EQUAL(gridhead[1], 1);
+    BOOST_CHECK_EQUAL(gridhead[2], 1);
+    BOOST_CHECK_EQUAL(gridhead[3], 1);      // halved NZ
+
+    const auto zcorn = file.get<float>("ZCORN");
+    BOOST_CHECK_EQUAL(zcorn.size(), 8U);    // one geometric cell only
+
+    const auto actnum = file.get<int>("ACTNUM");
+    BOOST_REQUIRE_EQUAL(actnum.size(), 1U);
+    BOOST_CHECK_EQUAL(actnum[0], 3);        // matrix AND fracture active
+
+    const auto nnc1 = file.get<int>("NNC1");
+    const auto nnc2 = file.get<int>("NNC2");
+    BOOST_REQUIRE_EQUAL(nnc1.size(), 1U);
+    BOOST_CHECK_EQUAL(nnc1[0], 2);          // fracture cell first
+    BOOST_CHECK_EQUAL(nnc2[0], 1);          // matrix cell second
+}
+
+BOOST_AUTO_TEST_CASE(DualPermeabilityGridBehavesAsDualPorosity) {
+    // DUALPERM implies the dual-porosity grid conventions without DUALPORO in
+    // the deck: odd NZ is rejected, and the twin bookkeeping is live.
+    const char* oddDeck =
+        "RUNSPEC\n"
+        "OIL\nWATER\n"
+        "DIMENS\n 1 1 3 /\n"
+        "DUALPERM\n"
+        "GRID\n"
+        "DX\n 3*100 /\n"
+        "DY\n 3*100 /\n"
+        "DZ\n 3*10 /\n"
+        "TOPS\n 3*2000 /\n"
+        "\n";
+    auto odd = Opm::Parser{}.parseString(oddDeck);
+    BOOST_CHECK_THROW(Opm::EclipseGrid{ odd }, Opm::OpmInputError);
+
+    const char* evenDeck =
+        "RUNSPEC\n"
+        "OIL\nWATER\n"
+        "DIMENS\n 1 1 2 /\n"
+        "DUALPERM\n"
+        "GRID\n"
+        "DX\n 2*100 /\n"
+        "DY\n 2*100 /\n"
+        "DZ\n 2*10 /\n"
+        "TOPS\n 2*2000 /\n"
+        "\n";
+    auto even = Opm::Parser{}.parseString(evenDeck);
+    const Opm::EclipseGrid grid{ even };
+    BOOST_CHECK(grid.dualPorosity());
+    BOOST_CHECK(grid.dualPermeability());
+    BOOST_CHECK(grid.isFractureCell(1));
+    BOOST_CHECK_EQUAL(grid.matrixTwin(1), 0U);
+    BOOST_CHECK_EQUAL(grid.fractureTwin(0), 1U);
+}
+
+BOOST_AUTO_TEST_CASE(DualPermeabilityEgridPorosityModelCode) {
+    // Same halved file layout as dual porosity, but the porosity-model code
+    // distinguishes the two: 2 for dual permeability.
+    const char* deckData =
+        "RUNSPEC\n"
+        "OIL\nWATER\n"
+        "DIMENS\n 1 1 2 /\n"
+        "DUALPERM\n"
+        "GRID\n"
+        "DX\n 2*100 /\n"
+        "DY\n 2*100 /\n"
+        "DZ\n 2*10 /\n"
+        "TOPS\n 2*2000 /\n"
+        "PORO\n 0.20 0.01 /\n"
+        "PERMX\n 1.0 1000.0 /\n"
+        "SIGMA\n 0.12 /\n"
+        "\n";
+    auto deck = Opm::Parser{}.parseString(deckData);
+    Opm::EclipseState es(deck);
+    const auto& grid = es.getInputGrid();
+    const auto units = Opm::UnitSystem::newMETRIC();
+
+    WorkArea work;
+    const std::string fileName = "DKSHAPE.EGRID";
+    grid.save(fileName, false, es.getInputNNC().input(), units);
+
+    Opm::EclIO::EclFile file(fileName);
+
+    const auto filehead = file.get<int>("FILEHEAD");
+    BOOST_CHECK_EQUAL(filehead[5], 2);      // porosity model: dual permeability
+
+    const auto gridhead = file.get<int>("GRIDHEAD");
+    BOOST_CHECK_EQUAL(gridhead[3], 1);      // layer count still halved
+
+    const auto nnc1 = file.get<int>("NNC1");
+    BOOST_REQUIRE_EQUAL(nnc1.size(), 1U);   // coupling still rides the NNC path
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityEgridSinglePorosityShapeUnchanged) {
+    // A single-porosity grid keeps the full shape — no halving, plain ACTNUM.
+    const std::string props =
+        "DX\n 2*100 /\n"
+        "DY\n 2*100 /\n"
+        "DZ\n 2*10 /\n"
+        "TOPS\n 2000 2010 /\n";
+    auto deck = createDualPorosityDeck("1 1 2", props, false);
+    Opm::EclipseGrid grid( deck );
+    const auto units = Opm::UnitSystem::newMETRIC();
+
+    WorkArea work;
+    const std::string fileName = "SPSHAPE.EGRID";
+    grid.save(fileName, false, std::vector<Opm::NNCdata>{}, units);
+
+    Opm::EclIO::EclFile file(fileName);
+    const auto filehead = file.get<int>("FILEHEAD");
+    BOOST_CHECK_EQUAL(filehead[5], 0);
+    const auto gridhead = file.get<int>("GRIDHEAD");
+    BOOST_CHECK_EQUAL(gridhead[3], 2);
+    BOOST_CHECK_EQUAL(file.get<float>("ZCORN").size(), 16U);
+    BOOST_CHECK_EQUAL(file.get<int>("ACTNUM").size(), 2U);
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityDepthSurvivesAllActiveReset) {
+    // The no-argument resetACTNUM() -- the all-active form, reached when a grid file
+    // carries no ACTNUM -- must maintain the twin-depth override too. It did not: only
+    // the ACTNUM-taking overload rebuilt it, so on that path every fracture cell reported
+    // its stacked geometric depth rather than its matrix twin's.
+    const std::string props =
+        "DX\n 8*100 /\n"
+        "DY\n 8*100 /\n"
+        "DZ\n 8*10 /\n"
+        "TOPS\n 4*2000 4*2010 /\n";
+    auto deck = createDualPorosityDeck("2 2 2", props, true);
+    Opm::EclipseGrid grid( deck );
+
+    const std::size_t half = grid.getCartesianSize() / 2;
+    std::vector<double> before;
+    for (std::size_t g = half; g < grid.getCartesianSize(); ++g)
+        before.push_back(grid.getCellDepth(g));
+
+    grid.resetACTNUM();
+
+    for (std::size_t g = half; g < grid.getCartesianSize(); ++g) {
+        // co-located: the fracture cell keeps its matrix twin's depth
+        BOOST_CHECK_CLOSE(grid.getCellDepth(g), grid.getCellDepth(grid.matrixTwin(g)), 1e-10);
+        BOOST_CHECK_CLOSE(grid.getCellDepth(g), before[g - half], 1e-10);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityDepthSurvivesActivityChange) {
+    // Field-property processing re-runs resetACTNUM after construction (e.g.
+    // zero-pore-volume cells get deactivated). The ACTIVE-indexed twin-depth
+    // override must be rebuilt with the new mapping — a stale vector reports
+    // the wrong depth for every fracture cell behind the deactivated one.
+    const char* deckData =
+        "RUNSPEC\n"
+        "OIL\nWATER\n"
+        "DIMENS\n 2 1 2 /\n"
+        "DUALPORO\n"
+        "GRID\n"
+        "DX\n 4*100 /\n"
+        "DY\n 4*100 /\n"
+        "DZ\n 4*10 /\n"
+        "TOPS\n 4*2000 /\n"
+        "PORO\n 0.20 0.0 0.01 0.01 /\n"
+        "PERMX\n 1.0 1.0 1000.0 1000.0 /\n"
+        "\n";
+    auto deck = Opm::Parser{}.parseString(deckData);
+    Opm::EclipseState es(deck);
+    const auto& grid = es.getInputGrid();
+
+    // matrix cell 1 died (zero pore volume) — 3 active cells remain
+    BOOST_CHECK_EQUAL(grid.getNumActive(), 3U);
+
+    // every ACTIVE fracture cell still reports its matrix twin's depth
+    BOOST_CHECK_CLOSE(grid.getCellDepth(2), 2005.0, 1e-10);
+    BOOST_CHECK_CLOSE(grid.getCellDepth(3), 2005.0, 1e-10);
+    BOOST_CHECK_CLOSE(grid.getCellDepth(0), 2005.0, 1e-10);
+}
+
+BOOST_AUTO_TEST_CASE(DPGRIDCopiesMatrixGeometry) {
+    // DPGRID: the fracture half's cell sizes come from the matrix twins no
+    // matter what the deck supplied there.
+    const char* deckData =
+        "RUNSPEC\n"
+        "OIL\nWATER\n"
+        "DIMENS\n 2 1 2 /\n"
+        "DUALPORO\n"
+        "GRID\n"
+        "DPGRID\n"
+        "DX\n 2*100 2*7 /\n"
+        "DY\n 2*100 2*7 /\n"
+        "DZ\n 2*10 2*99 /\n"
+        "TOPS\n 4*2000 /\n"
+        "PORO\n 0.20 0.20 0.01 0.01 /\n"
+        "PERMX\n 4*1.0 /\n"
+        "\n";
+    auto deck = Opm::Parser{}.parseString(deckData);
+    Opm::EclipseGrid grid( deck );
+
+    BOOST_CHECK_CLOSE(grid.getCellThickness(2), 10.0, 1e-10);   // not 99
+    BOOST_CHECK_CLOSE(grid.getCellThickness(3), 10.0, 1e-10);
+    BOOST_CHECK_CLOSE(grid.getCellVolume(std::size_t{2}), 1.0e5, 1e-10);  // not 7*7*99
+    BOOST_CHECK_CLOSE(grid.getCellDepth(2), 2005.0, 1e-10);     // twin depth contract
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityGdfileRejected) {
+    // A grid read back from file cannot carry the dual-continuum layout: the reader takes
+    // NZ from the file header and treats any non-zero ACTNUM entry as active, so the
+    // doubled grid would come back as a half-height single-porosity one. Refuse instead.
+    const char* deckData =
+        "RUNSPEC\n"
+        "OIL\nWATER\n"
+        "DIMENS\n 1 1 2 /\n"
+        "DUALPORO\n"
+        "GRID\n"
+        "GDFILE\n 'SOMEGRID.EGRID' /\n"
+        "PORO\n 2*0.2 /\n"
+        "PERMX\n 2*1.0 /\n"
+        "\n";
+
+    Opm::Parser parser;
+    const auto deck = parser.parseString( deckData );
+    BOOST_CHECK_THROW( Opm::EclipseGrid{ deck }, Opm::OpmInputError );
+}
+
+BOOST_AUTO_TEST_CASE(DPGRIDCornerPointRejected) {
+    // Corner-point input with DPGRID is not supported — both halves must be
+    // written out explicitly.
+    const char* deckData =
+        "RUNSPEC\n"
+        "OIL\nWATER\n"
+        "DIMENS\n 1 1 2 /\n"
+        "DUALPORO\n"
+        "GRID\n"
+        "DPGRID\n"
+        "COORD\n 24*1 /\n"
+        "ZCORN\n 16*1 /\n"
+        "PORO\n 2*0.2 /\n"
+        "PERMX\n 2*1.0 /\n"
+        "\n";
+    auto deck = Opm::Parser{}.parseString(deckData);
+    BOOST_CHECK_THROW(Opm::EclipseGrid{ deck }, Opm::OpmInputError);
+}

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -44,7 +44,11 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
 
+#include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
+
 #include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
 
 #include <cstddef>
 #include <filesystem>
@@ -676,3 +680,138 @@ BOOST_AUTO_TEST_CASE(SALTMFTest) {
     const double epsilon = 0.00001;
     BOOST_CHECK_CLOSE(salinity, saltmf, epsilon);
 }
+
+namespace {
+
+Deck createDualPorosityStateDeck(const std::string& dimens,
+                                 const std::string& gridProps,
+                                 bool dualporo = true)
+{
+    const std::string deckData =
+        "RUNSPEC\n"
+        "\n"
+        "OIL\n"
+        "WATER\n"
+        "DIMENS\n"
+        " " + dimens + " /\n" +
+        (dualporo ? "DUALPORO\n" : "") +
+        "GRID\n" +
+        gridProps +
+        "\n";
+    Parser parser;
+    return parser.parseString(deckData);
+}
+
+const std::string dpMinProps =
+    "DX\n 2*100 /\n"
+    "DY\n 2*100 /\n"
+    "DZ\n 2*10 /\n"
+    "TOPS\n 2*2000 /\n"
+    "PORO\n 0.20 0.01 /\n"
+    "PERMX\n 1.0 1000.0 /\n";
+
+// 1 mD in SI times bulk volume (1e5 m3) times sigma (0.12 1/m2).
+constexpr double dpMinExpectedTrans = 9.869232667160130e-16 * 1.0e5 * 0.12;
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(DualPorositySigmaNNCFromScalarSigma) {
+    // One block, sigma as a single field value.
+    auto deck = createDualPorosityStateDeck("1 1 2", dpMinProps + "SIGMA\n 0.12 /\n");
+    EclipseState es(deck);
+
+    const auto& nnc = es.getInputNNC().input();
+    BOOST_REQUIRE_EQUAL(nnc.size(), 1U);
+    BOOST_CHECK_EQUAL(nnc[0].cell1, 0U);
+    BOOST_CHECK_EQUAL(nnc[0].cell2, 1U);
+    BOOST_CHECK_CLOSE(nnc[0].trans, dpMinExpectedTrans, 1e-4);
+}
+
+BOOST_AUTO_TEST_CASE(DualPorositySigmaNNCFromSigmav) {
+    // Cell-by-cell sigma: the matrix cell's value drives the coupling, the
+    // fracture-half entry carries no meaning.
+    auto deck = createDualPorosityStateDeck("1 1 2", dpMinProps + "SIGMAV\n 0.12 0.0 /\n");
+    EclipseState es(deck);
+
+    const auto& nnc = es.getInputNNC().input();
+    BOOST_REQUIRE_EQUAL(nnc.size(), 1U);
+    BOOST_CHECK_EQUAL(nnc[0].cell1, 0U);
+    BOOST_CHECK_EQUAL(nnc[0].cell2, 1U);
+    BOOST_CHECK_CLOSE(nnc[0].trans, dpMinExpectedTrans, 1e-4);
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityNoSigmaNoCoupling) {
+    // Without SIGMA/SIGMAV there is no coupling — and no failure.
+    auto deck = createDualPorosityStateDeck("1 1 2", dpMinProps);
+    EclipseState es(deck);
+    BOOST_CHECK(es.getInputNNC().input().empty());
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityInactiveTwinNoCoupling) {
+    // An inactive fracture twin suppresses the pair's connection.
+    auto deck = createDualPorosityStateDeck(
+        "1 1 2", dpMinProps + "SIGMA\n 0.12 /\n" + "ACTNUM\n 1 0 /\n");
+    EclipseState es(deck);
+    BOOST_CHECK(es.getInputNNC().input().empty());
+}
+
+BOOST_AUTO_TEST_CASE(DualPorositySigmaNNCMultiBlock) {
+    // 2x1x4: four matrix cells, each coupled to its twin four cells later.
+    const std::string props =
+        "DX\n 8*100 /\n"
+        "DY\n 8*100 /\n"
+        "DZ\n 8*10 /\n"
+        "TOPS\n 2*2000 2*2010 2*2000 2*2010 /\n"
+        "PORO\n 4*0.20 4*0.01 /\n"
+        "PERMX\n 4*1.0 4*1000.0 /\n"
+        "SIGMA\n 0.12 /\n";
+    auto deck = createDualPorosityStateDeck("2 1 4", props);
+    EclipseState es(deck);
+
+    const auto& nnc = es.getInputNNC().input();
+    BOOST_REQUIRE_EQUAL(nnc.size(), 4U);
+    for (std::size_t n = 0; n < 4; ++n) {
+        BOOST_CHECK_EQUAL(nnc[n].cell1, n);
+        BOOST_CHECK_EQUAL(nnc[n].cell2, n + 4);
+        BOOST_CHECK_CLOSE(nnc[n].trans, dpMinExpectedTrans, 1e-4);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(DualPorositySinglePorosityNoInjectedNNC) {
+    // Without DUALPORO nothing is injected, SIGMA or not: the keyword still
+    // aborts later in the simulator, but the state must not invent NNCs.
+    auto deck = createDualPorosityStateDeck("1 1 2", dpMinProps, false);
+    EclipseState es(deck);
+    BOOST_CHECK(es.getInputNNC().input().empty());
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityCouplingCannotBeEdited) {
+    // The coupling transmissibility is computed from the shape factor and the matrix
+    // permeability. An EDITNNC naming the same pair would rescale it silently, because
+    // edits are applied after the coupling is built. Refuse instead.
+    const char* deckData =
+        "RUNSPEC\n"
+        "OIL\nWATER\n"
+        // Two matrix layers, so a twin pair is NOT also a geometric neighbour: at one
+        // matrix layer the twins are adjacent cells and the edit is treated as an
+        // ordinary neighbour multiplier rather than an NNC edit.
+        "DIMENS\n 1 1 4 /\n"
+        "DUALPORO\n"
+        "GRID\n"
+        "DX\n 4*100 /\n"
+        "DY\n 4*100 /\n"
+        "DZ\n 4*10 /\n"
+        "TOPS\n 4*2000 /\n"
+        "PORO\n 2*0.2 2*0.01 /\n"
+        "PERMX\n 2*1.0 2*1000.0 /\n"
+        "SIGMA\n 0.1 /\n"
+        "EDIT\n"
+        "EDITNNC\n"
+        " 1 1 1 1 1 3 0.5 /\n"
+        "/\n"
+        "\n";
+
+    const auto deck = Opm::Parser{}.parseString(deckData);
+    BOOST_CHECK_THROW(Opm::EclipseState{ deck }, Opm::OpmInputError);
+}
+

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -179,6 +179,10 @@ SIGMAV
     }
 }
 
+
+
+
+
 BOOST_AUTO_TEST_CASE(SigmaDeckScalar) {
     // SIGMA is a single global scalar (JSON schema: "size": 1), not a per-cell array like
     // SIGMAV (schema: "data", no "size"). FieldProps::GRID::double_keywords is strictly a
@@ -3632,4 +3636,147 @@ MULTZ
         BOOST_CHECK_EQUAL(multz2[ij]      , 20.0);
         BOOST_CHECK_EQUAL(multz2[ij + 100], 40.0);
     }
+}
+
+namespace {
+
+Opm::Deck dualPorosityRegionsDeck(const std::string& runspecExtra,
+                                  const std::string& dimens,
+                                  const std::string& gridProps,
+                                  const std::string& tail)
+{
+    const std::string deckData =
+        "RUNSPEC\n"
+        "OIL\n"
+        "WATER\n" +
+        runspecExtra +
+        "DIMENS\n"
+        " " + dimens + " /\n"
+        "DUALPORO\n"
+        "GRID\n" +
+        gridProps +
+        tail +
+        "\n";
+    return Opm::Parser{}.parseString(deckData);
+}
+
+const std::string dpRegionGrid1x1x2 =
+    "DX\n 2*100 /\n"
+    "DY\n 2*100 /\n"
+    "DZ\n 2*10 /\n"
+    "TOPS\n 2*2000 /\n"
+    "PORO\n 0.20 0.01 /\n"
+    "PERMX\n 1.0 1000.0 /\n";
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(DualPorosityRegionArraysPerContinuum) {
+    // Matrix cell reads table 1, fracture cell table 2 — through the plain
+    // region machinery, no dual-porosity special case anywhere.
+    auto deck = dualPorosityRegionsDeck(
+        "TABDIMS\n 2 2 /\n"
+        "EQLDIMS\n 2 /\n",
+        "1 1 2", dpRegionGrid1x1x2,
+        "REGIONS\n"
+        "SATNUM\n 1 2 /\n"
+        "PVTNUM\n 1 2 /\n"
+        "EQLNUM\n 1 2 /\n");
+    Opm::EclipseState es(deck);
+    const auto& fpm = es.fieldProps();
+
+    for (const auto* kw : {"SATNUM", "PVTNUM", "EQLNUM"}) {
+        const auto& reg = fpm.get_int(kw);
+        BOOST_REQUIRE_EQUAL(reg.size(), 2U);
+        BOOST_CHECK_EQUAL(reg[0], 1);
+        BOOST_CHECK_EQUAL(reg[1], 2);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityRegionDefaultsSharedTable) {
+    // No REGIONS section: both continua fall back to table 1 everywhere.
+    auto deck = dualPorosityRegionsDeck("", "1 1 2", dpRegionGrid1x1x2, "");
+    Opm::EclipseState es(deck);
+    const auto& fpm = es.fieldProps();
+
+    for (const auto* kw : {"SATNUM", "PVTNUM", "EQLNUM"}) {
+        const auto& reg = fpm.get_int(kw);
+        BOOST_REQUIRE_EQUAL(reg.size(), 2U);
+        BOOST_CHECK_EQUAL(reg[0], 1);
+        BOOST_CHECK_EQUAL(reg[1], 1);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityRegionsAlignWithTwinHalves) {
+    // 2x1x4: regions assigned half-by-half must agree with the grid's own
+    // matrix/fracture classification for every cell.
+    const std::string props =
+        "DX\n 8*100 /\n"
+        "DY\n 8*100 /\n"
+        "DZ\n 8*10 /\n"
+        "TOPS\n 2*2000 2*2010 2*2000 2*2010 /\n"
+        "PORO\n 4*0.20 4*0.01 /\n"
+        "PERMX\n 4*1.0 4*1000.0 /\n";
+    auto deck = dualPorosityRegionsDeck(
+        "TABDIMS\n 2 2 /\n",
+        "2 1 4", props,
+        "REGIONS\n"
+        "SATNUM\n 4*1 4*2 /\n");
+    Opm::EclipseState es(deck);
+    const auto& grid = es.getInputGrid();
+    const auto& satnum = es.fieldProps().get_int("SATNUM");
+
+    BOOST_REQUIRE_EQUAL(satnum.size(), grid.getCartesianSize());
+    for (std::size_t g = 0; g < satnum.size(); ++g) {
+        BOOST_CHECK_EQUAL(satnum[g] == 2, grid.isFractureCell(g));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityTwoSaturationTablesLoad) {
+    // The documented convention: matrix keeps a curved table, the fracture
+    // gets its own straight-line zero-capillary table. Both must load.
+    auto deck = dualPorosityRegionsDeck(
+        "TABDIMS\n 2 2 /\n",
+        "1 1 2", dpRegionGrid1x1x2,
+        "REGIONS\n"
+        "SATNUM\n 1 2 /\n"
+        "PROPS\n"
+        "SWOF\n"
+        "  0.20 0.000 1.000 0.9\n"
+        "  0.80 0.600 0.000 0.1 /\n"
+        "  0.00 0.000 1.000 0.0\n"
+        "  1.00 1.000 0.000 0.0 /\n");
+    Opm::EclipseState es(deck);
+    BOOST_CHECK_EQUAL(es.getTableManager().getSwofTables().size(), 2U);
+}
+
+BOOST_AUTO_TEST_CASE(DPGRIDCopiesDefaultedProperties) {
+    // Properties given for the matrix half only follow onto the fracture
+    // twins; explicitly-supplied fracture values are kept.
+    const std::string deckData =
+        "RUNSPEC\n"
+        "OIL\nWATER\n"
+        "DIMENS\n 2 1 2 /\n"
+        "DUALPORO\n"
+        "GRID\n"
+        "DPGRID\n"
+        "DX\n 4*100 /\n"
+        "DY\n 4*100 /\n"
+        "DZ\n 4*10 /\n"
+        "TOPS\n 4*2000 /\n"
+        "PERMX\n 5.0 7.0 2* /\n"          // fracture half defaulted -> copied
+        "PORO\n 0.20 0.20 0.01 0.01 /\n"  // fracture given -> kept
+        "\n";
+    auto deck = Opm::Parser{}.parseString(deckData);
+    Opm::EclipseState es(deck);
+    const auto& fpm = es.fieldProps();
+
+    const auto& permx_si = fpm.get_double("PERMX");
+    // PERMX is stored in SI internally; compare fracture vs matrix twins.
+    BOOST_CHECK_CLOSE(permx_si[2], permx_si[0], 1e-10);
+    BOOST_CHECK_CLOSE(permx_si[3], permx_si[1], 1e-10);
+    BOOST_CHECK_GT(permx_si[1], permx_si[0]);   // 7 > 5 preserved
+
+    const auto& poro = fpm.get_double("PORO");
+    BOOST_CHECK_CLOSE(poro[2], 0.01, 1e-10);    // explicit fracture value kept
+    BOOST_CHECK_CLOSE(poro[0], 0.20, 1e-10);
 }

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -155,6 +155,51 @@ PERMX
 
 
 
+BOOST_AUTO_TEST_CASE(SigmaVFieldProps) {
+    // SIGMAV is a per-cell array (JSON schema: "data", no "size") -- fits FieldProps'
+    // GRID::double_keywords registry exactly like PORO/PERMX.
+    std::string deck_string_sigmav = R"(
+GRID
+
+PORO
+   8*0.10 /
+
+SIGMAV
+  8*0.12 /
+)";
+    EclipseGrid grid(EclipseGrid(2,2,2));
+    Deck deck_sigmav = Parser{}.parseString(deck_string_sigmav);
+    FieldPropsManager fpm_sigmav(deck_sigmav, Phases{true, true, false}, grid, TableManager());
+
+    BOOST_CHECK(fpm_sigmav.has_double("SIGMAV"));
+    const auto& sigmav = fpm_sigmav.get_double("SIGMAV");
+    BOOST_CHECK_EQUAL(sigmav.size(), grid.getNumActive());
+    for (const auto& value : sigmav) {
+        BOOST_CHECK_CLOSE(value, 0.12, 1e-10);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(SigmaDeckScalar) {
+    // SIGMA is a single global scalar (JSON schema: "size": 1), not a per-cell array like
+    // SIGMAV (schema: "data", no "size"). FieldProps::GRID::double_keywords is strictly a
+    // per-cell array registry: verify_deck_data() in FieldProps.cpp requires
+    // deck_data.size() == box.size() * num_value unconditionally, with no broadcast path for
+    // a single supplied value. SIGMA is intentionally not registered there; in dual-continuum
+    // runs applyDualPorosityScalars broadcasts its value into the SIGMAV carrier instead.
+    // This test proves the raw parse of a size-1 keyword works standalone.
+    std::string deck_string_sigma = R"(
+GRID
+
+SIGMA
+  0.12 /
+)";
+    auto deck_sigma = Parser{}.parseString(deck_string_sigma);
+    BOOST_CHECK(deck_sigma.hasKeyword("SIGMA"));
+    const auto sigma_value = deck_sigma["SIGMA"].back().getRecord(0).getItem(0).get<double>(0);
+    BOOST_CHECK_CLOSE(sigma_value, 0.12, 1e-10);
+}
+
+
 BOOST_AUTO_TEST_CASE(CreateFieldPropsForActnum) {
     std::string deck_string = R"(
 GRID

--- a/tests/parser/RunspecTests.cpp
+++ b/tests/parser/RunspecTests.cpp
@@ -1067,6 +1067,126 @@ BOOST_AUTO_TEST_CASE(Co2Storage_oilwater) {
     BOOST_CHECK_THROW( Runspec{deck}, std::runtime_error );
 }
 
+BOOST_AUTO_TEST_CASE(PorosityModel_SinglePorosityByDefault) {
+    const auto deck = Parser{}.parseString(R"(
+    RUNSPEC
+    OIL
+    WATER
+    )");
+
+    const Runspec runspec( deck );
+    const auto& model = runspec.porosityModel();
+
+    BOOST_CHECK( model.type() == PorosityModel::Type::SinglePorosity );
+    BOOST_CHECK( !model.dualContinuum() );
+    BOOST_CHECK( !model.dualPermeability() );
+    BOOST_CHECK( !model.fracturePermeabilityScalingActive() );
+    BOOST_CHECK( model == PorosityModel{} );
+}
+
+BOOST_AUTO_TEST_CASE(PorosityModel_DualPorosity) {
+    const auto deck = Parser{}.parseString(R"(
+    RUNSPEC
+    OIL
+    WATER
+    DUALPORO
+    )");
+
+    const Runspec runspec( deck );
+    const auto& model = runspec.porosityModel();
+
+    BOOST_CHECK( model.type() == PorosityModel::Type::DualPorosity );
+    BOOST_CHECK( model.dualContinuum() );
+    BOOST_CHECK( !model.dualPermeability() );
+    BOOST_CHECK( model.fracturePermeabilityScalingActive() );
+}
+
+BOOST_AUTO_TEST_CASE(PorosityModel_DualPermeability) {
+    const auto deck = Parser{}.parseString(R"(
+    RUNSPEC
+    OIL
+    WATER
+    DUALPERM
+    )");
+
+    const Runspec runspec( deck );
+    const auto& model = runspec.porosityModel();
+
+    BOOST_CHECK( model.type() == PorosityModel::Type::DualPermeability );
+    BOOST_CHECK( model.dualContinuum() );      // dual permeability is a dual-continuum model
+    BOOST_CHECK( model.dualPermeability() );
+    BOOST_CHECK( model.fracturePermeabilityScalingActive() );
+}
+
+BOOST_AUTO_TEST_CASE(PorosityModel_DualPermeabilityTakesPrecedence) {
+    const auto deck = Parser{}.parseString(R"(
+    RUNSPEC
+    OIL
+    WATER
+    DUALPORO
+    DUALPERM
+    )");
+
+    const Runspec runspec( deck );
+    BOOST_CHECK( runspec.porosityModel().type() == PorosityModel::Type::DualPermeability );
+}
+
+BOOST_AUTO_TEST_CASE(PorosityModel_FracturePermeabilityScaling) {
+    // Dual continuum, scaling switched off by NODPPM.
+    {
+        const auto deck = Parser{}.parseString(R"(
+    RUNSPEC
+    OIL
+    WATER
+    DUALPORO
+    NODPPM
+    )");
+
+        const Runspec runspec( deck );
+        const auto& model = runspec.porosityModel();
+
+        BOOST_CHECK( model.type() == PorosityModel::Type::DualPorosity );
+        BOOST_CHECK( !model.fracturePermeabilityScalingActive() );
+    }
+
+    // Single porosity: never active, whatever NODPPM says.
+    {
+        const auto deck = Parser{}.parseString(R"(
+    RUNSPEC
+    OIL
+    WATER
+    NODPPM
+    )");
+
+        const Runspec runspec( deck );
+        const auto& model = runspec.porosityModel();
+
+        BOOST_CHECK( model.type() == PorosityModel::Type::SinglePorosity );
+        BOOST_CHECK( !model.fracturePermeabilityScalingActive() );
+    }
+}
+
+BOOST_AUTO_TEST_CASE(PorosityModel_Equality) {
+    const auto dualporo = Parser{}.parseString(R"(
+    RUNSPEC
+    OIL
+    WATER
+    DUALPORO
+    )");
+
+    const auto dualporo_nodppm = Parser{}.parseString(R"(
+    RUNSPEC
+    OIL
+    WATER
+    DUALPORO
+    NODPPM
+    )");
+
+    BOOST_CHECK( PorosityModel{ dualporo } == PorosityModel{ dualporo } );
+    BOOST_CHECK( !(PorosityModel{ dualporo } == PorosityModel{ dualporo_nodppm }) );
+    BOOST_CHECK( !(PorosityModel{ dualporo } == PorosityModel{}) );
+}
+
 BOOST_AUTO_TEST_CASE(H2Storage) {
     const std::string input = R"(
     RUNSPEC

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -7232,3 +7232,85 @@ END
         BOOST_CHECK_CLOSE(s->width(), 1819.202122, 1.0e-8);
     }
 }
+
+namespace {
+    Schedule make_dual_porosity_schedule(const bool fracture_perm_scaling_disabled)
+    {
+        const auto deck_string = std::string { R"(
+RUNSPEC
+DIMENS
+ 1 1 2 /
+OIL
+WATER
+DUALPORO
+)" } + (fracture_perm_scaling_disabled ? std::string{ "NODPPM\n" } : std::string{}) + R"(
+WELLDIMS
+ 2 2 2 2 /
+GRID
+DX
+ 2*100 /
+DY
+ 2*100 /
+DZ
+ 2*10 /
+TOPS
+ 2000 /
+PORO
+ 0.25 0.05 /
+PERMX
+ 5 20000 /
+PERMY
+ 5 20000 /
+PERMZ
+ 0.5 2000 /
+SCHEDULE
+WELSPECS
+ 'PF' 'G' 1 1 2005 'OIL' 7* /
+ 'PM' 'G' 1 1 2005 'OIL' 7* /
+/
+COMPDAT
+ 'PF' 1 1 2 2 'OPEN' 1* 1* 0.2 /
+ 'PM' 1 1 1 1 'OPEN' 1* 1* 0.2 /
+/
+)";
+
+        const auto deck = Parser{}.parseString(deck_string);
+
+        EclipseGrid grid(deck);
+        const TableManager table (deck);
+        const FieldPropsManager fp(deck, Phases{true, true, false}, grid, table);
+        const Runspec runspec (deck);
+
+        return { deck, grid, fp, NumericalAquifers{}, runspec, std::make_shared<Python>() };
+    }
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityFractureConnectionFactorScaled) {
+    const auto scaled   = make_dual_porosity_schedule(false);
+    const auto unscaled = make_dual_porosity_schedule(true);
+
+    const auto& conn_scaled   = scaled  .getWell("PF", 0).getConnections()[0];
+    const auto& conn_unscaled = unscaled.getWell("PF", 0).getConnections()[0];
+
+    // Fracture-cell porosity is 0.05: the defaulted connection factor and
+    // Kh computed from the scaled permeability are exactly the fracture
+    // porosity times their unscaled counterparts (isotropic scaling leaves
+    // the Peaceman denominator unchanged).
+    BOOST_CHECK_CLOSE(conn_scaled.CF(), 0.05 * conn_unscaled.CF(), 1.0e-8);
+    BOOST_CHECK_CLOSE(conn_scaled.Kh(), 0.05 * conn_unscaled.Kh(), 1.0e-8);
+
+    BOOST_CHECK(conn_scaled.CF() > 0.0);
+    BOOST_CHECK(conn_scaled.Kh() > 0.0);
+}
+
+BOOST_AUTO_TEST_CASE(DualPorosityMatrixConnectionFactorUnaffected) {
+    const auto scaled   = make_dual_porosity_schedule(false);
+    const auto unscaled = make_dual_porosity_schedule(true);
+
+    const auto& conn_scaled   = scaled  .getWell("PM", 0).getConnections()[0];
+    const auto& conn_unscaled = unscaled.getWell("PM", 0).getConnections()[0];
+
+    // Matrix cells keep their deck permeability either way.
+    BOOST_CHECK_CLOSE(conn_scaled.CF(), conn_unscaled.CF(), 1.0e-10);
+    BOOST_CHECK_CLOSE(conn_scaled.Kh(), conn_unscaled.Kh(), 1.0e-10);
+}

--- a/tests/parser/SimulationConfigTest.cpp
+++ b/tests/parser/SimulationConfigTest.cpp
@@ -575,3 +575,52 @@ END
     BOOST_CHECK_CLOSE(dd("FIPNUM", 0), 2005.0, 1.0e-8);
     BOOST_CHECK_CLOSE(dd("FIPABC", 42), 2005.0, 1.0e-8);
 }
+
+BOOST_AUTO_TEST_CASE(DualContinuumWithNONNCIsRejected)
+{
+    // The matrix-fracture coupling is expressed as non-neighbour connections, so NONNC would
+    // remove it while the run still completes -- the matrix continuum ends up isolated and the
+    // material balance still closes.  The combination must be rejected, not silently resolved.
+    const auto deck = createDeck(R"(RUNSPEC
+DIMENS
+ 3 3 2 /
+DUALPORO
+NONNC
+GRID
+DXV
+ 3*100.0 /
+DYV
+ 3*100.0 /
+DZV
+ 2*10.0 /
+DEPTHZ
+ 16*2000.0 /
+SIGMA
+ 2.0E-4 /
+)");
+
+    BOOST_CHECK_THROW(SimulationConfig(false, deck, FieldPropsManager{}), OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(DualContinuumWithoutNONNCIsAccepted)
+{
+    // The negative control for the case above: the same deck without NONNC must still build.
+    const auto deck = createDeck(R"(RUNSPEC
+DIMENS
+ 3 3 2 /
+DUALPORO
+GRID
+DXV
+ 3*100.0 /
+DYV
+ 3*100.0 /
+DZV
+ 2*10.0 /
+DEPTHZ
+ 16*2000.0 /
+SIGMA
+ 2.0E-4 /
+)");
+
+    BOOST_CHECK_NO_THROW(SimulationConfig(false, deck, FieldPropsManager{}));
+}

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -22,6 +22,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/output/eclipse/EclipseIO.hpp>
+#include <opm/output/eclipse/VectorItems/logihead.hpp>
 #include <opm/output/eclipse/RestartValue.hpp>
 
 #include <opm/output/data/Cells.hpp>
@@ -948,4 +949,114 @@ SCHEDULE
 BOOST_AUTO_TEST_CASE(MULTPVBOXInit)
 {
     checkMULTPV(createMULTPVBOXDECK());
+}
+
+BOOST_AUTO_TEST_CASE(EclipseIODualPorosityStaticFiles) {
+    // Full write pipeline for a dual-porosity case: EclipseIO::writeInitial
+    // must produce the reference-simulator file shape end-to-end — halved
+    // EGRID with extended ACTNUM and the coupling connection pair, INIT with
+    // the dual-porosity flag, doubled matrix-first arrays, co-located depths
+    // and the coupling transmissibility.
+    const std::string deckString { R"(RUNSPEC
+TITLE
+  Minimal dual porosity write test
+OIL
+WATER
+METRIC
+DIMENS
+ 1 1 2 /
+DUALPORO
+NODPPM
+TABDIMS
+ 1 1 20 20 /
+EQLDIMS
+/
+WELLDIMS
+ 2 1 1 2 /
+START
+ 1 'JAN' 2020 /
+GRID
+DX
+ 2*100 /
+DY
+ 2*100 /
+DZ
+ 2*10 /
+TOPS
+ 2*2000 /
+PORO
+ 0.20 0.01 /
+PERMX
+ 1.0 1000.0 /
+COPY
+ PERMX PERMY /
+ PERMX PERMZ /
+/
+SIGMA
+ 0.12 /
+INIT
+PROPS
+PVTW
+ 200 1.0 4.0E-5 0.5 0.0 /
+PVDO
+ 150 1.05 1.0
+ 200 1.02 1.1
+ 250 1.00 1.2 /
+DENSITY
+ 800 1000 1.0 /
+ROCK
+ 200 5.0E-5 /
+SWOF
+ 0.20 0.000 1.000 0.0
+ 0.80 0.600 0.000 0.0 /
+SOLUTION
+EQUIL
+ 2000 200 2100 0.0 /
+SCHEDULE
+WELSPECS
+ 'PROD' 'G1' 1 1 2000 'OIL' /
+/
+COMPDAT
+ 'PROD' 1 1 2 2 'OPEN' 2* 0.2 /
+/
+WCONPROD
+ 'PROD' 'OPEN' 'BHP' 5* 100 /
+/
+TSTEP
+ 10*30 /
+END
+)" };
+
+    WorkArea work_area("test_dp_static");
+    const auto deck = Parser().parseString(deckString);
+    auto es = EclipseState(deck);
+    const auto& eclGrid = es.getInputGrid();
+    const Schedule schedule(deck, es, std::make_shared<Python>());
+    const SummaryConfig summary_config(deck, schedule, es.fieldProps(), es.aquifer());
+    es.getIOConfig().setBaseName("DPIO");
+
+    EclipseIO eclWriter(es, eclGrid, schedule, summary_config);
+    eclWriter.writeInitial(data::Solution{}, {}, es.getInputNNC().input());
+
+    // EGRID shape details are pinned by EclipseGridTests; here only the
+    // porosity-model flag, as written through the full EclipseIO pipeline.
+    EclIO::EclFile egrid("DPIO.EGRID");
+    constexpr int fileheadPorosityModel = 5;   // 0-based index; 1 = dual porosity
+    BOOST_CHECK_EQUAL(egrid.get<int>("FILEHEAD")[fileheadPorosityModel], 1);
+
+    // INIT: flag, doubled matrix-first arrays, co-located depths, coupling.
+    EclIO::EclFile init("DPIO.INIT");
+    namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
+    BOOST_CHECK_EQUAL(init.get<bool>("LOGIHEAD")[VI::logihead::DualPoro], true);
+    const auto porv = init.get<float>("PORV");
+    BOOST_REQUIRE_EQUAL(porv.size(), 2U);
+    BOOST_CHECK_CLOSE(porv[0], 20000.0f, 1e-4);
+    BOOST_CHECK_CLOSE(porv[1], 1000.0f, 1e-4);
+    const auto depth = init.get<float>("DEPTH");
+    BOOST_REQUIRE_EQUAL(depth.size(), 2U);
+    BOOST_CHECK_CLOSE(depth[0], 2005.0f, 1e-4);
+    BOOST_CHECK_CLOSE(depth[1], 2005.0f, 1e-4);
+    const auto trannnc = init.get<float>("TRANNNC");
+    BOOST_REQUIRE_EQUAL(trannnc.size(), 1U);
+    BOOST_CHECK_CLOSE(trannnc[0], 102.324f, 1e-2);
 }

--- a/tests/test_LogiHEAD.cpp
+++ b/tests/test_LogiHEAD.cpp
@@ -252,3 +252,19 @@ BOOST_AUTO_TEST_CASE(SaturationFunction)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_CASE(DualPorosityFlag)
+{
+    namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
+
+    {
+        const auto lh = ::Opm::RestartIO::LogiHEAD{}.dualPorosity(true);
+        const auto& v = lh.data();
+        BOOST_CHECK_EQUAL(v[VI::logihead::DualPoro], true);
+    }
+    {
+        const auto lh = ::Opm::RestartIO::LogiHEAD{}.dualPorosity(false);
+        const auto& v = lh.data();
+        BOOST_CHECK_EQUAL(v[VI::logihead::DualPoro], false);
+    }
+}

--- a/tests/test_Serialization.cpp
+++ b/tests/test_Serialization.cpp
@@ -53,6 +53,7 @@
 #include <opm/input/eclipse/EclipseState/InitConfig/FieldSep.hpp>
 #include <opm/input/eclipse/EclipseState/InitConfig/FoamConfig.hpp>
 #include <opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp>
+#include <opm/input/eclipse/EclipseState/PorosityModel.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.hpp>
@@ -303,6 +304,7 @@ TEST_FOR_TYPE_NAMED(Network::Node, NetworkNode)
 TEST_FOR_TYPE(OilVaporizationProperties)
 TEST_FOR_TYPE(PAvg)
 TEST_FOR_TYPE(Phases)
+TEST_FOR_TYPE(PorosityModel)
 TEST_FOR_TYPE(PlymwinjTable)
 TEST_FOR_TYPE(PlyshlogTable)
 TEST_FOR_TYPE(PvcdoTable)


### PR DESCRIPTION
Builds on #5317. Its commits are included in this diff and merge first; review only the last commit here.

## What this does

Scales well connection factors for wells perforating fracture cells by the fracture porosity,
at the single property choke point, so every connection-factor consumer inherits it.

## Why

The effective fracture permeability is scaled by fracture porosity unless the run disables it.
Without this, a well completed in a fracture cell would be given a connection factor computed
from the unscaled permeability — inconsistent with the transmissibilities around it.

## Behavior impact

None for flow — the keywords are still rejected. Within opm-common, connection factors for
fracture cells in a dual-continuum deck now carry the scaling.

## Testing

Connection-factor ratio cases, including `DUALPERM` with `NODPPM`.

## Requirements and limitations

Numerical aquifer cells are deliberately exempt: their properties come from the aquifer
definition, so there is no deck permeability to scale.