### PR TITLE
Use Map_Member<> For GSATPROD Group Handling

### DIFF
--- a/opm/input/eclipse/Schedule/Group/GSatProd.cpp
+++ b/opm/input/eclipse/Schedule/Group/GSatProd.cpp
@@ -19,82 +19,88 @@
 
 #include <opm/input/eclipse/Schedule/Group/GSatProd.hpp>
 
+#include <opm/input/eclipse/Schedule/SummaryState.hpp>
+
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
+
 #include "../eval_uda.hpp"
 
-#include <stdexcept>
+#include <string>
+#include <type_traits>
 
-namespace Opm {
+namespace {
+    template <typename Body>
+    void rateLoop(Body&& body)
+    {
+        constexpr auto num_rates =
+            static_cast<std::underlying_type_t<Opm::GSatProd::Rate>>
+            (Opm::GSatProd::Rate::Num);
 
-GSatProd GSatProd::serializationTestObject()
-{
-    GSatProd result;
-    result.groups_ = { {"test1", {{UDAValue(1.0), UDAValue(2.0), UDAValue(3.0),
-                                   UDAValue(4.0), UDAValue(5.0)}, 6.0} } };
-
-    return result;
-}
-
-bool GSatProd::has(const std::string& name) const
-{
-    return this->groups_.find(name) != this->groups_.end();
-}
-
-const GSatProd::GSatProdGroup& GSatProd::get(const std::string& name) const
-{
-    auto it = this->groups_.find(name);
-    if (it == this->groups_.end()) {
-        throw std::invalid_argument {
-            "Current GSatPRod obj. does not contain '" + name + "'."
-        };
+        for (auto rate = 0*num_rates; rate < num_rates; ++rate) {
+            body(static_cast<Opm::GSatProd::Rate>(rate));
+        }
     }
+} // Anonymous namespace
 
-    return it->second;
-}
+Opm::GSatProd::GSatProd(const std::string& group)
+    : group_ { group }
+{}
 
-const GSatProd::GSatProdGroupProp GSatProd::get(const std::string& name, const SummaryState& st) const
+Opm::GSatProd
+Opm::GSatProd::serializationTestObject()
 {
-    using Rate = GSatProdGroupProp::Rate;
+    using namespace std::string_literals;
 
-    GSatProdGroupProp prop;
-    const GSatProd::GSatProdGroup& group = this->get(name);
-    prop.rate[Rate::Oil] = UDA::eval_group_uda(group.rate[Rate::Oil], name, st, group.udq_undefined);
-    prop.rate[Rate::Gas] = UDA::eval_group_uda(group.rate[Rate::Gas], name, st, group.udq_undefined);
-    prop.rate[Rate::Water] = UDA::eval_group_uda(group.rate[Rate::Water], name, st, group.udq_undefined);
-    prop.rate[Rate::Resv] = UDA::eval_group_uda(group.rate[Rate::Resv], name, st, group.udq_undefined);
-    prop.rate[Rate::GLift] = UDA::eval_group_uda(group.rate[Rate::GLift], name, st, group.udq_undefined);
+    auto test_object = GSatProd { "test1"s };
 
-    return prop;
+    rateLoop([rate_value = 1.0, &test_object](const Rate r) mutable
+    {
+        test_object.rate_[r] = UDAValue { rate_value++ };
+    });
+
+    return test_object;
 }
 
-void GSatProd::assign(const std::string& name,
-                      const UDAValue&    oil_rate,
-                      const UDAValue&    gas_rate,
-                      const UDAValue&    water_rate,
-                      const UDAValue&    resv_rate,
-                      const UDAValue&    glift_rate,
-                      double             udq_undefined)
+void Opm::GSatProd::assign(const Values<UDAValue>& input)
 {
-    using Rate = GSatProdGroupProp::Rate;
-
-    GSatProd::GSatProdGroup& group = groups_[name];
-
-    group.rate[Rate::Oil] = oil_rate;
-    group.rate[Rate::Gas] = gas_rate;
-    group.rate[Rate::Water] = water_rate;
-    group.rate[Rate::Resv] = resv_rate;
-    group.rate[Rate::GLift] = glift_rate;
-    group.udq_undefined = udq_undefined;
+    this->rate_ = input;
 }
 
-std::size_t GSatProd::size() const
+std::optional<std::string>
+Opm::GSatProd::udq(const Rate r) const
 {
-    return this->groups_.size();
+    if (const auto& uda = this->rate_[r]; uda.is_numeric()) {
+        return {};
+    }
+    else {
+        return { uda.get<std::string>() };
+    }
 }
 
-bool GSatProd::operator==(const GSatProd& data) const
+double
+Opm::GSatProd::getRate(const Rate r, const SummaryState& st) const
 {
-    return this->groups_ == data.groups_;
+    return UDA::eval_group_uda(this->rate_[r],
+                               this->group_,
+                               st, st.get_udq_undefined());
 }
 
-} // namespace Opm
+Opm::GSatProd::Values<double>
+Opm::GSatProd::getRates(const SummaryState& st) const
+{
+    auto rate_value = Values<double>{};
+
+    rateLoop([this, &st, &rate_value](const Rate r)
+    {
+        rate_value[r] = this->getRate(r, st);
+    });
+
+    return rate_value;
+}
+
+bool Opm::GSatProd::operator==(const GSatProd& that) const
+{
+    return (this->group_ == that.group_)
+        && (this->rate_ == that.rate_)
+        ;
+}

--- a/opm/input/eclipse/Schedule/Group/GSatProd.hpp
+++ b/opm/input/eclipse/Schedule/Group/GSatProd.hpp
@@ -17,46 +17,116 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef GSATPROD_H
-#define GSATPROD_H
+#ifndef OPM_GROUP_SATELLITE_PRODUCTION_HPP_INCLUDED
+#define OPM_GROUP_SATELLITE_PRODUCTION_HPP_INCLUDED
 
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
-#include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 #include <array>
 #include <cstddef>
-#include <map>
+#include <optional>
 #include <string>
+#include <type_traits>
 
 namespace Opm {
 
     class SummaryState;
 
-    /// Group level satellite production
+} // namespace Opm
+
+namespace Opm {
+
+    /// Satellite production rates for a single, named group.
     class GSatProd
     {
     public:
-        /// Satellite production rates for a single group.
-        struct GSatProdGroup
+        /// Satellite production rate items.
+        enum class Rate : std::size_t
         {
-            /// Satellite production rates.
-            ///
-            /// One rate for each enumerated item.
-            std::array<UDAValue, 5> rate{};
+            /// Oil phase production rate.
+            Oil,
 
-            /// Default udq value.
-            double udq_undefined;
+            /// Gas phase production rate.
+            Gas,
 
-            /// Equality predicate
+            /// Water phase production rate.
+            Water,
+
+            /// Reservoir voidage volume production rate.
+            Resv,
+
+            /// Gas lift production rate.
+            GLift,
+
+            // ---------------------------------------------------------------
+            //
+            // Bookkeping information.  No other enumerators below this
+            // line.
+            //
+            // ---------------------------------------------------------------
+
+            /// Number of enumerators.
+            Num,
+        };
+
+        /// Container of satellite production rate values.
+        ///
+        /// Indexed by \c Rate.
+        ///
+        /// \tparam T Element type of the satellite production rate values.
+        /// Typically \c double or \c UDAValue.
+        template <typename T>
+        class Values
+        {
+        private:
+            /// Translate a \c Rate to a numeric index.
             ///
-            /// \param[in] data Object against which \code *this \endcode
+            /// Equivalent to C++23's \code std::to_underlying() \endcode.
+            ///
+            /// \param[in] r Descriptor for a particular satellite
+            /// production rate.
+            ///
+            /// \return Numeric index corresponding to rate descriptor \p r.
+            static constexpr auto index(const Rate r) noexcept
+                -> std::underlying_type_t<Rate>
+            {
+                return static_cast<std::underlying_type_t<Rate>>(r);
+            }
+
+        public:
+            /// Read-only access to individual rate item.
+            ///
+            /// \param[in] r Rate item descriptor.
+            ///
+            /// \returns Immutable rate value defined by descriptor \p r.
+            [[nodiscard]] constexpr decltype(auto)
+            operator[](const Rate r) const noexcept
+            {
+                return this->v_[index(r)];
+            }
+
+            /// Read/write access to individual rate item.
+            ///
+            /// \param[in] r Rate item descriptor.
+            ///
+            /// \returns Reference to mutable rate value defined by
+            /// descriptor \p r.
+            [[nodiscard]] constexpr decltype(auto)
+            operator[](const Rate r) noexcept
+            {
+                return this->v_[index(r)];
+            }
+
+            /// Equality predicate.
+            ///
+            /// \param[in] that Object against which \code *this \endcode
             /// will be tested for equality.
             ///
             /// \return Whether or not \code *this \endcode is the same as
-            /// \p data.
-            bool operator==(const GSatProdGroup& data) const {
-                return rate == data.rate &&
-                       udq_undefined == data.udq_undefined;
+            /// \p that.
+            bool operator==(const Values& that) const
+            {
+                return this->v_ == that.v_;
             }
 
             /// Convert between byte array and object representation.
@@ -64,23 +134,59 @@ namespace Opm {
             /// \tparam Serializer Byte array conversion protocol.
             ///
             /// \param[in,out] serializer Byte array conversion object.
-            template<class Serializer>
+            template <class Serializer>
             void serializeOp(Serializer& serializer)
             {
-                serializer(rate);
-                serializer(udq_undefined);
+                serializer(this->v_);
             }
+
+        private:
+            /// Convenience count for sizing the rate value container.
+            static constexpr auto NumComponents =
+                static_cast<std::underlying_type_t<Rate>>(Rate::Num);
+
+            /// Rate values.
+            std::array<T, NumComponents> v_{};
         };
 
-        struct GSatProdGroupProp {
-            /// Satellite production rate items
-            enum Rate { Oil, Gas, Water, Resv, GLift, };
+        /// Default constructor.
+        ///
+        /// Resulting object is mostly usable as a target for a
+        /// serialisation operation.
+        GSatProd() = default;
 
-            /// Satellite production rates.
-            ///
-            /// One rate for each enumerated item.
-            std::array<double, 5> rate{};
-        };
+        /// Constructor.
+        ///
+        /// \param[in] group Name of group to which this collection of
+        /// satellite production rates applies.  Mostly needed to meet API
+        /// requirements of the ScheduleState::map_member<> class.
+        explicit GSatProd(const std::string& group);
+
+        /// Copy constructor.
+        ///
+        /// \param[in] rhs Source object.
+        GSatProd(const GSatProd& rhs) = default;
+
+        /// Move constructor.
+        ///
+        /// \param[in] rhs Source object.  Left in a valid but unspecificed
+        /// state when constructor completes.
+        GSatProd(GSatProd&& rhs) = default;
+
+        /// Assignment operator.
+        ///
+        /// \param[in] rhs Source object.
+        ///
+        /// \return \code *this \endcode
+        GSatProd& operator=(const GSatProd& rhs) = default;
+
+        /// Move-assignment operator.
+        ///
+        /// \param[in] rhs Source object.  Left in a valid but unspecificed
+        /// state when assignment function completes.
+        ///
+        /// \return \code *this \endcode
+        GSatProd& operator=(GSatProd&& rhs) = default;
 
         /// Create a serialisation test object.
         static GSatProd serializationTestObject();
@@ -89,104 +195,82 @@ namespace Opm {
         ///
         /// Effectively internalises items from the GSATPROD keyword.
         ///
-        /// \param[in] name Group name.
-        ///
-        /// \param[in] oil_rate Satellite production oil surface rate for
-        /// group \p name.
-        ///
-        /// \param[in] gas_rate Satellite production gas surface rate for
-        /// group \p name.
-        ///
-        /// \param[in] water_rate Satellite production water surface rate
-        /// for group \p name.
-        ///
-        /// \param[in] resv_rate Satellite production reservoir voidage rate
-        /// for group \p name.
-        ///
-        /// \param[in] glift_rate Satellite production gas lift rate for
-        /// group \p name.
-        ///
-        /// \param[in] udq_undefined Satellite udq undefined value for
-        /// group \p name.
-        void assign(const std::string& name,
-                    const UDAValue&    oil_rate,
-                    const UDAValue&    gas_rate,
-                    const UDAValue&    water_rate,
-                    const UDAValue&    resv_rate,
-                    const UDAValue&    glift_rate,
-                    double             udq_undefined);
+        /// \param[in] input Satellite production rates as defined by the
+        /// GSATPROD keyword.
+        void assign(const Values<UDAValue>& input);
 
-        /// Whether or not satellite production rates have been defined for
-        /// a named group.
+        /// Retrieve name of group to which this collection applies.
         ///
-        /// \param[in] name Group name.
+        /// Needed to meet API requirements of ScheduleState::map_member<>.
         ///
-        /// \return Whether or not satellite production rates have been
-        /// defined for group \p name.
-        bool has(const std::string& name) const;
+        /// \return Name of group to which this collection of satellite
+        /// production rates applies.
+        const std::string& name() const noexcept { return this->group_; }
 
-        /// Retrieve satellite production rates for named group.
+        /// Name of user-defined quantity backing a particular production rate.
         ///
-        /// Throws an exception of type \code std::invalid_argument \endcode
-        /// if there are no satellite production rates defined for that
-        /// named group.  Clients should invoke the predicate has() to
-        /// determine availability of satellite production rates for a
-        /// particular named group.
+        /// \param[in] r Rate descriptor.
         ///
-        /// \param[in] name Group name.
-        ///
-        /// \return Satellite production rates for group \p name.
-        const GSatProdGroup& get(const std::string& name) const;
+        /// \return Name of the UDQ backing satellite production rate \p r.
+        /// Nullopt if the production rate \p r is entered as a numeric
+        /// value in the GSATPROD keyword.
+        std::optional<std::string> udq(const Rate r) const;
 
-        /// Retrieve scalar satellite production rates for named group.
+        /// Retrieve single satellite production rate.
         ///
-        /// \param[in] name Group name.
+        /// \param[in] r Rate descriptor.
+        ///
+        /// \param[in] st Current summary vectors from which to exctract
+        /// applicable UDQ values.
+        ///
+        /// \returns Current group's satellite production rate for
+        /// descriptor \p r.
+        double getRate(const Rate r, const SummaryState& st) const;
+
+        /// Retrieve scalar satellite production rates for current group.
+        ///
+        /// Equivalent to calling getRate(r, st) for all \c Rate descriptors
+        /// \c r.
         ///
         /// \param[in] st Summary state.
         ///
-        /// \return Satellite production rates for group \p name.
-        const GSatProdGroupProp get(const std::string& name,
-                                    const SummaryState& st) const;
+        /// \return All satellite production rates for the current group.
+        Values<double> getRates(const SummaryState& st) const;
 
-        /// Whether or not any groups have associate satellite production
-        /// rates.
+        /// Equality predicate.
         ///
-        /// This is mostly a convenience function for certain logical
-        /// statements.
-        ///
-        /// \return True if no groups have satellite production rates and
-        /// false otherwise.
-        bool empty() const { return this->size() == 0; }
-
-        /// Number of groups for which satellite production rates have been
-        /// defined.
-        std::size_t size() const;
-
-        /// Equality predicate
-        ///
-        /// \param[in] data Object against which \code *this \endcode will
+        /// \param[in] that Object against which \code *this \endcode will
         /// be tested for equality.
         ///
         /// \return Whether or not \code *this \endcode is the same as \p
-        /// data.
-        bool operator==(const GSatProd& data) const;
+        /// that.
+        bool operator==(const GSatProd& that) const;
 
         /// Convert between byte array and object representation.
         ///
         /// \tparam Serializer Byte array conversion protocol.
         ///
         /// \param[in,out] serializer Byte array conversion object.
-        template<class Serializer>
+        template <class Serializer>
         void serializeOp(Serializer& serializer)
         {
-            serializer(groups_);
+            serializer(this->group_);
+            serializer(this->rate_);
         }
 
     private:
-        /// Satellite production rates for all pertinent groups.
-        std::map<std::string, GSatProdGroup> groups_;
+        /// Group name.
+        ///
+        /// Needed to support ScheduleState::map_member<> type requirements
+        /// and to simplify UDA evaluation.  Is otherwise mostly redundant.
+        std::string group_{};
+
+        /// Satellite production rates.
+        ///
+        /// One rate for each enumerated item.
+        Values<UDAValue> rate_{};
     };
 
 } // namespace Opm
 
-#endif // GSATPROD_H
+#endif // OPM_GROUP_SATELLITE_PRODUCTION_HPP_INCLUDED

--- a/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
@@ -24,7 +24,6 @@
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
-#include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
 
 #include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
@@ -43,6 +42,8 @@
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <opm/input/eclipse/Deck/UDAValue.hpp>
+
 #include "../HandlerContext.hpp"
 
 #include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
@@ -55,6 +56,37 @@
 #include <vector>
 
 namespace {
+
+    Opm::GSatProd::Values<Opm::UDAValue>
+    parseGSatProd(const Opm::DeckRecord& record)
+    {
+        auto input = Opm::GSatProd::Values<Opm::UDAValue>{};
+
+        using Kw = Opm::ParserKeywords::GSATPROD;
+        using Rate = Opm::GSatProd::Rate;
+
+        input[Rate::Oil] = record
+            .getItem<Kw::OIL_PRODUCTION_RATE>()
+            .get<Opm::UDAValue>(0);
+
+        input[Rate::Gas] = record
+            .getItem<Kw::GAS_PRODUCTION_RATE>()
+            .get<Opm::UDAValue>(0);
+
+        input[Rate::Water] = record
+            .getItem<Kw::WATER_PRODUCTION_RATE>()
+            .get<Opm::UDAValue>(0);
+
+        input[Rate::Resv] = record
+            .getItem<Kw::RES_FLUID_VOL_PRODUCTION_RATE>()
+            .get<Opm::UDAValue>(0);
+
+        input[Rate::GLift] = record
+            .getItem<Kw::LIFT_GAS_SUPPLY_RATE>()
+            .get<Opm::UDAValue>(0);
+
+        return input;
+    }
 
     Opm::GroupSatelliteInjection::Rate
     parseGSatInje(const Opm::Phase       phase,
@@ -138,18 +170,16 @@ namespace Opm {
 
 namespace {
 
-/*
-  The function trim_wgname() is used to trim the leading and trailing spaces
-  away from the group and well arguments given in the GRUPTREE
-  keyword. If the deck argument contains a leading or trailing space that is
-  treated as an input error, and the action taken is regulated by the setting
-  ParseContext::PARSE_WGNAME_SPACE.
-
-  Observe that the spaces are trimmed *unconditionally* - i.e. if the
-  ParseContext::PARSE_WGNAME_SPACE setting is set to InputError::IGNORE that
-  means that we do not inform the user about "our fix", but it is *not* possible
-  to configure the parser to leave the spaces intact.
-*/
+// The function trim_wgname() is used to trim the leading and trailing
+// spaces away from the group and well arguments given in the GRUPTREE
+// keyword. If the deck argument contains a leading or trailing space that
+// is treated as an input error, and the action taken is regulated by the
+// setting ParseContext::PARSE_WGNAME_SPACE.
+//
+// Observe that the spaces are trimmed *unconditionally* - i.e. if the
+// ParseContext::PARSE_WGNAME_SPACE setting is set to InputError::IGNORE
+// that means that we do not inform the user about "our fix", but it is
+// *not* possible to configure the parser to leave the spaces intact.
 std::string trim_wgname(const DeckKeyword& keyword,
                         const std::string& wgname_arg,
                         const ParseContext& parseContext,
@@ -652,9 +682,8 @@ void handleGSATINJE(HandlerContext& handlerContext)
     using Kw = ParserKeywords::GSATINJE;
 
     for (const auto& record : handlerContext.keyword) {
-        const auto group_names =
-            getGroupNamesAndCreateIfNeeded(record.getItem<Kw::GROUP>()
-                                           .getTrimmedString(0), handlerContext);
+        const auto group_names = getGroupNamesAndCreateIfNeeded
+            (record.getItem<Kw::GROUP>().getTrimmedString(0), handlerContext);
 
         const auto phase = get_phase(record.getItem<Kw::PHASE>().getTrimmedString(0));
         const auto rate =
@@ -682,48 +711,29 @@ void handleGSATPROD(HandlerContext& handlerContext)
 {
     using Kw = ParserKeywords::GSATPROD;
 
-    const auto& keyword = handlerContext.keyword;
+    for (const auto& record : handlerContext.keyword) {
+        const auto group_names = getGroupNamesAndCreateIfNeeded
+            (record
+             .getItem<Kw::SATELLITE_GROUP_NAME_OR_GROUP_NAME_ROOT>()
+             .getTrimmedString(0), handlerContext);
 
-    auto new_gsatprod = handlerContext.state().gsatprod.get();
-
-    auto update = false;
-
-    for (const auto& record : keyword) {
-        const auto group_names =
-            getGroupNamesAndCreateIfNeeded(record
-                                           .getItem<Kw::SATELLITE_GROUP_NAME_OR_GROUP_NAME_ROOT>()
-                                           .getTrimmedString(0), handlerContext);
-
-        const auto oil_rate = record.getItem<Kw::OIL_PRODUCTION_RATE>().get<UDAValue>(0);
-        const auto gas_rate = record.getItem<Kw::GAS_PRODUCTION_RATE>().get<UDAValue>(0);
-        const auto water_rate = record.getItem<Kw::WATER_PRODUCTION_RATE>().get<UDAValue>(0);
-        const auto resv_rate = record.getItem<Kw::RES_FLUID_VOL_PRODUCTION_RATE>().get<UDAValue>(0);
-        const auto glift_rate = record.getItem<Kw::LIFT_GAS_SUPPLY_RATE>().get<UDAValue>(0);
+        const auto input = parseGSatProd(record);
 
         for (const auto& group_name : group_names) {
             rejectGroupIfField(group_name, handlerContext);
 
-            auto udq_undefined = handlerContext.state().udq.get().params().undefinedValue();
+            auto p = handlerContext.state().satelliteProduction.has(group_name)
+                ? handlerContext.state().satelliteProduction(group_name)
+                : GSatProd { group_name };
 
-            new_gsatprod.assign(group_name,
-                                oil_rate,
-                                gas_rate,
-                                water_rate,
-                                resv_rate,
-                                glift_rate,
-                                udq_undefined);
+            p.assign(input);
+            handlerContext.state().satelliteProduction.update(std::move(p));
 
             auto grp = handlerContext.state().groups(group_name);
             grp.recordSatelliteProduction();
 
             handlerContext.state().groups.update(std::move(grp));
-
-            update = true;
         }
-    }
-
-    if (update) {
-        handlerContext.state().gsatprod.update(std::move(new_gsatprod));
     }
 }
 

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -2582,8 +2582,6 @@ namespace {
             }
 
             if (group.hasSatelliteProduction()) {
-                auto satellite_prod = this->snapshots.back().gsatprod();
-
                 const auto dim_l = this->m_static.m_unit_system
                     .getDimension(UnitSystem::measure::liquid_surface_rate);
 
@@ -2593,17 +2591,20 @@ namespace {
                 const auto dim_r = this->m_static.m_unit_system
                     .getDimension(UnitSystem::measure::rate);
 
-                const auto qo    = UDAValue { rst_group.oil_rate_limit  , dim_l };
-                const auto qw    = UDAValue { rst_group.water_rate_limit, dim_l };
-                const auto qg    = UDAValue { rst_group.gas_rate_limit  , dim_g };
-                const auto qr    = UDAValue { rst_group.resv_rate_limit , dim_r };
-                const auto glift = UDAValue { rst_group.glift_max_supply, dim_g };
+                using Rate = GSatProd::Rate;
 
-                satellite_prod.assign(rst_group.name,
-                                      qo, qg, qw, qr, glift,
-                                      udq_undefined);
+                auto input = GSatProd::Values<UDAValue>{};
 
-                this->snapshots.back().gsatprod.update(std::move(satellite_prod));
+                input[Rate::Oil]   = UDAValue { rst_group.oil_rate_limit  , dim_l };
+                input[Rate::Gas]   = UDAValue { rst_group.gas_rate_limit  , dim_g };
+                input[Rate::Water] = UDAValue { rst_group.water_rate_limit, dim_l };
+                input[Rate::Resv]  = UDAValue { rst_group.resv_rate_limit , dim_r };
+                input[Rate::GLift] = UDAValue { rst_group.glift_max_supply, dim_g };
+
+                auto gsatprod = GSatProd { rst_group.name };
+                gsatprod.assign(input);
+
+                this->snapshots.back().satelliteProduction.update(std::move(gsatprod));
             }
         }
 
@@ -3011,7 +3012,6 @@ void Schedule::create_first(const time_point& start_time, const std::optional<ti
     sched_state.wtest_config.update( WellTestConfig() );
     sched_state.gconsale.update( GConSale() );
     sched_state.gconsump.update( GConSump() );
-    sched_state.gsatprod.update( GSatProd() );
     sched_state.gecon.update( GroupEconProductionLimits() );
     sched_state.wlist_manager.update( WListManager() );
     sched_state.network.update( Network::ExtNetwork() );

--- a/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -392,7 +392,6 @@ bool ScheduleState::operator==(const ScheduleState& other) const {
         && this->group_order.get() == other.group_order.get()
         && this->gconsale.get() == other.gconsale.get()
         && this->gconsump.get() == other.gconsump.get()
-        && this->gsatprod.get() == other.gsatprod.get()
         && this->wlist_manager.get() == other.wlist_manager.get()
         && this->rpt_config.get() == other.rpt_config.get()
         && this->actions.get() == other.actions.get()
@@ -407,6 +406,7 @@ bool ScheduleState::operator==(const ScheduleState& other) const {
         && this->wcycle() == other.wcycle()
         && this->wlist_tracker() == other.wlist_tracker()
         && this->wells == other.wells
+        && this->satelliteProduction == other.satelliteProduction
         && this->satelliteInjection == other.satelliteInjection
         && this->injectionNetwork == other.injectionNetwork
         && this->inj_streams == other.inj_streams
@@ -449,7 +449,6 @@ ScheduleState ScheduleState::serializationTestObject() {
     ts.wtest_config.update( WellTestConfig::serializationTestObject() );
     ts.gconsump.update( GConSump::serializationTestObject() );
     ts.gconsale.update( GConSale::serializationTestObject() );
-    ts.gsatprod.update( GSatProd::serializationTestObject() );
     ts.gecon.update( GroupEconProductionLimits::serializationTestObject() );
     ts.rescoup.update( ReservoirCoupling::CouplingInfo::serializationTestObject() );
     ts.wlist_manager.update( WListManager::serializationTestObject() );
@@ -469,6 +468,9 @@ ScheduleState ScheduleState::serializationTestObject() {
     ts.source.update( Source::serializationTestObject() );
     ts.wcycle.update(WCYCLE::serializationTestObject());
     ts.wlist_tracker.update(WellListChangeTracker::serializationTestObject());
+
+    ts.satelliteProduction.update(GSatProd::serializationTestObject());
+    ts.satelliteInjection.update(GroupSatelliteInjection::serializationTestObject());
 
     return ts;
 }

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -530,7 +530,6 @@ namespace Opm {
 
         ptr_member<GConSale> gconsale;
         ptr_member<GConSump> gconsump;
-        ptr_member<GSatProd> gsatprod;
         ptr_member<GroupEconProductionLimits> gecon;
         ptr_member<GuideRateConfig> guide_rate;
 
@@ -579,8 +578,6 @@ namespace Opm {
                                   return this->gconsale;
             else if constexpr ( std::is_same_v<T, GConSump> )
                                   return this->gconsump;
-            else if constexpr ( std::is_same_v<T, GSatProd> )
-                                  return this->gsatprod;
             else if constexpr ( std::is_same_v<T, GroupEconProductionLimits> )
                                   return this->gecon;
             else if constexpr ( std::is_same_v<T, WListManager> )
@@ -634,6 +631,9 @@ namespace Opm {
         map_member<std::string, Group> groups;
         map_member<std::string, Well> wells;
 
+        /// Group level satellite production rates.
+        map_member<std::string, GSatProd> satelliteProduction;
+
         /// Group level satellite injection rates.
         map_member<std::string, GroupSatelliteInjection> satelliteInjection;
 
@@ -668,7 +668,6 @@ namespace Opm {
         {
             serializer(gconsale);
             serializer(gconsump);
-            serializer(gsatprod);
             serializer(gecon);
             serializer(guide_rate);
             serializer(wlist_manager);
@@ -696,6 +695,7 @@ namespace Opm {
             serializer(gptable);
             serializer(groups);
             serializer(wells);
+            serializer(this->satelliteProduction);
             serializer(this->satelliteInjection);
             serializer(this->injectionNetwork);
             serializer(wseed);

--- a/opm/output/eclipse/AggregateGroupData.cpp
+++ b/opm/output/eclipse/AggregateGroupData.cpp
@@ -1252,23 +1252,20 @@ void assignSatelliteGroupProduction(const Opm::Group&        group,
                                     SGProp&&                 sgprop,
                                     SGrpArray&               sGrp)
 {
-    if (! gsatprod.has(group.name())) { return; }
-
     clearSatelliteRatesCommon(sGrp);
     clearSatelliteRatesProduction(sGrp);
 
     using Ix = ::Opm::RestartIO::Helpers::VectorItems::SGroup::prod_index;
     using M  = ::Opm::UnitSystem::measure;
-    using QI = ::Opm::GSatProd::GSatProdGroupProp::Rate;
+    using QI = ::Opm::GSatProd::Rate;
 
     using namespace std::string_view_literals;
 
-    const auto& gsp = gsatprod.get(group.name());
-    const auto rates = gsatprod.get(group.name(), sumState).rate;
+    const auto rates = gsatprod.getRates(sumState);
 
-    auto udaWarning = [&gname = group.name()](std::string_view   item,
-                                              const std::string& udq,
-                                              const float        value)
+    auto udaWarning = [&gname = group.name()](std::string_view item,
+                                              std::string_view udq,
+                                              const float      value)
     {
         Opm::OpmLog::warning(fmt::format("Restart:GSATPROD:{}:IsUDA", item),
                              fmt::format("{} UDA '{}' in GSATPROD for group "
@@ -1287,10 +1284,8 @@ void assignSatelliteGroupProduction(const Opm::Group&        group,
         if (const auto value = rates[itemIx]; value > 0.0) {
             sGrp[outIx] = sgprop(unit, value);
 
-            if (const auto& item = gsp.rate[itemIx]; !item.is_numeric()) {
-                udaWarning(descr,
-                           item.template get<std::string>(),
-                           sGrp[outIx]);
+            if (const auto udq = gsatprod.udq(itemIx); udq.has_value()) {
+                udaWarning(descr, *udq, sGrp[outIx]);
             }
         }
     }
@@ -1300,10 +1295,9 @@ void assignSatelliteGroupProduction(const Opm::Group&        group,
             = sGrp[Ix::ResvRateLimit_2]
             = sgprop(M::rate, qr);
 
-        if (const auto& item = gsp.rate[QI::Resv]; !item.is_numeric()) {
+        if (const auto udq = gsatprod.udq(QI::Resv); udq.has_value()) {
             udaWarning("Reservoir voidage rate",
-                       item.template get<std::string>(),
-                       sGrp[Ix::ResvRateLimit]);
+                       *udq, sGrp[Ix::ResvRateLimit]);
         }
     }
 }
@@ -1428,8 +1422,10 @@ void staticContrib(const Opm::Group&         group,
     }
 
     if (group.hasSatelliteProduction()) {
+        assert (sched.satelliteProduction.has(group.name()));
+
         assignSatelliteGroupProduction(group, sumState,
-                                       sched.gsatprod(),
+                                       sched.satelliteProduction(group.name()),
                                        sgprop, sGrp);
     }
 

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -861,27 +861,25 @@ double satellite_prod(const Opm::SummaryState&  st,
                       const Opm::ScheduleState& sched,
                       const std::string&        group)
 {
-    using Rate = Opm::GSatProd::GSatProdGroupProp::Rate;
+    using Rate = Opm::GSatProd::Rate;
 
-    const auto& gsatprod = sched.gsatprod();
-
-    if (! gsatprod.has(group)) {
+    if (! sched.satelliteProduction.has(group)) {
         return 0.0;
     }
 
-    const auto gs = gsatprod.get(group, st);
+    const auto& gsatprod = sched.satelliteProduction(group);
 
     if constexpr (phase == rt::oil) {
-        return gs.rate[Rate::Oil];
+        return gsatprod.getRate(Rate::Oil, st);
     }
     else if constexpr (phase == rt::gas) {
-        return gs.rate[Rate::Gas];
+        return gsatprod.getRate(Rate::Gas, st);
     }
     else if constexpr (phase == rt::wat) {
-        return gs.rate[Rate::Water];
+        return gsatprod.getRate(Rate::Water, st);
     }
     else if constexpr (phase == rt::alq) {
-        return gs.rate[Rate::GLift];
+        return gsatprod.getRate(Rate::GLift, st);
     }
 
     return 0.0;
@@ -1032,7 +1030,7 @@ double satellite_rate(const fn_args& args)
         return accum_groups(sched, gname, efac, group_sat_rate);
     };
 
-    if (!injection && !sched.gsatprod().empty()) {
+    if (!injection && (sched.satelliteProduction().size() > 0)) {
         // Down-tree satellite production rates.
 
         return satRate([&st = args.st, &sched](const std::string& gname)

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -53,6 +53,7 @@
 
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
@@ -432,17 +433,20 @@ GSATPROD
 TSTEP
   1 /)";
 
-    auto schedule = create_schedule(input);
-    double metric_to_si = 1.0 / (24.0 * 3600.0);  //cubic meters / day
-    const auto& gsatprod = schedule[0].gsatprod.get();
-    SummaryState st(TimeService::now(), 0.0);
-    BOOST_CHECK_EQUAL(gsatprod.size(), 1U);
-    BOOST_CHECK(!gsatprod.has("G1"));
-    BOOST_CHECK(gsatprod.has("G2"));
-    const GSatProd::GSatProdGroupProp& group = gsatprod.get("G2", st);
-    using Rate = GSatProd::GSatProdGroupProp::Rate;
-    BOOST_CHECK_EQUAL(group.rate[Rate::Oil], 1000*metric_to_si);
-    BOOST_CHECK_EQUAL(group.rate[Rate::Water], 0.0);
+    constexpr auto sm3d = unit::cubic(unit::meter) / unit::day;
+
+    const auto schedule = create_schedule(input);
+    const auto st = SummaryState { TimeService::now(), 0.0 };
+
+    const auto& gsatprod = schedule[0].satelliteProduction;
+
+    BOOST_CHECK_EQUAL(gsatprod.size(), std::size_t{1});
+    BOOST_CHECK_MESSAGE(!gsatprod.has("G1"), R"(GSATPROD must NOT have values for group "G1" at time zero)");
+    BOOST_CHECK_MESSAGE(gsatprod.has("G2"), R"(GSATPROD must have values for group "G2" at time zero)");
+
+    const auto group_rates = gsatprod("G2").getRates(st);
+    BOOST_CHECK_CLOSE(group_rates[GSatProd::Rate::Oil], 1000*sm3d, 1.0e-8);
+    BOOST_CHECK_CLOSE(group_rates[GSatProd::Rate::Water], 0.0, 1.0e-8);
 }
 
 BOOST_AUTO_TEST_CASE(GSatProd_NewGroup)
@@ -470,21 +474,20 @@ END
 
     BOOST_CHECK_MESSAGE(sched[0].groups.has("G2"), R"(Group "G2" must exist)");
 
-    const auto& gsatprod = sched[0].gsatprod();
-    SummaryState st(TimeService::now(), 0.0);
+    const auto& gsatprod = sched[0].satelliteProduction;
+    const auto st = SummaryState { TimeService::now(), 0.0 };
 
-    BOOST_CHECK_EQUAL(gsatprod.size(), 1U);
+    BOOST_CHECK_EQUAL(gsatprod.size(), std::size_t{1});
     BOOST_CHECK_MESSAGE(!gsatprod.has("G1"), R"(Group "G1" must NOT have satellite production)");
     BOOST_CHECK_MESSAGE(gsatprod.has("G2"), R"(Group "G2" must have satellite production)");
 
-    const auto& gsrate = gsatprod.get("G2", st).rate;
-    using Rate = GSatProd::GSatProdGroupProp::Rate;
+    const auto gsrate = gsatprod("G2").getRates(st);
 
     constexpr auto sm3d = unit::cubic(unit::meter)/unit::day;
 
-    BOOST_CHECK_CLOSE(gsrate[Rate::Oil], 1000*sm3d, 1.0e-8);
-    BOOST_CHECK_CLOSE(gsrate[Rate::Water], 500*sm3d, 1.0e-8);
-    BOOST_CHECK_CLOSE(gsrate[Rate::Gas], 10.0e3*sm3d, 1.0e-8);
+    BOOST_CHECK_CLOSE(gsrate[GSatProd::Rate::Oil], 1000*sm3d, 1.0e-8);
+    BOOST_CHECK_CLOSE(gsrate[GSatProd::Rate::Water], 500*sm3d, 1.0e-8);
+    BOOST_CHECK_CLOSE(gsrate[GSatProd::Rate::Gas], 10.0e3*sm3d, 1.0e-8);
 }
 
 BOOST_AUTO_TEST_CASE(GSatProd_Status)

--- a/tests/parser/ScheduleSerializeTest.cpp
+++ b/tests/parser/ScheduleSerializeTest.cpp
@@ -456,8 +456,8 @@ BOOST_AUTO_TEST_CASE(SerializeGCONSUMP)
 BOOST_AUTO_TEST_CASE(SerializeGSatProd) {
     auto sched  = make_schedule(GCONSALE_deck);
     Opm::Schedule sched0;
-    auto gsatprod1 = sched[0].gsatprod.get();
-    auto gsatprod2 = sched[3].gsatprod.get();
+    auto gsatprod1 = sched[0].satelliteProduction;
+    auto gsatprod2 = sched[3].satelliteProduction;
 
     {
         Opm::Serialization::MemPacker packer;
@@ -466,13 +466,13 @@ BOOST_AUTO_TEST_CASE(SerializeGSatProd) {
         ser.unpack(sched0);
     }
 
-    BOOST_CHECK( gsatprod1 == sched0[0].gsatprod());
-    BOOST_CHECK( gsatprod1 == sched0[1].gsatprod());
-    BOOST_CHECK( gsatprod1 == sched0[2].gsatprod());
+    BOOST_CHECK( gsatprod1 == sched0[0].satelliteProduction);
+    BOOST_CHECK( gsatprod1 == sched0[1].satelliteProduction);
+    BOOST_CHECK( gsatprod1 == sched0[2].satelliteProduction);
 
-    BOOST_CHECK( gsatprod2 == sched0[3].gsatprod());
-    BOOST_CHECK( gsatprod2 == sched0[4].gsatprod());
-    BOOST_CHECK( gsatprod2 == sched0[5].gsatprod());
+    BOOST_CHECK( gsatprod2 == sched0[3].satelliteProduction);
+    BOOST_CHECK( gsatprod2 == sched0[4].satelliteProduction);
+    BOOST_CHECK( gsatprod2 == sched0[5].satelliteProduction);
 }
 
 BOOST_AUTO_TEST_CASE(SerializeVFP) {


### PR DESCRIPTION
This PR removes the special purpose `GSatProd` class logic to map from group names to satellite production rate values, and instead makes the satellite production member of class `ScheduleState` into a `map_member<string, GSatProd>`.  We also give the member a new name (`satelliteProduction`) that more closely resembles the convention for satellite injection rates (`GSATINJE`).  The practical benefit of this change is that we're no longer creating separate copies of the satellite production rate objects for **all** groups if the rates change for **any** group, and we remove one level of type nesting.

We represent a collection of satellite production rate values for a single named group as a nested type, `GSatProd::Values<>`, templated on the element type of the values&ndash;typically `double` or `UDAValue`.  The `getRates() `function, renamed from the original `get()` function, returns a `Values<double>` of numeric rates.  The `assign()` function takes a `Values<UDAValue>` and the `GSatProd` object itself stores its input rates as an object of that type.  As a service to those clients that need only one or a select few production rates, we also introduce a new member function, `getRate()` (singular), that computes a single production rate.  This function then avoids calculating all rates, possibly by moderately expensive UDQ lookup, if just one rate will actually be used by the client.

Overall this is an API change for satellite production rates, so update all applicable callers accordingly.