### PR TITLE
ZMFVD unit dimensions

### DIFF
--- a/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -750,13 +750,14 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         const std::size_t numTables = m_eqldims.getNumEquilRegions();
         auto& container = forceGetTables(keywordName, numTables);
         const auto& keyword = tableKeywords.back();
+        const auto& usys = deck.getActiveUnitSystem();
 
         for (std::size_t tableIdx = 0; tableIdx < keyword.size(); ++tableIdx) {
             const auto& tableRecord = keyword.getRecord(tableIdx);
             const auto& dataItem = tableRecord.getItem("DATA");
             if (dataItem.data_size() > 0) {
                 auto table = std::make_shared<ZmfvdTable>(
-                    dataItem, static_cast<int>(tableIdx), numComponents, keyword.location());
+                    dataItem, static_cast<int>(tableIdx), numComponents, usys, keyword.location());
                 container.addTable(tableIdx, table);
             }
         }

--- a/opm/input/eclipse/EclipseState/Tables/Tables.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Tables.cpp
@@ -2958,7 +2958,7 @@ ZmfvdTable::ZmfvdTable(const DeckItem& item,
         // Component mole-fraction columns (dimensionless)
         for (int c = 0; c < numComponents; ++c) {
             const std::size_t compIdx = row * ncol + 1 + c;
-            moles[c] = item.get<double>(compIdx);
+            moles[c] = item.getSIDouble(compIdx);
         }
 
         if (const auto sum = normalizeMoleFractions(moles,
@@ -3028,7 +3028,7 @@ CompvdTable::CompvdTable(const DeckItem& item,
 
     const auto nrows = item.data_size() / ncol;
     phaseFlags_.reserve(nrows);
-    const auto& data = item.getData<double>();
+    const auto& data = item.getSIDoubleData();
 
     const std::string tableName{"COMPVD"};
     std::vector<double> moles(numComponents, 0.0);

--- a/opm/input/eclipse/EclipseState/Tables/Tables.cpp
+++ b/opm/input/eclipse/EclipseState/Tables/Tables.cpp
@@ -2920,7 +2920,11 @@ struct NormalizedRows
 
 } // Anonymous namespace
 
-ZmfvdTable::ZmfvdTable(const DeckItem& item, const int tableID, const int numComponents, const KeywordLocation& location)
+ZmfvdTable::ZmfvdTable(const DeckItem& item,
+                       const int tableID,
+                       const int numComponents,
+                       const UnitSystem& unitSystem,
+                       const KeywordLocation& location)
 {
     m_schema.addColumn(ColumnSchema("DEPTH", Table::STRICTLY_INCREASING, Table::DEFAULT_NONE));
     for (int c = 0; c < numComponents; ++c) {
@@ -2944,9 +2948,11 @@ ZmfvdTable::ZmfvdTable(const DeckItem& item, const int tableID, const int numCom
     std::vector<double> moles(numComponents, 0.);
     NormalizedRows normalized{};
     for (std::size_t row = 0; row < nrows; ++row) {
-        // Depth column
+        // Depth column.  Every column of the keyword is declared dimensionless,
+        // because the record width depends on COMPS, so convert the depth here.
         const std::size_t depthIdx = row * ncol;
-        const double siDepth = item.getSIDouble(depthIdx);
+        const double siDepth = unitSystem.to_si(UnitSystem::measure::length,
+                                                item.get<double>(depthIdx));
         getColumn(0).addValue(siDepth, tableName);
 
         // Component mole-fraction columns (dimensionless)

--- a/opm/input/eclipse/EclipseState/Tables/ZmfvdTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/ZmfvdTable.hpp
@@ -25,10 +25,15 @@ namespace Opm {
 
     class DeckItem;
     class KeywordLocation;
+    class UnitSystem;
 
     class ZmfvdTable : public SimpleTable {
     public:
-        ZmfvdTable(const DeckItem& item, const int tableID, const int numComponents, const KeywordLocation& location);
+        ZmfvdTable(const DeckItem& item,
+                   const int tableID,
+                   const int numComponents,
+                   const UnitSystem& unitSystem,
+                   const KeywordLocation& location);
 
         const TableColumn& getDepthColumn() const;
         const TableColumn& getMoleFractionColumn(int componentIdx) const;

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZMFVD
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZMFVD
@@ -1,6 +1,6 @@
 {
   "name": "ZMFVD",
-  "comment": "Hardcoded two components.",
+  "comment": "Each record contains depth followed by NCOMPS mole fractions. The record width depends on COMPS, so a per-column dimension list cannot line up; every column is declared dimensionless and the depth is converted during parsing.",
   "sections": [
     "PROPS"
   ],
@@ -14,8 +14,6 @@
       "value_type": "DOUBLE",
       "size_type": "ALL",
       "dimension": [
-        "Length",
-        "1",
         "1"
       ]
     }

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -3546,6 +3546,50 @@ END
                       Opm::OpmInputError);
 }
 
+BOOST_AUTO_TEST_CASE(ZmfvdTable_FieldUnitsWithThreeComponents) {
+    // The DATA item holds every value of every record in one flat vector, and
+    // the keyword used to declare three dimensions ("Length", "1", "1") that
+    // DeckItem applies by position, as dim[index % 3].  A record is 1 + COMPS
+    // wide, so the two only line up for COMPS 2.  At COMPS 3 they slip a slot
+    // per row:
+    //
+    //   idx:  0     1    2    3      4     5    6    7
+    //   val:  2000  0.3  0.3  0.4    2100  0.2  0.3  0.5
+    //   dim:  Len   1    1    Len    1     1    Len  1
+    //                         ^^^    ^^^
+    //         a mole fraction scaled by 0.3048, and a depth left in feet.
+    //
+    // Reading the depth converts the whole item in place, so the fractions were
+    // already mangled by the time they were read back.
+    const auto deck = Opm::Parser{}.parseString(R"(
+RUNSPEC
+FIELD
+COMPS
+3 /
+EQLDIMS
+1 /
+PROPS
+ZMFVD
+  2000.0  0.3 0.3 0.4
+  2100.0  0.2 0.3 0.5 /
+END
+)");
+
+    const auto tmgr = Opm::TableManager{ deck };
+    const auto& table = tmgr.getZmfvdTables().getTable<Opm::ZmfvdTable>(0);
+
+    // 2000 ft and 2100 ft in metres.
+    BOOST_CHECK_CLOSE(table.getDepthColumn()[0], 609.6,  1.0e-10);
+    BOOST_CHECK_CLOSE(table.getDepthColumn()[1], 640.08, 1.0e-10);
+
+    const double expected[2][3] = {{0.3, 0.3, 0.4}, {0.2, 0.3, 0.5}};
+    for (std::size_t row = 0; row < 2; ++row) {
+        for (int c = 0; c < 3; ++c) {
+            BOOST_CHECK_CLOSE(table.getMoleFractionColumn(c)[row], expected[row][c], 1.0e-10);
+        }
+    }
+}
+
 BOOST_AUTO_TEST_CASE(ZmfvdTable_ExactRowIsNotReported) {
     BOOST_CHECK(warningsFromTables(R"(
 RUNSPEC


### PR DESCRIPTION
ZMFVD declares one dimension per column, but a record is 1 + COMPS wide, so at COMPS 3 in FIELD units a mole fraction gets scaled by 0.3048 and the deck is rejected, while the next row's depth is left in feet and is silently wrong.
Declare every column dimensionless and convert the depth during parsing, as COMPVD already does. 

The problem was not spotted earlier on due to that we only have METRIC unit cases to test with. 