### PR TITLE
Relax the tolerance on the mole fractions of a composition

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -971,7 +971,6 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
   opm/input/eclipse/EclipseState/Co2StoreConfig.hpp
   opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
-  opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp
   opm/input/eclipse/EclipseState/EclipseConfig.hpp
   opm/input/eclipse/EclipseState/EclipseState.hpp
   opm/input/eclipse/EclipseState/EndpointScaling.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -104,6 +104,7 @@ list(APPEND MAIN_SOURCE_FILES
   opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
   opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
   opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.cpp
+  opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.cpp
   opm/input/eclipse/EclipseState/Geochemistry/SpeciesConfig.cpp
   opm/input/eclipse/EclipseState/Geochemistry/MineralConfig.cpp
   opm/input/eclipse/EclipseState/Geochemistry/IonExchangeConfig.cpp
@@ -970,6 +971,7 @@ list(APPEND PUBLIC_HEADER_FILES
   opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
   opm/input/eclipse/EclipseState/Co2StoreConfig.hpp
   opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
+  opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp
   opm/input/eclipse/EclipseState/EclipseConfig.hpp
   opm/input/eclipse/EclipseState/EclipseState.hpp
   opm/input/eclipse/EclipseState/EndpointScaling.hpp

--- a/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.cpp
@@ -46,9 +46,9 @@ void normalizeMoleFractions(std::vector<double>& fractions,
 {
     for (std::size_t component = 0; component < fractions.size(); ++component) {
         const double fraction = fractions[component];
-        if (!std::isfinite(fraction)) {
+        if (!std::isfinite(fraction) || fraction < 0.0) {
             throw OpmInputError(fmt::format("Mole fraction {} of {} is {}, "
-                                            "but mole fractions must be finite.",
+                                            "but mole fractions must be finite and non-negative.",
                                             component + 1, what, fraction),
                                 location);
         }
@@ -57,8 +57,7 @@ void normalizeMoleFractions(std::vector<double>& fractions,
     const double sum = std::accumulate(fractions.begin(), fractions.end(), 0.0);
 
     // The individually finite values above can still overflow while they are
-    // summed.  Every comparison against a NaN is false, so check the result
-    // before applying either tolerance below.
+    // summed.  Check the result before applying either tolerance below.
     if (!std::isfinite(sum)) {
         throw OpmInputError(fmt::format("The mole fractions of {} sum to {}, "
                                         "which is not a finite number.", what, sum),

--- a/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.cpp
@@ -44,7 +44,27 @@ void normalizeMoleFractions(std::vector<double>& fractions,
                             const std::string& what,
                             const KeywordLocation& location)
 {
+    for (std::size_t component = 0; component < fractions.size(); ++component) {
+        const double fraction = fractions[component];
+        if (!std::isfinite(fraction)) {
+            throw OpmInputError(fmt::format("Mole fraction {} of {} is {}, "
+                                            "but mole fractions must be finite.",
+                                            component + 1, what, fraction),
+                                location);
+        }
+    }
+
     const double sum = std::accumulate(fractions.begin(), fractions.end(), 0.0);
+
+    // The individually finite values above can still overflow while they are
+    // summed.  Every comparison against a NaN is false, so check the result
+    // before applying either tolerance below.
+    if (!std::isfinite(sum)) {
+        throw OpmInputError(fmt::format("The mole fractions of {} sum to {}, "
+                                        "which is not a finite number.", what, sum),
+                            location);
+    }
+
     const double deviation = std::abs(sum - 1.0);
 
     if (deviation > moleFractionTolerance()) {

--- a/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.cpp
@@ -23,26 +23,33 @@
 #include <opm/common/utility/OpmInputError.hpp>
 
 #include <cmath>
+#include <cstddef>
 #include <limits>
 #include <numeric>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include <fmt/format.h>
 
-namespace Opm {
+namespace {
 
-double moleFractionTolerance()
-{
-    return 1.0e-4;
-}
+// Accept compositions rounded to five or six decimal places.
+constexpr double moleFractionTolerance = 1.0e-4;
 
 double exactSumSlack(const std::size_t numValues)
 {
+    // One rounding per value, and one more per addition.
     return 2.0 * numValues * std::numeric_limits<double>::epsilon();
 }
 
-void normalizeMoleFractions(std::vector<double>& fractions,
-                            const std::string& what,
-                            const KeywordLocation& location)
+} // Anonymous namespace
+
+namespace Opm {
+
+std::optional<double> normalizeMoleFractions(std::vector<double>& fractions,
+                                             const std::string& what,
+                                             const KeywordLocation& location)
 {
     for (std::size_t component = 0; component < fractions.size(); ++component) {
         const double fraction = fractions[component];
@@ -56,8 +63,7 @@ void normalizeMoleFractions(std::vector<double>& fractions,
 
     const double sum = std::accumulate(fractions.begin(), fractions.end(), 0.0);
 
-    // The individually finite values above can still overflow while they are
-    // summed.  Check the result before applying either tolerance below.
+    // Finite values may overflow when summed.
     if (!std::isfinite(sum)) {
         throw OpmInputError(fmt::format("The mole fractions of {} sum to {}, "
                                         "which is not a finite number.", what, sum),
@@ -66,22 +72,44 @@ void normalizeMoleFractions(std::vector<double>& fractions,
 
     const double deviation = std::abs(sum - 1.0);
 
-    if (deviation > moleFractionTolerance()) {
+    if (deviation > moleFractionTolerance) {
         throw OpmInputError(fmt::format("The mole fractions of {} sum to {}, "
                                         "which is not one.", what, sum),
                             location);
     }
 
-    if (deviation > exactSumSlack(fractions.size())) {
-        // Printed round-trip: a deviation small enough to round away at a
-        // fixed precision is exactly the one worth naming.
-        OpmLog::warning(fmt::format("The mole fractions of {} sum to {}: they should "
-                                    "sum to unity and have been normalized.", what, sum));
-    }
-
     for (auto& x : fractions) {
         x /= sum;
     }
+
+    // Do not warn about floating-point summation error.
+    if (deviation <= exactSumSlack(fractions.size())) {
+        return {};
+    }
+
+    return { sum };
+}
+
+void warnNormalizedMoleFractions(const std::string& what,
+                                 const double sum,
+                                 const std::size_t others,
+                                 const KeywordLocation& location)
+{
+    auto message = fmt::format("The mole fractions of {} sum to {}: they should "
+                               "sum to unity and have been normalized", what, sum);
+
+    if (others > 0) {
+        message += fmt::format(", as {} {} further composition{} in this keyword",
+                               (others == 1) ? "was" : "were",
+                               others,
+                               (others == 1) ? "" : "s");
+    }
+
+    message += '.';
+
+    // Format the fixed template separately because 'message' contains deck input.
+    OpmLog::warning(message +
+                    OpmInputError::format("\nIn {keyword} in {file} line {line}.", location));
 }
 
 } // namespace Opm

--- a/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.cpp
+++ b/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.cpp
@@ -1,0 +1,68 @@
+/*
+  Copyright 2026 SINTEF Digital
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp>
+
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
+
+#include <cmath>
+#include <limits>
+#include <numeric>
+
+#include <fmt/format.h>
+
+namespace Opm {
+
+double moleFractionTolerance()
+{
+    return 1.0e-4;
+}
+
+double exactSumSlack(const std::size_t numValues)
+{
+    return 2.0 * numValues * std::numeric_limits<double>::epsilon();
+}
+
+void normalizeMoleFractions(std::vector<double>& fractions,
+                            const std::string& what,
+                            const KeywordLocation& location)
+{
+    const double sum = std::accumulate(fractions.begin(), fractions.end(), 0.0);
+    const double deviation = std::abs(sum - 1.0);
+
+    if (deviation > moleFractionTolerance()) {
+        throw OpmInputError(fmt::format("The mole fractions of {} sum to {}, "
+                                        "which is not one.", what, sum),
+                            location);
+    }
+
+    if (deviation > exactSumSlack(fractions.size())) {
+        // Printed round-trip: a deviation small enough to round away at a
+        // fixed precision is exactly the one worth naming.
+        OpmLog::warning(fmt::format("The mole fractions of {} sum to {}: they should "
+                                    "sum to unity and have been normalized.", what, sum));
+    }
+
+    for (auto& x : fractions) {
+        x /= sum;
+    }
+}
+
+} // namespace Opm

--- a/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp
+++ b/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp
@@ -42,8 +42,8 @@ double exactSumSlack(std::size_t numValues);
 /// \param what  Names the input in the warning, e.g. "row 2 of COMPVD table 1"
 ///              or "stream 'ISTR'".
 ///
-/// \throw OpmInputError when the sum is too far from one to be the rounding of
-///        the values.
+/// \throw OpmInputError when a fraction is non-finite, or when the sum is too
+///        far from one to be the rounding of the values.
 void normalizeMoleFractions(std::vector<double>& fractions,
                             const std::string& what,
                             const KeywordLocation& location);

--- a/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp
+++ b/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp
@@ -42,8 +42,8 @@ double exactSumSlack(std::size_t numValues);
 /// \param what  Names the input in the warning, e.g. "row 2 of COMPVD table 1"
 ///              or "stream 'ISTR'".
 ///
-/// \throw OpmInputError when a fraction is non-finite, or when the sum is too
-///        far from one to be the rounding of the values.
+/// \throw OpmInputError when a fraction is negative or non-finite, or when the
+///        sum is too far from one to be the rounding of the values.
 void normalizeMoleFractions(std::vector<double>& fractions,
                             const std::string& what,
                             const KeywordLocation& location);

--- a/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp
+++ b/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp
@@ -1,0 +1,53 @@
+/*
+  Copyright 2026 SINTEF Digital
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_NORMALIZE_MOLE_FRACTIONS_HPP
+#define OPM_NORMALIZE_MOLE_FRACTIONS_HPP
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace Opm {
+
+class KeywordLocation;
+
+/// How far a set of mole fractions may sum away from one before it is
+/// rejected.  Writing a composition with a few digits costs this much.
+double moleFractionTolerance();
+
+/// Slack below which a sum counts as exactly one: summing n values of order
+/// one costs about n roundings, and representing them costs as many again.
+double exactSumSlack(std::size_t numValues);
+
+/// Scales \p fractions so that they sum to one, and says so when the scaling
+/// was more than the arithmetic of the sum.
+///
+/// \param what  Names the input in the warning, e.g. "row 2 of COMPVD table 1"
+///              or "stream 'ISTR'".
+///
+/// \throw OpmInputError when the sum is too far from one to be the rounding of
+///        the values.
+void normalizeMoleFractions(std::vector<double>& fractions,
+                            const std::string& what,
+                            const KeywordLocation& location);
+
+} // namespace Opm
+
+#endif // OPM_NORMALIZE_MOLE_FRACTIONS_HPP

--- a/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp
+++ b/opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp
@@ -21,6 +21,7 @@
 #define OPM_NORMALIZE_MOLE_FRACTIONS_HPP
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -28,25 +29,27 @@ namespace Opm {
 
 class KeywordLocation;
 
-/// How far a set of mole fractions may sum away from one before it is
-/// rejected.  Writing a composition with a few digits costs this much.
-double moleFractionTolerance();
-
-/// Slack below which a sum counts as exactly one: summing n values of order
-/// one costs about n roundings, and representing them costs as many again.
-double exactSumSlack(std::size_t numValues);
-
-/// Scales \p fractions so that they sum to one, and says so when the scaling
-/// was more than the arithmetic of the sum.
+/// Scales finite, non-negative \p fractions to sum to one.
 ///
-/// \param what  Names the input in the warning, e.g. "row 2 of COMPVD table 1"
-///              or "stream 'ISTR'".
+/// Accepts sums near one and rejects larger deviations.
 ///
-/// \throw OpmInputError when a fraction is negative or non-finite, or when the
-///        sum is too far from one to be the rounding of the values.
-void normalizeMoleFractions(std::vector<double>& fractions,
-                            const std::string& what,
-                            const KeywordLocation& location);
+/// \param what Names the composition in diagnostics.
+///
+/// \return The original sum when normalization should be reported; otherwise
+///         std::nullopt.  Does not log, so callers can report once per table
+///         via warnNormalizedMoleFractions().
+///
+/// \throw OpmInputError for invalid fractions or an out-of-tolerance sum.
+std::optional<double> normalizeMoleFractions(std::vector<double>& fractions,
+                                             const std::string& what,
+                                             const KeywordLocation& location);
+
+/// Warns that one or more compositions were normalized.
+/// \param others Number of additional normalized compositions.
+void warnNormalizedMoleFractions(const std::string& what,
+                                 double sum,
+                                 std::size_t others,
+                                 const KeywordLocation& location);
 
 } // namespace Opm
 

--- a/opm/input/eclipse/EclipseState/Tables/Tables.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Tables.cpp
@@ -23,6 +23,8 @@
 #include <opm/input/eclipse/EclipseState/Tables/TableColumn.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableSchema.hpp>
 
+#include <opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp>
+
 #include <opm/input/eclipse/EclipseState/Tables/AqutabTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/BiofilmTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/CompvdTable.hpp>
@@ -95,8 +97,6 @@
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 #include <opm/input/eclipse/Units/Units.hpp>
 
-#include <opm/common/OpmLog/OpmLog.hpp>
-#include <opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
@@ -116,8 +116,7 @@
 #include <cstddef>
 #include <functional>
 #include <initializer_list>
-#include <limits>
-#include <numeric>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -2888,6 +2887,39 @@ template FlatTable<TlmixparRecord>::FlatTable(const DeckKeyword&);
 template FlatTable<VISCREFRecord>::FlatTable(const DeckKeyword&);
 template FlatTable<WATDENTRecord>::FlatTable(const DeckKeyword&);
 
+namespace {
+
+/// Collects normalized rows so each table emits one warning.
+struct NormalizedRows
+{
+    void add(const std::size_t row, const double sum)
+    {
+        if (count++ == 0) {
+            firstRow = row;
+            firstSum = sum;
+        }
+    }
+
+    void report(const std::string& tableName,
+                const int tableID,
+                const KeywordLocation& location) const
+    {
+        if (count == 0) {
+            return;
+        }
+
+        warnNormalizedMoleFractions(fmt::format("row {} of {} table {}",
+                                                firstRow, tableName, tableID + 1),
+                                    firstSum, count - 1, location);
+    }
+
+    std::size_t count{0};
+    std::size_t firstRow{0};
+    double firstSum{0.0};
+};
+
+} // Anonymous namespace
+
 ZmfvdTable::ZmfvdTable(const DeckItem& item, const int tableID, const int numComponents, const KeywordLocation& location)
 {
     m_schema.addColumn(ColumnSchema("DEPTH", Table::STRICTLY_INCREASING, Table::DEFAULT_NONE));
@@ -2910,6 +2942,7 @@ ZmfvdTable::ZmfvdTable(const DeckItem& item, const int tableID, const int numCom
 
     const std::string tableName {"ZMFVD"};
     std::vector<double> moles(numComponents, 0.);
+    NormalizedRows normalized{};
     for (std::size_t row = 0; row < nrows; ++row) {
         // Depth column
         const std::size_t depthIdx = row * ncol;
@@ -2922,14 +2955,19 @@ ZmfvdTable::ZmfvdTable(const DeckItem& item, const int tableID, const int numCom
             moles[c] = item.get<double>(compIdx);
         }
 
-        // Normalize, so the rounding never reaches the equilibration.
-        normalizeMoleFractions(moles,
-                               fmt::format("row {} of ZMFVD table {}", row + 1, tableID + 1),
-                               location);
+        if (const auto sum = normalizeMoleFractions(moles,
+                                                    fmt::format("row {} of {} table {}",
+                                                                row + 1, tableName, tableID + 1),
+                                                    location)) {
+            normalized.add(row + 1, *sum);
+        }
+
         for (int c = 0; c < numComponents; ++c) {
             getColumn(1 + c).addValue(moles[c], tableName);
         }
     }
+
+    normalized.report(tableName, tableID, location);
 }
 
 const TableColumn&
@@ -2988,6 +3026,7 @@ CompvdTable::CompvdTable(const DeckItem& item,
 
     const std::string tableName{"COMPVD"};
     std::vector<double> moles(numComponents, 0.0);
+    NormalizedRows normalized{};
     for (std::size_t row = 0; row < nrows; ++row) {
         const std::size_t rowStart = row * ncol;
 
@@ -3000,10 +3039,13 @@ CompvdTable::CompvdTable(const DeckItem& item,
             moles[c] = data.at(rowStart + 1 + c);
         }
 
-        // Normalize, so the rounding never reaches the equilibration.
-        normalizeMoleFractions(moles,
-                               fmt::format("row {} of COMPVD table {}", row + 1, tableID + 1),
-                               location);
+        if (const auto sum = normalizeMoleFractions(moles,
+                                                    fmt::format("row {} of {} table {}",
+                                                                row + 1, tableName, tableID + 1),
+                                                    location)) {
+            normalized.add(row + 1, *sum);
+        }
+
         for (int c = 0; c < numComponents; ++c) {
             getColumn(1 + c).addValue(moles[c], tableName);
         }
@@ -3022,6 +3064,8 @@ CompvdTable::CompvdTable(const DeckItem& item,
         const double siPsat = unitSystem.to_si(UnitSystem::measure::pressure, data.at(rowStart + 2 + numComponents));
         getColumn(1 + numComponents).addValue(siPsat, tableName);
     }
+
+    normalized.report(tableName, tableID, location);
 }
 
 const TableColumn&

--- a/opm/input/eclipse/EclipseState/Tables/Tables.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Tables.cpp
@@ -95,6 +95,8 @@
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 #include <opm/input/eclipse/Units/Units.hpp>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
@@ -114,6 +116,7 @@
 #include <cstddef>
 #include <functional>
 #include <initializer_list>
+#include <limits>
 #include <numeric>
 #include <stdexcept>
 #include <string>
@@ -2906,27 +2909,25 @@ ZmfvdTable::ZmfvdTable(const DeckItem& item, const int tableID, const int numCom
     const auto nrows = item.data_size() / ncol;
 
     const std::string tableName {"ZMFVD"};
+    std::vector<double> moles(numComponents, 0.);
     for (std::size_t row = 0; row < nrows; ++row) {
         // Depth column
         const std::size_t depthIdx = row * ncol;
         const double siDepth = item.getSIDouble(depthIdx);
         getColumn(0).addValue(siDepth, tableName);
 
-        std::vector<double> moles(numComponents, 0.);
         // Component mole-fraction columns (dimensionless)
         for (int c = 0; c < numComponents; ++c) {
             const std::size_t compIdx = row * ncol + 1 + c;
-            const auto mole_fraction = item.get<double>(compIdx);
-            moles[c] = mole_fraction;
-            getColumn(1 + c).addValue(mole_fraction, tableName);
+            moles[c] = item.get<double>(compIdx);
         }
-        // checking to make sure the sum of the mole fractions are 1.
-        constexpr double epsilon = 1.e-5;
-        const double sum_fractions = std::accumulate(moles.begin(), moles.end(), 0.);
-        if (std::abs(sum_fractions - 1.) > epsilon) {
-            const std::string reason = fmt::format("ZMFVD table {}: sum of mole fractions in row {} is not 1 (sum is {})",
-                            tableID + 1, row + 1, sum_fractions);
-            throw OpmInputError(reason, location);
+
+        // Normalize, so the rounding never reaches the equilibration.
+        normalizeMoleFractions(moles,
+                               fmt::format("row {} of ZMFVD table {}", row + 1, tableID + 1),
+                               location);
+        for (int c = 0; c < numComponents; ++c) {
+            getColumn(1 + c).addValue(moles[c], tableName);
         }
     }
 }
@@ -2986,6 +2987,7 @@ CompvdTable::CompvdTable(const DeckItem& item,
     const auto& data = item.getData<double>();
 
     const std::string tableName{"COMPVD"};
+    std::vector<double> moles(numComponents, 0.0);
     for (std::size_t row = 0; row < nrows; ++row) {
         const std::size_t rowStart = row * ncol;
 
@@ -2994,21 +2996,16 @@ CompvdTable::CompvdTable(const DeckItem& item,
         getColumn(0).addValue(siDepth, tableName);
 
         // Component mole-fraction columns (dimensionless).
-        std::vector<double> moles(numComponents, 0.0);
         for (int c = 0; c < numComponents; ++c) {
-            const auto z = data.at(rowStart + 1 + c);
-            moles[c] = z;
-            getColumn(1 + c).addValue(z, tableName);
+            moles[c] = data.at(rowStart + 1 + c);
         }
 
-        // Sum-to-one check, same epsilon is used in ZMFVD
-        constexpr double epsilon = 1.e-5;
-        const double sum_fractions = std::accumulate(moles.begin(), moles.end(), 0.);
-        if (std::abs(sum_fractions - 1.) > epsilon) {
-            const std::string reason = fmt::format(
-                "COMPVD table {}: sum of mole fractions in row {} is not 1 (sum is {})",
-                tableID + 1, row + 1, sum_fractions);
-            throw OpmInputError(reason, location);
+        // Normalize, so the rounding never reaches the equilibration.
+        normalizeMoleFractions(moles,
+                               fmt::format("row {} of COMPVD table {}", row + 1, tableID + 1),
+                               location);
+        for (int c = 0; c < numComponents; ++c) {
+            getColumn(1 + c).addValue(moles[c], tableName);
         }
 
         // Phase flag: stored as a strong enum, validated to be exactly 0 or 1.

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -23,6 +23,7 @@
 #include <opm/common/utility/OpmInputError.hpp>
 #include <opm/common/utility/String.hpp>
 
+#include <opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
 #include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
@@ -36,7 +37,6 @@
 #include <opm/input/eclipse/Schedule/Well/WListManager.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPDP.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>
-#include <opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp>
@@ -63,7 +63,7 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
-#include <numeric>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -477,13 +477,13 @@ void handleWELLSTRE(HandlerContext& handlerContext)
             throw OpmInputError(msg, handlerContext.keyword.location());
         }
 
-        // A composition written with a few digits does not sum to one
-        // exactly; scale it rather than reject the deck over the rounding.
-        normalizeMoleFractions(composition,
-                               fmt::format("stream '{}'", stream_name),
-                               handlerContext.keyword.location());
+        const auto what = fmt::format("stream '{}'", stream_name);
+        if (const auto sum = normalizeMoleFractions(composition, what,
+                                                    handlerContext.keyword.location())) {
+            warnNormalizedMoleFractions(what, *sum, 0, handlerContext.keyword.location());
+        }
 
-        auto composition_ptr = std::make_shared<std::vector<double>>(composition);
+        auto composition_ptr = std::make_shared<std::vector<double>>(std::move(composition));
         inj_streams.update(stream_name, std::move(composition_ptr));
     }
 

--- a/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -36,6 +36,7 @@
 #include <opm/input/eclipse/Schedule/Well/WListManager.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPDP.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>
+#include <opm/input/eclipse/EclipseState/Compositional/NormalizeMoleFractions.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp>
@@ -469,18 +470,19 @@ void handleWELLSTRE(HandlerContext& handlerContext)
     auto& inj_streams = handlerContext.state().inj_streams;
     for (const auto& record : handlerContext.keyword) {
         const auto stream_name = record.getItem<ParserKeywords::WELLSTRE::STREAM>().getTrimmedString(0);
-        const auto& composition = record.getItem<ParserKeywords::WELLSTRE::COMPOSITIONS>().getSIDoubleData();
+        auto composition = record.getItem<ParserKeywords::WELLSTRE::COMPOSITIONS>().getSIDoubleData();
         const std::size_t num_comps = handlerContext.static_schedule().m_runspec.numComps();
         if (composition.size() != num_comps) {
             const std::string msg = fmt::format("The number of the composition values for stream '{}' is not the same as the number of components.", stream_name);
             throw OpmInputError(msg, handlerContext.keyword.location());
         }
 
-        const double sum = std::accumulate(composition.begin(), composition.end(), 0.0);
-        if (std::abs(sum - 1.0) > std::numeric_limits<double>::epsilon()) {
-            const std::string msg = fmt::format("The sum of the composition values for stream '{}' is not 1.0, but {}.", stream_name, sum);
-            throw OpmInputError(msg, handlerContext.keyword.location());
-        }
+        // A composition written with a few digits does not sum to one
+        // exactly; scale it rather than reject the deck over the rounding.
+        normalizeMoleFractions(composition,
+                               fmt::format("stream '{}'", stream_name),
+                               handlerContext.keyword.location());
+
         auto composition_ptr = std::make_shared<std::vector<double>>(composition);
         inj_streams.update(stream_name, std::move(composition_ptr));
     }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -5286,6 +5286,47 @@ SCHEDULE
     }
 }
 
+BOOST_AUTO_TEST_CASE(WELLSTRE_rounded_composition_is_normalized) {
+    // An injection stream written with a few digits sums to 0.999968 rather
+    // than one.  It is accepted, scaled, and reaches the well through WINJGAS
+    // with its ratios intact.
+    const auto sched = make_schedule(gptable_deck(R"(
+WELSPECS
+ 'INJ' 'G1' 1 1 2000 'GAS' /
+/
+WELLSTRE
+ 'STR1' 0.749520 0.240448 0.010000 /
+/
+WINJGAS
+ 'INJ' 'STREAM' 'STR1' /
+/
+WCONINJE
+ 'INJ' 'GAS' 'OPEN' 'RATE' 100 /
+/
+TSTEP
+ 1 /
+)"));
+
+    const auto& composition = sched.getWell("INJ", 0).getInjectionProperties().gasInjComposition();
+    BOOST_REQUIRE_EQUAL(composition.size(), std::size_t{3});
+
+    const double sum = std::accumulate(composition.begin(), composition.end(), 0.0);
+    BOOST_CHECK_CLOSE(sum, 1.0, 1.0e-12);
+
+    // Scaling preserves the ratios of the stream.
+    BOOST_CHECK_CLOSE(composition[0] / composition[1], 0.749520 / 0.240448, 1.0e-10);
+    BOOST_CHECK_CLOSE(composition[0], 0.749520 / 0.999968, 1.0e-10);
+}
+
+BOOST_AUTO_TEST_CASE(WELLSTRE_composition_far_from_one_is_rejected) {
+    // A sum too far from one to be the rounding of the values is still an error.
+    BOOST_CHECK_THROW(make_schedule(gptable_deck(R"(
+WELLSTRE
+ 'STR1' 0.70 0.20 0.05 /
+/
+)")), Opm::OpmInputError);
+}
+
 BOOST_AUTO_TEST_CASE(GPTABLE_solution_seed_and_schedule_respec) {
     const auto sched = make_schedule(R"(
 RUNSPEC

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -5327,6 +5327,23 @@ WELLSTRE
 )")), Opm::OpmInputError);
 }
 
+BOOST_AUTO_TEST_CASE(WELLSTRE_negative_composition_is_rejected) {
+    // Relaxing the sum tolerance must not admit a negative component: the sum
+    // is 0.99995, well inside the tolerance.
+    BOOST_CHECK_THROW(make_schedule(gptable_deck(R"(
+WELLSTRE
+ 'STR1' 0.75 0.25 -0.00005 /
+/
+)")), Opm::OpmInputError);
+
+    // Individual values must also be checked when their sum is exactly one.
+    BOOST_CHECK_THROW(make_schedule(gptable_deck(R"(
+WELLSTRE
+ 'STR1' 0.75 0.35 -0.10 /
+/
+)")), Opm::OpmInputError);
+}
+
 BOOST_AUTO_TEST_CASE(GPTABLE_solution_seed_and_schedule_respec) {
     const auto sched = make_schedule(R"(
 RUNSPEC

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -30,6 +30,8 @@
 
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
 #include <opm/common/utility/ActiveGridCells.hpp>
 #include <opm/common/utility/TimeService.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
@@ -90,6 +92,8 @@
 #include <cstddef>
 #include <fstream>
 #include <memory>
+#include <numeric>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -5287,9 +5291,6 @@ SCHEDULE
 }
 
 BOOST_AUTO_TEST_CASE(WELLSTRE_rounded_composition_is_normalized) {
-    // An injection stream written with a few digits sums to 0.999968 rather
-    // than one.  It is accepted, scaled, and reaches the well through WINJGAS
-    // with its ratios intact.
     const auto sched = make_schedule(gptable_deck(R"(
 WELSPECS
  'INJ' 'G1' 1 1 2000 'GAS' /
@@ -5313,13 +5314,43 @@ TSTEP
     const double sum = std::accumulate(composition.begin(), composition.end(), 0.0);
     BOOST_CHECK_CLOSE(sum, 1.0, 1.0e-12);
 
-    // Scaling preserves the ratios of the stream.
     BOOST_CHECK_CLOSE(composition[0] / composition[1], 0.749520 / 0.240448, 1.0e-10);
     BOOST_CHECK_CLOSE(composition[0], 0.749520 / 0.999968, 1.0e-10);
 }
 
+BOOST_AUTO_TEST_CASE(WELLSTRE_normalization_is_reported) {
+    const auto deckString = gptable_deck(R"(
+WELLSTRE
+ 'STR1' 0.749520 0.240448 0.010000 /
+/
+TSTEP
+ 1 /
+)");
+
+    std::ostringstream warnings;
+    Opm::OpmLog::addBackend("STREAM",
+                            std::make_shared<Opm::StreamLog>(warnings, Opm::Log::MessageType::Warning));
+
+    try {
+        const auto sched = make_schedule(deckString);
+    }
+    catch (...) {
+        // Avoid leaving a backend that references 'warnings'.
+        Opm::OpmLog::removeBackend("STREAM");
+        throw;
+    }
+
+    Opm::OpmLog::removeBackend("STREAM");
+
+    const std::string text = warnings.str();
+    BOOST_CHECK(text.find("stream 'STR1'") != std::string::npos);
+    BOOST_CHECK(text.find("0.999968") != std::string::npos);
+    BOOST_CHECK(text.find("normalized") != std::string::npos);
+    BOOST_CHECK(text.find("WELLSTRE") != std::string::npos);
+    BOOST_CHECK(text.find("line") != std::string::npos);
+}
+
 BOOST_AUTO_TEST_CASE(WELLSTRE_composition_far_from_one_is_rejected) {
-    // A sum too far from one to be the rounding of the values is still an error.
     BOOST_CHECK_THROW(make_schedule(gptable_deck(R"(
 WELLSTRE
  'STR1' 0.70 0.20 0.05 /
@@ -5328,15 +5359,14 @@ WELLSTRE
 }
 
 BOOST_AUTO_TEST_CASE(WELLSTRE_negative_composition_is_rejected) {
-    // Relaxing the sum tolerance must not admit a negative component: the sum
-    // is 0.99995, well inside the tolerance.
+    // Negative fraction with an otherwise acceptable sum.
     BOOST_CHECK_THROW(make_schedule(gptable_deck(R"(
 WELLSTRE
  'STR1' 0.75 0.25 -0.00005 /
 /
 )")), Opm::OpmInputError);
 
-    // Individual values must also be checked when their sum is exactly one.
+    // Negative fraction whose total is exactly one.
     BOOST_CHECK_THROW(make_schedule(gptable_deck(R"(
 WELLSTRE
  'STR1' 0.75 0.35 -0.10 /

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -3571,6 +3571,30 @@ END
     BOOST_CHECK_THROW(Opm::TableManager{ deck }, Opm::OpmInputError);
 }
 
+BOOST_AUTO_TEST_CASE(ZmfvdTable_NegativeMoleFractionIsRejected) {
+    const auto make_table_manager = [](const std::string& composition) {
+        const auto deck = Opm::Parser{}.parseString(std::string{R"(
+RUNSPEC
+METRIC
+COMPS
+2 /
+EQLDIMS
+1 /
+PROPS
+ZMFVD
+  100.0 )"} + composition + R"( /
+END
+)");
+        return Opm::TableManager{ deck };
+    };
+
+    // Relaxing the sum tolerance must not admit an invalid component.
+    BOOST_CHECK_THROW(make_table_manager("-0.00005 1.0"), Opm::OpmInputError);
+
+    // Individual values must also be checked when their sum is exactly one.
+    BOOST_CHECK_THROW(make_table_manager("-0.1 1.1"), Opm::OpmInputError);
+}
+
 BOOST_AUTO_TEST_CASE(CompvdTable_MoleFractionsMustSumToOne) {
     const auto deck = Opm::Parser{}.parseString(R"(
 RUNSPEC

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -3550,6 +3550,27 @@ END
     BOOST_CHECK_CLOSE(sum, 1.0, 1.0e-12);
 }
 
+BOOST_AUTO_TEST_CASE(ZmfvdTable_NonFiniteMoleFractionIsRejected) {
+    // NaN is an acceptable floating-point token to the parser.  It must not
+    // reach the normalization: a NaN sum makes every tolerance comparison
+    // false, so an unguarded helper would divide the row through by it and
+    // store a composition of NaNs.
+    const auto deck = Opm::Parser{}.parseString(R"(
+RUNSPEC
+METRIC
+COMPS
+2 /
+EQLDIMS
+1 /
+PROPS
+ZMFVD
+  100.0  NaN  0.5 /
+END
+)");
+
+    BOOST_CHECK_THROW(Opm::TableManager{ deck }, Opm::OpmInputError);
+}
+
 BOOST_AUTO_TEST_CASE(CompvdTable_MoleFractionsMustSumToOne) {
     const auto deck = Opm::Parser{}.parseString(R"(
 RUNSPEC

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -25,7 +25,7 @@
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/StreamLog.hpp>
-#include <sstream>
+
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
 
@@ -67,6 +67,8 @@
 
 #include <cstddef>
 #include <iostream>
+#include <memory>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -3423,9 +3425,34 @@ END
 }
 
 
-BOOST_AUTO_TEST_CASE(CompvdTable_NormalizationIsReported) {
-    // The row that was scaled must be named, with the sum it had before.
-    const auto deck = Opm::Parser{}.parseString(R"(
+namespace {
+
+    std::string warningsFromTables(const std::string& deckString)
+    {
+        const auto deck = Opm::Parser{}.parseString(deckString);
+
+        std::ostringstream warnings;
+        Opm::OpmLog::addBackend("STREAM",
+                                std::make_shared<Opm::StreamLog>(warnings, Opm::Log::MessageType::Warning));
+
+        try {
+            const auto tmgr = Opm::TableManager{ deck };
+        }
+        catch (...) {
+            // Avoid leaving a backend that references 'warnings'.
+            Opm::OpmLog::removeBackend("STREAM");
+            throw;
+        }
+
+        Opm::OpmLog::removeBackend("STREAM");
+
+        return warnings.str();
+    }
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(CompvdTable_RoundedCompositionIsNormalizedAndReported) {
+    const std::string deckString = R"(
 RUNSPEC
 METRIC
 COMPS
@@ -3436,23 +3463,91 @@ PROPS
 COMPVD
   2573.5  0.73779563 0.04261 0.122439 0.04501 0.04351 0.007502 0.0011211  0  277.56 /
 END
-)");
+)";
 
-    std::ostringstream warnings;
-    Opm::OpmLog::addBackend("STREAM",
-                            std::make_shared<Opm::StreamLog>(warnings, Opm::Log::MessageType::Warning));
+    const auto deck = Opm::Parser{}.parseString(deckString);
     const auto tmgr = Opm::TableManager{ deck };
-    Opm::OpmLog::removeBackend("STREAM");
+    const auto& compvd = tmgr.getCompvdTables();
+    BOOST_REQUIRE_EQUAL(compvd.size(), std::size_t{1});
 
-    const std::string text = warnings.str();
+    const auto& table = compvd.getTable<Opm::CompvdTable>(0);
+    double sum = 0.0;
+    for (int c = 0; c < 7; ++c) {
+        sum += table.getMoleFractionColumn(c)[0];
+    }
+    BOOST_CHECK_CLOSE(sum, 1.0, 1.0e-12);
+
+    BOOST_CHECK_CLOSE(table.getMoleFractionColumn(0)[0] / table.getMoleFractionColumn(1)[0],
+                      0.73779563 / 0.04261, 1.0e-10);
+
+    const std::string text = warningsFromTables(deckString);
     BOOST_CHECK(text.find("row 1 of COMPVD table 1") != std::string::npos);
     BOOST_CHECK(text.find("0.99998") != std::string::npos);
     BOOST_CHECK(text.find("normalized") != std::string::npos);
+    BOOST_CHECK(text.find("COMPVD") != std::string::npos);
+    BOOST_CHECK(text.find("line") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(ZmfvdTable_ManyRoundedRowsAreReportedOnce) {
+    const std::string text = warningsFromTables(R"(
+RUNSPEC
+METRIC
+COMPS
+3 /
+EQLDIMS
+1 /
+PROPS
+ZMFVD
+  2000.0  0.30001 0.29999 0.39998
+  2100.0  0.31001 0.28999 0.39998
+  2200.0  0.32001 0.27999 0.39998
+  2300.0  0.33001 0.26999 0.39998 /
+END
+)");
+
+    const auto occurrences =
+        [&text](const std::string& needle)
+        {
+            std::size_t n = 0;
+            for (auto at = text.find(needle); at != std::string::npos; at = text.find(needle, at + 1)) {
+                ++n;
+            }
+            return n;
+        };
+
+    BOOST_CHECK_EQUAL(occurrences("normalized"), std::size_t{1});
+    BOOST_CHECK(text.find("row 1 of ZMFVD table 1") != std::string::npos);
+    BOOST_CHECK(text.find("3 further compositions") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(MoleFractionToleranceBoundary) {
+    // Deviations of 9e-5 and 2e-4, either side of the tolerance.
+    const auto zmfvd =
+        [](const std::string& composition)
+        {
+            return std::string{R"(
+RUNSPEC
+METRIC
+COMPS
+2 /
+EQLDIMS
+1 /
+PROPS
+ZMFVD
+  2000.0 )"} + composition + R"( /
+END
+)";
+        };
+
+    BOOST_CHECK_NO_THROW(Opm::TableManager{ Opm::Parser{}.parseString(zmfvd("0.49995 0.49996")) });
+    BOOST_CHECK(warningsFromTables(zmfvd("0.49995 0.49996")).find("normalized") != std::string::npos);
+
+    BOOST_CHECK_THROW(Opm::TableManager{ Opm::Parser{}.parseString(zmfvd("0.4999 0.4999")) },
+                      Opm::OpmInputError);
 }
 
 BOOST_AUTO_TEST_CASE(ZmfvdTable_ExactRowIsNotReported) {
-    // A row that already sums to one is scaled by one, and says nothing.
-    const auto deck = Opm::Parser{}.parseString(R"(
+    BOOST_CHECK(warningsFromTables(R"(
 RUNSPEC
 METRIC
 COMPS
@@ -3463,19 +3558,10 @@ PROPS
 ZMFVD
   2000.0  0.3 0.3 0.4 /
 END
-)");
-
-    std::ostringstream warnings;
-    Opm::OpmLog::addBackend("STREAM",
-                            std::make_shared<Opm::StreamLog>(warnings, Opm::Log::MessageType::Warning));
-    const auto tmgr = Opm::TableManager{ deck };
-    Opm::OpmLog::removeBackend("STREAM");
-
-    BOOST_CHECK(warnings.str().find("normalized") == std::string::npos);
+)").find("normalized") == std::string::npos);
 }
 
 BOOST_AUTO_TEST_CASE(ZmfvdTable_TooFarFromOneIsRejected) {
-    // A row that misses one by more than rounding is still an error.
     const auto deck = Opm::Parser{}.parseString(R"(
 RUNSPEC
 METRIC
@@ -3490,39 +3576,6 @@ END
 )");
 
     BOOST_CHECK_THROW(Opm::TableManager{ deck }, Opm::OpmInputError);
-}
-
-BOOST_AUTO_TEST_CASE(CompvdTable_RoundedCompositionIsNormalized) {
-    // A lumped characterization quoted to a handful of digits sums to one only
-    // to within its rounding; the row is accepted and stored normalized.  This
-    // row is taken from a customer deck and sums to 0.99998773.
-    const auto deck = Opm::Parser{}.parseString(R"(
-RUNSPEC
-METRIC
-COMPS
-7 /
-EQLDIMS
-1 /
-PROPS
-COMPVD
-  2573.5  0.73779563 0.04261 0.122439 0.04501 0.04351 0.007502 0.0011211  0  277.56 /
-END
-)");
-
-    const auto tmgr = Opm::TableManager{ deck };
-    const auto& compvd = tmgr.getCompvdTables();
-    BOOST_REQUIRE_EQUAL(compvd.size(), std::size_t{1});
-
-    const auto& table = compvd.getTable<Opm::CompvdTable>(0);
-    double sum = 0.0;
-    for (int c = 0; c < 7; ++c) {
-        sum += table.getMoleFractionColumn(c)[0];
-    }
-    BOOST_CHECK_CLOSE(sum, 1.0, 1.0e-12);
-
-    // The normalization is a rescaling, so the component ratios are untouched.
-    BOOST_CHECK_CLOSE(table.getMoleFractionColumn(0)[0] / table.getMoleFractionColumn(1)[0],
-                      0.73779563 / 0.04261, 1.0e-10);
 }
 
 BOOST_AUTO_TEST_CASE(ZmfvdTable_RoundedCompositionIsNormalized) {
@@ -3551,10 +3604,7 @@ END
 }
 
 BOOST_AUTO_TEST_CASE(ZmfvdTable_NonFiniteMoleFractionIsRejected) {
-    // NaN is an acceptable floating-point token to the parser.  It must not
-    // reach the normalization: a NaN sum makes every tolerance comparison
-    // false, so an unguarded helper would divide the row through by it and
-    // store a composition of NaNs.
+    // The parser accepts NaN as a floating-point token.
     const auto deck = Opm::Parser{}.parseString(R"(
 RUNSPEC
 METRIC
@@ -3588,10 +3638,10 @@ END
         return Opm::TableManager{ deck };
     };
 
-    // Relaxing the sum tolerance must not admit an invalid component.
+    // Negative fraction with an otherwise acceptable sum.
     BOOST_CHECK_THROW(make_table_manager("-0.00005 1.0"), Opm::OpmInputError);
 
-    // Individual values must also be checked when their sum is exactly one.
+    // Negative fraction whose total is exactly one.
     BOOST_CHECK_THROW(make_table_manager("-0.1 1.1"), Opm::OpmInputError);
 }
 

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -23,6 +23,9 @@
 
 #include <opm/common/utility/OpmInputError.hpp>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
+#include <sstream>
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
 
@@ -3419,6 +3422,133 @@ END
     BOOST_CHECK_THROW(Opm::TableManager{ deck }, Opm::OpmInputError);
 }
 
+
+BOOST_AUTO_TEST_CASE(CompvdTable_NormalizationIsReported) {
+    // The row that was scaled must be named, with the sum it had before.
+    const auto deck = Opm::Parser{}.parseString(R"(
+RUNSPEC
+METRIC
+COMPS
+7 /
+EQLDIMS
+1 /
+PROPS
+COMPVD
+  2573.5  0.73779563 0.04261 0.122439 0.04501 0.04351 0.007502 0.0011211  0  277.56 /
+END
+)");
+
+    std::ostringstream warnings;
+    Opm::OpmLog::addBackend("STREAM",
+                            std::make_shared<Opm::StreamLog>(warnings, Opm::Log::MessageType::Warning));
+    const auto tmgr = Opm::TableManager{ deck };
+    Opm::OpmLog::removeBackend("STREAM");
+
+    const std::string text = warnings.str();
+    BOOST_CHECK(text.find("row 1 of COMPVD table 1") != std::string::npos);
+    BOOST_CHECK(text.find("0.99998") != std::string::npos);
+    BOOST_CHECK(text.find("normalized") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(ZmfvdTable_ExactRowIsNotReported) {
+    // A row that already sums to one is scaled by one, and says nothing.
+    const auto deck = Opm::Parser{}.parseString(R"(
+RUNSPEC
+METRIC
+COMPS
+3 /
+EQLDIMS
+1 /
+PROPS
+ZMFVD
+  2000.0  0.3 0.3 0.4 /
+END
+)");
+
+    std::ostringstream warnings;
+    Opm::OpmLog::addBackend("STREAM",
+                            std::make_shared<Opm::StreamLog>(warnings, Opm::Log::MessageType::Warning));
+    const auto tmgr = Opm::TableManager{ deck };
+    Opm::OpmLog::removeBackend("STREAM");
+
+    BOOST_CHECK(warnings.str().find("normalized") == std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(ZmfvdTable_TooFarFromOneIsRejected) {
+    // A row that misses one by more than rounding is still an error.
+    const auto deck = Opm::Parser{}.parseString(R"(
+RUNSPEC
+METRIC
+COMPS
+3 /
+EQLDIMS
+1 /
+PROPS
+ZMFVD
+  2000.0  0.30 0.30 0.35 /
+END
+)");
+
+    BOOST_CHECK_THROW(Opm::TableManager{ deck }, Opm::OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(CompvdTable_RoundedCompositionIsNormalized) {
+    // A lumped characterization quoted to a handful of digits sums to one only
+    // to within its rounding; the row is accepted and stored normalized.  This
+    // row is taken from a customer deck and sums to 0.99998773.
+    const auto deck = Opm::Parser{}.parseString(R"(
+RUNSPEC
+METRIC
+COMPS
+7 /
+EQLDIMS
+1 /
+PROPS
+COMPVD
+  2573.5  0.73779563 0.04261 0.122439 0.04501 0.04351 0.007502 0.0011211  0  277.56 /
+END
+)");
+
+    const auto tmgr = Opm::TableManager{ deck };
+    const auto& compvd = tmgr.getCompvdTables();
+    BOOST_REQUIRE_EQUAL(compvd.size(), std::size_t{1});
+
+    const auto& table = compvd.getTable<Opm::CompvdTable>(0);
+    double sum = 0.0;
+    for (int c = 0; c < 7; ++c) {
+        sum += table.getMoleFractionColumn(c)[0];
+    }
+    BOOST_CHECK_CLOSE(sum, 1.0, 1.0e-12);
+
+    // The normalization is a rescaling, so the component ratios are untouched.
+    BOOST_CHECK_CLOSE(table.getMoleFractionColumn(0)[0] / table.getMoleFractionColumn(1)[0],
+                      0.73779563 / 0.04261, 1.0e-10);
+}
+
+BOOST_AUTO_TEST_CASE(ZmfvdTable_RoundedCompositionIsNormalized) {
+    const auto deck = Opm::Parser{}.parseString(R"(
+RUNSPEC
+METRIC
+COMPS
+3 /
+EQLDIMS
+1 /
+PROPS
+ZMFVD
+  2000.0  0.30001 0.29999 0.39998 /
+END
+)");
+
+    const auto tmgr = Opm::TableManager{ deck };
+    const auto& zmfvd = tmgr.getZmfvdTables();
+    const auto& table = zmfvd.getTable<Opm::ZmfvdTable>(0);
+
+    double sum = 0.0;
+    for (int c = 0; c < 3; ++c) {
+        sum += table.getMoleFractionColumn(c)[0];
+    }
+    BOOST_CHECK_CLOSE(sum, 1.0, 1.0e-12);
+}
 
 BOOST_AUTO_TEST_CASE(CompvdTable_MoleFractionsMustSumToOne) {
     const auto deck = Opm::Parser{}.parseString(R"(


### PR DESCRIPTION
A row summing to 0.999968 is rejected by flow but accepted by other simulators, so decks that run elsewhere stop here. ZMFVD and COMPVD rejected anything past 1e-5, and WELLSTRE anything past one machine epsilon, which is below the noise of adding the values up.

They now share one tolerance: a composition is accepted when the deviation is small, scaled to sum to one, and reported in a warning, as the other simulators do. A deviation too large to be rounding is still an error.