### PR TITLE
Add EInit::hasArray()

### DIFF
--- a/opm/io/eclipse/EInit.cpp
+++ b/opm/io/eclipse/EInit.cpp
@@ -114,6 +114,19 @@ bool EInit::hasLGR(const std::string& name) const
     return std::ranges::find(lgr_names, name) != lgr_names.end();
 }
 
+bool EInit::hasArray(const std::string& name, const std::string& grid_name) const
+{
+    if (grid_name == "global") {
+        return global_array_index.contains(name);
+    }
+
+    if (!hasLGR(grid_name)) {
+        return false;
+    }
+
+    return lgr_array_index[get_lgr_index(grid_name)].contains(name);
+}
+
 int EInit::get_lgr_index(const std::string& grid_name) const
 {
     const auto it = std::ranges::find(lgr_names, grid_name);

--- a/opm/io/eclipse/EInit.hpp
+++ b/opm/io/eclipse/EInit.hpp
@@ -41,6 +41,7 @@ public:
     int activeCells(const std::string& grid_name = "global") const;
 
     bool hasLGR(const std::string& name) const;
+    bool hasArray(const std::string& name, const std::string& grid_name = "global") const;
 
     template <typename T>
     const std::vector<T>& getInitData(const std::string& name, const std::string& grid_name = "global")

--- a/tests/test_EInit.cpp
+++ b/tests/test_EInit.cpp
@@ -185,6 +185,25 @@ BOOST_AUTO_TEST_CASE(TestEInit_2) {
 
     BOOST_CHECK_EQUAL(init1.hasLGR("LGR1"), true);
     BOOST_CHECK_EQUAL(init1.hasLGR("LGR2"), true);
+
+    // TRANNNC is present in the global grid and in both LGRs, TRANGL only in
+    // the LGRs and MULTX only in the global grid.
+    BOOST_CHECK_EQUAL(init1.hasArray("PORO"), true);
+    BOOST_CHECK_EQUAL(init1.hasArray("PORO", "global"), true);
+    BOOST_CHECK_EQUAL(init1.hasArray("PORO", "LGR1"), true);
+
+    BOOST_CHECK_EQUAL(init1.hasArray("XXXX"), false);
+    BOOST_CHECK_EQUAL(init1.hasArray("XXXX", "LGR1"), false);
+
+    BOOST_CHECK_EQUAL(init1.hasArray("MULTX", "global"), true);
+    BOOST_CHECK_EQUAL(init1.hasArray("MULTX", "LGR2"), false);
+
+    BOOST_CHECK_EQUAL(init1.hasArray("TRANGL", "global"), false);
+    BOOST_CHECK_EQUAL(init1.hasArray("TRANGL", "LGR1"), true);
+
+    // An unknown grid name is not an array, as a non existing report step is
+    // not an array in ERst::hasArray().
+    BOOST_CHECK_EQUAL(init1.hasArray("PORO", "XXXX"), false);
 }
 
 BOOST_AUTO_TEST_CASE(TestEInit_3) {


### PR DESCRIPTION
Callers that read optional arrays from an INIT file, e.g. SWATINIT or the LGR only TRANGL, had to catch the exception from getInitData() or scan the output of list_arrays() to find out whether an array is present. ERst already offers hasArray() for the same purpose.

Look the name up in the array index of the requested grid, so an array which is present in an LGR but not in the global grid is reported for that LGR only.  An unknown grid name is rejected as in the other grid aware members.