### PR TITLE
Fix write-all-solutions summary indexing

### DIFF
--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -377,13 +377,12 @@ public:
     /// Source object from which to retrieve the values that go into the
     /// output buffer.
     ///
-    /// \param[in] report_step One-based report step index for which to
-    /// create output.  This is the number that gets incorporated into the
-    /// file extension of "separate" summary output files (i.e., .S000n).
-    /// Report_step=0 represents time zero.
+    /// \param[in] report_step One-based schedule report step index for which
+    /// to create output.  Report_step=0 represents time zero.
     ///
-    /// \param[in] time_step Zero-based time step ID.  Nullopt if the
-    /// sequence number should be the same as the report step.
+    /// \param[in] time_step Zero-based physical time step ID.  When present,
+    /// time_step+1 is used as the output sequence number; otherwise the
+    /// output sequence number is the report step.
     ///
     /// \param[in] secs_elapsed Elapsed physical (i.e., simulated) time in
     /// seconds since start of simulation.
@@ -633,7 +632,7 @@ private:
     /// seconds since start of simulation.
     void recordSummaryOutput(const double secs_elapsed);
 
-    /// Compute report sequence number.
+    /// Compute output sequence number.
     ///
     /// Typically equal to the report step index.
     ///

--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -888,9 +888,9 @@ void Opm::EclipseIO::Impl::writeSummaryFile(const SummaryState&      st,
                                             const bool               isSubstep,
                                             const bool               forceFinalWrite)
 {
-    this->summary_.add_timestep(st, this->reportIndex(report_step, time_step),
-                                this->miniStepId_,
-                                !time_step.has_value() || isSubstep);
+    this->summary_.add_timestep(st, report_step, this->miniStepId_,
+                                !time_step.has_value() || isSubstep,
+                                this->reportIndex(report_step, time_step));
 
     const auto is_final_summary =
         this->isFinalWrite(report_step, isSubstep, forceFinalWrite);

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -6136,7 +6136,8 @@ public:
     void internal_store(const SummaryState& st,
                         const int           report_step,
                         const int           ministep_id,
-                        const bool          isSubstep);
+                        const bool          isSubstep,
+                        const int           output_step);
 
     void write(const bool is_final_summary);
 
@@ -6144,7 +6145,8 @@ private:
     struct MiniStep
     {
         int id{0};
-        int seq{-1};
+        int outputStep{-1};
+        int reportStep{-1};
         bool isSubstep{false};
         std::vector<float> params{};
     };
@@ -6163,7 +6165,7 @@ private:
     Opm::EclIO::OutputStream::Unified   unif_;
 
     int prevCreate_{-1};
-    int prevReportStepID_{-1};
+    int prevOutputStepID_{-1};
     std::vector<MiniStep>::size_type numUnwritten_{0};
 
     SummaryOutputParameters                  outputParameters_{};
@@ -6207,14 +6209,15 @@ private:
 
     MiniStep& getNextMiniStep(const int  report_step,
                               const int  ministep_id,
-                              const bool isSubstep);
+                              const bool isSubstep,
+                              const int  output_step);
 
     const MiniStep& lastUnwritten() const;
 
     void write(const MiniStep& ms);
 
     void createSMSpecIfNecessary();
-    void createSmryStreamIfNecessary(const int report_step);
+    void createSmryStreamIfNecessary(const int output_step);
 };
 
 Opm::out::Summary::SummaryImplementation::
@@ -6288,9 +6291,10 @@ void Opm::out::Summary::SummaryImplementation::
 internal_store(const SummaryState& st,
                const int           report_step,
                const int           ministep_id,
-               const bool          isSubstep)
+               const bool          isSubstep,
+               const int           output_step)
 {
-    auto& ms = this->getNextMiniStep(report_step, ministep_id, isSubstep);
+    auto& ms = this->getNextMiniStep(report_step, ministep_id, isSubstep, output_step);
 
     const auto nParam = this->valueKeys_.size();
 
@@ -6442,11 +6446,11 @@ void Opm::out::Summary::SummaryImplementation::write(const bool is_final_summary
     // intermediate timestep.
     // Because of adaptive time stepping there could have been previous writes for the same
     // report step that missed information.
-    if (const auto& last = this->lastUnwritten(); (this->prevReportStepID_ < this->lastUnwritten().seq
+    if (const auto& last = this->lastUnwritten(); (this->prevOutputStepID_ < last.outputStep
                                                    || is_final_summary)) {
         this->smspec_->write(this->outputParameters_.summarySpecification(),
-                             is_final_summary, last.seq,
-                             sched_.get()[last.seq].get<RSTConfig>().get()
+                             is_final_summary, last.outputStep,
+                             sched_.get()[last.reportStep].get<RSTConfig>().get()
                              .basic.value_or(0));
     }
 
@@ -6460,7 +6464,7 @@ void Opm::out::Summary::SummaryImplementation::write(const bool is_final_summary
     if (this->esmry_ != nullptr) {
         for (auto i = 0*this->numUnwritten_; i < this->numUnwritten_; ++i) {
             this->esmry_->write(this->unwritten_[i].params,
-                                this->unwritten_[i].seq,
+                                this->unwritten_[i].outputStep,
                                 is_final_summary);
         }
     }
@@ -6472,13 +6476,13 @@ void Opm::out::Summary::SummaryImplementation::write(const bool is_final_summary
 
 void Opm::out::Summary::SummaryImplementation::write(const MiniStep& ms)
 {
-    this->createSmryStreamIfNecessary(ms.seq);
+    this->createSmryStreamIfNecessary(ms.outputStep);
 
-    if (this->prevReportStepID_ < ms.seq) {
+    if (this->prevOutputStepID_ < ms.outputStep) {
         // XXX: Should probably write SEQHDR = 0 here since
         ///     we do not know the actual encoding needed.
-        this->stream_->write("SEQHDR", std::vector<int>{ ms.seq });
-        this->prevReportStepID_ = ms.seq;
+        this->stream_->write("SEQHDR", std::vector<int>{ ms.outputStep });
+        this->prevOutputStepID_ = ms.outputStep;
     }
 
     this->stream_->write("MINISTEP", std::vector<int>{ ms.id });
@@ -6819,7 +6823,8 @@ Opm::out::Summary::SummaryImplementation::MiniStep&
 Opm::out::Summary::SummaryImplementation::
 getNextMiniStep(const int  report_step,
                 const int  ministep_id,
-                const bool isSubstep)
+                const bool isSubstep,
+                const int  output_step)
 {
     if (this->numUnwritten_ == this->unwritten_.size()) {
         this->unwritten_.emplace_back();
@@ -6830,8 +6835,9 @@ getNextMiniStep(const int  report_step,
 
     auto& ms = this->unwritten_[this->numUnwritten_++];
 
-    ms.id  = ministep_id;
-    ms.seq = report_step;
+    ms.id         = ministep_id;
+    ms.outputStep = output_step;
+    ms.reportStep = report_step;
     ms.isSubstep = isSubstep;
 
     ms.params.resize(this->valueKeys_.size(), 0.0f);
@@ -6864,22 +6870,22 @@ void Opm::out::Summary::SummaryImplementation::createSMSpecIfNecessary()
 
 void
 Opm::out::Summary::SummaryImplementation::
-createSmryStreamIfNecessary(const int report_step)
+createSmryStreamIfNecessary(const int output_step)
 {
     // Create stream if unset or if non-unified (separate) and new step.
 
-    assert ((this->prevCreate_ <= report_step) &&
-            "Inconsistent Report Step Sequence Detected");
+    assert ((this->prevCreate_ <= output_step) &&
+            "Inconsistent Output Step Sequence Detected");
 
     const auto do_create = ! this->stream_
-        || (! this->unif_.set && (this->prevCreate_ < report_step));
+        || (! this->unif_.set && (this->prevCreate_ < output_step));
 
     if (do_create) {
         this->stream_ = Opm::EclIO::OutputStream::
-            createSummaryFile(this->rset_, report_step,
+            createSummaryFile(this->rset_, output_step,
                               this->fmt_, this->unif_);
 
-        this->prevCreate_ = report_step;
+        this->prevCreate_ = output_step;
     }
 }
 
@@ -6929,7 +6935,17 @@ void Summary::add_timestep(const SummaryState& st,
                            const int           ministep_id,
                            const bool          isSubstep)
 {
-    this->pImpl_->internal_store(st, report_step, ministep_id, isSubstep);
+    this->add_timestep(st, report_step, ministep_id, isSubstep, report_step);
+}
+
+void Summary::add_timestep(const SummaryState& st,
+                           const int           report_step,
+                           const int           ministep_id,
+                           const bool          isSubstep,
+                           const int           output_step)
+{
+    this->pImpl_->internal_store(st, report_step, ministep_id,
+                                 isSubstep, output_step);
 }
 
 void Summary::write(const bool is_final_summary) const

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -6914,11 +6914,9 @@ void Summary::eval(const int                    report_step,
                    const DynamicSimulatorState& values,
                    SummaryState&                st) const
 {
-    // Report_step is the one-based sequence number of the containing report.
+    // Report_step is the one-based schedule index of the containing report.
     // Report_step = 0 for the initial condition, before simulation starts.
-    // We typically don't get reports_step = 0 here.  When outputting
-    // separate summary files 'report_step' is the number that gets
-    // incorporated into the filename extension.
+    // We typically don't get report_step = 0 here.
     //
     // Sim_step is the timestep which has been effective in the simulator,
     // and as such is the value necessary to use when looking up active

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -243,10 +243,8 @@ public:
     /// Source object from which to retrieve the values that go into the
     /// output buffer.
     ///
-    /// \param[in] report_step One-based report step index for which to
-    /// create output.  This is the number that gets incorporated into the
-    /// file extension of "separate" summary output files (i.e., .S000n).
-    /// Report_step=0 represents time zero.
+    /// \param[in] report_step One-based schedule report step index for
+    /// which to create output.  Report_step=0 represents time zero.
     ///
     /// \param[in] ministep_id Zero based count of time steps performed.
     ///
@@ -256,6 +254,18 @@ public:
                       const int           report_step,
                       const int           ministep_id,
                       const bool          isSubstep);
+
+    /// Linearise summary values using an output sequence number distinct
+    /// from the schedule report step.
+    ///
+    /// \param[in] output_step One-based output sequence number.  This is the
+    /// number that gets incorporated into the file extension of "separate"
+    /// summary output files (i.e., .S000n).
+    void add_timestep(const SummaryState& st,
+                      const int           report_step,
+                      const int           ministep_id,
+                      const bool          isSubstep,
+                      const int           output_step);
 
     /// Activate pre-allocated summary vector slots for newly established
     /// well connections arising from dynamic fracturing.

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -258,6 +258,18 @@ public:
     /// Linearise summary values using an output sequence number distinct
     /// from the schedule report step.
     ///
+    /// \param[in] st Summary values from most recent call to eval().
+    /// Source object from which to retrieve the values that go into the
+    /// output buffer.
+    ///
+    /// \param[in] report_step One-based schedule report step index for
+    /// which to create output.  Report_step=0 represents time zero.
+    ///
+    /// \param[in] ministep_id Zero based count of time steps performed.
+    ///
+    /// \param[in] isSubstep Whether or not we're being called in the middle
+    /// of a report step.
+    ///
     /// \param[in] output_step One-based output sequence number.  This is the
     /// number that gets incorporated into the file extension of "separate"
     /// summary output files (i.e., .S000n).
@@ -296,10 +308,8 @@ public:
 
     /// Calculate summary vector values.
     ///
-    /// \param[in] report_step One-based report step index for which to
-    /// create output.  This is the number that gets incorporated into the
-    /// file extension of "separate" summary output files (i.e., .S000n).
-    /// Report_step=0 represents time zero.
+    /// \param[in] report_step One-based schedule report step index for which
+    /// to calculate summary values.  Report_step=0 represents time zero.
     ///
     /// \param[in] secs_elapsed Elapsed physical time in seconds since start
     /// of simulation.

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -45,6 +45,7 @@
 
 #include <opm/io/eclipse/ERsm.hpp>
 #include <opm/io/eclipse/ESmry.hpp>
+#include <opm/io/eclipse/EclFile.hpp>
 
 #include <opm/common/utility/TimeService.hpp>
 
@@ -657,6 +658,39 @@ BOOST_AUTO_TEST_SUITE(Summary)
 
 // Tests read the deck, write (synthetic) summary output, read the summary
 // output, and compare those values with the input.
+
+BOOST_AUTO_TEST_CASE(PhysicalOutputSequenceBeyondScheduleSize)
+{
+    setup cfg {"summary_output_sequence"};
+
+    auto writer = out::Summary {cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name};
+
+    const auto st
+        = SummaryState {TimeService::now(), cfg.es.runspec().udqParams().undefinedValue()};
+
+    // Deliberately use the first output step outside the Schedule's valid index range.
+    const auto outputStep = static_cast<int>(cfg.schedule.size());
+    writer.add_timestep(st,
+                        /* report_step = */ 1,
+                        /* ministep_id = */ 0,
+                        /* isSubstep = */ true,
+                        outputStep);
+
+    BOOST_CHECK_NO_THROW(writer.write());
+
+    auto summaryFile = EclIO::EclFile {cfg.name + ".UNSMRY"};
+    auto sequence = std::optional<int> {};
+    const auto& arrayNames = summaryFile.arrayNames();
+    for (auto index = std::size_t {0}; index < arrayNames.size(); ++index) {
+        if (arrayNames[index] == "SEQHDR") {
+            sequence = summaryFile.get<int>(static_cast<int>(index)).front();
+            break;
+        }
+    }
+
+    BOOST_REQUIRE(sequence.has_value());
+    BOOST_CHECK_EQUAL(*sequence, outputStep);
+}
 
 BOOST_AUTO_TEST_CASE(LGR_summaryconfig_grid_ctor_populates_NUMS)
 {


### PR DESCRIPTION
Fixes https://github.com/OPM/opm-common/issues/5254.

The same issue occurs when working with https://github.com/OPM/opm-simulators/pull/7389.

## Approach

Keep the schedule report-step index separate from the physical summary output sequence. The report step is used for schedule and restart-configuration lookups, while the output sequence is used for summary file numbering and the `SEQHDR`, ESMRY, and SMSPEC output. Existing callers retain the previous behavior by using the report step as the output sequence unless they provide a distinct value.

A regression test covers an output sequence beyond the valid schedule index range.
