### PR TITLE
Wrap deck output at 132 characters

### DIFF
--- a/opm/input/eclipse/Deck/DeckOutput.cpp
+++ b/opm/input/eclipse/Deck/DeckOutput.cpp
@@ -21,7 +21,9 @@
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 #include <opm/input/eclipse/Utility/Typetools.hpp>
 
+#include <locale>
 #include <ostream>
+#include <sstream>
 
 namespace Opm {
 
@@ -29,6 +31,7 @@ namespace Opm {
         os( s ),
         default_count( 0 ),
         row_count( 0 ),
+        current_width( 0 ),
         record_on( false ),
         org_precision( os.precision(precision) ),
         split_line( false )
@@ -47,56 +50,68 @@ namespace Opm {
 
     void DeckOutput::endl() {
         this->os << std::endl;
+        this->current_width = 0;
     }
 
     void DeckOutput::write_string(const std::string& s) {
         this->os << s;
+
+        const auto newline = s.rfind('\n');
+        if (newline == std::string::npos)
+            this->current_width += s.size();
+        else
+            this->current_width = s.size() - newline - 1;
     }
 
 
     template <typename T>
     void DeckOutput::write( const T& value ) {
         if (default_count > 0) {
-            write_sep( );
-
-            os << default_count << "*";
+            this->write_token(std::to_string(default_count) + "*");
             default_count = 0;
-            row_count++;
         }
 
-        write_sep( );
-        write_value( value );
-        row_count++;
+        this->write_token(this->format_value(value));
     }
 
     template <>
-    void DeckOutput::write_value( const std::string& value ) {
-        this->os << "'" << value << "'";
+    std::string DeckOutput::format_value( const std::string& value ) {
+        return "'" + value + "'";
     }
 
     template <>
-    void DeckOutput::write_value( const RawString& value ) {
-        this->os << value;
+    std::string DeckOutput::format_value( const RawString& value ) {
+        return { value };
     }
 
     template <>
-    void DeckOutput::write_value( const int& value ) {
-        this->os << value;
+    std::string DeckOutput::format_value( const int& value ) {
+        return std::to_string( value );
     }
 
     template <>
-    void DeckOutput::write_value( const double& value ) {
-        this->os << value;
+    std::string DeckOutput::format_value( const double& value ) {
+        std::ostringstream ss;
+        ss.flags( this->os.flags() );
+        ss.imbue( std::locale::classic() );
+        ss.precision( this->os.precision() );
+        ss << value;
+        return ss.str();
     }
 
     template <>
-    void DeckOutput::write_value( const UDAValue& value ) {
-        if (value.is<double>()) {
-            double deck_value = value.get<double>();
-            this->write_value(deck_value);
-        }
+    std::string DeckOutput::format_value( const UDAValue& value ) {
+        if (value.is<double>())
+            return this->format_value( value.get<double>() );
         else
-            this->write_value(value.get<std::string>());
+            return this->format_value( value.get<std::string>() );
+    }
+
+    void DeckOutput::write_token( const std::string& token ) {
+        this->write_sep( token.size() );
+        this->os << token;
+        this->current_width += token.size();
+        this->row_count++;
     }
 
     void DeckOutput::stash_default( ) {
@@ -106,26 +121,43 @@ namespace Opm {
 
     void DeckOutput::start_keyword(const std::string& kw, bool split_line_arg) {
         this->os << kw << std::endl;
+        this->current_width = 0;
         this->split_line = split_line_arg;
     }
 
 
     void DeckOutput::end_keyword(bool add_slash) {
-        if (add_slash)
+        if (add_slash) {
             this->os << "/" << std::endl;
+            this->current_width = 0;
+        }
     }
 
 
-    void DeckOutput::write_sep( ) {
-        if (record_on && this->split_line) {
-            if ((row_count > 0) && ((row_count % this->fmt.columns) == 0))
+    void DeckOutput::write_sep( std::size_t next_token_width ) {
+        if (record_on && (row_count > 0)) {
+            bool split = this->split_line && ((row_count % this->fmt.columns) == 0);
+
+            // Break the line before it grows past the maximum width.  Two characters
+            // are reserved for the " /" which terminates the record.
+            if (this->fmt.max_line_width > 0) {
+                const auto width = this->current_width + this->fmt.item_sep.size()
+                    + next_token_width + 2;
+
+                split = split || (width > this->fmt.max_line_width);
+            }
+
+            if (split)
                 split_record();
         }
 
-        if (row_count > 0)
+        if (row_count > 0) {
             os << this->fmt.item_sep;
-        else if (record_on)
+            this->current_width += this->fmt.item_sep.size();
+        } else if (record_on) {
             os << this->fmt.record_indent;
+            this->current_width += this->fmt.record_indent.size();
+        }
     }
 
     void DeckOutput::start_record( ) {
@@ -138,11 +170,13 @@ namespace Opm {
     void DeckOutput::split_record() {
         this->os << std::endl;
         this->row_count = 0;
+        this->current_width = 0;
     }
 
 
     void DeckOutput::end_record( ) {
         this->os << " /" << std::endl;
+        this->current_width = 0;
         this->record_on = false;
     }
 

--- a/opm/input/eclipse/Deck/DeckOutput.hpp
+++ b/opm/input/eclipse/Deck/DeckOutput.hpp
@@ -33,6 +33,7 @@ namespace Opm {
             std::size_t      columns = 7;          // The maximum number of columns on a record.
             std::string record_indent = " "; // The indentation when starting a new line.
             std::string keyword_sep = "";  // The separation between keywords;
+            std::size_t max_line_width = 132; // Maximum width of a line, 0 for unlimited.
         };
 
         explicit DeckOutput(std::ostream& s, int precision = 10);
@@ -53,13 +54,15 @@ namespace Opm {
         std::ostream& os;
         std::size_t default_count;
         std::size_t row_count;
+        std::size_t current_width;
         bool record_on;
         int org_precision;
         bool split_line;
 
-        template <typename T> void write_value(const T& value);
+        template <typename T> std::string format_value(const T& value);
+        void write_token(const std::string& token);
         void split_record();
-        void write_sep( );
+        void write_sep(std::size_t next_token_width);
         void set_precision(int precision);
     };
 }

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -42,9 +42,12 @@
 
 #include "../../opm/input/eclipse/Parser/raw/RawRecord.hpp"
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
+#include <locale>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -52,6 +55,14 @@
 #include <vector>
 
 using namespace Opm;
+
+namespace {
+
+class CommaNumpunct : public std::numpunct<char> {
+    char do_decimal_point() const override { return ','; }
+};
+
+} // Anonymous namespace
 
 BOOST_AUTO_TEST_CASE(hasKeyword_empty_returnFalse) {
     Deck deck;
@@ -584,6 +595,140 @@ ABC";
     out.write_string( out.fmt.keyword_sep );
 
     BOOST_CHECK_EQUAL( expected, s.str());
+}
+
+BOOST_AUTO_TEST_CASE(DeckOutputWriteStringTracksCurrentLine) {
+    std::stringstream s;
+    DeckOutput out(s);
+
+    out.fmt.max_line_width = 7;
+    out.write_string("long line\nx");
+    out.start_record();
+    out.write<int>(1);
+    out.write<int>(2);
+    out.end_record();
+
+    BOOST_CHECK_EQUAL(s.str(), "long line\nx 1 2 /\n");
+}
+
+BOOST_AUTO_TEST_CASE(DeckOutputUsesClassicLocale) {
+    std::stringstream s;
+    s.imbue(std::locale(std::locale::classic(), new CommaNumpunct));
+
+    DeckOutput out(s);
+    out.write<double>(1.5);
+
+    BOOST_CHECK_EQUAL(s.str(), "1.5");
+}
+
+BOOST_AUTO_TEST_CASE(DeckOutputMaxLineWidth) {
+    std::stringstream s;
+    DeckOutput out(s);
+
+    // Only the line width should break the record, not the column count.
+    out.fmt.columns = 1000;
+    out.fmt.max_line_width = 40;
+
+    out.start_keyword("KEYWORD", true);
+    out.start_record();
+    for (int i = 0; i < 20; ++i)
+        out.write<std::string>("MNEMONIC");
+    out.end_record();
+    out.end_keyword(true);
+
+    std::string line;
+    std::size_t num_lines = 0;
+    std::size_t num_values = 0;
+    while (std::getline(s, line)) {
+        BOOST_CHECK_LE(line.size(), out.fmt.max_line_width);
+
+        // A quoted value must not be broken across lines.
+        BOOST_CHECK_EQUAL(std::count(line.begin(), line.end(), '\'') % 2, 0);
+
+        num_values += std::count(line.begin(), line.end(), '\'') / 2;
+        ++num_lines;
+    }
+
+    BOOST_CHECK_EQUAL(num_values, 20);
+    BOOST_CHECK_GT(num_lines, 3);
+}
+
+BOOST_AUTO_TEST_CASE(DeckOutputUnlimitedLineWidth) {
+    std::stringstream s;
+    DeckOutput out(s);
+
+    out.fmt.columns = 1000;
+    out.fmt.max_line_width = 0;
+
+    out.start_keyword("KEYWORD", true);
+    out.start_record();
+    for (int i = 0; i < 20; ++i)
+        out.write<std::string>("MNEMONIC");
+    out.end_record();
+    out.end_keyword(true);
+
+    std::string line;
+    std::getline(s, line);            // KEYWORD
+    std::getline(s, line);
+
+    BOOST_CHECK_EQUAL(std::count(line.begin(), line.end(), '\'') / 2, 20);
+}
+
+BOOST_AUTO_TEST_CASE(DeckWriteLineWidth) {
+    // A table with more numbers than fit on one line, and a record of quoted
+    // mnemonics which must not be split inside the quotes.
+    std::string input = R"(RUNSPEC
+
+DIMENS
+  2 2 2 /
+
+OIL
+WATER
+GAS
+
+TABDIMS
+/
+
+PROPS
+
+SWOF
+)";
+
+    for (int i = 0; i < 40; ++i) {
+        const double sw = 0.2 + (0.8 * i) / 40;
+        input += fmt::format("  {} {} {} 0.0\n", sw, sw * sw * 0.987654321,
+                             (1.0 - sw) * 0.876543219);
+    }
+
+    input += R"(/
+
+SOLUTION
+
+RPTRST
+  'BASIC=4' 'FREQ=6' 'FLOWS' 'KRO' 'KRW' 'KRG' 'SGTRAP' 'RK' 'CONV' 'PORV'
+  'RPORV' 'BG' 'BO' 'BW' 'SFIP' 'PBPD' 'PCOW' /
+)";
+
+    const auto deck = Parser{}.parseString(input);
+
+    std::stringstream s;
+    DeckOutput out(s);
+    deck.write(out);
+
+    std::string line;
+    while (std::getline(s, line)) {
+        BOOST_CHECK_LE(line.size(), 132);
+        BOOST_CHECK_EQUAL(std::count(line.begin(), line.end(), '\'') % 2, 0);
+    }
+
+    // The wrapped deck must parse back to the same values.
+    const auto deck2 = Parser{}.parseString(s.str());
+
+    BOOST_REQUIRE_EQUAL(deck2.size(), deck.size());
+    BOOST_CHECK_EQUAL(deck2["SWOF"].back().getDataRecord().getDataItem().data_size(),
+                      deck["SWOF"].back().getDataRecord().getDataItem().data_size());
+    BOOST_CHECK_EQUAL(deck2["RPTRST"].back().getRecord(0).getItem(0).get<std::string>(6),
+                      "SGTRAP");
 }
 
 BOOST_AUTO_TEST_CASE(DeckItemWriteDefault) {


### PR DESCRIPTION
DeckOutput broke a record into lines by counting items only, so keywords whose records hold more than fmt.columns items were split, while data keywords such as SWOF or PVTO were written as one line per record.  A rel. perm. table with 40 rows became a single line of more than a thousand characters, and Eclipse 100 rejects lines longer than 132 characters.  Decks written by FileDeck could therefore not be run by that simulator.

Track the width of the line being written and break the record before it grows past fmt.max_line_width, which defaults to 132 and disables the check when set to zero.  A value is measured before it is written, so a break never falls inside a quoted string.  Values are formatted through format_value() and written by write_token() to make the width known before anything reaches the stream.