### PR TITLE
serializer: replace map/set data on deserialize

### DIFF
--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -355,6 +355,7 @@ protected:
             std::size_t size = 0;
             (*this)(size);
             auto& data_mut = const_cast<Map&>(data);
+            data_mut.clear();
             for (std::size_t i = 0; i < size; ++i) {
                 typename Map::value_type entry;
                 (*this)(entry);
@@ -376,6 +377,7 @@ protected:
             std::size_t size = 0;
             (*this)(size);
             auto& data_mut = const_cast<Set&>(data);
+            data_mut.clear();
             for (std::size_t i = 0; i < size; ++i) {
                 typename Set::value_type entry{};
                 (*this)(entry);

--- a/tests/test_Serialization.cpp
+++ b/tests/test_Serialization.cpp
@@ -166,9 +166,15 @@
 #include <opm/common/utility/Serializer.hpp>
 #include <opm/common/utility/MemPacker.hpp>
 
+#include <boost/mpl/list.hpp>
+
 #include <cstddef>
+#include <map>
 #include <memory>
+#include <set>
 #include <tuple>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace {
@@ -185,6 +191,11 @@ namespace {
 
         return std::make_tuple(out, pos1, pos2);
     }
+
+    using MapTypes = boost::mpl::list<std::map<std::string, int>,
+                                      std::unordered_map<std::string, int>>;
+    using SetTypes = boost::mpl::list<std::set<std::string>,
+                                      std::unordered_set<std::string>>;
 }
 
 #define TEST_FOR_TYPE_NAMED_OBJ(TYPE, NAME, OBJ) \
@@ -201,6 +212,36 @@ BOOST_AUTO_TEST_CASE(NAME) \
 
 #define TEST_FOR_TYPE(TYPE) \
     TEST_FOR_TYPE_NAMED(TYPE, TYPE)
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(UnpackMapReplacesExistingEntries, Map, MapTypes)
+{
+    Map source{{"W21", 2}, {"W53", 3}};
+    Map result{{"W21", 1}, {"W56", 4}};
+    Opm::Serialization::MemPacker packer;
+    Opm::Serializer serializer(packer);
+    serializer.pack(source);
+    serializer.unpack(result);
+
+    BOOST_CHECK_EQUAL(result.size(), source.size());
+    BOOST_CHECK_EQUAL(result.at("W21"), 2);
+    BOOST_CHECK_EQUAL(result.at("W53"), 3);
+    BOOST_CHECK_EQUAL(result.count("W56"), 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(UnpackSetReplacesExistingEntries, Set, SetTypes)
+{
+    Set source{"W21", "W53"};
+    Set result{"W21", "W56"};
+    Opm::Serialization::MemPacker packer;
+    Opm::Serializer serializer(packer);
+    serializer.pack(source);
+    serializer.unpack(result);
+
+    BOOST_CHECK_EQUAL(result.size(), source.size());
+    BOOST_CHECK(result.contains("W21"));
+    BOOST_CHECK(result.contains("W53"));
+    BOOST_CHECK(!result.contains("W56"));
+}
 
 TEST_FOR_TYPE(Actdims)
 TEST_FOR_TYPE(Aqudims)


### PR DESCRIPTION
Map and set unpacking inserted saved entries into existing containers. Existing map keys retained pre-load values. Stale set members survived. That left deck-parsed Schedule wells in place during serialized restart.

Clear containers before unpacking. Cover colliding map keys, stale map entries, and stale set members.

The amount of roundtrips with my agent it took track down a restart issue to these two (actually, only the map one) lines...