### PR TITLE
Take std::filesystem::path where opm-common opens a file

### DIFF
--- a/opm/input/eclipse/Generator/KeywordGenerator.cpp
+++ b/opm/input/eclipse/Generator/KeywordGenerator.cpp
@@ -33,20 +33,21 @@
 #include <string>
 
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 namespace {
 
-    void updateFile(const std::string& newContent, const std::string& filename)
+    void updateFile(const std::string& newContent, const std::filesystem::path& filename)
     {
         Opm::KeywordGenerator::ensurePath(filename);
 
         std::ofstream { filename } << newContent;
     }
 
-    void write_file(const std::string& content,
-                    const std::string& file,
-                    const bool         verbose,
-                    const std::string& desc)
+    void write_file(const std::string&           content,
+                    const std::filesystem::path& file,
+                    const bool                   verbose,
+                    const std::string&           desc)
     {
         updateFile(content, file);
 
@@ -55,10 +56,10 @@ namespace {
         }
     }
 
-    void write_file(const std::stringstream& stream,
-                    const std::string&       file,
-                    const bool               verbose,
-                    const std::string&       desc)
+    void write_file(const std::stringstream&     stream,
+                    const std::filesystem::path& file,
+                    const bool                   verbose,
+                    const std::string&           desc)
     {
         write_file(stream.str(), file, verbose, desc);
     }
@@ -89,17 +90,15 @@ namespace Opm {
                            "namespace Opm::ParserKeywords {{\n\n", suffix);
     }
 
-    void KeywordGenerator::ensurePath(const std::string& file_name)
+    void KeywordGenerator::ensurePath(const std::filesystem::path& file)
     {
-        std::filesystem::path file(file_name);
-
         if (!std::filesystem::is_directory(file.parent_path())) {
             std::filesystem::create_directories(file.parent_path());
         }
     }
 
     void KeywordGenerator::updateFile(const std::stringstream& newContent,
-                                      const std::string& filename)
+                                      const std::filesystem::path& filename)
     {
         ::updateFile(newContent.str(), filename);
     }

--- a/opm/input/eclipse/Generator/KeywordGenerator.hpp
+++ b/opm/input/eclipse/Generator/KeywordGenerator.hpp
@@ -21,6 +21,7 @@
 #ifndef KEYWORD_GENERATOR_HPP
 #define KEYWORD_GENERATOR_HPP
 
+#include <filesystem>
 #include <string>
 
 namespace Opm {
@@ -33,12 +34,12 @@ namespace Opm {
     public:
         explicit KeywordGenerator(bool verbose);
 
-        static void ensurePath(const std::string& file_name);
+        static void ensurePath(const std::filesystem::path& file);
         static std::string endTest();
         static std::string startTest(const std::string& test_name);
         static std::string headerHeader(const std::string&);
         static void updateFile(const std::stringstream& newContent,
-                               const std::string& filename);
+                               const std::filesystem::path& filename);
 
         void updateBuiltInHeader(const KeywordLoader& loader,
                                  const std::string& headerBuildPath,

--- a/opm/input/eclipse/Parser/Parser.cpp
+++ b/opm/input/eclipse/Parser/Parser.cpp
@@ -1691,7 +1691,7 @@ bool parseState( ParserState& parserState, const Parser& parser, ErrorGuard& err
         return parse(deck, context).getInputGrid();
     }
 
-    Deck Parser::parseFile(const std::string&  dataFileName,
+    Deck Parser::parseFile(const std::filesystem::path& dataFileName,
                            const ParseContext& parseContext,
                            ErrorGuard& errors,
                            const std::vector<Ecl::SectionType>& sections) const
@@ -1728,8 +1728,10 @@ bool parseState( ParserState& parserState, const Parser& parser, ErrorGuard& err
            2. The relative/abolute status of the path is retained.
         */
 
+        // has_root_directory() is the portable spelling of the former leading-'/' test;
+        // is_absolute() implies it but would not keep a rooted path without a root name.
         std::string data_file;
-        if (dataFileName[0] == '/')
+        if (dataFileName.has_root_directory())
             data_file = std::filesystem::canonical(dataFileName).generic_string();
         else
             data_file = std::filesystem::proximate(std::filesystem::canonical(dataFileName)).generic_string();
@@ -1753,20 +1755,20 @@ bool parseState( ParserState& parserState, const Parser& parser, ErrorGuard& err
         return std::move( parserState.deck );
     }
 
-    Deck Parser::parseFile(const std::string& dataFileName,
+    Deck Parser::parseFile(const std::filesystem::path& dataFileName,
                            const ParseContext& parseContext) const {
         ErrorGuard errors;
         return this->parseFile(dataFileName, parseContext, errors, {});
     }
 
-    Deck Parser::parseFile(const std::string& dataFileName,
+    Deck Parser::parseFile(const std::filesystem::path& dataFileName,
                            const ParseContext& parseContext,
                            const std::vector<Opm::Ecl::SectionType>& sections) const {
         ErrorGuard errors;
         return this->parseFile(dataFileName, parseContext, errors, sections);
     }
 
-    Deck Parser::parseFile(const std::string& dataFileName) const {
+    Deck Parser::parseFile(const std::filesystem::path& dataFileName) const {
         ErrorGuard errors;
         return this->parseFile(dataFileName, ParseContext(), errors);
     }

--- a/opm/input/eclipse/Parser/Parser.hpp
+++ b/opm/input/eclipse/Parser/Parser.hpp
@@ -65,20 +65,20 @@ namespace Opm {
         static std::string stripComments(const std::string& inputString);
 
         /// The starting point of the parsing process. The supplied file is parsed, and the resulting Deck is returned.
-        Deck parseFile(const std::string &dataFile,
+        Deck parseFile(const std::filesystem::path& dataFile,
                        const ParseContext&,
                        ErrorGuard& errors,
                        const std::vector<Opm::Ecl::SectionType>& sections = {}) const;
 
-        Deck parseFile(const std::string&,
+        Deck parseFile(const std::filesystem::path&,
                        const ParseContext&) const;
 
-        Deck parseFile(const std::string&,
+        Deck parseFile(const std::filesystem::path&,
                        const ParseContext&,
                        const std::vector<Opm::Ecl::SectionType>& sections
                       ) const;
 
-        Deck parseFile(const std::string& datafile) const;
+        Deck parseFile(const std::filesystem::path& datafile) const;
 
         Deck parseString(const std::string &data,
                          const ParseContext&,

--- a/opm/io/eclipse/EGrid.cpp
+++ b/opm/io/eclipse/EGrid.cpp
@@ -36,12 +36,13 @@
 #include <string>
 
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 namespace Opm::EclIO {
 
 using NNCentry = std::tuple<int, int, int, int, int, int, float>;
 
-EGrid::EGrid(const std::string& filename, const std::string& grid_name)
+EGrid::EGrid(const std::filesystem::path& filename, const std::string& grid_name)
     : EclFile(filename), inputFileName { filename }, m_grid_name {grid_name}
 {
     initFileName = inputFileName.parent_path() / inputFileName.stem();
@@ -259,7 +260,7 @@ void EGrid::load_nnc_data()
         nnc2_array = getImpl(nnc2_array_index, Opm::EclIO::INTE, inte_array, "inte");
 
         if ((std::filesystem::exists(initFileName)) && (nnc1_array.size() > 0)){
-            Opm::EclIO::EInit init(initFileName.generic_string());
+            Opm::EclIO::EInit init(initFileName);
 
             auto init_dims = init.grid_dimension(m_grid_name);
             int init_nactive = init.activeCells(m_grid_name);
@@ -540,7 +541,7 @@ std::vector<float> EGrid::  get_zcorn_from_disk(int layer, bool bottom)
     fileH.open(inputFileName, std::ios::in |  std::ios::binary);
 
     if (!fileH)
-        throw std::runtime_error("Can not open EGrid file" + this->inputFilename);
+        throw std::runtime_error(fmt::format("Can not open EGrid file {}", this->inputFilename));
 
     std::string arrName(8,' ');
     eclArrType arrType;

--- a/opm/io/eclipse/EGrid.hpp
+++ b/opm/io/eclipse/EGrid.hpp
@@ -32,7 +32,7 @@ namespace Opm { namespace EclIO {
 class EGrid : public EclFile
 {
 public:
-    explicit EGrid(const std::string& filename, const std::string& grid_name = "global");
+    explicit EGrid(const std::filesystem::path& filename, const std::string& grid_name = "global");
 
     int global_index(int i, int j, int k) const;
     int active_index(int i, int j, int k) const;

--- a/opm/io/eclipse/EInit.cpp
+++ b/opm/io/eclipse/EInit.cpp
@@ -24,7 +24,7 @@
 
 namespace Opm::EclIO {
 
-EInit::EInit(const std::string &filename) : EclFile(filename)
+EInit::EInit(const std::filesystem::path &filename) : EclFile(filename)
 {
     std::string lgrname;
 

--- a/opm/io/eclipse/EInit.hpp
+++ b/opm/io/eclipse/EInit.hpp
@@ -30,7 +30,7 @@ namespace Opm { namespace EclIO {
 class EInit : public EclFile
 {
 public:
-    explicit EInit(const std::string& filename);
+    explicit EInit(const std::filesystem::path& filename);
 
     const std::vector<std::string>& list_of_lgrs() const { return lgr_names; }
 

--- a/opm/io/eclipse/ERft.cpp
+++ b/opm/io/eclipse/ERft.cpp
@@ -30,7 +30,7 @@
 
 namespace Opm::EclIO {
 
-ERft::ERft(const std::string &filename) : EclFile(filename)
+ERft::ERft(const std::filesystem::path& filename) : EclFile(filename)
 {
     loadData();
     std::vector<int> first;

--- a/opm/io/eclipse/ERft.hpp
+++ b/opm/io/eclipse/ERft.hpp
@@ -24,6 +24,7 @@
 #include <ctime>
 #include <map>
 #include <set>
+#include <filesystem>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -34,7 +35,7 @@ namespace Opm { namespace EclIO {
 class ERft : public EclFile
 {
 public:
-    explicit ERft(const std::string &filename);
+    explicit ERft(const std::filesystem::path& filename);
 
     using RftDate = std::tuple<int,int,int>;
     template <typename T>

--- a/opm/io/eclipse/ERsm.cpp
+++ b/opm/io/eclipse/ERsm.cpp
@@ -27,10 +27,12 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <filesystem>
 #include <fstream>
 #include <string>
 
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 namespace Opm {
 namespace EclIO {
@@ -41,11 +43,11 @@ constexpr std::size_t num_columns  = 10;
 constexpr std::size_t column_width = 13;
 
 
-std::deque<std::string> load(const std::string& fname) {
+std::deque<std::string> load(const std::filesystem::path& fname) {
     std::deque<std::string> lines;
-    std::ifstream is(fname.c_str());
+    std::ifstream is(fname);
     if (!is.good())
-        throw std::invalid_argument("Can not open: " + fname + " for reading");
+        throw std::invalid_argument(fmt::format("Can not open: {} for reading", fname));
 
     std::string line;
     while(std::getline(is, line)) {
@@ -277,7 +279,7 @@ bool ERsm::has(const std::string& key) const {
     return this->vectors.count(key) == 1;
 }
 
-ERsm::ERsm(const std::string& fname) {
+ERsm::ERsm(const std::filesystem::path& fname) {
     auto lines = load(fname);
     std::size_t vector_length = 0;
     while (!lines.empty())

--- a/opm/io/eclipse/ERsm.hpp
+++ b/opm/io/eclipse/ERsm.hpp
@@ -20,6 +20,7 @@
 #define OPM_IO_ERSM_HPP
 
 #include <deque>
+#include <filesystem>
 #include <string>
 #include <unordered_map>
 #include <variant>
@@ -56,7 +57,7 @@ struct Vector{
 
 
 public:
-    explicit ERsm(const std::string& fname);
+    explicit ERsm(const std::filesystem::path& fname);
 
     const std::vector<TimeStampUTC>& dates() const;
     const std::vector<double>& days() const;

--- a/opm/io/eclipse/ERst.cpp
+++ b/opm/io/eclipse/ERst.cpp
@@ -53,7 +53,7 @@ namespace {
 
 namespace Opm::EclIO {
 
-ERst::ERst(const std::string& filename)
+ERst::ERst(const std::filesystem::path& filename)
     : EclFile(filename)
 {
     if (this->hasKey("SEQNUM")) {

--- a/opm/io/eclipse/ERst.hpp
+++ b/opm/io/eclipse/ERst.hpp
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <ios>
 #include <map>
+#include <filesystem>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -37,7 +38,7 @@ namespace Opm { namespace EclIO {
 class ERst : public EclFile
 {
 public:
-    explicit ERst(const std::string& filename);
+    explicit ERst(const std::filesystem::path& filename);
 
     bool hasReportStepNumber(int number) const;
     bool hasArray(const std::string& name, int number) const;

--- a/opm/io/eclipse/ESmry.cpp
+++ b/opm/io/eclipse/ESmry.cpp
@@ -48,6 +48,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 /*
 
@@ -120,7 +121,7 @@ bool is_well_completion(const std::string& keyword)
 
 namespace Opm::EclIO {
 
-ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
+ESmry::ESmry(const std::filesystem::path &filename, bool loadBaseRunData) :
     inputFileName { filename },
     summaryNodes { }
 {
@@ -163,7 +164,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
 
     // Read data from the summary into local data members.
     {
-        smspecList.emplace_back(smspec_file.string());
+        smspecList.emplace_back(smspec_file);
 
         auto arrays = smspecList.back().getList();
         std::vector<int> vectIndices;
@@ -272,7 +273,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
         if ((rstRootN.string() != "") && (loadBaseRunData)) {
 
             if (! std::filesystem::exists(pathRstFile))
-                OPM_THROW(std::runtime_error, "path to restart file not found, '" + pathRstFile.string() + "'");
+                OPM_THROW(std::runtime_error, fmt::format("path to restart file not found, {}", pathRstFile));
 
             auto abs_rst_file = std::filesystem::canonical(pathRstFile) / rstRootN;
             std::filesystem::path rel_path;
@@ -310,7 +311,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
             baseRunFmt = true;
         }
 
-        smspecList.emplace_back(EclFile(rstFile.string()));
+        smspecList.emplace_back(EclFile(rstFile));
 
         auto arrays = smspecList.back().getList();
         std::vector<int> vectIndices;
@@ -1091,7 +1092,7 @@ bool ESmry::make_esmry_file()
     std::filesystem::path smryDataFile = path / rootName;
     smryDataFile.replace_extension(".ESMRY");
 
-    if (Opm::EclIO::fileExists(smryDataFile.generic_string()))
+    if (Opm::EclIO::fileExists(smryDataFile))
     {
         return false;
 
@@ -1131,7 +1132,7 @@ bool ESmry::make_esmry_file()
             std::ranges::transform(keyword, std::back_inserter(units),
                                    [this](const auto& key) { return kwunits.at(key); });
 
-            Opm::EclIO::EclOutput outFile(smryDataFile.generic_string(), false, std::ios::out);
+            Opm::EclIO::EclOutput outFile(smryDataFile, false, std::ios::out);
 
             outFile.write<int>("START", start_date_vect);
 

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -44,7 +44,7 @@ class ESmry
 public:
 
     // input is smspec (or fsmspec file)
-    explicit ESmry(const std::string& filename, bool loadBaseRunData=false);
+    explicit ESmry(const std::filesystem::path& filename, bool loadBaseRunData=false);
 
     int numberOfVectors() const { return nVect; }
 

--- a/opm/io/eclipse/EclFile.cpp
+++ b/opm/io/eclipse/EclFile.cpp
@@ -30,6 +30,7 @@
 #include <cmath>
 
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 namespace Opm { namespace EclIO {
 
@@ -97,7 +98,7 @@ void EclFile::load(bool preload) {
 }
 
 
-EclFile::EclFile(const std::string& filename, EclFile::Formatted fmt, bool preload) :
+EclFile::EclFile(const std::filesystem::path& filename, EclFile::Formatted fmt, bool preload) :
     formatted(fmt.value),
     inputFilename(filename)
 {
@@ -105,7 +106,7 @@ EclFile::EclFile(const std::string& filename, EclFile::Formatted fmt, bool prelo
 }
 
 
-EclFile::EclFile(const std::string& filename, bool preload) :
+EclFile::EclFile(const std::filesystem::path& filename, bool preload) :
     inputFilename(filename)
 {
     if (!fileExists(filename))
@@ -198,7 +199,7 @@ void EclFile::loadData()
         fileH.open(inputFilename, std::ios::in |  std::ios::binary);
 
         if (!fileH) {
-            OPM_THROW(std::runtime_error, "Could not open file: '" + inputFilename +"'");
+            OPM_THROW(std::runtime_error, fmt::format("Could not open file: {}", inputFilename));
         }
 
         for (std::size_t i = 0; i < array_name.size(); i++) {
@@ -241,7 +242,7 @@ void EclFile::loadData(const std::string& name)
         fileH.open(inputFilename, std::ios::in |  std::ios::binary);
 
         if (!fileH) {
-            OPM_THROW(std::runtime_error, "Could not open file: '" + inputFilename +"'");
+            OPM_THROW(std::runtime_error, fmt::format("Could not open file: {}", inputFilename));
         }
 
         for (std::size_t i = 0; i < array_name.size(); i++) {
@@ -282,7 +283,7 @@ void EclFile::loadData(const std::vector<int>& arrIndex)
         fileH.open(inputFilename, std::ios::in |  std::ios::binary);
 
         if (!fileH) {
-            OPM_THROW(std::runtime_error, "Could not open file: '" + inputFilename +"'");
+            OPM_THROW(std::runtime_error, fmt::format("Could not open file: {}", inputFilename));
         }
 
         for (int ind : arrIndex) {
@@ -318,7 +319,7 @@ void EclFile::loadData(int arrIndex)
         fileH.open(inputFilename, std::ios::in |  std::ios::binary);
 
         if (!fileH) {
-            OPM_THROW(std::runtime_error, "Could not open file: '" + inputFilename +"'");
+            OPM_THROW(std::runtime_error, fmt::format("Could not open file: {}", inputFilename));
         }
 
         loadBinaryArray(fileH, arrIndex);
@@ -387,7 +388,7 @@ std::vector<unsigned int> EclFile::get_bin_logi_raw_values(int arrIndex) const
     fileH.open(inputFilename, std::ios::in |  std::ios::binary);
 
     if (!fileH) {
-        OPM_THROW(std::runtime_error, "Could not open file: '" + inputFilename +"'");
+        OPM_THROW(std::runtime_error, fmt::format("Could not open file: {}", inputFilename));
     }
 
     fileH.seekg (ifStreamPos[arrIndex], fileH.beg);
@@ -405,7 +406,7 @@ std::vector<std::string> EclFile::get_fmt_real_raw_str_values(int arrIndex) cons
     std::ifstream inFile(inputFilename);
 
     if (!inFile) {
-        OPM_THROW(std::runtime_error, "Could not open file: '" + inputFilename +"'");
+        OPM_THROW(std::runtime_error, fmt::format("Could not open file: {}", inputFilename));
     }
 
     inFile.seekg(ifStreamPos[arrIndex]);

--- a/opm/io/eclipse/EclFile.hpp
+++ b/opm/io/eclipse/EclFile.hpp
@@ -22,6 +22,7 @@
 #include <opm/io/eclipse/EclIOdata.hpp>
 
 #include <algorithm>
+#include <filesystem>
 #include <map>
 #include <string>
 #include <tuple>
@@ -38,8 +39,8 @@ public:
         bool value;
     };
 
-    explicit EclFile(const std::string& filename, bool preload = false);
-    EclFile(const std::string& filename, Formatted fmt, bool preload = false);
+    explicit EclFile(const std::filesystem::path& filename, bool preload = false);
+    EclFile(const std::filesystem::path& filename, Formatted fmt, bool preload = false);
     bool formattedInput() const { return formatted; }
 
     void loadData();                            // load all data
@@ -78,7 +79,7 @@ public:
 
 protected:
     bool formatted;
-    std::string inputFilename;
+    std::filesystem::path inputFilename;
 
     std::unordered_map<int, std::vector<int>> inte_array;
     std::unordered_map<int, std::vector<bool>> logi_array;

--- a/opm/io/eclipse/EclOutput.cpp
+++ b/opm/io/eclipse/EclOutput.cpp
@@ -57,7 +57,7 @@ namespace {
 
 namespace Opm { namespace EclIO {
 
-EclOutput::EclOutput(const std::string&            filename,
+EclOutput::EclOutput(const std::filesystem::path&  filename,
                      const bool                    formatted,
                      const std::ios_base::openmode mode)
     : isFormatted{formatted}

--- a/opm/io/eclipse/EclOutput.hpp
+++ b/opm/io/eclipse/EclOutput.hpp
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <ios>
 #include <stdexcept>
+#include <filesystem>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -39,7 +40,7 @@ namespace Opm::EclIO {
 class EclOutput
 {
 public:
-    EclOutput(const std::string&            filename,
+    EclOutput(const std::filesystem::path&  filename,
               const bool                    formatted,
               const std::ios_base::openmode mode = std::ios::out);
 

--- a/opm/io/eclipse/EclUtil.cpp
+++ b/opm/io/eclipse/EclUtil.cpp
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 #ifdef _MSC_VER
 #include <intrin.h>
@@ -81,9 +82,9 @@ double Opm::EclIO::flipEndianDouble(double num)
     return value;
 }
 
-bool Opm::EclIO::fileExists(const std::string& filename){
+bool Opm::EclIO::fileExists(const std::filesystem::path& filename){
 
-    std::ifstream fileH(filename.c_str());
+    std::ifstream fileH(filename);
     return fileH.good();
 }
 
@@ -96,15 +97,13 @@ bool Opm::EclIO::is_number(const std::string& numstr)
 }
 
 
-bool Opm::EclIO::isFormatted(const std::string& filename)
+bool Opm::EclIO::isFormatted(const std::filesystem::path& filename)
 {
-    const auto pth = std::filesystem::path { filename };
-
-    const auto& ext = pth.extension();
+    const auto& ext = filename.extension();
     if (ext.empty()) {
         OPM_THROW(std::invalid_argument,
-                  "Purported ECLIPSE Filename '" +
-                  filename + "' does not contain extension");
+                  fmt::format("Purported ECLIPSE Filename {} "
+                              "does not contain extension", filename));
     }
 
     return (ext != ".GRID")

--- a/opm/io/eclipse/EclUtil.hpp
+++ b/opm/io/eclipse/EclUtil.hpp
@@ -23,6 +23,7 @@
 #include <opm/io/eclipse/EclIOdata.hpp>
 
 #include <cstdint>
+#include <filesystem>
 #include <functional>
 #include <string>
 #include <tuple>
@@ -35,8 +36,8 @@ namespace Opm { namespace EclIO {
     float flipEndianFloat(float num);
     double flipEndianDouble(double num);
     bool isEOF(std::fstream* fileH);
-    bool fileExists(const std::string& filename);
-    bool isFormatted(const std::string& filename);
+    bool fileExists(const std::filesystem::path& filename);
+    bool isFormatted(const std::filesystem::path& filename);
     bool is_number(const std::string& numstr);
 
     /// Compute the linearly combined summary vector ID number from two

--- a/opm/io/eclipse/ExtESmry.cpp
+++ b/opm/io/eclipse/ExtESmry.cpp
@@ -18,6 +18,9 @@
 
 #include <opm/io/eclipse/ExtESmry.hpp>
 
+#include <fmt/format.h>
+#include <fmt/std.h>
+
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/TimeService.hpp>
 #include <opm/common/utility/shmatch.hpp>
@@ -84,7 +87,7 @@ Opm::time_point make_date(const std::vector<int>& datetime) {
 
 namespace Opm { namespace EclIO {
 
-ExtESmry::ExtESmry(const std::string &filename, bool loadBaseRunData) :
+ExtESmry::ExtESmry(const std::filesystem::path &filename, bool loadBaseRunData) :
     m_inputFileName { filename },
     m_loadBaseRun(loadBaseRunData)
 {
@@ -122,7 +125,7 @@ ExtESmry::ExtESmry(const std::string &filename, bool loadBaseRunData) :
     }
 
     if (n_attempts == 10)
-        OPM_THROW( std::runtime_error, "when opening ESMRY file " + filename );
+        OPM_THROW( std::runtime_error, fmt::format("when opening ESMRY file {}", filename) );
 
     m_startdat = std::get<0>(ext_esmry_head);
     m_rstep_offset.push_back(rstep_offset);
@@ -170,7 +173,7 @@ ExtESmry::ExtESmry(const std::string &filename, bool loadBaseRunData) :
             m_esmry_files.push_back(rstESmryFile);
 
             if (!open_esmry(rstESmryFile, ext_esmry_head, rstep_offset))
-                OPM_THROW( std::runtime_error, "when opening ESMRY file" + rstESmryFile.string() );
+                OPM_THROW( std::runtime_error, fmt::format("when opening ESMRY file {}", rstESmryFile) );
 
             m_rstep_offset.push_back(rstep_offset);
 
@@ -278,7 +281,7 @@ bool ExtESmry::open_esmry(const std::filesystem::path& inputFileName, ExtSmryHea
     }
 
     if ((arrName != "START   ") or (arrType != Opm::EclIO::INTE))
-        OPM_THROW(std::invalid_argument, "reading start, invalid esmry file " + inputFileName.string() );
+        OPM_THROW(std::invalid_argument, fmt::format("reading start, invalid esmry file {}", inputFileName));
 
 
     try {
@@ -319,7 +322,7 @@ bool ExtESmry::open_esmry(const std::filesystem::path& inputFileName, ExtSmryHea
     }
 
     if (arrName != "KEYCHECK")
-        OPM_THROW(std::invalid_argument, "reading keycheck, invalid esmry file " + inputFileName.string() );
+        OPM_THROW(std::invalid_argument, fmt::format("reading keycheck, invalid esmry file {}", inputFileName));
 
     std::vector<std::string> keywords;
 
@@ -339,7 +342,7 @@ bool ExtESmry::open_esmry(const std::filesystem::path& inputFileName, ExtSmryHea
     }
 
     if (arrName != "UNITS   ")
-        OPM_THROW(std::invalid_argument, "reading UNITS, invalid esmry file " + inputFileName.string() );
+        OPM_THROW(std::invalid_argument, fmt::format("reading UNITS, invalid esmry file {}", inputFileName));
 
     std::vector<std::string> units;
 
@@ -351,7 +354,7 @@ bool ExtESmry::open_esmry(const std::filesystem::path& inputFileName, ExtSmryHea
     }
 
     if (keywords.size() != units.size())
-        OPM_THROW( std::runtime_error, "invalid ESMRY file " + inputFileName.string() + ". Size of UNITS not equal size of KEYCHECK");
+        OPM_THROW( std::runtime_error, fmt::format("invalid ESMRY file {}. Size of UNITS not equal size of KEYCHECK", inputFileName));
 
     rstep_offset = static_cast<std::uint64_t>(fileH.tellg());
 
@@ -363,7 +366,7 @@ bool ExtESmry::open_esmry(const std::filesystem::path& inputFileName, ExtSmryHea
     }
 
     if ((arrName != "RSTEP   ") or (arrType != Opm::EclIO::INTE))
-        OPM_THROW(std::invalid_argument, "Reading RSTEP, invalid esmry file " + inputFileName.string() );
+        OPM_THROW(std::invalid_argument, fmt::format("Reading RSTEP, invalid esmry file {}", inputFileName));
 
     std::vector<int> rstep;
 
@@ -382,7 +385,7 @@ bool ExtESmry::open_esmry(const std::filesystem::path& inputFileName, ExtSmryHea
     }
 
     if ((arrName != "TSTEP   ") or (arrType != Opm::EclIO::INTE))
-        OPM_THROW(std::invalid_argument, "reading TSTEP, invalid esmry file " + inputFileName.string() );
+        OPM_THROW(std::invalid_argument, fmt::format("reading TSTEP, invalid esmry file {}", inputFileName));
 
     std::vector<int> tstep;
 
@@ -543,7 +546,7 @@ void ExtESmry::loadData(const std::vector<std::string>& stringVect)
 
         if (n_attempts == 10){
             OPM_THROW(std::runtime_error,
-                      "when loading data from ESMRY file" + m_esmry_files[ind].string());
+                      fmt::format("when loading data from ESMRY file {}", m_esmry_files[ind]));
         }
 
         ind--;

--- a/opm/io/eclipse/ExtESmry.hpp
+++ b/opm/io/eclipse/ExtESmry.hpp
@@ -46,7 +46,7 @@ class ExtESmry
 public:
 
     // input is esmry, only binary supported.
-    explicit ExtESmry(const std::string& filename, bool loadBaseRunData=false);
+    explicit ExtESmry(const std::filesystem::path& filename, bool loadBaseRunData=false);
 
     const std::vector<float>& get(const std::string& name);
     std::vector<float> get_at_rstep(const std::string& name);

--- a/python/cxx/parser.cpp
+++ b/python/cxx/parser.cpp
@@ -67,10 +67,11 @@ void python::common::export_Parser(py::module& module) {
 
     py::class_<Parser>(module, "Parser", Parser_docstring)
         .def(py::init<bool>(), py::arg("add_default") = true, Parser_init_docstring)
-        .def("parse"       , py::overload_cast<const std::string&>(&Parser::parseFile, py::const_), py::arg("filename"), Parser_parse_file_docstring)
-        .def("parse"       , py::overload_cast<const std::string&, const ParseContext&>(&Parser::parseFile, py::const_),
+        .def("parse"       , [](const Parser& parser, const std::string& filename) { return parser.parseFile(filename); },
+            py::arg("filename"), Parser_parse_file_docstring)
+        .def("parse"       , [](const Parser& parser, const std::string& filename, const ParseContext& context) { return parser.parseFile(filename, context); },
             py::arg("filename"), py::arg("context"), Parser_parse_file_context_docstring)
-        .def("parse"       , py::overload_cast<const std::string&, const ParseContext&, const std::vector<Opm::Ecl::SectionType>&>(&Parser::parseFile, py::const_),
+        .def("parse"       , [](const Parser& parser, const std::string& filename, const ParseContext& context, const std::vector<Opm::Ecl::SectionType>& sections) { return parser.parseFile(filename, context, sections); },
             py::arg("filename"), py::arg("context"), py::arg("sections"), Parser_parse_file_context_sections_docstring)
         .def("parse_string", py::overload_cast<const std::string&>(&Parser::parseString, py::const_), py::arg("data"), Parser_parse_string_docstring)
         .def("parse_string", py::overload_cast<const std::string&, const ParseContext&>(&Parser::parseString, py::const_),


### PR DESCRIPTION
1. Takes std::filesystem::path where opm-common opens a file — the EclIO readers and writers, Parser::parseFile(), and the keyword generator's file helpers — so a caller holding a path passes it as is. std::string still converts implicitly: no call site changes, and every consumer in opm-common, opm-grid and opm-simulators builds unchanged.
2. Removes the conversions the library was doing to itself (EclFile(rstFile.string()), EclOutput(smryDataFile.generic_string(), …), EInit(initFileName.generic_string())) and retires the parser's dataFileName[0] == '/' in favour of has_root_directory(), the same test expressed on the path rather than on its first byte.
3. No functional change: the names simply travel as the type the standard library opens files with, and nothing decides anything by inspecting their characters any more; the full opm-common test suite passes as before.
