### PR TITLE
Add ERst::dataSize()

### DIFF
--- a/opm/io/eclipse/ERst.cpp
+++ b/opm/io/eclipse/ERst.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <exception>
 #include <iterator>
@@ -170,6 +171,29 @@ int ERst::occurrence_count(const std::string& name, int reportStepNumber) const
     }
 
     return count;
+}
+
+std::int64_t ERst::dataSize(const std::string& name, int reportStepNumber) const
+{
+    if (!hasReportStepNumber(reportStepNumber)) {
+        OPM_THROW(std::invalid_argument,
+                  fmt::format("Trying to get size of vectors of name {}"
+                              " from non existing sequence {}", name, reportStepNumber));
+    }
+
+    std::int64_t size = 0;
+
+    auto range_it = arrIndexRange.find(reportStepNumber);
+
+    std::pair<int,int> indexRange = range_it->second;
+
+    for (int i=std::get<0>(indexRange); i<std::get<1>(indexRange);i++){
+        if (array_name[i] == name){
+            size += array_size[i];
+        }
+    }
+
+    return size;
 }
 
 void ERst::initUnified()

--- a/opm/io/eclipse/ERst.hpp
+++ b/opm/io/eclipse/ERst.hpp
@@ -22,6 +22,7 @@
 #include <opm/io/eclipse/EclFile.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <ios>
 #include <map>
 #include <string>
@@ -71,6 +72,7 @@ public:
     const std::vector<T>& getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
 
     int occurrence_count(const std::string& name, int reportStepNumber) const;
+    std::int64_t dataSize(const std::string& name, int reportStepNumber) const;
     std::size_t numberOfReportSteps() const { return seqnum.size(); };
 
     const std::vector<int>& listOfReportStepNumbers() const { return seqnum; }

--- a/tests/test_ERst.cpp
+++ b/tests/test_ERst.cpp
@@ -525,6 +525,47 @@ BOOST_AUTO_TEST_CASE(TestERst_5b) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(TestERst_dataSize) {
+
+    std::string testRstFile = "LGR_TESTMOD.UNRST";
+
+    ERst rst1(testRstFile);
+
+    const int rstep = 0;
+
+    // PRESSURE is stored once for the global grid and once for each of the
+    // two LGRs, with 30, 128 and 192 elements.
+    BOOST_CHECK_EQUAL(rst1.occurrence_count("PRESSURE", rstep), 3);
+    BOOST_CHECK_EQUAL(rst1.dataSize("PRESSURE", rstep), 30 + 128 + 192);
+
+    // SEQNUM exists in the global grid only.
+    BOOST_CHECK_EQUAL(rst1.dataSize("SEQNUM", rstep), 1);
+
+    // Sum of all occurrences of a name must match the arrays reported for the
+    // global grid and the LGRs.
+    for (const auto& name : { std::string {"PRESSURE"}, std::string {"ICON"},
+                              std::string {"INTEHEAD"}, std::string {"ZWEL"} })
+    {
+        std::int64_t size = 0;
+        for (const auto& grid : { std::string {"global"}, std::string {"LGR1"},
+                                  std::string {"LGR2"} })
+        {
+            for (const auto& array : rst1.listOfRstArrays(rstep, grid)) {
+                if (std::get<0>(array) == name) {
+                    size += std::get<2>(array);
+                }
+            }
+        }
+
+        BOOST_CHECK_EQUAL(rst1.dataSize(name, rstep), size);
+    }
+
+    BOOST_CHECK_EQUAL(rst1.dataSize("XXXX", rstep), 0);
+
+    // Non existing report step number, as in occurrence_count()
+    BOOST_CHECK_THROW(rst1.dataSize("PRESSURE", 99), std::invalid_argument);
+}
+
 // ====================================================================
 
 class RSet


### PR DESCRIPTION
ERst reports how many times a name occurs in a report step through occurrence_count(), but not how many elements those occurrences hold. A caller building a summary of the arrays of a restart file, for instance one that treats the global grid and the LGRs as a single result, therefore had to walk listOfRstArrays() for every grid and add the sizes up itself.

Add dataSize(), which returns the total number of elements stored under a name in a report step, counting every occurrence.  An unknown name gives zero and a non existing report step throws, as in occurrence_count().