### PR TITLE
This fix allows "ECHO" and "NOECHO" keywords to appear inside "ACTION…

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ActionX.cpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.cpp
@@ -100,6 +100,7 @@ bool ActionX::valid_keyword(const std::string& keyword)
 
         "COMPLUMP", "COMPDAT", "COMPSEGS",
 
+        "ECHO",
         "ENDBOX", "EXIT",
 
         //INCLUDE is allowed as well, but is handled differently by the Parser and thus does not need to be in this list
@@ -111,6 +112,7 @@ bool ActionX::valid_keyword(const std::string& keyword)
 
         "MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-",
         "NEXT", "NEXTSTEP",
+        "NOECHO",
 
         "UDQ",
 

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -266,6 +266,46 @@ TSTEP
     BOOST_CHECK_THROW( make_schedule(WITH_GRID, parseContext), OpmInputError );
 }
 
+BOOST_AUTO_TEST_CASE(ECHO_NOECHO_ALLOWED_IN_ACTIONX)
+{
+    const auto deck_string = std::string{ R"(
+SCHEDULE
+
+WELSPECS
+  'P1'  'OP'  1 1 3.33  'OIL' 7*/
+/
+
+ACTIONX
+   'ACTION' /
+   WWCT P1 > 0.75 /
+/
+
+ECHO
+
+NOECHO
+
+WELOPEN
+  'P1' 'SHUT' 5* /
+/
+
+ENDACTIO
+
+TSTEP
+   10 /
+)"};
+
+    ParseContext parseContext( {{ParseContext::ACTIONX_ILLEGAL_KEYWORD, InputErrorAction::THROW_EXCEPTION}} );
+    Schedule sched = make_schedule(deck_string, parseContext);
+
+    const auto& action = sched[0].actions.get()["ACTION"];
+    const auto& keyword_strings = action.keyword_strings();
+
+    BOOST_CHECK(std::ranges::find(keyword_strings, "ECHO") != keyword_strings.end());
+    BOOST_CHECK(std::ranges::find(keyword_strings, "NOECHO") != keyword_strings.end());
+    BOOST_CHECK(std::ranges::find(keyword_strings, "WELOPEN") != keyword_strings.end());
+    BOOST_CHECK_EQUAL(keyword_strings.back(), "ENDACTIO");
+}
+
 BOOST_AUTO_TEST_CASE(COMPDAT)
 {
 


### PR DESCRIPTION
This fix allows "ECHO" and "NOECHO" keywords to appear inside "ACTIONX" ... "ENDACTIO" blocks without raising parser errors.

Seems like in certain input decks contain "ECHO" or "NOECHO" keywords within "ACTIONX" definition blocks to toggle printout logging. Previously, OPM's "ACTIONX" parser treated these as invalid action keywords under default parsing strictness, causing deck loading failures.

What we did:
- Added `"ECHO"` and `"NOECHO"` to `ActionX::valid_keyword()` in `opm-common/opm/input/eclipse/Schedule/Action/ActionX.cpp`.
- Added unit test `ECHO_NOECHO_ALLOWED_IN_ACTIONX` in `tests/parser/ACTIONX.cpp` to verify that `ECHO` and `NOECHO` are accepted and retained in `ActionX::keyword_strings()`.

We also built and ran unit test target in ACTIONX