### PR TITLE
Fix rst_deck crash when the SOLUTION section spans several files

### DIFF
--- a/opm/input/eclipse/Deck/FileDeck.cpp
+++ b/opm/input/eclipse/Deck/FileDeck.cpp
@@ -94,17 +94,23 @@ FileDeck::Index& FileDeck::Index::operator--()
 {
     if (this->keyword_index > 0) {
         --this->keyword_index;
+        return *this;
     }
-    else {
-        if (this->file_index == 0) {
-            throw std::logic_error("Going beyond start of container");
-        }
 
+    // At the start of a block.  Move to the last keyword of the closest
+    // preceding block which still holds keywords; a block is left empty when
+    // all of its keywords have been erased.
+    while (this->file_index > 0) {
         --this->file_index;
-        this->keyword_index = this->deck->blocks[this->file_index].size() - 1;
+
+        const auto block_size = this->deck->blocks[this->file_index].size();
+        if (block_size > 0) {
+            this->keyword_index = block_size - 1;
+            return *this;
+        }
     }
 
-    return *this;
+    throw std::logic_error("Going beyond start of container");
 }
 
 FileDeck::Index FileDeck::Index::operator--(int)
@@ -122,14 +128,12 @@ FileDeck::Index& FileDeck::Index::operator++()
         throw std::logic_error("Trying to iterate empty container");
     }
 
-    const auto& block = this->deck->blocks[this->file_index];
-    if (this->keyword_index < block.size() - 1) {
-        ++this->keyword_index;
+    if (this->file_index >= this->deck->blocks.size()) {
+        throw std::logic_error("Going beyond end of container");
     }
-    else {
-        ++this->file_index;
-        this->keyword_index = 0;
-    }
+
+    *this = this->deck->next_valid_index(this->file_index,
+                                         this->keyword_index + 1);
 
     return *this;
 }
@@ -248,11 +252,16 @@ FileDeck::Block::find(const std::string& keyword,
     return std::distance(this->keywords.begin(), iter);
 }
 
-void FileDeck::erase(const FileDeck::Index& index)
+FileDeck::Index FileDeck::erase(const FileDeck::Index& index)
 {
     auto& block = this->blocks.at(index.file_index);
     this->modified_files.insert(block.fname);
     block.erase(index);
+
+    // The keyword which followed the erased one has moved into its position.
+    // If the erased keyword was the last one in its block the successor is the
+    // first keyword of the next non-empty block, possibly stop().
+    return this->next_valid_index(index.file_index, index.keyword_index);
 }
 
 void FileDeck::erase(const Index& begin, const Index& end)
@@ -347,9 +356,27 @@ void FileDeck::insert(const Index& index, const DeckKeyword& keyword)
     this->modified_files.insert(block.fname);
 }
 
+FileDeck::Index
+FileDeck::next_valid_index(std::size_t file_index,
+                           std::size_t keyword_index) const
+{
+    while ((file_index < this->blocks.size()) &&
+           (keyword_index >= this->blocks[file_index].size()))
+    {
+        ++file_index;
+        keyword_index = 0;
+    }
+
+    if (file_index >= this->blocks.size()) {
+        return this->stop();
+    }
+
+    return FileDeck::Index { file_index, keyword_index, this };
+}
+
 FileDeck::Index FileDeck::start() const
 {
-    return FileDeck::Index {0, 0, this};
+    return this->next_valid_index(0, 0);
 }
 
 FileDeck::Index FileDeck::stop() const
@@ -497,6 +524,9 @@ void FileDeck::dump(const std::string& output_dir,
     }
 
     if (mode == OutputMode::COPY) {
+        // An included file whose keywords have all been erased is emitted as an
+        // empty file in COPY mode, and its parent still includes it.  In SHARE
+        // and INLINE modes it contributes nothing to the output.
         DumpContext context;
         this->dump_block(this->blocks[0], output_dir, fname, context);
 
@@ -557,22 +587,23 @@ void FileDeck::dump_stdout(const std::string& output_dir,
 void FileDeck::rst_solution(const std::string& rst_base,
                             const int report_step)
 {
-    auto index = this->find("SOLUTION").value();
-    auto summary_index = this->find("SUMMARY").value();
+    if (! this->find("SUMMARY").has_value()) {
+        throw std::logic_error("Deck does not have a SUMMARY section");
+    }
 
+    // Discard solution keywords superseded by the restart file.  Erasing a
+    // keyword shifts later positions within its block and may empty the block,
+    // so terminate on the SUMMARY keyword rather than maintaining its index.
+    auto index = this->find("SOLUTION").value();
     ++index;
 
-    while (true) {
+    const auto stop_index = this->stop();
+    while ((index != stop_index) && ((*this)[index].name() != "SUMMARY")) {
         if (::rst_keep_in_solution.count((*this)[index].name()) == 0) {
-            this->erase(index);
-            --summary_index;
+            index = this->erase(index);
         }
         else {
             ++index;
-        }
-
-        if (index == summary_index) {
-            break;
         }
     }
 
@@ -586,8 +617,12 @@ void FileDeck::rst_solution(const std::string& rst_base,
             units
         };
 
-        auto solution = this->find("SOLUTION").value();
-        this->insert(++solution, restart);
+        // Insert RESTART immediately after SOLUTION.  Note that ++solution is
+        // not used here: when SOLUTION is the last keyword of its file, that
+        // would place RESTART at the start of the next file instead.
+        const auto solution = this->find("SOLUTION").value();
+        this->insert(Index { solution.file_index,
+                             solution.keyword_index + 1, this }, restart);
     }
 }
 
@@ -595,10 +630,12 @@ void FileDeck::insert_skiprest()
 {
     DeckKeyword skiprest( ParserKeywords::SKIPREST{} );
 
-    const auto schedule = this->find("SCHEDULE");
-    auto index = schedule.value();
+    // Immediately after SCHEDULE, in the same file--see the note on the
+    // RESTART keyword in rst_solution().
+    const auto schedule = this->find("SCHEDULE").value();
 
-    this->insert(++index, skiprest);
+    this->insert(Index { schedule.file_index,
+                         schedule.keyword_index + 1, this }, skiprest);
 }
 
 void FileDeck::skip(const int report_step)
@@ -638,16 +675,14 @@ void FileDeck::skip(const int report_step)
         const auto& keyword = (*this)[index];
 
         if (rst_keep_in_schedule.count(keyword.name()) == 0) {
-            auto next_index = index + 1;
-            this->erase(index);
+            // Erasing a keyword which precedes end_pos in the same block
+            // moves end_pos one position down.  Keywords in earlier blocks do
+            // not affect it.
+            const auto same_block = index.file_index == end_pos.file_index;
 
-            if (next_index.file_index != index.file_index) {
-                // Erased the last element on this block, move to the next.
-                index = next_index;
-            }
+            index = this->erase(index);
 
-            if (index.file_index == end_pos.file_index) {
-                // On the last block.
+            if (same_block) {
                 --end_pos;
             }
         }

--- a/opm/input/eclipse/Deck/FileDeck.hpp
+++ b/opm/input/eclipse/Deck/FileDeck.hpp
@@ -83,7 +83,7 @@ public:
     std::optional<Index> find(const std::string& keyword, const Index& offset) const;
     std::optional<Index> find(const std::string& keyword) const;
     std::size_t count(const std::string& keyword) const;
-    void erase(const Index& index);
+    Index erase(const Index& index);
     void erase(const Index& begin, const Index& end);
     void insert(const Index& index, const DeckKeyword& keyword);
 
@@ -140,6 +140,12 @@ private:
     std::unordered_set<std::string> modified_files;
 
     DeckTree deck_tree;
+
+    // Position of the first keyword at or after (file_index, keyword_index).
+    // Skips blocks which have been emptied by erase() and returns stop() if
+    // there is no such keyword.
+    Index next_valid_index(std::size_t file_index,
+                           std::size_t keyword_index) const;
 
     void dump(std::ostream& os) const;
     void dump_shared(std::ostream& stream, const std::string& output_dir) const;

--- a/tests/parser/ScheduleRestartTests.cpp
+++ b/tests/parser/ScheduleRestartTests.cpp
@@ -54,9 +54,12 @@
 
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
+#include "tests/WorkArea.hpp"
+
 #include <algorithm>
 #include <cstddef>
 #include <filesystem>
+#include <fstream>
 #include <iterator>
 #include <memory>
 #include <stdexcept>
@@ -435,4 +438,284 @@ BOOST_AUTO_TEST_CASE(RestartTest)
     //         return date == tp;
     //     }
     // };
+}
+
+// ---------------------------------------------------------------------------
+// Decks in which a section is split across several files.  FileDeck represents
+// each contiguous run of keywords from the same file as a separate block, so
+// these decks exercise the block boundaries of the index arithmetic.
+
+namespace {
+
+void write_file(const fs::path& fname, const std::string& contents)
+{
+    if (fname.has_parent_path()) {
+        fs::create_directories(fname.parent_path());
+    }
+
+    std::ofstream { fname } << contents;
+}
+
+std::string case_deck(const std::string& solution_body,
+                      const std::string& schedule_body)
+{
+    return R"(RUNSPEC
+
+DIMENS
+  5 5 2 /
+
+EQLDIMS
+  1 /
+
+OIL
+WATER
+GAS
+
+METRIC
+
+START
+  1 'JAN' 2020 /
+
+GRID
+
+DXV
+  5*100 /
+
+DYV
+  5*100 /
+
+DZV
+  2*10 /
+
+DEPTHZ
+  36*2000 /
+
+PROPS
+
+SOLUTION
+
+)" + solution_body + R"(
+SUMMARY
+
+WOPR
+  'OP1' /
+
+SCHEDULE
+
+)" + schedule_body;
+}
+
+const std::string equil = R"(EQUIL
+  2000 200 2050 0 1950 0 /
+)";
+
+const std::string simple_schedule = R"(WELSPECS
+  'OP1' 'G1' 1 1 1* 'OIL' /
+/
+
+DATES
+  1 'FEB' 2020 /
+/
+
+DATES
+  1 'MAR' 2020 /
+/
+)";
+
+// Norne's layout: RPTRST and RPTSOL in the deck file, the equilibration data in
+// an include file, and THPRES back in the deck file.
+FileDeck norne_style_deck()
+{
+    write_file("include/solution.inc", equil);
+    write_file("CASE.DATA", case_deck(R"(RPTRST
+  'BASIC=2' /
+
+RPTSOL
+  'RESTART=2' /
+
+INCLUDE
+  'include/solution.inc' /
+
+THPRES
+/
+
+)", simple_schedule));
+
+    return FileDeck { Parser{}.parseFile("CASE.DATA") };
+}
+
+// The include file holds the entire SOLUTION body, i.e. SOLUTION is the last
+// keyword of its block and the include block is emptied outright.
+FileDeck included_solution_body_deck()
+{
+    write_file("include/solution.inc", R"(RPTSOL
+  'RESTART=2' /
+
+)" + equil);
+
+    write_file("CASE.DATA", case_deck(R"(INCLUDE
+  'include/solution.inc' /
+
+)", simple_schedule));
+
+    return FileDeck { Parser{}.parseFile("CASE.DATA") };
+}
+
+void check_restart_solution(const FileDeck& fd)
+{
+    const auto solution = fd.find("SOLUTION");
+    const auto restart = fd.find("RESTART");
+    const auto summary = fd.find("SUMMARY");
+
+    BOOST_REQUIRE(restart.has_value());
+    BOOST_CHECK(solution.value() < restart.value());
+    BOOST_CHECK(restart.value() < summary.value());
+
+    // RESTART must be inserted into the same block as SOLUTION, not into the
+    // included file.
+    BOOST_CHECK_EQUAL(restart.value().file_index, solution.value().file_index);
+    BOOST_CHECK_EQUAL(restart.value().keyword_index,
+                      solution.value().keyword_index + 1);
+
+    // The solution state comes from the restart file.
+    BOOST_CHECK(! fd.find("EQUIL").has_value());
+    BOOST_CHECK(! fd.find("RPTSOL").has_value());
+    BOOST_CHECK(! fd.find("THPRES").has_value());
+
+    // Everything from SUMMARY on is untouched.
+    BOOST_CHECK(fd.find("WOPR").has_value());
+    BOOST_CHECK(fd.find("SCHEDULE").has_value());
+    BOOST_CHECK(fd.find("WELSPECS").has_value());
+    BOOST_CHECK_EQUAL(fd.count("DATES"), 2);
+
+    // Full traversal of a deck containing empty blocks.
+    BOOST_CHECK_NO_THROW({
+        for (auto index = fd.start(); index != fd.stop(); ++index) {
+            fd[index];
+        }
+    });
+}
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(RestartSolutionSpanningIncludeFile)
+{
+    WorkArea work {};
+
+    auto fd = norne_style_deck();
+
+    // The keywords of the SOLUTION section must really be spread across files,
+    // otherwise this test degenerates into the single file case.
+    BOOST_REQUIRE(fd.find("SOLUTION").value().file_index <
+                  fd.find("EQUIL").value().file_index);
+    BOOST_REQUIRE(fd.find("EQUIL").value().file_index <
+                  fd.find("SUMMARY").value().file_index);
+
+    BOOST_CHECK_NO_THROW(fd.rst_solution("CASE", 5));
+
+    check_restart_solution(fd);
+
+    // RPTRST is kept, and it is still the first keyword after RESTART.
+    const auto rptrst = fd.find("RPTRST");
+    BOOST_REQUIRE(rptrst.has_value());
+    BOOST_CHECK_EQUAL(rptrst.value().keyword_index,
+                      fd.find("RESTART").value().keyword_index + 1);
+}
+
+BOOST_AUTO_TEST_CASE(RestartSolutionBodyEntirelyInIncludeFile)
+{
+    WorkArea work {};
+
+    auto fd = included_solution_body_deck();
+
+    BOOST_REQUIRE(fd.find("SOLUTION").value().file_index <
+                  fd.find("EQUIL").value().file_index);
+
+    BOOST_CHECK_NO_THROW(fd.rst_solution("CASE", 5));
+
+    check_restart_solution(fd);
+    BOOST_CHECK(! fd.find("RPTRST").has_value());
+}
+
+BOOST_AUTO_TEST_CASE(RestartSolutionSpanningIncludeFileDump)
+{
+    WorkArea work {};
+
+    auto fd = norne_style_deck();
+    fd.rst_solution("CASE", 5);
+
+    // An emptied include file is written as an empty file which the deck still
+    // includes (COPY), or simply contributes nothing (SHARE and INLINE).  The
+    // result must parse in all three cases.
+    const auto modes = std::vector {
+        std::pair { FileDeck::OutputMode::COPY,   std::string {"copy"} },
+        std::pair { FileDeck::OutputMode::SHARE,  std::string {"share"} },
+        std::pair { FileDeck::OutputMode::INLINE, std::string {"inline"} },
+    };
+
+    for (const auto& [mode, dir] : modes) {
+        BOOST_TEST_CONTEXT("Output mode " << dir) {
+            fd.dump(dir, "RST.DATA", mode);
+
+            const auto rst_deck = Parser{}.parseFile(dir + "/RST.DATA");
+            BOOST_CHECK(rst_deck.hasKeyword("RESTART"));
+            BOOST_CHECK(rst_deck.hasKeyword("RPTRST"));
+            BOOST_CHECK(rst_deck.hasKeyword("WELSPECS"));
+            BOOST_CHECK(! rst_deck.hasKeyword("EQUIL"));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(SkipScheduleSpanningIncludeFile)
+{
+    WorkArea work {};
+
+    write_file("include/solution.inc", equil);
+    write_file("include/schedule.inc", R"(WCONPROD
+  'OP1' 'OPEN' 'ORAT' 1000 /
+/
+)");
+
+    write_file("CASE.DATA", case_deck(R"(INCLUDE
+  'include/solution.inc' /
+
+)", R"(TUNING
+/
+/
+/
+
+WELSPECS
+  'OP1' 'G1' 1 1 1* 'OIL' /
+/
+
+INCLUDE
+  'include/schedule.inc' /
+
+DATES
+  1 'FEB' 2020 /
+/
+
+DATES
+  1 'MAR' 2020 /
+/
+)"));
+
+    auto fd = FileDeck { Parser{}.parseFile("CASE.DATA") };
+
+    // The last keyword before the first report step is in the include file
+    // while the DATES keyword which ends the skipped range is not.
+    BOOST_REQUIRE(fd.find("WCONPROD").value().file_index <
+                  fd.find("DATES").value().file_index);
+
+    BOOST_CHECK_NO_THROW(fd.skip(1));
+
+    BOOST_CHECK(! fd.find("WELSPECS").has_value());
+    BOOST_CHECK(! fd.find("WCONPROD").has_value());
+    BOOST_CHECK(fd.find("SCHEDULE").has_value());
+    BOOST_CHECK(fd.find("TUNING").has_value());
+
+    BOOST_REQUIRE_EQUAL(fd.count("DATES"), 1);
+    const auto& dates = fd[fd.find("DATES").value()];
+    BOOST_CHECK_EQUAL(dates[0].getItem<ParserKeywords::DATES::MONTH>()
+                      .get<std::string>(0), "MAR");
 }


### PR DESCRIPTION
`rst_deck` aborts with an uncaught `std::out_of_range` for any restart step > 0
on decks whose SOLUTION section continues in an INCLUDE file:

    rst_deck -s NORNE_ATW2013.DATA NORNE_ATW2013:5 out/RST.DATA

`FileDeck` keeps one block of keywords per source file, and `rst_solution()`
kept using an index left past the end of a block once that block's last keyword
had been erased. It also decremented a saved SUMMARY index after every erase,
even when SUMMARY was in a later block, and `Index::operator++`/`operator--`
underflowed `block.size() - 1` on an emptied block. `erase()` now returns the
successor of the erased keyword, the index operators skip empty blocks, and
`rst_solution()` terminates on the SUMMARY keyword instead of maintaining an
index the erasures invalidate. `skip()` had the same class of error. Single-file
decks (SPE1 etc.) were never affected, which is why this went unnoticed.

Note it is not only a crash: when the include file holds the whole SOLUTION
body the old loop broke early instead, silently keeping EQUIL and writing
RESTART into the include file.

Platform independent — found on Windows, reproduces on Linux with the same deck.

Tested: four new FileDeck cases (all fail without the fix), the full opm-common
ctest suite, and Norne at step 5 in `-m copy/share/inline` with and without
`-s`; every generated deck parses, and the `-s` ones build EclipseState,
Schedule and SummaryConfig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)