### PR TITLE
Recognize the AIM solution method keyword

### DIFF
--- a/opm/input/eclipse/EclipseState/Runspec.cpp
+++ b/opm/input/eclipse/EclipseState/Runspec.cpp
@@ -34,6 +34,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/F.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/H.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/I.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/M.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/N.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/O.hpp>
@@ -835,6 +836,11 @@ Runspec::Runspec(const Deck& deck)
     if (DeckSection::hasRUNSPEC(deck)) {
         const RUNSPECSection runspecSection{deck};
 
+        m_solution_method_specified =
+            runspecSection.hasKeyword<ParserKeywords::AIM>() ||
+            runspecSection.hasKeyword<ParserKeywords::FULLIMP>() ||
+            runspecSection.hasKeyword<ParserKeywords::IMPES>();
+
         if (runspecSection.hasKeyword<ParserKeywords::MINNPCOL>()) {
             const auto& min_item = runspecSection.get<ParserKeywords::MINNPCOL>()
                 .back().getRecord(0).getItem<ParserKeywords::MINNPCOL::VALUE>();
@@ -1001,6 +1007,7 @@ Runspec Runspec::serializationTestObject()
     result.m_tracers = Tracers::serializationTestObject();
     result.m_comps = 3;
     result.m_max_gas_plant_tables = 2;
+    result.m_solution_method_specified = true;
     result.m_co2storage = true;
     result.m_co2sol = true;
     result.m_h2sol = true;
@@ -1130,6 +1137,11 @@ bool Runspec::compositional() const noexcept
     return (this->m_comps > 0) && !this->m_co2storage && !this->m_h2storage;
 }
 
+bool Runspec::solutionMethodSpecified() const noexcept
+{
+    return this->m_solution_method_specified;
+}
+
 bool Runspec::biof() const noexcept
 {
     return this->m_biof;
@@ -1208,6 +1220,7 @@ bool Runspec::operator==(const Runspec& data) const
         && (this->m_tracers == data.m_tracers)
         && (this->m_comps == data.m_comps)
         && (this->m_max_gas_plant_tables == data.m_max_gas_plant_tables)
+        && (this->m_solution_method_specified == data.m_solution_method_specified)
         && (this->m_co2storage == data.m_co2storage)
         && (this->m_co2sol == data.m_co2sol)
         && (this->m_h2sol == data.m_h2sol)

--- a/opm/input/eclipse/EclipseState/Runspec.hpp
+++ b/opm/input/eclipse/EclipseState/Runspec.hpp
@@ -647,6 +647,7 @@ public:
     bool frac() const noexcept;
     bool temp() const noexcept;
     bool compositional() const noexcept;
+    bool solutionMethodSpecified() const noexcept;
     bool biof() const noexcept;
 
     bool operator==(const Runspec& data) const;
@@ -672,6 +673,7 @@ public:
         serializer(m_tracers);
         serializer(m_comps);
         serializer(m_max_gas_plant_tables);
+        serializer(m_solution_method_specified);
         serializer(m_co2storage);
         serializer(m_co2sol);
         serializer(m_h2sol);
@@ -705,6 +707,7 @@ private:
     Geochem m_geochem{};
     std::size_t m_comps = 0;
     std::size_t m_max_gas_plant_tables = 0;
+    bool m_solution_method_specified{false};
     bool m_co2storage{false};
     bool m_co2sol{false};
     bool m_h2sol{false};

--- a/opm/input/eclipse/share/keywords/001_Eclipse300/A/AIM
+++ b/opm/input/eclipse/share/keywords/001_Eclipse300/A/AIM
@@ -1,0 +1,6 @@
+{
+  "name": "AIM",
+  "sections": [
+    "RUNSPEC"
+  ]
+}

--- a/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1051,6 +1051,7 @@ set( keywords
      001_Eclipse300/A/ACF
      001_Eclipse300/A/ACFS
      001_Eclipse300/A/ACTCO2S
+     001_Eclipse300/A/AIM
      001_Eclipse300/B/BIC
      001_Eclipse300/B/BICS
      001_Eclipse300/B/BLOCK_PROBE300

--- a/tests/parser/CompositionalTests.cpp
+++ b/tests/parser/CompositionalTests.cpp
@@ -815,6 +815,19 @@ BOOST_AUTO_TEST_CASE(CompositionalParsingTest) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(SolutionMethodKeywordsAreRecognized)
+{
+    const auto defaultedDeck = Parser{}.parseString("RUNSPEC\n");
+    BOOST_CHECK(!Runspec {defaultedDeck}.solutionMethodSpecified());
+
+    for (const auto* method : {"AIM", "FULLIMP", "IMPES"}) {
+        const auto deck = Parser{}.parseString(std::string{"RUNSPEC\n"} + method + "\n");
+
+        BOOST_CHECK(deck.hasKeyword(method));
+        BOOST_CHECK(Runspec {deck}.solutionMethodSpecified());
+    }
+}
+
 Deck createCompositionalDeckZMF()
 {
     return Parser{}.parseString(R"(


### PR DESCRIPTION
Recognize `AIM` as a RUNSPEC keyword and record in `Runspec` whether `AIM`, `FULLIMP`, or `IMPES` was explicitly selected. This gives downstream consumers a single parsed source of truth for distinguishing an omitted solution method from an explicit selection and includes parser and serialization coverage.

Used by OPM/opm-simulators#7401.