### PR TITLE
Fixes ambiguous lookup of abs for __float128 with gcc16

### DIFF
--- a/cmake/Modules/FindQuadMath.cmake
+++ b/cmake/Modules/FindQuadMath.cmake
@@ -84,9 +84,19 @@ if(QuadMath_FOUND AND NOT TARGET QuadMath::QuadMath)
      __float128 b=10;
      __float128 c=std::atan(b);
   }" QuadMath_HAS_MATH_OPS)
+  check_cxx_source_compiles("
+  #include <cmath>
+  int main()
+  {
+     __float128 b=10;
+     __float128 c=std::abs(b);
+  }" QuadMath_HAS_MATH_ABS)
   cmake_pop_check_state()  # Reset CMAKE_REQUIRED_XXX variables
   if(QuadMath_HAS_MATH_OPS)
     target_compile_definitions(QuadMath::QuadMath INTERFACE QUADMATH_HAS_MATH_OPERATORS=1)
+  endif()
+  if(QuadMath_HAS_MATH_ABS)
+    target_compile_definitions(QuadMath::QuadMath INTERFACE QUADMATH_HAS_MATH_ABS=1)
   endif()
   cmake_pop_check_state()  # Reset CMAKE_REQUIRED_XXX variables
 endif()

--- a/opm/material/common/quad.hpp
+++ b/opm/material/common/quad.hpp
@@ -267,6 +267,11 @@ inline typename std::istream& operator>>(std::istream& is, quad& val)
 }
 #endif
 
+#if !QUADMATH_HAS_MATH_ABS
+inline quad abs(quad val)
+{ return (val < 0) ? -val : val; }
+#endif
+
 #if !QUADMATH_HAS_MATH_OPERATORS
 inline quad real(quad val)
 { return val; }
@@ -279,9 +284,6 @@ inline quad imag(quad)
 
 inline quad imag(const std::complex<quad>& val)
 { return val.imag(); }
-
-inline quad abs(quad val)
-{ return (val < 0) ? -val : val; }
 
 inline quad floor(quad val)
 { return floorq(val); }


### PR DESCRIPTION
With this we are able to compile with gcc16. That one has std::abs for __float128 but not atan. We only tested for the latter.

There might be more ambiguous functions that we never use.