### PR TITLE
Always include memory for unique_ptr in ml_model

### DIFF
--- a/opm/ml/ml_model.hpp
+++ b/opm/ml/ml_model.hpp
@@ -31,6 +31,7 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace Opm::ML
 {


### PR DESCRIPTION
Often this is included implicitly, but on some compilers it is not. This fixes compilation on those and it not invasive.