### PR TITLE
TPSA: Parsing SPRING type info in BCMECH

### DIFF
--- a/opm/input/eclipse/Schedule/BCState.cpp
+++ b/opm/input/eclipse/Schedule/BCState.cpp
@@ -18,6 +18,7 @@
   along with OPM.
 */
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/B.hpp>
 #include <opm/input/eclipse/Schedule/BCState.hpp>
@@ -58,6 +59,9 @@ BCMECHType bcmechtype(const std::string& s) {
 
     if (s == "FIXED")
         return BCMECHType::FIXED;
+
+    if (s == "SPRING")
+        return BCMECHType::SPRING;
 
     if (s == "NONE")
         return BCMECHType::NONE;
@@ -149,6 +153,17 @@ BCState::BCFace BCState::BCFace::fromBCMech(const DeckRecord& record)
     mechbcvaluetmp.fixeddir[0] = record.getItem<BCMECHKEY::FIXEDX>().get<int>(0);
     mechbcvaluetmp.fixeddir[1] = record.getItem<BCMECHKEY::FIXEDY>().get<int>(0);
     mechbcvaluetmp.fixeddir[2] = record.getItem<BCMECHKEY::FIXEDZ>().get<int>(0);
+    if (const auto& P = record.getItem<BCMECHKEY::DISTANCE>(); ! P.defaultApplied(0)) {
+        mechbcvaluetmp.distance = P.getSIDouble(0);
+    }
+    if (const auto& P = record.getItem<BCMECHKEY::SHEAR_MODULUS>(); ! P.defaultApplied(0)) {
+        mechbcvaluetmp.shearmodulus = P.getSIDouble(0);
+    }
+    if (bcmechface.bcmechtype == BCMECHType::SPRING && mechbcvaluetmp.shearmodulus == 0.0) {
+        OPM_THROW(std::invalid_argument,
+                  "BCMECH: SHEAR_MODULUS (item 13) must be non-zero when MECHTYPE is SPRING for "
+                  "INDEX " + std::to_string(bcmechface.index));
+    }
     bcmechface.mechbcvalue = mechbcvaluetmp;
 
     return bcmechface;

--- a/opm/input/eclipse/Schedule/BCState.hpp
+++ b/opm/input/eclipse/Schedule/BCState.hpp
@@ -45,6 +45,7 @@ enum class BCType {
 enum class BCMECHType {
      FREE,
      FIXED,
+     SPRING,
      NONE
 };
 
@@ -64,12 +65,16 @@ struct MechBCValue {
     std::array<double,3> disp{};
     std::array<double,6> stress{};
     std::array<bool,3> fixeddir{};
+    double distance = 0.0;
+    double shearmodulus = 0.0;
 
     static MechBCValue serializationTestObject()
     {
         return MechBCValue{{1.0, 2.0, 3.0},
                            {3.0, 4.0, 5.0, 6.0, 7.0, 8.0},
-                           {true, false, true}};
+                           {true, false, true},
+                           9.0,
+                           10.0};
     }
 
     template<class Serializer>
@@ -78,13 +83,17 @@ struct MechBCValue {
         serializer(disp);
         serializer(stress);
         serializer(fixeddir);
+        serializer(distance);
+        serializer(shearmodulus);
     }
 
     bool operator==(const MechBCValue& other) const
     {
         return disp == other.disp &&
                stress == other.stress &&
-               fixeddir == other.fixeddir;
+               fixeddir == other.fixeddir &&
+               distance == other.distance &&
+               shearmodulus == other.shearmodulus;
     }
 };
 

--- a/opm/input/eclipse/share/keywords/900_OPM/B/BCMECH
+++ b/opm/input/eclipse/share/keywords/900_OPM/B/BCMECH
@@ -63,6 +63,18 @@
       "value_type": "DOUBLE",
       "default": 0,
       "dimension": "Length"
+    },
+    {
+      "name": "DISTANCE",
+      "value_type": "DOUBLE",
+      "default": 0,
+      "dimension": "Length"
+    },
+    {
+      "name": "SHEAR_MODULUS",
+      "value_type": "DOUBLE",
+      "default": 0,
+      "dimension": "Ymodule"
     }
   ]
 }

--- a/tests/parser/BCConfigTests.cpp
+++ b/tests/parser/BCConfigTests.cpp
@@ -216,12 +216,14 @@ BCCON
   1 1* * 1 5 1 10 Y- /
   2 20 20 4* Y /
   3 10 15 1 10 4 7 Z /
+  4 5 5 1 10 1 3 Z- /
 /
 SCHEDULE
 BCMECH
  1 FIXED 1 0 0 1.0 * * 2.0 * * /
  2 FIXED 0 1 0 * 3.0 * /
  3 FREE 0 0 1 * * 4.0 * * 5.0 /
+ 4 SPRING * * * * * * * * * 6.0 7.0 /
 /
 )";
 
@@ -232,9 +234,9 @@ BCMECH
         prop.updateBCMech(record);
     }
 
-    BOOST_CHECK_EQUAL(config.size(), 3U);
+    BOOST_CHECK_EQUAL(config.size(), 4U);
 
-    BOOST_CHECK_EQUAL(prop.size(), 3U);
+    BOOST_CHECK_EQUAL(prop.size(), 4U);
 
     using measure = Opm::UnitSystem::measure;
     constexpr Opm::BCState::BCFace defaultFace{};
@@ -305,6 +307,27 @@ BCMECH
     BOOST_CHECK_SMALL(prop[3].mechbcvalue.disp[1], 1e-12);
     BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::length, 5.0),
                       prop[3].mechbcvalue.disp[2]);
+
+    BOOST_CHECK(prop[4].bctype == defaultFace.bctype);
+    BOOST_CHECK(prop[4].component == defaultFace.component);
+    BOOST_CHECK_EQUAL(prop[4].rate, defaultFace.rate);
+    BOOST_CHECK(prop[4].pressure == defaultFace.pressure);
+    BOOST_CHECK(prop[4].temperature == defaultFace.temperature);
+
+    BOOST_CHECK(prop[4].bcmechtype == Opm::BCMECHType::SPRING);
+    BOOST_CHECK_EQUAL(prop[4].mechbcvalue.fixeddir[0], 1);
+    BOOST_CHECK_EQUAL(prop[4].mechbcvalue.fixeddir[1], 1);
+    BOOST_CHECK_EQUAL(prop[4].mechbcvalue.fixeddir[2], 1);
+    BOOST_CHECK_SMALL(prop[4].mechbcvalue.stress[0], 1e-12);
+    BOOST_CHECK_SMALL(prop[4].mechbcvalue.stress[1], 1e-12);
+    BOOST_CHECK_SMALL(prop[4].mechbcvalue.stress[2], 1e-12);
+    BOOST_CHECK_SMALL(prop[4].mechbcvalue.disp[0], 1e-12);
+    BOOST_CHECK_SMALL(prop[4].mechbcvalue.disp[1], 1e-12);
+    BOOST_CHECK_SMALL(prop[4].mechbcvalue.disp[2], 1e-12);
+    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si(measure::length, 6.0),
+                      prop[4].mechbcvalue.distance);
+    BOOST_CHECK_EQUAL(deck.getActiveUnitSystem().to_si("Ymodule", 7.0),
+                      prop[4].mechbcvalue.shearmodulus);
 }
 
 BOOST_AUTO_TEST_CASE(BcPropAndBcMech)

--- a/tests/test_Serialization.cpp
+++ b/tests/test_Serialization.cpp
@@ -98,6 +98,7 @@
 #include <opm/input/eclipse/Schedule/Action/Condition.hpp>
 #include <opm/input/eclipse/Schedule/Action/PyAction.hpp>
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
+#include <opm/input/eclipse/Schedule/BCState.hpp>
 #include <opm/input/eclipse/Schedule/Events.hpp>
 #include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
 #include <opm/input/eclipse/Schedule/GasPlantTable.hpp>
@@ -257,6 +258,7 @@ TEST_FOR_TYPE_NAMED(Action::AST, ActionAST)
 TEST_FOR_TYPE_NAMED(Action::ASTNode, ActionASTNode)
 TEST_FOR_TYPE_NAMED(Action::State, ActionState)
 TEST_FOR_TYPE(BCConfig)
+TEST_FOR_TYPE(BCState)
 TEST_FOR_TYPE(BrineDensityTable)
 TEST_FOR_TYPE(Carfin)
 TEST_FOR_TYPE(ColumnSchema)


### PR DESCRIPTION
Adds parsing SPRING type, and distance and shear modulus input to BCMECH. Needed to calculate spring (i.e. robin type) boundary condition in https://github.com/OPM/opm-simulators/pull/7392.