### PR TITLE
[LGR] Restart records follow-up: count tracer components by solution-tracer support

### DIFF
--- a/opm/output/eclipse/AggregateWellData.cpp
+++ b/opm/output/eclipse/AggregateWellData.cpp
@@ -705,6 +705,18 @@ namespace {
         }
     } // IWell
 
+    // A hydrocarbon tracer carries a dissolved/vaporised solution
+    // component only when the run supports the corresponding solution
+    // tracer; the free component always exists.  Water and temperature
+    // tracers have a single component.
+    template <typename TracerEntry>
+    bool tracerHasSolutionPart(const TracerEntry& tracer,
+                               const Opm::TracerConfig& tracers)
+    {
+        return ((tracer.phase == Opm::Phase::GAS) && tracers.supportsSolutionGasTracer())
+            || ((tracer.phase == Opm::Phase::OIL) && tracers.supportsVaporisedOilTracer());
+    }
+
     namespace SWell {
         std::size_t entriesPerWell(const std::vector<int>& inteHead)
         {
@@ -1200,8 +1212,10 @@ namespace {
                 } else {
                     sWell[output_index++] =
                         smry.get_well_var(wname, fmt::format("WTICF{}", tracer.name), 0.0);
-                    sWell[output_index++] =
-                        smry.get_well_var(wname, fmt::format("WTICS{}", tracer.name), 0.0);
+                    if (tracerHasSolutionPart(tracer, tracers)) {
+                        sWell[output_index++] =
+                            smry.get_well_var(wname, fmt::format("WTICS{}", tracer.name), 0.0);
+                    }
                 }
             }
         }
@@ -1467,7 +1481,9 @@ namespace {
                     ix += processWaterTracer(tracer, &xWell[ix]);
                 }
                 else {
-                    ix += processHCTracer(tracer, &xWell[ix]);
+                    ix += processHCTracer(tracer,
+                                          tracerHasSolutionPart(tracer, tracers),
+                                          &xWell[ix]);
                 }
             }
 
@@ -1489,9 +1505,13 @@ namespace {
                 return std::size_t{1};
             };
 
-            auto processHCTracer = [&smry, sign, quantityPrefix, &wellName](const auto& tracer, auto* xwel)
+            auto processHCTracer = [&smry, sign, quantityPrefix, &wellName]
+                (const auto& tracer, const bool hasSolutionPart, auto* xwel)
             {
                 xwel[0] = sign * smry.get_well_var(wellName, quantityPrefix + 'F' + tracer.name, 0.0);
+                if (! hasSolutionPart) {
+                    return std::size_t{1};
+                }
                 xwel[1] = sign * smry.get_well_var(wellName, quantityPrefix + 'S' + tracer.name, 0.0);
                 return std::size_t{2};
             };

--- a/opm/output/eclipse/CreateInteHead.cpp
+++ b/opm/output/eclipse/CreateInteHead.cpp
@@ -314,7 +314,13 @@ namespace {
         // This seems to be some sort of default value for LGR grid and should be enabled when AggregateGroupData.cpp is fixed.
         const auto maxGroupInField = 1;
 
-        const auto nWMaxz = wd.maxWellsInField();
+        // NWMAXZ is a per-grid quantity: the number of wells this grid is
+        // dimensioned for, with a minimum of one for array allocation.  The
+        // field-wide WELLDIMS item 1 value belongs in the global grid's
+        // header only; restart readers validate the local grid's slot
+        // against the local grid's own well count and reject the file when
+        // the field-wide value appears here.
+        const auto nWMaxz = std::max(numWells, 1);
 
         return {
             (report_step > 0) ? numWells : 0,

--- a/opm/output/eclipse/CreateInteHead.cpp
+++ b/opm/output/eclipse/CreateInteHead.cpp
@@ -666,6 +666,9 @@ createInteHead(const EclipseState& es,
     const auto ih = InteHEAD{}
         .dimensions         (grid.getNXYZ())
         .numActive          (static_cast<int>(grid.getNumActive()))
+        // Model-total LGR count (from the global input grid), written to
+        // the global and every LGR INTEHEAD alike.
+        .numLocalGrids      (static_cast<int>(es.getInputGrid().get_all_lgr_labels().size()))
         .unitConventions    (es.getDeckUnitSystem())
         .wellTableDimensions(getWellTableDims(nwgmax, ngmax, rspec, sched,
                                               report_step, lookup_step, grid.get_lgr_tag()))

--- a/opm/output/eclipse/CreateInteHead.cpp
+++ b/opm/output/eclipse/CreateInteHead.cpp
@@ -56,6 +56,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <vector>
 
 namespace {
@@ -112,21 +113,6 @@ namespace {
 
         // Number of non-FIELD groups.
         return ngmax - 1;
-    }
-
-    int numGroupsInField(const Opm::Schedule& sched,
-                         const std::size_t    lookup_step,
-                         [[maybe_unused]] const std::string&   lgr_tag)
-    {
-        return numGroupsInField(sched, lookup_step);
-        // Following code should be enabled when AggregateGroupData.cpp is fixed
-        // if (lgr_tag == "GLOBAL" or  lgr_tag.empty()){
-        //     return numGroupsInField(sched, lookup_step);
-        // }
-        // else {
-        //     // This is the default value and correspond to a single well group for LGR grids.
-        //     return 1;
-        // }
     }
 
     int GroupControl(const Opm::Schedule& sched,
@@ -281,6 +267,24 @@ namespace {
     }
 
 
+    // Number of distinct well groups among the wells inside the named
+    // local grid, with a minimum of one.  Local-grid restart headers
+    // carry group counts of this per-grid form, and restart readers
+    // validate them against the input description.
+    int numLgrWellGroups(const ::Opm::Schedule& sched,
+                         const std::size_t      lookup_step,
+                         const std::string&     lgr_tag)
+    {
+        auto groups = std::unordered_set<std::string> {};
+        for (const auto& wname : sched.wellNames(lookup_step)) {
+            const auto& well = sched[lookup_step].wells(wname);
+            if (well.get_lgr_well_tag().value_or("") == lgr_tag) {
+                groups.insert(well.groupName());
+            }
+        }
+        return std::max(static_cast<int>(groups.size()), 1);
+    }
+
     Opm::RestartIO::InteHEAD::WellTableDim
     getWellTableDims(const int              nwgmax,
                      const int              ngmax,
@@ -308,11 +312,27 @@ namespace {
             std::max(wd.maxConnPerWell(),
                      maxConnPerWell(sched, report_step, lookup_step));
 
-        const auto maxWellInGroup =
-             std::max(wd.maxWellsPerGroup(), nwgmax); // WellsPerGroup computed in terms of the Global Grid
+        // Group CAPACITY is a field-wide property, repeated in every
+        // local grid's header.  Group COUNT quantities are per grid: a
+        // local grid's header is dimensioned for the groups of the wells
+        // inside that grid, with a minimum of one.  A restarting run
+        // cross-checks the count against the input description and
+        // rejects the file when the field-wide value appears here (only
+        // models with more than one group distinguish the two
+        // conventions).
+        const auto globalDims =
+            getWellTableDims(nwgmax, ngmax, rspec, sched, report_step, lookup_step);
 
-        // This seems to be some sort of default value for LGR grid and should be enabled when AggregateGroupData.cpp is fixed.
-        const auto maxGroupInField = 1;
+        // The NWGMAX header item is written as the maximum of the two
+        // quantities below and holds the field-wide capacity in every
+        // grid's header, so fold the global grid's value into the
+        // capacity channel while maxGroupInField carries the per-grid
+        // group count.
+        const auto maxWellInGroup =
+            std::max(globalDims.maxWellInGroup, globalDims.maxGroupInField);
+
+        const auto maxGroupInField =
+            numLgrWellGroups(sched, lookup_step, lgr_tag);
 
         // NWMAXZ is a per-grid quantity: the number of wells this grid is
         // dimensioned for, with a minimum of one for array allocation.  The
@@ -650,7 +670,7 @@ createInteHead(const EclipseState& es,
     const auto nwgmax = ::maxGroupSize(sched, report_step, lookup_step,
                                       grid.get_lgr_tag());
     const auto ngmax  = (report_step == 0)
-        ? 0 : numGroupsInField(sched, lookup_step, grid.get_lgr_tag());
+        ? 0 : numGroupsInField(sched, lookup_step);
 
     const auto& acts  = sched[lookup_step].actions.get();
     const auto& rspec = es.runspec();
@@ -662,6 +682,15 @@ createInteHead(const EclipseState& es,
     const auto num_tracers = tracers.water_tracers() + tracers.oil_tracers() + tracers.gas_tracers() + (es.runspec().temp() ? 1 : 0);
     const auto num_tracer_comps = num_tracers + tracers.oil_tracers() + tracers.gas_tracers();
     int nxwelz_tracer_shift = num_tracer_comps*5 + 2 * (num_tracers > 0);
+
+    // NGRP is a per-grid actual-group count: the global header carries
+    // the model's group count, a local grid's header the count of groups
+    // of the wells inside that grid (minimum one).
+    const auto& hdrLgrTag = grid.get_lgr_tag();
+    const bool  localGridHeader = ! (hdrLgrTag.empty() || (hdrLgrTag == "GLOBAL"));
+    const int   headerNumGroups = localGridHeader
+        ? numLgrWellGroups(sched, lookup_step, hdrLgrTag)
+        : ngmax;
 
     const auto ih = InteHEAD{}
         .dimensions         (grid.getNXYZ())
@@ -693,7 +722,7 @@ createInteHead(const EclipseState& es,
         .liftOptParam       (getLiftOptPar(sched, report_step, lookup_step))
         .wellSegDimensions  (getWellSegDims(num_tracer_comps, rspec, sched, report_step, lookup_step))
         .regionDimensions   (getRegDims(tdim, rdim))
-        .ngroups            ({ ngmax })
+        .ngroups            ({ headerNumGroups })
         .params_NGCTRL      (GroupControl(sched, report_step, lookup_step))
         .variousParam       (202204, 100, num_tracer_comps)  // Output should be compatible with Eclipse 100, 2022.04 version.
         .udqParam_1         (getUdqParam(rspec, sched, report_step, lookup_step))

--- a/opm/output/eclipse/CreateInteHead.cpp
+++ b/opm/output/eclipse/CreateInteHead.cpp
@@ -29,6 +29,7 @@
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/Regdims.hpp>
+#include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 
 #include <opm/input/eclipse/Schedule/Action/ActionX.hpp>
@@ -678,9 +679,16 @@ createInteHead(const EclipseState& es,
     const auto& rdim  = tdim.getRegdims();
     const auto& rckcfg = es.getSimulationConfig().rock_config();
     const auto& tracers = es.runspec().tracers();
-    // TEMP is a tracer, oil&gas tracers have both free and solution parts.
+    // TEMP is a tracer.
     const auto num_tracers = tracers.water_tracers() + tracers.oil_tracers() + tracers.gas_tracers() + (es.runspec().temp() ? 1 : 0);
-    const auto num_tracer_comps = num_tracers + tracers.oil_tracers() + tracers.gas_tracers();
+    // A tracer occupies one component per phase state it can exist in: a
+    // free component always, plus a solution component only when the run
+    // supports the corresponding solution tracer.  The tracer-dependent
+    // restart array dimensions follow this per-support counting.
+    const auto& tracerCfg = es.tracer();
+    const auto num_tracer_comps = num_tracers
+        + (tracerCfg.supportsSolutionGasTracer()  ? tracers.gas_tracers() : 0)
+        + (tracerCfg.supportsVaporisedOilTracer() ? tracers.oil_tracers() : 0);
     int nxwelz_tracer_shift = num_tracer_comps*5 + 2 * (num_tracers > 0);
 
     // NGRP is a per-grid actual-group count: the global header carries

--- a/opm/output/eclipse/InteHEAD.cpp
+++ b/opm/output/eclipse/InteHEAD.cpp
@@ -153,7 +153,7 @@ enum index : std::vector<int>::size_type {
   ih_092       =       92       ,              //       0       0
   ih_093       =       93       ,              //       0       0
   IPROG        =       VI::intehead::IPROG,    //       0       100
-  INITSIZE     =       95       ,              //       0       0
+  NLGR         =       VI::intehead::NLGR,     //       0       0
   ih_096       =       96       ,              //       0       0
   ih_097       =       97       ,              //       0       0
   ih_098       =       98       ,              //       0       0
@@ -505,6 +505,17 @@ Opm::RestartIO::InteHEAD&
 Opm::RestartIO::InteHEAD::numActive(const int nactive)
 {
     this->data_[NACTIV] = nactive;
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::numLocalGrids(const int nlgr)
+{
+    // Model-total count of local grid refinements, written to every
+    // grid's header.  Restart readers cross-check this count against the
+    // input description and select the local-grid restore path from it.
+    this->data_[NLGR] = nlgr;
 
     return *this;
 }

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -209,6 +209,7 @@ namespace Opm { namespace RestartIO {
         InteHEAD& dimensions(const int nx, const int ny, const int nz);
         InteHEAD& dimensions(const std::array<int,3>& cartDims);
         InteHEAD& numActive(const int nactive);
+        InteHEAD& numLocalGrids(const int nlgr);
 
         InteHEAD& unitConventions(const UnitSystem& usys);
         InteHEAD& wellTableDimensions(const WellTableDim& wtdim);

--- a/opm/output/eclipse/LoadRestart.cpp
+++ b/opm/output/eclipse/LoadRestart.cpp
@@ -1340,7 +1340,13 @@ namespace {
         smry.update_well_var(well, "WGITH", xwel[VI::XWell::index::HistGasInjTotal]);
 
         // Tracer production/injection totals
-        const auto num_tracer_comps = tracer_dims.water_tracers() + 2* (tracer_dims.oil_tracers() + tracer_dims.gas_tracers()) + (isTemp ? 1 : 0);
+        // A hydrocarbon tracer has a solution component only when the run
+        // supports the corresponding solution tracer -- the same counting
+        // the writer uses.
+        const auto num_tracer_comps = tracer_dims.water_tracers()
+            + (tracer_config.supportsVaporisedOilTracer() ? 2 : 1) * tracer_dims.oil_tracers()
+            + (tracer_config.supportsSolutionGasTracer()  ? 2 : 1) * tracer_dims.gas_tracers()
+            + (isTemp ? 1 : 0);
         auto offset = VI::XWell::index::TracerOffset + num_tracer_comps; // First num_tracer_comps are the rates
         for (const auto* type : { "P", "I", }) { // Production followed by injection
             if (isTemp) {
@@ -1353,6 +1359,14 @@ namespace {
                 }
                 else {
                     const auto free_total = xwel[offset++];
+                    const auto hasSolutionPart =
+                        ((tracer.phase == Opm::Phase::GAS) && tracer_config.supportsSolutionGasTracer()) ||
+                        ((tracer.phase == Opm::Phase::OIL) && tracer_config.supportsVaporisedOilTracer());
+                    if (! hasSolutionPart) {
+                        smry.update_well_var(well, fmt::format("WT{}TF{}", type, tracer.name), free_total);
+                        smry.update_well_var(well, fmt::format("WT{}T{}", type, tracer.name), free_total);
+                        continue;
+                    }
                     const auto solution_total = xwel[offset++];
 
                     smry.update_well_var(well, fmt::format("WT{}TF{}", type, tracer.name), free_total);

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -111,6 +111,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
         IPROG = 94, //  IPROG = simulation program identifier:  100 - ECLIPSE 100, 300 - ECLIPSE 300, 500 - ECLIPSE 300
                     //  (thermal option), negative - Other simulator,
+        NLGR = 95, //  Number of local grid refinements (LGRs) in the model
         NMFIPR = 99, // REGDIMS item2
 
         ROCKOPTS_TABTYP = 103, // ROCKOPTS item3 (PVTNUM=1 - default)

--- a/tests/test_HeadersLGR.cpp
+++ b/tests/test_HeadersLGR.cpp
@@ -529,10 +529,16 @@ BOOST_AUTO_TEST_CASE(LGRHEADERS_3WELLS)
                 // BOOST_CHECK_EQUAL(intehead_lgr1[Ix::NGMAXZ], 2);
                 // BOOST_CHECK_EQUAL(intehead_lgr2[Ix::NGMAXZ], 2);
 
-                BOOST_CHECK_EQUAL(intehead_global[Ix::NWMAXZ],3);     // Maximum number of groups in field
-                // following code should be enabled once we fixed AggregateGroupData LGR
-                // BOOST_CHECK_EQUAL(intehead_lgr1[Ix::NWMAXZ], 2);
-                // BOOST_CHECK_EQUAL(intehead_lgr2[Ix::NWMAXZ], 2);
+                BOOST_CHECK_EQUAL(intehead_global[Ix::NWMAXZ],3);     // Maximum number of wells in field (WELLDIMS)
+                // Each LGR grid is dimensioned for the wells it actually contains
+                // (minimum 1 for array allocation), NOT the field-global WELLDIMS value.
+                BOOST_CHECK_EQUAL(intehead_lgr1[Ix::NWMAXZ], 1);
+                BOOST_CHECK_EQUAL(intehead_lgr2[Ix::NWMAXZ], 1);
+
+                // Model-total LGR count, present in every grid's header
+                BOOST_CHECK_EQUAL(intehead_global[Ix::NLGR], 2);
+                BOOST_CHECK_EQUAL(intehead_lgr1[Ix::NLGR], 2);
+                BOOST_CHECK_EQUAL(intehead_lgr2[Ix::NLGR], 2);
 
             }
 
@@ -613,10 +619,14 @@ BOOST_AUTO_TEST_CASE(LGRHEADERS_DIFFGROUP)
                 // BOOST_CHECK_EQUAL(intehead_lgr1[Ix::NGMAXZ], 2);
                 // BOOST_CHECK_EQUAL(intehead_lgr2[Ix::NGMAXZ], 2);
 
-                BOOST_CHECK_EQUAL(intehead_global[Ix::NWMAXZ],3);     // Maximum number of groups in field
-                // following code should be enabled once we fixed AggregateGroupData LGR
-                // BOOST_CHECK_EQUAL(intehead_lgr1[Ix::NWMAXZ], 2);
-                // BOOST_CHECK_EQUAL(intehead_lgr2[Ix::NWMAXZ], 2);
+                BOOST_CHECK_EQUAL(intehead_global[Ix::NWMAXZ],3);     // Maximum number of wells in field (WELLDIMS)
+                BOOST_CHECK_EQUAL(intehead_lgr1[Ix::NWMAXZ], 2);      // two wells in LGR1
+                BOOST_CHECK_EQUAL(intehead_lgr2[Ix::NWMAXZ], 1);      // no wells in LGR2 -> minimum allocation 1
+
+                // Model-total LGR count, present in every grid's header
+                BOOST_CHECK_EQUAL(intehead_global[Ix::NLGR], 2);
+                BOOST_CHECK_EQUAL(intehead_lgr1[Ix::NLGR], 2);
+                BOOST_CHECK_EQUAL(intehead_lgr2[Ix::NLGR], 2);
 
 
 
@@ -714,10 +724,16 @@ BOOST_AUTO_TEST_CASE(LGRHEADERS_GROUPEX01)
                 // BOOST_CHECK_EQUAL(intehead_lgr3[Ix::NGMAXZ], 2);
 
 
-                BOOST_CHECK_EQUAL(intehead_global[Ix::NWMAXZ],4);     // Maximum number of groups in field
-                BOOST_CHECK_EQUAL(intehead_lgr1[Ix::NWMAXZ], 4);
-                BOOST_CHECK_EQUAL(intehead_lgr2[Ix::NWMAXZ], 4);
-                BOOST_CHECK_EQUAL(intehead_lgr3[Ix::NWMAXZ], 4);
+                BOOST_CHECK_EQUAL(intehead_global[Ix::NWMAXZ],4);     // Maximum number of wells in field (WELLDIMS)
+                BOOST_CHECK_EQUAL(intehead_lgr1[Ix::NWMAXZ], 2);      // two wells in LGR1
+                BOOST_CHECK_EQUAL(intehead_lgr2[Ix::NWMAXZ], 1);      // no wells in LGR2 -> minimum allocation 1
+                BOOST_CHECK_EQUAL(intehead_lgr3[Ix::NWMAXZ], 1);      // no wells in LGR3 -> minimum allocation 1
+
+                // Model-total LGR count, present in every grid's header
+                BOOST_CHECK_EQUAL(intehead_global[Ix::NLGR], 3);
+                BOOST_CHECK_EQUAL(intehead_lgr1[Ix::NLGR], 3);
+                BOOST_CHECK_EQUAL(intehead_lgr2[Ix::NLGR], 3);
+                BOOST_CHECK_EQUAL(intehead_lgr3[Ix::NLGR], 3);
 
 
             }


### PR DESCRIPTION
**Depends on #5246** — this is the tracer follow-up split out of that PR
at review request, and it is based on that PR's branch: the commits of
#5246 appear stacked here until it merges, after which this PR reduces
to its single commit. Review of this PR only makes sense after #5246.

## What this does

Counts a hydrocarbon tracer's solution component only when the run
supports the corresponding solution tracer: a gas tracer carries a
dissolved component only with `DISGAS`, an oil tracer a vaporised
component only with `VAPOIL`. Previously every hydrocarbon tracer
unconditionally contributed a second component, oversizing the
tracer-dependent restart arrays for runs without the corresponding
phase transfer.

The counting uses the solution-tracer support tracking that #5302 added
to `TracerConfig`, whose commit message names restart array allocation
as the immediate use case — this PR is that use.

## The changes

One commit — the counting rule changes at its three sites together, so
every point in history keeps the header dimensions, the array contents,
and the read-back in agreement:

- **`CreateInteHead`**: the header component count follows the
  per-support counting, so the tracer-dependent well- and
  connection-array dimensions no longer reserve space for solution
  entries that cannot exist.
- **`AggregateWellData`**: a well's tracer entries follow the same rule —
  the initial-concentration entry and the solution-part rate/total
  entries are written only for tracers that have a solution component.
- **`LoadRestart`**: the read-back path counts identically and restores
  only the free-component totals for tracers without a solution part,
  keeping reader and writer dimensions in agreement.

## Scope

Runs where the corresponding transfer is active, and runs without
hydrocarbon tracers, produce identical restart files.

## Testing performed

Unit battery: the header, restart, and tracer suites and the full
opm-common test suite pass.
