### PR TITLE
Test file deck iteration over empty blocks

### DIFF
--- a/tests/parser/ScheduleRestartTests.cpp
+++ b/tests/parser/ScheduleRestartTests.cpp
@@ -341,6 +341,50 @@ BOOST_AUTO_TEST_CASE(TestFileDeck)
     fd.erase(index6.value(), index7.value());
 }
 
+BOOST_AUTO_TEST_CASE(FileDeckIterationSkipsEmptyIncludeBlock)
+{
+    const auto deck = Parser{}.parseFile("UDQ_WCONPROD.DATA");
+    FileDeck fd(deck);
+
+    // The keywords of the include file form a block of their own.  Erase all
+    // of them to get a deck with an empty block in the middle.
+    const auto include_block = fd.find("COORD").value().file_index;
+
+    auto num_include_kw = std::size_t{0};
+    for (auto index = fd.start(); index != fd.stop(); ++index) {
+        if (index.file_index == include_block) {
+            ++num_include_kw;
+        }
+    }
+
+    BOOST_REQUIRE_GT(num_include_kw, 0);
+
+    fd.erase(FileDeck::Index {include_block, 0, &fd},
+             FileDeck::Index {include_block + 1, 0, &fd});
+
+    // Forward iteration must visit every remaining keyword, and no keyword of
+    // the empty block.
+    auto num_kw = std::size_t{0};
+    for (auto index = fd.start(); index != fd.stop(); ++index) {
+        BOOST_CHECK_NE(index.file_index, include_block);
+        BOOST_CHECK_NO_THROW(fd[index]);
+        ++num_kw;
+    }
+
+    BOOST_CHECK_EQUAL(num_kw, deck.size() - num_include_kw);
+
+    // Reverse iteration must visit the same keywords in the opposite order.
+    auto index = fd.stop();
+    while (index != fd.start()) {
+        --index;
+        BOOST_CHECK_NE(index.file_index, include_block);
+        BOOST_CHECK_NO_THROW(fd[index]);
+        --num_kw;
+    }
+
+    BOOST_CHECK_EQUAL(num_kw, 0);
+}
+
 BOOST_AUTO_TEST_CASE(RestartTest2)
 {
     const auto deck = Parser{}.parseFile("UDQ_WCONPROD.DATA");


### PR DESCRIPTION
FileDeck::Index steps through the keywords of one input file at a time, and erasing every keyword of an included file leaves a block with no keywords behind.  operator++ then stopped on that block and compared the keyword index to blocks[file_index].size() - 1, which wraps around for an empty block, so the iteration never left the block.  operator-- placed the index on the same wrapped keyword index, and dereferencing it threw.

Move past empty blocks in both operators.  Reverse iteration reports the same error as an index at the start of the deck if only empty blocks remain.