### PR TITLE
Do not advertise rock tables that are never written; write ROCK to TAB

### DIFF
--- a/opm/output/eclipse/Tables.cpp
+++ b/opm/output/eclipse/Tables.cpp
@@ -3662,6 +3662,14 @@ namespace Opm {
         // Initialize subset of base pointers and dimensions to 1 to honour
         // requirements of TABDIMS protocol.
         std::fill_n(std::begin(this->tabdims_), 59, 1);
+
+        // The fill above is needed for the base pointers, but it also leaves
+        // the ROCK and ROCKTAB table *counts* at 1.  Counts for the tables we
+        // do emit are assigned in the matching add*(), so zeroing them here
+        // is safe.
+        this->tabdims_[Ix::NumRockTables]     = 0;
+        this->tabdims_[Ix::NumRockCompNodes]  = 0;
+        this->tabdims_[Ix::NumRockCompTables] = 0;
     }
 
     void Tables::addDensity(const DensityTable& density)

--- a/opm/output/eclipse/Tables.cpp
+++ b/opm/output/eclipse/Tables.cpp
@@ -23,7 +23,7 @@
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Phase.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/FlatTable.hpp> // PVTW, PVCDO, SWOFLET, SGOFLET
+#include <opm/input/eclipse/EclipseState/Tables/FlatTable.hpp> // ROCK, PVTW, PVCDO, SWOFLET, SGOFLET
 #include <opm/input/eclipse/EclipseState/Tables/GsfTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PvdgTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PvdoTable.hpp>
@@ -3698,6 +3698,28 @@ namespace Opm {
         this->addData(Ix::DensityTableStart, densityData);
 
         this->tabdims_[Ix::DensityNumTables] = nreg;
+    }
+
+    void Tables::addRock(const RockTable& rock)
+    {
+        const auto nreg = rock.size();
+
+        if (nreg == 0) { return; }
+
+        // ROCK(NTROCK, 2), column major: Pref in column 0, Cr in column 1.
+        auto rockData = std::vector<double>(nreg * 2);
+
+        using M = ::Opm::UnitSystem::measure;
+
+        // Compressibility unit hack here (*to_si()*)
+        for (auto i = 0*nreg; i < nreg; ++i) {
+            rockData[0*nreg + i] = this->units_.from_si(M::pressure, rock[i].reference_pressure);
+            rockData[1*nreg + i] = this->units_.to_si  (M::pressure, rock[i].compressibility);
+        }
+
+        this->addData(Ix::RockTableStart, rockData);
+
+        this->tabdims_[Ix::NumRockTables] = nreg;
     }
 
     void Tables::addPVTTables(const EclipseState& es)

--- a/opm/output/eclipse/Tables.hpp
+++ b/opm/output/eclipse/Tables.hpp
@@ -29,6 +29,7 @@ namespace Opm {
 
     struct DensityTable;
     class EclipseState;
+    struct RockTable;
     class UnitSystem;
 
 } // namespace Opm
@@ -54,6 +55,15 @@ namespace Opm {
         /// \param[in] density Run's phase densities at surface conditions,
         ///    typically from the DENSITY keyword.
         void addDensity(const DensityTable& density);
+
+        /// Incorporate the rock compressibility table into the INIT
+        /// file's TAB vector.
+        ///
+        /// Does nothing if the run does not specify the ROCK keyword.
+        ///
+        /// \param[in] rock Run's rock compressibility table, from the
+        ///    ROCK keyword.
+        void addRock(const RockTable& rock);
 
         /// Add normalised PVT function tables to INIT file's TAB vector.
         ///

--- a/opm/output/eclipse/VectorItems/tabdims.hpp
+++ b/opm/output/eclipse/VectorItems/tabdims.hpp
@@ -29,8 +29,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             // Number of elements in 'TAB' array
             TabSize           = 0,
 
-            // Rock table (ROCK).  Not written by this writer; named so the
-            // constructor can keep the table count at zero.
+            // Rock compressibility table (ROCK)
             RockTableStart    =  1,
             NumRockTables     =  2,
 

--- a/opm/output/eclipse/VectorItems/tabdims.hpp
+++ b/opm/output/eclipse/VectorItems/tabdims.hpp
@@ -29,6 +29,16 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             // Number of elements in 'TAB' array
             TabSize           = 0,
 
+            // Rock table (ROCK).  Not written by this writer; named so the
+            // constructor can keep the table count at zero.
+            RockTableStart    =  1,
+            NumRockTables     =  2,
+
+            // Rock compaction tables (ROCKTAB).  Not written by this
+            // writer; slots 3..5 unverified.
+            NumRockCompNodes  =  4,
+            NumRockCompTables =  5,
+
             // Oil PVT table
             PvtoMainStart     =  6,
             PvtoCompStart     =  7,

--- a/opm/output/eclipse/WriteInit.cpp
+++ b/opm/output/eclipse/WriteInit.cpp
@@ -729,6 +729,7 @@ namespace {
     {
         ::Opm::Tables tables(units);
 
+        tables.addRock(es.getTableManager().getRockTable());
         tables.addPVTTables(es);
         tables.addDensity(es.getTableManager().getDensityTable());
         tables.addSatFunc(es);

--- a/tests/test_Tables.cpp
+++ b/tests/test_Tables.cpp
@@ -3413,6 +3413,49 @@ BOOST_AUTO_TEST_SUITE_END ()
 
 // =====================================================================
 
+BOOST_AUTO_TEST_SUITE (Rock)
+
+BOOST_AUTO_TEST_CASE (No_Rock_Keyword_Advertises_No_Table)
+{
+    // TABDIMS must not claim a rock table when the deck declares none.  The
+    // base pointers are pre-filled with 1 to satisfy the one-based TABDIMS
+    // protocol, so a non-zero count here would send a reader to the start of
+    // TAB and hand it whichever table happens to be there.
+    const auto rspec = std::string { R"(RUNSPEC
+DIMENS
+  10 10 10 /
+
+TITLE
+  Test ROCK Output
+
+WATER
+
+METRIC
+
+TABDIMS
+/
+)"  };
+
+    const auto props = std::string { R"(
+PVTW
+-- Pref  Bw(Pref)  Cw        Vw(Pref)  Cv
+   200   1.23      0.321e-4  0.25      0.654e-3 /
+)"  };
+
+    const auto es = parse(rspec, props);
+
+    auto tables = ::Opm::Tables(es.getUnits());
+    tables.addPVTTables(es);
+
+    const auto& tabdims = tables.tabdims();
+
+    BOOST_CHECK_EQUAL(tabdims[ Ix::NumRockTables ], 0);
+    BOOST_CHECK_EQUAL(tabdims[ Ix::NumRockCompNodes ], 0);
+    BOOST_CHECK_EQUAL(tabdims[ Ix::NumRockCompTables ], 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END ()    // Rock
+
 BOOST_AUTO_TEST_SUITE_END ()
 
 // =====================================================================

--- a/tests/test_Tables.cpp
+++ b/tests/test_Tables.cpp
@@ -3419,8 +3419,8 @@ BOOST_AUTO_TEST_CASE (No_Rock_Keyword_Advertises_No_Table)
 {
     // TABDIMS must not claim a rock table when the deck declares none.  The
     // base pointers are pre-filled with 1 to satisfy the one-based TABDIMS
-    // protocol, so a non-zero count here would send a reader to the start of
-    // TAB and hand it whichever table happens to be there.
+    // protocol, so a non-zero count here would send a reader that trusts
+    // NTROCK to the start of TAB, and hand it whichever table is there.
     const auto rspec = std::string { R"(RUNSPEC
 DIMENS
   10 10 10 /
@@ -3445,13 +3445,75 @@ PVTW
     const auto es = parse(rspec, props);
 
     auto tables = ::Opm::Tables(es.getUnits());
-    tables.addPVTTables(es);
+    tables.addRock(es.getTableManager().getRockTable());
 
     const auto& tabdims = tables.tabdims();
 
     BOOST_CHECK_EQUAL(tabdims[ Ix::NumRockTables ], 0);
     BOOST_CHECK_EQUAL(tabdims[ Ix::NumRockCompNodes ], 0);
     BOOST_CHECK_EQUAL(tabdims[ Ix::NumRockCompTables ], 0);
+
+    BOOST_CHECK(tables.tab().empty());
+}
+
+BOOST_AUTO_TEST_CASE (Rock_Keyword_Is_Written_To_TAB)
+{
+    const auto rspec = std::string { R"(RUNSPEC
+DIMENS
+  10 10 10 /
+
+TITLE
+  Test ROCK Output
+
+WATER
+
+METRIC
+
+TABDIMS
+-- NTSFUN  NTPVT
+   1*      2
+/
+)"  };
+
+    // Two rock regions.  One region would not discriminate the column major
+    // layout, since row zero and column zero coincide there.
+    const auto props = std::string { R"(
+ROCK
+-- Pref  Cr
+   277   4.84E-5 /
+   300   6.00E-5 /
+
+PVTW
+-- Pref  Bw(Pref)  Cw        Vw(Pref)  Cv
+   200   1.23      0.321e-4  0.25      0.654e-3 /
+   210   1.24      0.322e-4  0.26      0.655e-3 /
+)"  };
+
+    const auto es = parse(rspec, props);
+
+    auto tables = ::Opm::Tables(es.getUnits());
+    tables.addRock(es.getTableManager().getRockTable());
+
+    const auto& tabdims = tables.tabdims();
+
+    BOOST_CHECK_EQUAL(tabdims[ Ix::NumRockTables ], 2);
+
+    // Base pointers are one-based offsets into TAB.
+    const auto start = static_cast<std::size_t>(tabdims[ Ix::RockTableStart ]) - 1;
+
+    const auto& tab = tables.tab();
+
+    BOOST_REQUIRE_GE(tab.size(), start + 4);
+
+    // METRIC: reference pressures in bar, compressibilities in 1/bar.
+    // Column major: both pressures, then both compressibilities.
+    const auto expect = std::vector<double> {
+        277.0, 300.0, 4.84e-5, 6.0e-5,
+    };
+
+    check_is_close(std::vector<double> {
+        tab[start + 0], tab[start + 1], tab[start + 2], tab[start + 3],
+    }, expect);
 }
 
 BOOST_AUTO_TEST_SUITE_END ()    // Rock


### PR DESCRIPTION
We were reading an INIT written by Flow 2025.10 to reconstruct pore volume at pressure, which needs the rock reference pressure and compressibility. TABDIMS said the table was there via NTROCK = 1, IBROCK = 1. So we followed the pointer and got TAB[0:2] = 20.0, 50.0. Those are the first two pressure nodes of the gas PVT table. What was missing is the table itself. Nothing in Tables ever appended ROCK to TAB.

ECLIPSE writes the table at the very start of TAB, two slots wide. That is the shape implemented here.

ROCKTAB is still not written, and the PVT, density and saturation-function counts have the same problem when their table is absent.